### PR TITLE
chore(api-server): More forgiving unit tests

### DIFF
--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -109,7 +109,7 @@ describe('createServer', () => {
   // This should be fixed so that all logs go to the same place
   it("doesn't handle logs consistently", async () => {
     // Here we create a logger that outputs to an array.
-    const loggerLogs: string[] = []
+    const loggerLogs: Record<string, Record<string, string> | string>[] = []
     const stream = build(async (source) => {
       for await (const obj of source) {
         loggerLogs.push(obj)
@@ -175,14 +175,20 @@ describe('createServer', () => {
       },
     })
 
+    // There will be two lines saying what address the server is listening to,
+    // one IPv4 and one IPv6. But after a recent OS update the order of the
+    // logs switched. So now I just check that they're there, but don't care
+    // what order they're in
     expect(loggerLogs[2]).toMatchObject({
       level: 30,
-      msg: 'Server listening at http://[::1]:8910',
+      msg: /Server listening at http:\/\/(127\.0\.0\.1|\[::1\]):8910/,
     })
     expect(loggerLogs[3]).toMatchObject({
       level: 30,
-      msg: 'Server listening at http://127.0.0.1:8910',
+      msg: /Server listening at http:\/\/(127\.0\.0\.1|\[::1\]):8910/,
     })
+
+    expect(loggerLogs[2].msg).not.toEqual(loggerLogs[3].msg)
   })
 
   describe('`server.start`', () => {


### PR DESCRIPTION
I was getting this error about what address the server was listening to

```
      - Expected
      + Received

        Object {
          "level": 30,
      -   "msg": "Server listening at http://[::1]:8910",
      +   "msg": "Server listening at http://127.0.0.1:8910",
        }

       ❯ src/__tests__/createServer.test.ts:178:27
```

![image](https://github.com/user-attachments/assets/b2c190f1-855b-4ea8-8cad-2fed838c7bbe)

This PR fixes that by not caring about the order of the log lines