### PR TITLE
feat(dataMigrate): Don't use Babel's require hook

### DIFF
--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@cedarjs/babel-config": "workspace:*",
     "@cedarjs/project-config": "workspace:*",
+    "bundle-require": "^5.1.0",
     "chalk": "4.1.2",
     "dotenv-defaults": "5.0.2",
     "execa": "5.1.1",

--- a/packages/cli-packages/dataMigrate/src/commands/upHandler.ts
+++ b/packages/cli-packages/dataMigrate/src/commands/upHandler.ts
@@ -2,10 +2,10 @@ import fs from 'fs'
 import path from 'path'
 
 import type { PrismaClient } from '@prisma/client'
+import { bundleRequire } from 'bundle-require'
 import { Listr } from 'listr2'
 
-import { registerApiSideBabelHook } from '@cedarjs/babel-config'
-import { getPaths } from '@cedarjs/project-config'
+import { getPaths, resolveFile } from '@cedarjs/project-config'
 
 import c from '../lib/colors'
 import type { DataMigrateUpOptions, DataMigration } from '../types'
@@ -15,7 +15,6 @@ export async function handler({
   distPath,
 }: DataMigrateUpOptions) {
   let db: any
-  let requireHookRegistered = false
 
   if (importDbClientFromDist) {
     if (!fs.existsSync(distPath)) {
@@ -41,10 +40,27 @@ export async function handler({
 
     db = (await import(distLibDbPath)).db
   } else {
-    registerApiSideBabelHook()
-    requireHookRegistered = true
+    const dbPath = resolveFile(path.join(getPaths().api.lib, 'db'))
 
-    db = require(path.join(getPaths().api.lib, 'db')).db
+    if (!dbPath) {
+      console.error(`Can't find your db file in ${getPaths().api.lib}`)
+      process.exitCode = 1
+      return
+    }
+
+    // Needed plugins:
+    // - babel-plugin-module-resolver: 'src' -> './src' etc
+    // - rwjs-babel-directory-named-modules: 'src/services/userExamples' -> './src/services/userExamples/userExamples.ts'
+    // - babel-plugin-auto-import: `import gql from 'graphql-tag`, `import { context } from '@cedarjs/context`
+    // - babel-plugin-graphql-tag: ???
+    // - rwjs-babel-glob-import-dir: Handle imports like src/services/**/*.{js,ts}
+    // - rwjs-babel-otel-wrapping: Wrap code in OpenTelemetry spans
+    const { mod } = await bundleRequire({
+      filepath: dbPath,
+      // TODO: Add plugins
+    })
+
+    db = mod.db
   }
 
   const pendingDataMigrations = await getPendingDataMigrations(db)
@@ -71,10 +87,6 @@ export async function handler({
         }
       },
       async task() {
-        if (!requireHookRegistered) {
-          registerApiSideBabelHook()
-        }
-
         try {
           const { startedAt, finishedAt } = await runDataMigration(
             db,
@@ -187,10 +199,15 @@ function sortDataMigrationsByVersion(
 }
 
 async function runDataMigration(db: PrismaClient, dataMigrationPath: string) {
-  const dataMigration = require(dataMigrationPath)
+  const { mod } = await bundleRequire({
+    filepath: dataMigrationPath,
+    // TODO: Add plugins
+  })
+
+  const dataMigration = mod.default
 
   const startedAt = new Date()
-  await dataMigration.default({ db })
+  await dataMigration({ db })
   const finishedAt = new Date()
 
   return { startedAt, finishedAt }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2618,6 +2618,7 @@ __metadata:
     "@prisma/client": "npm:5.20.0"
     "@types/fs-extra": "npm:11.0.4"
     "@types/yargs": "npm:17.0.33"
+    bundle-require: "npm:^5.1.0"
     chalk: "npm:4.1.2"
     dotenv-defaults: "npm:5.0.2"
     execa: "npm:5.1.1"
@@ -13436,6 +13437,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bundle-require@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "bundle-require@npm:5.1.0"
+  dependencies:
+    load-tsconfig: "npm:^0.2.3"
+  peerDependencies:
+    esbuild: ">=0.18"
+  checksum: 10c0/8bff9df68eb686f05af952003c78e70ffed2817968f92aebb2af620cc0b7428c8154df761d28f1b38508532204278950624ef86ce63644013dc57660a9d1810f
+  languageName: node
+  linkType: hard
+
 "busboy@npm:^1.6.0":
   version: 1.6.0
   resolution: "busboy@npm:1.6.0"
@@ -21530,6 +21542,13 @@ __metadata:
     pify: "npm:^3.0.0"
     strip-bom: "npm:^3.0.0"
   checksum: 10c0/6b48f6a0256bdfcc8970be2c57f68f10acb2ee7e63709b386b2febb6ad3c86198f840889cdbe71d28f741cbaa2f23a7771206b138cd1bdd159564511ca37c1d5
+  languageName: node
+  linkType: hard
+
+"load-tsconfig@npm:^0.2.3":
+  version: 0.2.5
+  resolution: "load-tsconfig@npm:0.2.5"
+  checksum: 10c0/bf2823dd26389d3497b6567f07435c5a7a58d9df82e879b0b3892f87d8db26900f84c85bc329ef41c0540c0d6a448d1c23ddc64a80f3ff6838b940f3915a3fcb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Use esbuild instead of babel to run data migrations

🚨 Breaking:
Running data migrations does not include your custom babel config anymore.