### PR TITLE
chore(prerender): Match tsconfig.build options with tsconfig

### DIFF
--- a/packages/prerender/tsconfig.build.json
+++ b/packages/prerender/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "rootDir": "src",
     "outDir": "dist",
     "allowJs": true

--- a/packages/prerender/tsconfig.json
+++ b/packages/prerender/tsconfig.json
@@ -6,6 +6,7 @@
     "allowJs": true
   },
   "include": ["."],
+  "exclude": ["dist", "node_modules", "**/__tests__/fixtures"],
   "references": [
     { "path": "../babel-config" },
     { "path": "../project-config" },
@@ -13,6 +14,5 @@
     { "path": "../structure" },
     { "path": "../web/tsconfig.build.json" },
     { "path": "../framework-tools" }
-  ],
-  "exclude": ["dist", "node_modules", "**/__mocks__", "**/__tests__/fixtures"]
+  ]
 }


### PR DESCRIPTION
Match build and normal tsconfig options, so that the IDE and the build process reports the same errors