### PR TITLE
fix(jobs): Pass custom logger to scheduler

### DIFF
--- a/packages/jobs/src/core/JobManager.ts
+++ b/packages/jobs/src/core/JobManager.ts
@@ -50,7 +50,7 @@ export class JobManager<
   createScheduler(schedulerConfig: CreateSchedulerConfig<TAdapters>) {
     const scheduler = new Scheduler({
       adapter: this.adapters[schedulerConfig.adapter],
-      logger: this.logger,
+      logger: schedulerConfig.logger ?? this.logger,
     })
 
     return <TJob extends Job<TQueues, any[]>>(

--- a/packages/jobs/src/core/__tests__/JobManager.test.ts
+++ b/packages/jobs/src/core/__tests__/JobManager.test.ts
@@ -89,7 +89,7 @@ describe('createScheduler()', () => {
     )
   })
 
-  it('initializes the scheduler with a logger', () => {
+  it('initializes the scheduler with the correct logger', () => {
     const manager = new JobManager({
       adapters: {
         mock: mockAdapter,
@@ -98,10 +98,23 @@ describe('createScheduler()', () => {
       logger: mockLogger,
       workers: [],
     })
-    manager.createScheduler({ adapter: 'mock', logger: mockLogger })
+
+    // When not passing a logger it should use the default logger
+    manager.createScheduler({ adapter: 'mock' })
 
     expect(Scheduler).toHaveBeenCalledWith(
       expect.objectContaining({ logger: mockLogger }),
+    )
+
+    // When passing a custom logger it should use that one
+    const customLogger = { ...mockLogger, custom: true }
+    manager.createScheduler({
+      adapter: 'mock',
+      logger: customLogger,
+    })
+
+    expect(Scheduler).toHaveBeenCalledWith(
+      expect.objectContaining({ logger: customLogger }),
     )
   })
 


### PR DESCRIPTION
When you pass a logger to `createScheduler()` on your `JobManager` instance the scheduler should use the logger you pass it. If you don't pass in a logger it should use the one that the `JobManager` already has (this was already working).