### PR TITLE
fix(corepack): Switch to installing corepack globally from npm

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -27,7 +27,8 @@ runs:
   steps:
     - name: ⬢ Enable Corepack
       shell: bash
-      run: npm install --global corepack
+      # Using --force to make this work on Windows
+      run: npm install --global --force corepack
 
     - name: ⬢ Set up Node.js
       uses: actions/setup-node@v4
@@ -40,7 +41,8 @@ runs:
     - name: ⬢ Enable Corepack
       if: runner.os == 'Windows'
       shell: bash
-      run: npm install --global corepack
+      # Using --force to make this work on Windows
+      run: npm install --global --force corepack
 
     - name: 🐈 Set up yarn cache
       if: inputs.set-up-yarn-cache == 'true'

--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
     - name: ⬢ Enable Corepack
       shell: bash
-      run: corepack enable
+      run: npm install --global corepack
 
     - name: ⬢ Set up Node.js
       uses: actions/setup-node@v4
@@ -40,7 +40,7 @@ runs:
     - name: ⬢ Enable Corepack
       if: runner.os == 'Windows'
       shell: bash
-      run: corepack enable
+      run: npm install --global corepack
 
     - name: 🐈 Set up yarn cache
       if: inputs.set-up-yarn-cache == 'true'

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Enable Corepack
-        run: corepack enable
+        run: npm install --global corepack
 
       - name: Set up job
         uses: ./.github/actions/set-up-job

--- a/.github/workflows/publish-release-candidate.yml
+++ b/.github/workflows/publish-release-candidate.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Enable Corepack
-        run: corepack enable
+        run: npm install --global corepack
 
       - name: ⬢ Set up Node.js
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,7 +20,7 @@ tasks:
       export REDWOOD_DISABLE_TELEMETRY=1
     init: |
       cd /workspace/redwood
-      corepack enable
+      npm install --global corepack
       yarn install
       yarn run build:test-project ../rw-test-app --typescript --link --verbose
       cd /workspace/rw-test-app && sed -i "s/\(open *= *\).*/\1false/" redwood.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Replace `your-username` with your GitHub username below:
 ```terminal
 git clone https://github.com/your-username/cedar.git
 cd cedar
-corepack enable
+npm install --global corepack
 yarn install
 ```
 

--- a/docs/docs/docker.md
+++ b/docs/docs/docker.md
@@ -87,10 +87,10 @@ Just remember to change the `apt-get` instructions further down too if needed.
 
 :::
 
-Moving on, next we have `corepack enable`:
+Moving on, next we have `npm install --global corepack`:
 
 ```Dockerfile
-RUN corepack enable
+RUN npm install --global corepack
 ```
 
 [Corepack](https://nodejs.org/docs/latest-v18.x/api/corepack.html), Node's manager for package managers, needs to be enabled so that Yarn can use the `packageManager` field in your project's root `package.json` to pick the right version of itself.
@@ -205,7 +205,7 @@ The `api_serve` stage serves your GraphQL api and functions:
 ```Dockerfile
 FROM node:20-bookworm-slim as api_serve
 
-RUN corepack enable
+RUN npm install --global corepack
 
 RUN apt-get update && apt-get install -y \
     openssl \
@@ -326,7 +326,7 @@ The key line here is the first one—this stage uses the `api_build` stage as it
 ```Dockerfile
 FROM node:20-bookworm-slim as web_serve
 
-RUN corepack enable
+RUN npm install --global corepack
 
 USER node
 WORKDIR /home/node/app

--- a/docs/docs/how-to/test-in-github-actions.md
+++ b/docs/docs/how-to/test-in-github-actions.md
@@ -231,7 +231,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: corepack enable
+      - run: npm install --global corepack
       # install all the dependencies
       - run: yarn install
       # build the redwood app
@@ -329,7 +329,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: corepack enable
+      - run: npm install --global corepack
       # install all the dependencies
       - run: yarn install
       # build the redwood app

--- a/docs/docs/how-to/using-nvm.md
+++ b/docs/docs/how-to/using-nvm.md
@@ -84,10 +84,10 @@ nvm ls-remote
 :::warning
 You'll need to [install yarn](https://yarnpkg.com/getting-started/install) **for each version of Node that you install.**
 
-[Corepack](https://nodejs.org/dist/latest/docs/api/corepack.html) is included with all Node.js >=16.10 installs, but you must opt-in. To enable it, run the following command:
+As recommended in the yarn docs we use [Corepack](https://github.com/nodejs/corepack) to manage the yarn installation and version. So go ahead and install corepack:
 
 ```bash
-corepack enable
+npm install --global corepack
 ```
 
 We also have a doc specifically for [working with yarn](./using-yarn).

--- a/docs/docs/how-to/using-yarn.md
+++ b/docs/docs/how-to/using-yarn.md
@@ -6,12 +6,10 @@
 
 ## Installing yarn
 
-> "The preferred way to manage Yarn is through [Corepack](https://nodejs.org/dist/latest/docs/api/corepack.html), a new binary shipped with all Node.js releases starting from 16.10." <br />-[from the Yarn documentation](https://yarnpkg.com/getting-started/install)
-
-Corepack is included with all Node.js >=16.10 installs, but you must opt-in. To enable it, run the following command:
+The official installation instructions can be found at https://yarnpkg.com/getting-started/install, but basically you have to first install Corepack, and let that manage yarn for you.
 
 ```bash
-corepack enable
+npm install --global corepack
 ```
 
 ## Using the correct version of yarn
@@ -24,19 +22,26 @@ yarn --version
 
 **Redwood requires Yarn (>=1.22.21)**
 
-You can upgrade yarn by running the following command:
+You can upgrade your global yarn version by running the following command:
 
 ```bash
-corepack prepare yarn@stable --activate
+corepack install --global yarn@stable
+```
+
+If you want to upgrade the version of yarn that is used in your project these are the commands to use:
+
+```bash
+yarn set version stable
+yarn install
 ```
 
 :::info
-If this command fails, you may need to [uninstall the current version of Yarn first](#uninstalling-yarn).
+If the `set version` command fails, you may need to [uninstall the current version of Yarn first](#uninstalling-yarn).
 
 ```terminal
 corepack disable
 npm uninstall -g yarn --force
-corepack enable
+npm install --global corepack
 ```
 
 :::

--- a/docs/docs/tutorial/chapter1/prerequisites.md
+++ b/docs/docs/tutorial/chapter1/prerequisites.md
@@ -55,7 +55,7 @@ Using the recommended [LTS version from Nodejs.org](https://nodejs.org/en/) is p
 As of Node.js v18+, Node.js ships with a CLI tool called [Corepack](https://nodejs.org/docs/latest-v18.x/api/corepack.html) to manage package managers. All you have to do is enable it, then you'll have Yarn:
 
 ```
-corepack enable
+npm install --global corepack
 yarn -v
 ```
 

--- a/packages/cli/src/commands/setup/deploy/templates/render.js
+++ b/packages/cli/src/commands/setup/deploy/templates/render.js
@@ -13,7 +13,7 @@ services:
 - name: ${PROJECT_NAME}-web
   type: web
   env: static
-  buildCommand: corepack enable && yarn install && yarn rw deploy render web
+  buildCommand: npm install --global corepack && yarn install && yarn rw deploy render web
   staticPublishPath: ./web/dist
 
   envVars:
@@ -38,7 +38,7 @@ services:
   plan: free
   env: node
   region: oregon
-  buildCommand: corepack enable && yarn install && yarn rw build api
+  buildCommand: npm install --global corepack && yarn install && yarn rw build api
   startCommand: yarn rw deploy render api
 
   envVars:

--- a/packages/cli/src/commands/setup/docker/templates/Dockerfile
+++ b/packages/cli/src/commands/setup/docker/templates/Dockerfile
@@ -2,7 +2,7 @@
 # ----
 FROM node:20-bookworm-slim as base
 
-RUN corepack enable
+RUN npm install --global corepack
 
 # We tried to make the Dockerfile as lean as possible. In some cases, that means we excluded a dependency your project needs.
 # By far the most common is Python. If you're running into build errors because `python3` isn't available,
@@ -61,7 +61,7 @@ RUN yarn rw build web --no-prerender
 # ---------
 FROM node:20-bookworm-slim as api_serve
 
-RUN corepack enable
+RUN npm install --global corepack
 
 RUN apt-get update && apt-get install -y \
   openssl \
@@ -105,7 +105,7 @@ CMD [ "node_modules/.bin/rw-server", "api" ]
 # ---------
 FROM node:20-bookworm-slim as web_serve
 
-RUN corepack enable
+RUN npm install --global corepack
 
 USER node
 WORKDIR /home/node/app

--- a/packages/create-cedar-rsc-app/src/prerequisites.ts
+++ b/packages/create-cedar-rsc-app/src/prerequisites.ts
@@ -47,9 +47,9 @@ export function checkYarnInstallation(config: Config) {
   if (!allYarns) {
     console.log('')
     console.log('Could not find `yarn`')
-    console.log('Please enable yarn by running `corepack enable`')
+    console.log('Please enable yarn by running `npm install --global corepack`')
     console.log(
-      'and then upgrade by running `corepack install --global yarn@latest',
+      'and then upgrade by running `corepack install --global yarn@stable',
     )
     throw new ExitCodeError(1, 'Yarn not found')
   }


### PR DESCRIPTION
More context here https://github.com/redwoodjs/graphql/pull/12028, but basically corepack will soonish have to be installed from npm as it will no longer be shipped with Node. This PR makes sure we're prepared for that. And it also aligns our docs with the latest yarn docs.

Thanks to @trivikr for getting the PR started over in the Redwood repo 🙏 

This PR mostly updates docs and CI related files. 
But it does also touch our Render and Docker setup scripts. 
⚠️ If you're deploying to Render, or using Docker, you will probably want to manually make these changes to your own app

There's some good discussion related to corepack on GitHub runners here: https://github.com/actions/setup-node/issues/1222