### PR TITLE
fix(jsdoc): currentUser: Update link and remove unusual whitespace

### DIFF
--- a/packages/internal/src/generate/templates/all-currentUser.d.ts.template
+++ b/packages/internal/src/generate/templates/all-currentUser.d.ts.template
@@ -7,10 +7,12 @@ export type InferredCurrentUser = Awaited<ReturnType<typeof getCurrentUser>>
 
 type UndefinedRoles = {
   /**
-   * ⚠️ Heads-Up: This is undefined unless roles key is returned from {@link getCurrentUser()}
+   * ⚠️ Heads-Up: This is undefined unless a roles key is returned from
+   * {@link getCurrentUser()}
    *
-   * You may take a look at https://redwoodjs.com/docs/tutorial/chapter7/rbac for a tutorial on
-   * how to add fully-fledged RBAC (Role-based Access Control) to your database model.
+   * You may take a look at https://cedarjs.com/docs/tutorial/chapter7/rbac for
+   * a tutorial on how to add fully-fledged RBAC (Role-based Access Control) to
+   * your database model.
    */
   roles?: unknown | unknown[]
 }


### PR DESCRIPTION
* Link to cedarjs.com instead of redwoodjs.com
* Use a regular space instead of unicode character U+A0

This is what it looked like before
![image](https://github.com/user-attachments/assets/21cfd1ff-18df-44fc-a7f9-f6d6163d2524)
