### PR TITLE
chore(tests): Await rejects.toThrowErrorMatchingInlineSnapshot

### DIFF
--- a/packages/cli-helpers/src/lib/__tests__/version.test.ts
+++ b/packages/cli-helpers/src/lib/__tests__/version.test.ts
@@ -357,7 +357,7 @@ describe('version compatibility detection', () => {
       }),
     )
 
-    expect(
+    await expect(
       getCompatibilityData('@scope/package-name', 'latest'),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[Error: No compatible version of '@scope/package-name' was found]`,

--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-route-auto-loader.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-route-auto-loader.test.ts
@@ -292,7 +292,7 @@ describe('rscRoutesAutoLoader', () => {
     `)
   })
 
-  it('should throw for duplicate page import names', () => {
+  it('should throw for duplicate page import names', async () => {
     vi.mocked(processPagesDir).mockReturnValue(pagesWithDuplicate)
 
     const getOutput = async () => {
@@ -329,7 +329,7 @@ describe('rscRoutesAutoLoader', () => {
       return output
     }
 
-    expect(getOutput).rejects.toThrowErrorMatchingInlineSnapshot(
+    await expect(getOutput).rejects.toThrowErrorMatchingInlineSnapshot(
       "[Error: Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' in the following page directories: 'AboutPage']",
     )
   })


### PR DESCRIPTION
I was seeing this error on CI https://cloud.nx.app/runs/eLSbQ5d7FY/task/%40cedarjs%2Fvite%3Atest

```
Promise returned by `expect(actual).rejects.toThrowErrorMatchingInlineSnapshot(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
    at /home/runner/work/cedar/cedar/packages/vite/src/plugins/__tests__/vite-plugin-rsc-route-auto-loader.test.ts:332:21
```

This PR properly adds `await`