### PR TITLE
fix(create-cedar-app): Include `@cedarjs/testing` as devDep

### DIFF
--- a/packages/create-cedar-app/templates/js/package.json
+++ b/packages/create-cedar-app/templates/js/package.json
@@ -8,7 +8,8 @@
   },
   "devDependencies": {
     "@cedarjs/core": "0.0.5",
-    "@cedarjs/project-config": "0.0.5"
+    "@cedarjs/project-config": "0.0.5",
+    "@cedarjs/testing": "0.0.5"
   },
   "eslintConfig": {
     "extends": "@cedarjs/eslint-config",

--- a/packages/create-cedar-app/templates/ts/package.json
+++ b/packages/create-cedar-app/templates/ts/package.json
@@ -8,7 +8,8 @@
   },
   "devDependencies": {
     "@cedarjs/core": "0.0.5",
-    "@cedarjs/project-config": "0.0.5"
+    "@cedarjs/project-config": "0.0.5",
+    "@cedarjs/testing": "0.0.5"
   },
   "eslintConfig": {
     "extends": "@cedarjs/eslint-config",


### PR DESCRIPTION
The `@cedarjs/testing` package is used by the project when testing, so should be included in the list of dev dependencies