### PR TITLE
allow for custom sides in CLI dev script

### DIFF
--- a/packages/cli/src/commands/__tests__/dev.test.js
+++ b/packages/cli/src/commands/__tests__/dev.test.js
@@ -182,7 +182,7 @@ describe('yarn rw dev', () => {
       api: { port: 8911 },
       experimental: {
         sides: { app: { workspace: 'app', devScript: 'android' } },
-        dev: { defaultSides: ['app'] },
+        cli: { dev: { defaultSides: ['app'] } },
       },
     })
 

--- a/packages/cli/src/commands/__tests__/dev.test.js
+++ b/packages/cli/src/commands/__tests__/dev.test.js
@@ -176,6 +176,25 @@ describe('yarn rw dev', () => {
     expect(generateCommand.command).toEqual('yarn rw-gen-watch')
   })
 
+  it('Should run custom side', async () => {
+    getConfig.mockReturnValue({
+      web: { port: 8910 },
+      api: { port: 8911 },
+      experimental: {
+        sides: { app: { workspace: 'app', devScript: 'android' } },
+        dev: { defaultSides: ['app'] },
+      },
+    })
+
+    await handler({ side: ['app'] })
+
+    const concurrentlyArgs = concurrently.mock.lastCall[0]
+
+    const appCommand = find(concurrentlyArgs, { name: 'app' })
+
+    expect(appCommand.command).toEqual('yarn workspace app run android')
+  })
+
   it('Debug port passed in command line overrides TOML', async () => {
     getConfig.mockReturnValue({
       web: {

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -1,22 +1,28 @@
 import { terminalLink } from 'termi-link'
 
+import { getConfig } from '@cedarjs/project-config'
+
 import c from '../lib/colors.js'
 import { checkNodeVersion } from '../middleware/checkNodeVersion.js'
 
 export const command = 'dev [side..]'
-export const description = 'Start development servers for api, and web'
+export const description = 'Start development servers all your sides'
 
 export const builder = (yargs) => {
-  // The reason `forward` is hidden is that it's been broken with Vite
-  // and it's not clear how to fix it.
+  const projectConfig = getConfig()
 
   yargs
     .positional('side', {
-      choices: ['api', 'web'],
-      default: ['api', 'web'],
+      choices: ['api', 'web', ...Object.keys(projectConfig.experimental.sides)],
+      default:
+        projectConfig.experimental.dev.defaultSides.length > 0
+          ? projectConfig.experimental.dev.defaultSides
+          : ['api', 'web'],
       description: 'Which dev server(s) to start',
       type: 'array',
     })
+    // The reason `forward` is hidden is that it's been broken with Vite
+    // and it's not clear how to fix it.
     .option('forward', {
       alias: 'fwd',
       description:

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -6,7 +6,7 @@ import c from '../lib/colors.js'
 import { checkNodeVersion } from '../middleware/checkNodeVersion.js'
 
 export const command = 'dev [side..]'
-export const description = 'Start development servers all your sides'
+export const description = 'Start development servers for your sides'
 
 export const builder = (yargs) => {
   const projectConfig = getConfig()

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -15,8 +15,8 @@ export const builder = (yargs) => {
     .positional('side', {
       choices: ['api', 'web', ...Object.keys(projectConfig.experimental.sides)],
       default:
-        projectConfig.experimental.dev.defaultSides.length > 0
-          ? projectConfig.experimental.dev.defaultSides
+        projectConfig.experimental.cli.dev.defaultSides.length > 0
+          ? projectConfig.experimental.cli.dev.defaultSides
           : ['api', 'web'],
       description: 'Which dev server(s) to start',
       type: 'array',

--- a/packages/project-config/src/__tests__/config.test.ts
+++ b/packages/project-config/src/__tests__/config.test.ts
@@ -55,6 +55,9 @@ describe('getConfig', () => {
               },
             ],
           },
+          "dev": {
+            "defaultSides": [],
+          },
           "opentelemetry": {
             "enabled": false,
             "wrapApi": true,
@@ -69,6 +72,7 @@ describe('getConfig', () => {
           "rsc": {
             "enabled": false,
           },
+          "sides": {},
           "streamingSsr": {
             "enabled": false,
           },

--- a/packages/project-config/src/__tests__/config.test.ts
+++ b/packages/project-config/src/__tests__/config.test.ts
@@ -46,6 +46,9 @@ describe('getConfig', () => {
         "experimental": {
           "cli": {
             "autoInstall": true,
+            "dev": {
+              "defaultSides": [],
+            },
             "plugins": [
               {
                 "package": "@cedarjs/cli-storybook-vite",
@@ -54,9 +57,6 @@ describe('getConfig', () => {
                 "package": "@cedarjs/cli-data-migrate",
               },
             ],
-          },
-          "dev": {
-            "defaultSides": [],
           },
           "opentelemetry": {
             "enabled": false,

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -73,6 +73,14 @@ interface StudioConfig {
   graphiql?: GraphiQLStudioConfig
 }
 
+type Sides = Record<
+  string,
+  {
+    workspace: string
+    devScript: string
+  }
+>
+
 export interface Config {
   web: BrowserTargetConfig
   api: NodeTargetConfig
@@ -118,6 +126,10 @@ export interface Config {
     reactCompiler: {
       enabled: boolean
       lintOnly: boolean
+    }
+    sides: Sides
+    dev: {
+      defaultSides: string[]
     }
   }
 }
@@ -204,6 +216,10 @@ const DEFAULT_CONFIG: Config = {
     reactCompiler: {
       enabled: false,
       lintOnly: false,
+    },
+    sides: {},
+    dev: {
+      defaultSides: [],
     },
   },
 }

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -112,6 +112,9 @@ export interface Config {
     cli: {
       autoInstall: boolean
       plugins: CLIPlugin[]
+      dev: {
+        defaultSides: string[]
+      }
     }
     useSDLCodeGenForGraphQLTypes: boolean
     streamingSsr: {
@@ -128,9 +131,6 @@ export interface Config {
       lintOnly: boolean
     }
     sides: Sides
-    dev: {
-      defaultSides: string[]
-    }
   }
 }
 
@@ -202,6 +202,9 @@ const DEFAULT_CONFIG: Config = {
           package: '@cedarjs/cli-data-migrate',
         },
       ],
+      dev: {
+        defaultSides: [],
+      },
     },
     useSDLCodeGenForGraphQLTypes: false,
     streamingSsr: {
@@ -218,9 +221,6 @@ const DEFAULT_CONFIG: Config = {
       lintOnly: false,
     },
     sides: {},
-    dev: {
-      defaultSides: [],
-    },
   },
 }
 


### PR DESCRIPTION
This allows to run additional scripts when executing `yarn cedar dev`.
This is enabled by updating the `cedar.toml`, e.g.
```toml
[experimental.sides.app]
  workspace = "app"
  devScript = "android"
[experimental.dev]
  defaultSides = ["api", "app"]
```

Now when you run `yarn cedar dev` it will also execute the android script present in the app workspace.
It also allows to run `yarn cedar dev app` wich will only run the app side.

I'm not completely set on this configuration, let me know your opinion.

One small issue with this is that if you have interactive CLI scripts they will not work, cannot really be fixed with the solution in place right now.

---

Note from @Tobbe:

There was some related prior work started for Redwood here: https://github.com/redwoodjs/graphql/pull/355 
Maybe we could take some syntax ideas from that PR