### PR TITLE
fix(cca): Better intellisense for JS apps

### DIFF
--- a/packages/create-cedar-app/templates/js/web/vite.config.js
+++ b/packages/create-cedar-app/templates/js/web/vite.config.js
@@ -8,8 +8,6 @@ import redwood from '@cedarjs/vite'
 // See: https://vitejs.dev/config/server-options.html#server-host.
 dns.setDefaultResultOrder('verbatim')
 
-const viteConfig = {
+export default defineConfig({
   plugins: [redwood()],
-}
-
-export default defineConfig(viteConfig)
+})

--- a/packages/create-cedar-app/templates/ts/web/vite.config.ts
+++ b/packages/create-cedar-app/templates/ts/web/vite.config.ts
@@ -1,6 +1,5 @@
 import dns from 'dns'
 
-import type { UserConfig } from 'vite'
 import { defineConfig } from 'vite'
 
 import redwood from '@cedarjs/vite'
@@ -9,8 +8,6 @@ import redwood from '@cedarjs/vite'
 // See: https://vitejs.dev/config/server-options.html#server-host.
 dns.setDefaultResultOrder('verbatim')
 
-const viteConfig: UserConfig = {
+export default defineConfig({
   plugins: [redwood()],
-}
-
-export default defineConfig(viteConfig)
+})


### PR DESCRIPTION
By passing the config straight to `createConfig` also JS apps get intellisense help with setting the correct options