### PR TITLE
fix(api/cache): use named exports instead of default exports

### DIFF
--- a/.changesets/151.md
+++ b/.changesets/151.md
@@ -1,0 +1,4 @@
+- fix(api/cache): use named exports instead of default exports (#151) by @c-ciobanu
+
+Fixes a "TypeError: Class extends value #<Object> is not a constructor or null"
+error you'd get when trying to use `@cedarjs/api/cache`

--- a/packages/api/src/cache/__tests__/cache.test.ts
+++ b/packages/api/src/cache/__tests__/cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import InMemoryClient from '../clients/InMemoryClient.js'
+import { InMemoryClient } from '../clients/InMemoryClient.js'
 import { createCache } from '../index.js'
 
 describe('cache', () => {

--- a/packages/api/src/cache/__tests__/cacheFindMany.test.ts
+++ b/packages/api/src/cache/__tests__/cacheFindMany.test.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@prisma/client'
 import { describe, afterEach, it, vi, expect } from 'vitest'
 
-import InMemoryClient from '../clients/InMemoryClient.js'
+import { InMemoryClient } from '../clients/InMemoryClient.js'
 import { createCache } from '../index.js'
 
 const mockFindFirst = vi.fn()

--- a/packages/api/src/cache/__tests__/deleteCacheKey.test.ts
+++ b/packages/api/src/cache/__tests__/deleteCacheKey.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import InMemoryClient from '../clients/InMemoryClient.js'
+import { InMemoryClient } from '../clients/InMemoryClient.js'
 import { createCache } from '../index.js'
 
 describe('deleteCacheKey', () => {

--- a/packages/api/src/cache/__tests__/disconnect.test.ts
+++ b/packages/api/src/cache/__tests__/disconnect.test.ts
@@ -1,6 +1,6 @@
 import { describe, beforeEach, it, expect, vi } from 'vitest'
 
-import InMemoryClient from '../clients/InMemoryClient.js'
+import { InMemoryClient } from '../clients/InMemoryClient.js'
 import { CacheTimeoutError } from '../errors.js'
 import { createCache } from '../index.js'
 

--- a/packages/api/src/cache/clients/BaseClient.ts
+++ b/packages/api/src/cache/clients/BaseClient.ts
@@ -1,4 +1,4 @@
-export default abstract class BaseClient {
+export abstract class BaseClient {
   constructor() {}
 
   // if your client won't automatically reconnect, implement this function

--- a/packages/api/src/cache/clients/InMemoryClient.ts
+++ b/packages/api/src/cache/clients/InMemoryClient.ts
@@ -1,12 +1,12 @@
 // Simple in-memory cache client for testing. NOT RECOMMENDED FOR PRODUCTION
 
-import BaseClient from './BaseClient.js'
+import { BaseClient } from './BaseClient.js'
 
 type CacheOptions = {
   expires?: number
 }
 
-export default class InMemoryClient extends BaseClient {
+export class InMemoryClient extends BaseClient {
   storage: Record<string, { expires: number; value: string }>
 
   // initialize with pre-cached data if needed

--- a/packages/api/src/cache/clients/MemcachedClient.ts
+++ b/packages/api/src/cache/clients/MemcachedClient.ts
@@ -1,8 +1,8 @@
 import type { Client as ClientType, ClientOptions, ServerOptions } from 'memjs'
 
-import BaseClient from './BaseClient.js'
+import { BaseClient } from './BaseClient.js'
 
-export default class MemcachedClient extends BaseClient {
+export class MemcachedClient extends BaseClient {
   client?: ClientType | null
   servers
   options

--- a/packages/api/src/cache/clients/RedisClient.ts
+++ b/packages/api/src/cache/clients/RedisClient.ts
@@ -2,7 +2,7 @@ import type { RedisClientType, RedisClientOptions } from 'redis'
 
 import type { Logger } from '../../logger/index.js'
 
-import BaseClient from './BaseClient.js'
+import { BaseClient } from './BaseClient.js'
 
 interface SetOptions {
   EX?: number
@@ -12,7 +12,7 @@ type LoggerOptions = {
   logger?: Logger
 }
 
-export default class RedisClient extends BaseClient {
+export class RedisClient extends BaseClient {
   client?: RedisClientType | null
   logger?: Logger
   redisOptions?: RedisClientOptions

--- a/packages/api/src/cache/index.ts
+++ b/packages/api/src/cache/index.ts
@@ -1,11 +1,11 @@
 import type { Logger } from '../logger/index.js'
 
-import type BaseClient from './clients/BaseClient.js'
+import type { BaseClient } from './clients/BaseClient.js'
 import { CacheTimeoutError } from './errors.js'
 
-export { default as MemcachedClient } from './clients/MemcachedClient.js'
-export { default as RedisClient } from './clients/RedisClient.js'
-export { default as InMemoryClient } from './clients/InMemoryClient.js'
+export { MemcachedClient } from './clients/MemcachedClient.js'
+export { RedisClient } from './clients/RedisClient.js'
+export { InMemoryClient } from './clients/InMemoryClient.js'
 
 export interface CreateCacheOptions {
   logger?: Logger


### PR DESCRIPTION
Fixes #150
Not exactly sure why but it does the trick.