### PR TITLE
chore(tests): Flush promises before running test

### DIFF
--- a/packages/cli/src/commands/setup/middleware/ogImage/__codemod_tests__/vitePlugin.ts
+++ b/packages/cli/src/commands/setup/middleware/ogImage/__codemod_tests__/vitePlugin.ts
@@ -1,6 +1,14 @@
-import { describe, it } from 'vitest'
+import { beforeAll, describe, it } from 'vitest'
 
 describe('Vite plugin codemod', () => {
+  beforeAll(async () => {
+    // Was running into this issue
+    // https://github.com/vitest-dev/vitest/discussions/6511
+    // One workaround that was posted there was this:
+    // TODO: Remove this workaround once the issue is fixed
+    await new Promise((res) => setImmediate(res))
+  })
+
   it('Handles the default vite config case', async () => {
     await matchTransformSnapshot('codemodVitePlugin', 'defaultViteConfig')
   })

--- a/packages/cli/src/testUtils/matchTransformSnapshot.ts
+++ b/packages/cli/src/testUtils/matchTransformSnapshot.ts
@@ -30,7 +30,7 @@ export const matchTransformSnapshot: MatchTransformSnapshotFunction = async (
   const testPath = expect.getState().testPath
 
   if (!testPath) {
-    throw new Error('Could not find test path')
+    throw new Error('Could not find test path ' + testPath)
   }
 
   let fixturePath


### PR DESCRIPTION
Trying to work around this error in our CI

![image](https://github.com/user-attachments/assets/c4773b40-3d5f-4735-85f0-e8a7b62a9c63)

Discussion here: https://github.com/vitest-dev/vitest/discussions/6511
Original issue on vitest: https://github.com/vitest-dev/vitest/issues/6479