### PR TITLE
chore(storybook): tsconfig module and moduleResolution nodenext

### DIFF
--- a/packages/storybook/src/index.ts
+++ b/packages/storybook/src/index.ts
@@ -1,1 +1,1 @@
-export * from './types'
+export * from './types.js'

--- a/packages/storybook/src/mocks/MockProviders.tsx
+++ b/packages/storybook/src/mocks/MockProviders.tsx
@@ -9,7 +9,7 @@ import { useAuth } from '@cedarjs/testing/auth'
 import { RedwoodProvider } from '@cedarjs/web'
 import { RedwoodApolloProvider } from '@cedarjs/web/apollo'
 
-import { MockParamsProvider } from './MockParamsProvider'
+import { MockParamsProvider } from './MockParamsProvider.js'
 
 // Import the user's Routes from `./web/src/Routes.{tsx,jsx}`,
 // we pass the `children` from the user's Routes to `./MockRouter.Router`

--- a/packages/storybook/src/mocks/StorybookProvider.tsx
+++ b/packages/storybook/src/mocks/StorybookProvider.tsx
@@ -7,7 +7,7 @@ import {
   mockCurrentUser,
 } from '@cedarjs/testing/web'
 
-import { MockProviders } from './MockProviders'
+import { MockProviders } from './MockProviders.js'
 
 export const MockingLoader = async () => {
   /**

--- a/packages/storybook/src/plugins/react-docgen.ts
+++ b/packages/storybook/src/plugins/react-docgen.ts
@@ -12,7 +12,7 @@ import {
 } from 'react-docgen'
 import type { PluginOption } from 'vite'
 
-import actualNameHandler from './docgen-handlers/actualNameHandler'
+import actualNameHandler from './docgen-handlers/actualNameHandler.js'
 
 type DocObj = Documentation & { actualName: string }
 

--- a/packages/storybook/src/preset.ts
+++ b/packages/storybook/src/preset.ts
@@ -6,11 +6,11 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 import { getPaths } from '@cedarjs/project-config'
 
-import { autoImports } from './plugins/auto-imports'
-import { mockAuth } from './plugins/mock-auth'
-import { mockRouter } from './plugins/mock-router'
-import { reactDocgen } from './plugins/react-docgen'
-import type { StorybookConfig } from './types'
+import { autoImports } from './plugins/auto-imports.js'
+import { mockAuth } from './plugins/mock-auth.js'
+import { mockRouter } from './plugins/mock-router.js'
+import { reactDocgen } from './plugins/react-docgen.js'
+import type { StorybookConfig } from './types.js'
 
 const getAbsolutePath = (input: string) =>
   path.dirname(require.resolve(path.join(input, 'package.json')))

--- a/packages/storybook/src/preview.tsx
+++ b/packages/storybook/src/preview.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import type { Addon_DecoratorFunction, Addon_Loader } from '@storybook/types'
 
-import { MockingLoader, StorybookProvider } from './mocks/StorybookProvider'
+import { MockingLoader, StorybookProvider } from './mocks/StorybookProvider.js'
 
 const decorators: Addon_DecoratorFunction<any>[] = [
   (storyFn, { id }) => {

--- a/packages/storybook/src/types.ts
+++ b/packages/storybook/src/types.ts
@@ -1,4 +1,4 @@
-import type docgenTypescript from '@joshwooding/vite-plugin-react-docgen-typescript'
+import type { default as docgenTypescript } from '@joshwooding/vite-plugin-react-docgen-typescript'
 import type {
   StorybookConfigVite,
   BuilderOptions,
@@ -41,6 +41,8 @@ type StorybookConfigFramework = {
   }
 }
 
+type TDocgenTypescript = (typeof docgenTypescript)['default']
+
 type TypescriptOptions = TypescriptOptionsBase & {
   /**
    * Sets the type of Docgen when working with React and TypeScript
@@ -51,7 +53,7 @@ type TypescriptOptions = TypescriptOptionsBase & {
   /**
    * Configures `@joshwooding/vite-plugin-react-docgen-typescript`
    */
-  reactDocgenTypescriptOptions: Parameters<typeof docgenTypescript>[0]
+  reactDocgenTypescriptOptions: Parameters<TDocgenTypescript>[0]
 }
 
 /**

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.compilerOption.json",
   "compileOnSave": true,
   "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "outDir": "./dist",
     "rootDir": "./src",
     "types": ["node", "vite/client"],

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -6,11 +6,7 @@
     "moduleResolution": "nodenext",
     "outDir": "./dist",
     "rootDir": "./src",
-    "types": ["node", "vite/client"],
-    "paths": {
-      "@cedarjs/testing/auth": ["../testing/dist/web/mockAuth.d.ts"],
-      "@cedarjs/testing/web": ["../testing/dist/web/index.d.ts"]
-    }
+    "types": ["node", "vite/client"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Using modern tsconfig settings:
```json
    "module": "nodenext",
    "moduleResolution": "nodenext",
```

Allowed me to remove this workaround I had in place:
```json
    "paths": {
      "@cedarjs/testing/auth": ["../testing/dist/web/mockAuth.d.ts"],
      "@cedarjs/testing/web": ["../testing/dist/web/index.d.ts"]
    }
```