### PR TITLE
docs(README): Update the migration notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,25 @@ efforts of the RedwoodJS founders, maintainers and community.
 
 ## Migrating from RedwoodJS to CedarJS
 
-Search and replace all instances of `"@redwoodjs/(.*)": "\d+\.\d+\.\d+"`
-with `"@cedarjs/$1": "0.1.1"` (or whatever the latest version of Cedar is when
-you run this) in all three `package.json` files. Run `yarn install` to update
-your lock file.
-
-Search and replace all instances of `@redwoodjs` in all files with `@cedarjs`.
-Pay attention to `yarn.lock`. If anything changed in there you probably have to
-do some manual editing. Also find all mentions of
-`storybook-framework-redwoodjs-vite` and replace with
-`storybook-framework-cedarjs`
+1. Search and replace all instances of `"@redwoodjs/(.*)": "\d+\.\d+\.\d+"`
+   with `"@cedarjs/$1": "0.1.1"` (or whatever the latest version of Cedar is
+   when you run this) in all three `package.json` files.
+2. Run `yarn install` to update your lock file.
+3. Make a git commit with all changes as a checkpoint to make it easier to see
+   what changes in the following steps
+4. Search and replace all instances of `@redwoodjs` in all files with
+   `@cedarjs`.
+5. Also find all mentions of `storybook-framework-redwoodjs-vite` and replace
+   with `storybook-framework-cedarjs`
+6. Pay attention to `yarn.lock`. If anything changed in there you probably have
+   to do some manual editing. (Contact me if you need help.)
+7. Delete all files and folders inside `.redwood/` except `README.md`
+8. Run `yarn install` and `yarn rw build`. Make sure everything works as
+   expected.
+9. Make a new git commit (or amend the previous one you did)
 
 Cedar doesn't have the equivalent of Redwood Studio yet. So Studio will not
 work for now. Let me know if that's something you use and need.
-
-Delete all files and folders inside `.redwood/` except `README.md`
 
 ## Roadmap
 


### PR DESCRIPTION
Update the instructions for migrating from Redwood to CedarJS to make them more clear and detailed.