### PR TITLE
chore(vite): Track performance in buildWeb test

### DIFF
--- a/packages/vite/src/build/__tests__/buildWeb.test.ts
+++ b/packages/vite/src/build/__tests__/buildWeb.test.ts
@@ -37,7 +37,11 @@ test('web files are prebuilt (no prerender)', async () => {
     forJest: true,
   })
 
-  expect(performance.now() - perfNow).toBeLessThan(1000)
+  // This is ~500ms on my local machine. On Ubuntu CI, it's ~1200ms.
+  expect(
+    performance.now() - perfNow,
+    'prebuildWebFiles execution time',
+  ).toBeLessThan(1500)
 
   const relativePaths = prebuiltFiles
     .filter((x) => typeof x !== 'undefined')

--- a/packages/vite/src/build/__tests__/buildWeb.test.ts
+++ b/packages/vite/src/build/__tests__/buildWeb.test.ts
@@ -1,4 +1,5 @@
-import path from 'path'
+import path from 'node:path'
+import { performance } from 'node:perf_hooks'
 
 import { beforeEach, test, expect, afterAll } from 'vitest'
 
@@ -12,7 +13,7 @@ const FIXTURE_PATH = path.resolve(
   '../../../../../__fixtures__/example-todo-main',
 )
 
-const cleanPaths = (p) => {
+function cleanPaths(p: string) {
   return ensurePosixPath(path.relative(FIXTURE_PATH, p))
 }
 
@@ -20,15 +21,23 @@ beforeEach(() => {
   process.env.RWJS_CWD = FIXTURE_PATH
   cleanWebBuild()
 })
+
 afterAll(() => {
   delete process.env.RWJS_CWD
 })
 
 test('web files are prebuilt (no prerender)', async () => {
+  let perfNow = performance.now()
   const webFiles = findWebFiles()
+
+  expect(performance.now() - perfNow).toBeLessThan(50)
+
+  perfNow = performance.now()
   const prebuiltFiles = await prebuildWebFiles(webFiles, {
     forJest: true,
   })
+
+  expect(performance.now() - perfNow).toBeLessThan(1000)
 
   const relativePaths = prebuiltFiles
     .filter((x) => typeof x !== 'undefined')

--- a/packages/vite/src/build/__tests__/buildWeb.test.ts
+++ b/packages/vite/src/build/__tests__/buildWeb.test.ts
@@ -37,11 +37,12 @@ test('web files are prebuilt (no prerender)', async () => {
     forJest: true,
   })
 
-  // This is ~500ms on my local machine. On Ubuntu CI, it's ~1200ms.
+  // This is ~500ms on my local machine.
+  // ~1200ms on Ubuntu CI, ~1900ms on Windows CI
   expect(
     performance.now() - perfNow,
     'prebuildWebFiles execution time',
-  ).toBeLessThan(1500)
+  ).toBeLessThan(2500)
 
   const relativePaths = prebuiltFiles
     .filter((x) => typeof x !== 'undefined')


### PR DESCRIPTION
I'm seeing this error on CI https://github.com/cedarjs/cedar/actions/runs/16095689619/job/45418357644?pr=172
![image](https://github.com/user-attachments/assets/71c11a70-71a9-467f-ab85-db6cc410f1e5)

Adding some performance measurements to help me understand exactly what's taking so long