### PR TITLE
fix(supertokens): Fix whitespace handling in setup script

### DIFF
--- a/packages/auth-providers/supertokens/setup/src/__tests__/setupHandler.test.ts
+++ b/packages/auth-providers/supertokens/setup/src/__tests__/setupHandler.test.ts
@@ -35,7 +35,7 @@ describe('addRoutingLogic', () => {
   it('modifies the Routes.{jsx,tsx} file', () => {
     vol.fromJSON({
       'Routes.tsx':
-        "// In this file, all Page components from 'src/pages' are auto-imported.\n" +
+        "// In this file, all Page components from 'src/pages' are auto-imported." +
         `
 import { Router, Route } from '@cedarjs/router'
 
@@ -58,37 +58,35 @@ export default Routes
     addRoutingLogic.task()
 
     expect(fs.readFileSync('Routes.tsx', 'utf-8')).toMatchInlineSnapshot(`
-          "// In this file, all Page components from 'src/pages' are auto-imported.
+      "// In this file, all Page components from 'src/pages' are auto-imported.
+      import { canHandleRoute, getRoutingComponent } from 'supertokens-auth-react/ui'
 
-          import { canHandleRoute, getRoutingComponent } from 'supertokens-auth-react/ui'
+      import { Router, Route } from '@cedarjs/router'
 
-          import { Router, Route } from '@cedarjs/router'
+      import { useAuth, PreBuiltUI } from './auth'
 
-          import { useAuth, PreBuiltUI } from './auth'
+      const Routes = () => {
+        if (canHandleRoute(PreBuiltUI)) {
+          return getRoutingComponent(PreBuiltUI)
+        }
+        return (
+          <Router useAuth={useAuth}>
+            <Route path="/login" page={LoginPage} name="login" />
+            <Route path="/signup" page={SignupPage} name="signup" />
+            <Route notfound page={NotFoundPage} />
+          </Router>
+        )
+      }
 
-          const Routes = () => {
-            if (canHandleRoute(PreBuiltUI)) {
-              return getRoutingComponent(PreBuiltUI)
-            }
-
-            return (
-              <Router useAuth={useAuth}>
-                <Route path="/login" page={LoginPage} name="login" />
-                <Route path="/signup" page={SignupPage} name="signup" />
-                <Route notfound page={NotFoundPage} />
-              </Router>
-            )
-          }
-
-          export default Routes
-          "
-      `)
+      export default Routes
+      "
+    `)
   })
 
   it('handles a Routes.{jsx,tsx} file with a legacy setup', () => {
     vol.fromJSON({
       'Routes.tsx':
-        "// In this file, all Page components from 'src/pages' are auto-imported.\n" +
+        "// In this file, all Page components from 'src/pages' are auto-imported." +
         `
 import SuperTokens from 'supertokens-auth-react'
 
@@ -119,8 +117,6 @@ export default Routes
     expect(fs.readFileSync('Routes.tsx', 'utf-8')).toMatchInlineSnapshot(`
       "// In this file, all Page components from 'src/pages' are auto-imported.
 
-
-
       import { canHandleRoute, getRoutingComponent } from 'supertokens-auth-react/ui'
 
       import { Router, Route } from '@cedarjs/router'
@@ -131,8 +127,6 @@ export default Routes
         if (canHandleRoute(PreBuiltUI)) {
           return getRoutingComponent(PreBuiltUI)
         }
-
-
 
         return (
           <Router useAuth={useAuth}>

--- a/packages/auth-providers/supertokens/setup/src/setupHandler.ts
+++ b/packages/auth-providers/supertokens/setup/src/setupHandler.ts
@@ -46,8 +46,8 @@ export const addRoutingLogic = {
 
     // Remove the old setup if it's there.
     content = content
-      .replace("import SuperTokens from 'supertokens-auth-react'", '')
-      .replace(/if \(SuperTokens.canHandleRoute\(\)\) {[^}]+}/, '')
+      .replace("import SuperTokens from 'supertokens-auth-react'\n", '')
+      .replace(/[ \t]*if \(SuperTokens.canHandleRoute\(\)\) {[^}]+}\n/, '')
 
     if (!/\s*if\s*\(canHandleRoute\(PreBuiltUI\)\)\s*\{/.test(content)) {
       let hasImportedSuperTokensFunctions = false
@@ -84,7 +84,7 @@ export const addRoutingLogic = {
         'const Routes = () => {\n' +
           '  if (canHandleRoute(PreBuiltUI)) {\n' +
           '    return getRoutingComponent(PreBuiltUI)\n' +
-          '  }\n\n',
+          '  }\n',
       )
 
       fs.writeFileSync(routesPath, content)


### PR DESCRIPTION
I was upgrading to Vitest 3.x and noticed one of our snapshot tests started failing. Looking into it I realized we weren't handling whitespace properly when setting up Supertokens auth. This PR fixes that.

I'm guessing this is the Vitest change that caused the diff in snapshots: https://github.com/vitest-dev/vitest/pull/7400
It doesn't say in the PR description, but the [release notes for Vitest 3.1.0](https://github.com/vitest-dev/vitest/releases/tag/v3.1.0), where it was first included, says
> This change can cause small amount of very old snapshots to be updated, but there will be no functional change to how they work.
