### PR TITLE
feat(api-server): lambdaLoader: add discoverFunctionsGlob option

### DIFF
--- a/.changesets/189.md
+++ b/.changesets/189.md
@@ -1,0 +1,9 @@
+- feat(api-server): lambdaLoader: add discoverFunctionsGlob option (#189) by @Tobbe
+
+For function discovery in createServer and related modules.
+
+Allows overriding the glob used to discover functions, which is required when a different bundler is used, or the directory structure is not the default `dist/functions/`
+
+Defaults to: `'dist/functions/**/*.{ts,js}'`
+
+All credit for this one goes to @richard-stafflink who created the original PR over at https://github.com/redwoodjs/graphql/pull/12063

--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -243,7 +243,7 @@ describe('resolveOptions', () => {
         logger: defaults.logger,
         bodyLimit: defaults.fastifyServerOptions.bodyLimit,
       },
-      discoverfunctionsGlob: defaults.discoverfunctionsGlob,
+      discoverFunctionsGlob: defaults.discoverFunctionsGlob,
       apiHost: defaults.apiHost,
       apiPort: defaults.apiPort,
     })

--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -243,6 +243,7 @@ describe('resolveOptions', () => {
         logger: defaults.logger,
         bodyLimit: defaults.fastifyServerOptions.bodyLimit,
       },
+      discoverfunctionsGlob: defaults.discoverfunctionsGlob,
       apiHost: defaults.apiHost,
       apiPort: defaults.apiPort,
     })

--- a/packages/api-server/src/__tests__/lambdaLoader.test.ts
+++ b/packages/api-server/src/__tests__/lambdaLoader.test.ts
@@ -83,4 +83,55 @@ describe('loadFunctionsFromDist', () => {
       'does not have a function called handler defined.',
     )
   })
+
+  describe('when "discoverfunctionsGlob" is set', () => {
+    it('loads the same functions as the default value', async () => {
+      expect(LAMBDA_FUNCTIONS).toEqual({})
+
+      await loadFunctionsFromDist({
+        discoverfunctionsGlob: ['dist/functions/**/*.{ts,js}'],
+      })
+
+      expect(LAMBDA_FUNCTIONS).toEqual({
+        env: expect.any(Function),
+        graphql: expect.any(Function),
+        health: expect.any(Function),
+        hello: expect.any(Function),
+        nested: expect.any(Function),
+      })
+    })
+
+    it('loads functions when discoverfunctionsGlob is an array', async () => {
+      expect(LAMBDA_FUNCTIONS).toEqual({})
+
+      await loadFunctionsFromDist({
+        discoverfunctionsGlob: ['dist/functions/**/*.{ts,js}'],
+      })
+
+      expect(LAMBDA_FUNCTIONS).toEqual({
+        env: expect.any(Function),
+        graphql: expect.any(Function),
+        health: expect.any(Function),
+        hello: expect.any(Function),
+        nested: expect.any(Function),
+      })
+    })
+
+    it('loads functions when discoverfunctionsGlob has include and exclude values', async () => {
+      expect(LAMBDA_FUNCTIONS).toEqual({})
+
+      await loadFunctionsFromDist({
+        discoverfunctionsGlob: [
+          'dist/functions/**/*.{ts,js}',
+          '!dist/functions/**/he*.{ts,js}',
+        ],
+      })
+
+      expect(LAMBDA_FUNCTIONS).toEqual({
+        env: expect.any(Function),
+        graphql: expect.any(Function),
+        nested: expect.any(Function),
+      })
+    })
+  })
 })

--- a/packages/api-server/src/__tests__/lambdaLoader.test.ts
+++ b/packages/api-server/src/__tests__/lambdaLoader.test.ts
@@ -84,15 +84,16 @@ describe('loadFunctionsFromDist', () => {
     )
   })
 
-  describe('when "discoverfunctionsGlob" is set', () => {
+  describe('when "discoverFunctionsGlob" is set', () => {
     it('loads the same functions as the default value', async () => {
       expect(LAMBDA_FUNCTIONS).toEqual({})
 
       await loadFunctionsFromDist({
-        discoverfunctionsGlob: ['dist/functions/**/*.{ts,js}'],
+        discoverFunctionsGlob: ['dist/functions/**/*.{ts,js}'],
       })
 
       expect(LAMBDA_FUNCTIONS).toEqual({
+        'another-graphql': expect.any(Function),
         env: expect.any(Function),
         graphql: expect.any(Function),
         health: expect.any(Function),
@@ -101,33 +102,31 @@ describe('loadFunctionsFromDist', () => {
       })
     })
 
-    it('loads functions when discoverfunctionsGlob is an array', async () => {
+    it('loads functions when discoverFunctionsGlob is an array', async () => {
       expect(LAMBDA_FUNCTIONS).toEqual({})
 
       await loadFunctionsFromDist({
-        discoverfunctionsGlob: ['dist/functions/**/*.{ts,js}'],
+        discoverFunctionsGlob: ['dist/functions/**/[eg]*.{ts,js}'],
       })
 
       expect(LAMBDA_FUNCTIONS).toEqual({
-        env: expect.any(Function),
         graphql: expect.any(Function),
-        health: expect.any(Function),
-        hello: expect.any(Function),
-        nested: expect.any(Function),
+        env: expect.any(Function),
       })
     })
 
-    it('loads functions when discoverfunctionsGlob has include and exclude values', async () => {
+    it('loads functions when discoverFunctionsGlob has include and exclude values', async () => {
       expect(LAMBDA_FUNCTIONS).toEqual({})
 
       await loadFunctionsFromDist({
-        discoverfunctionsGlob: [
+        discoverFunctionsGlob: [
           'dist/functions/**/*.{ts,js}',
           '!dist/functions/**/he*.{ts,js}',
         ],
       })
 
       expect(LAMBDA_FUNCTIONS).toEqual({
+        'another-graphql': expect.any(Function),
         env: expect.any(Function),
         graphql: expect.any(Function),
         nested: expect.any(Function),

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -67,6 +67,7 @@ export async function createServer(options: CreateServerOptions = {}) {
   const {
     apiRootPath,
     fastifyServerOptions,
+    discoverfunctionsGlob,
     configureApiServer,
     apiPort,
     apiHost,
@@ -119,6 +120,7 @@ export async function createServer(options: CreateServerOptions = {}) {
       fastGlobOptions: {
         ignore: ['**/dist/functions/graphql.js'],
       },
+      discoverfunctionsGlob,
       configureServer: configureApiServer,
     },
   })

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -67,7 +67,7 @@ export async function createServer(options: CreateServerOptions = {}) {
   const {
     apiRootPath,
     fastifyServerOptions,
-    discoverfunctionsGlob,
+    discoverFunctionsGlob,
     configureApiServer,
     apiPort,
     apiHost,
@@ -120,7 +120,7 @@ export async function createServer(options: CreateServerOptions = {}) {
       fastGlobOptions: {
         ignore: ['**/dist/functions/graphql.js'],
       },
-      discoverfunctionsGlob,
+      discoverFunctionsGlob,
       configureServer: configureApiServer,
     },
   })

--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -32,6 +32,12 @@ export interface CreateServerOptions {
    */
   fastifyServerOptions?: Omit<FastifyServerOptions, 'logger'>
 
+  /**
+   * Override the glob used to discover functions.
+   * Defaults to: "dist/functions/**\/*.{ts,js}"
+   */
+  discoverfunctionsGlob?: string | string[]
+
   /** Customise the API server fastify plugin before it is registered */
   configureApiServer?: (server: Server) => void | Promise<void>
 
@@ -65,6 +71,7 @@ export const getDefaultCreateServerOptions: () => DefaultCreateServerOptions =
       requestTimeout: 15_000,
       bodyLimit: 1024 * 1024 * 100, // 100MB
     },
+    discoverfunctionsGlob: 'dist/functions/**/*.{ts,js}',
     configureApiServer: () => {},
     parseArgs: true,
     apiHost: getAPIHost(),
@@ -102,6 +109,8 @@ export function resolveOptions(
       requestTimeout: defaults.fastifyServerOptions.requestTimeout,
       bodyLimit: defaults.fastifyServerOptions.bodyLimit,
     },
+    discoverfunctionsGlob:
+      options.discoverfunctionsGlob ?? defaults.discoverfunctionsGlob,
     configureApiServer:
       options.configureApiServer ?? defaults.configureApiServer,
     apiHost: options.apiHost ?? defaults.apiHost,

--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -36,7 +36,7 @@ export interface CreateServerOptions {
    * Override the glob used to discover functions.
    * Defaults to: "dist/functions/**\/*.{ts,js}"
    */
-  discoverfunctionsGlob?: string | string[]
+  discoverFunctionsGlob?: string | string[]
 
   /** Customise the API server fastify plugin before it is registered */
   configureApiServer?: (server: Server) => void | Promise<void>
@@ -71,7 +71,7 @@ export const getDefaultCreateServerOptions: () => DefaultCreateServerOptions =
       requestTimeout: 15_000,
       bodyLimit: 1024 * 1024 * 100, // 100MB
     },
-    discoverfunctionsGlob: 'dist/functions/**/*.{ts,js}',
+    discoverFunctionsGlob: 'dist/functions/**/*.{ts,js}',
     configureApiServer: () => {},
     parseArgs: true,
     apiHost: getAPIHost(),
@@ -109,8 +109,8 @@ export function resolveOptions(
       requestTimeout: defaults.fastifyServerOptions.requestTimeout,
       bodyLimit: defaults.fastifyServerOptions.bodyLimit,
     },
-    discoverfunctionsGlob:
-      options.discoverfunctionsGlob ?? defaults.discoverfunctionsGlob,
+    discoverFunctionsGlob:
+      options.discoverFunctionsGlob ?? defaults.discoverFunctionsGlob,
     configureApiServer:
       options.configureApiServer ?? defaults.configureApiServer,
     apiHost: options.apiHost ?? defaults.apiHost,

--- a/packages/api-server/src/plugins/api.ts
+++ b/packages/api-server/src/plugins/api.ts
@@ -16,7 +16,7 @@ export interface RedwoodFastifyAPIOptions {
   redwood: {
     apiRootPath?: string
     fastGlobOptions?: FastGlobOptions
-    discoverfunctionsGlob?: string | string[]
+    discoverFunctionsGlob?: string | string[]
     loadUserConfig?: boolean
     configureServer?: (server: Server) => void | Promise<void>
   }
@@ -66,6 +66,6 @@ export async function redwoodFastifyAPI(
   fastify.all(`${redwoodOptions.apiRootPath}:routeName/*`, lambdaRequestHandler)
   await loadFunctionsFromDist({
     fastGlobOptions: redwoodOptions.fastGlobOptions,
-    discoverfunctionsGlob: redwoodOptions.discoverfunctionsGlob,
+    discoverFunctionsGlob: redwoodOptions.discoverFunctionsGlob,
   })
 }

--- a/packages/api-server/src/plugins/api.ts
+++ b/packages/api-server/src/plugins/api.ts
@@ -16,6 +16,7 @@ export interface RedwoodFastifyAPIOptions {
   redwood: {
     apiRootPath?: string
     fastGlobOptions?: FastGlobOptions
+    discoverfunctionsGlob?: string | string[]
     loadUserConfig?: boolean
     configureServer?: (server: Server) => void | Promise<void>
   }
@@ -65,5 +66,6 @@ export async function redwoodFastifyAPI(
   fastify.all(`${redwoodOptions.apiRootPath}:routeName/*`, lambdaRequestHandler)
   await loadFunctionsFromDist({
     fastGlobOptions: redwoodOptions.fastGlobOptions,
+    discoverfunctionsGlob: redwoodOptions.discoverfunctionsGlob,
   })
 }

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -54,16 +54,18 @@ export const setLambdaFunctions = async (foundFunctions: string[]) => {
 
 type LoadFunctionsFromDistOptions = {
   fastGlobOptions?: FastGlobOptions
+  discoverfunctionsGlob?: string | string[]
 }
 
 // TODO: Use v8 caching to load these crazy fast.
 export const loadFunctionsFromDist = async (
   options: LoadFunctionsFromDistOptions = {},
 ) => {
-  const serverFunctions = findApiDistFunctions(
-    getPaths().api.base,
-    options?.fastGlobOptions,
-  )
+  const serverFunctions = findApiDistFunctions({
+    cwd: getPaths().api.base,
+    options: options?.fastGlobOptions,
+    discoverfunctionsGlob: options?.discoverfunctionsGlob,
+  })
 
   // Place `GraphQL` serverless function at the start.
   const i = serverFunctions.findIndex((x) => path.basename(x) === 'graphql.js')
@@ -74,15 +76,25 @@ export const loadFunctionsFromDist = async (
   await setLambdaFunctions(serverFunctions)
 }
 
-// NOTE: Copied from @cedarjs/internal/dist/files to avoid depending on @cedarjs/internal.
+// NOTE: Copied from @cedarjs/internal/dist/files to avoid depending on
+// @cedarjs/internal.
 // import { findApiDistFunctions } from '@cedarjs/internal/dist/files'
-function findApiDistFunctions(
-  cwd: string = getPaths().api.base,
-  options: FastGlobOptions = {},
-) {
-  return fg.sync('dist/functions/**/*.{ts,js}', {
+const findApiDistFunctions = (params: {
+  cwd: string
+  options?: FastGlobOptions
+  discoverfunctionsGlob?: string | string[]
+}) => {
+  const {
+    cwd = getPaths().api.base,
+    options = {},
+    discoverfunctionsGlob = 'dist/functions/**/*.{ts,js}',
+  } = params
+
+  return fg.sync(discoverfunctionsGlob, {
     cwd,
-    deep: 2, // We don't support deeply nested api functions, to maximise compatibility with deployment providers
+    // We don't support deeply nested api functions, to maximise compatibility
+    // with deployment providers
+    deep: 2,
     absolute: true,
     ...options,
   })

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -54,7 +54,7 @@ export const setLambdaFunctions = async (foundFunctions: string[]) => {
 
 type LoadFunctionsFromDistOptions = {
   fastGlobOptions?: FastGlobOptions
-  discoverfunctionsGlob?: string | string[]
+  discoverFunctionsGlob?: string | string[]
 }
 
 // TODO: Use v8 caching to load these crazy fast.
@@ -64,7 +64,7 @@ export const loadFunctionsFromDist = async (
   const serverFunctions = findApiDistFunctions({
     cwd: getPaths().api.base,
     options: options?.fastGlobOptions,
-    discoverfunctionsGlob: options?.discoverfunctionsGlob,
+    discoverFunctionsGlob: options?.discoverFunctionsGlob,
   })
 
   // Place `GraphQL` serverless function at the start.
@@ -82,15 +82,15 @@ export const loadFunctionsFromDist = async (
 const findApiDistFunctions = (params: {
   cwd: string
   options?: FastGlobOptions
-  discoverfunctionsGlob?: string | string[]
+  discoverFunctionsGlob?: string | string[]
 }) => {
   const {
     cwd = getPaths().api.base,
     options = {},
-    discoverfunctionsGlob = 'dist/functions/**/*.{ts,js}',
+    discoverFunctionsGlob = 'dist/functions/**/*.{ts,js}',
   } = params
 
-  return fg.sync(discoverfunctionsGlob, {
+  return fg.sync(discoverFunctionsGlob, {
     cwd,
     // We don't support deeply nested api functions, to maximise compatibility
     // with deployment providers

--- a/packages/internal/src/files.ts
+++ b/packages/internal/src/files.ts
@@ -106,14 +106,14 @@ export const findApiServerFunctions = (
 export const findApiDistFunctions = (params: {
   cwd: string
   options?: FastGlobOptions
-  discoverfunctionsGlob?: string | string[]
+  discoverFunctionsGlob?: string | string[]
 }) => {
   const {
     cwd = getPaths().api.base,
     options = {},
-    discoverfunctionsGlob = 'dist/functions/**/*.{ts,js}',
+    discoverFunctionsGlob = 'dist/functions/**/*.{ts,js}',
   } = params
-  return fg.sync(discoverfunctionsGlob, {
+  return fg.sync(discoverFunctionsGlob, {
     cwd,
     // We don't support deeply nested api functions, to maximise compatibility
     // with deployment providers

--- a/packages/internal/src/files.ts
+++ b/packages/internal/src/files.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 
-import fg from 'fast-glob'
+import fg, { type Options as FastGlobOptions } from 'fast-glob'
 
 import { getPaths } from '@cedarjs/project-config'
 
@@ -99,11 +99,27 @@ export const findApiServerFunctions = (
   return files.filter((f) => isApiFunction(f, cwd))
 }
 
-export const findApiDistFunctions = (cwd: string = getPaths().api.base) => {
-  return fg.sync('dist/functions/**/*.{ts,js}', {
+// There is a copy of this function in
+// packages/api-server/src/plugins/lambdaLoader.ts
+// This is done to avoid to avoid @cedarjs/api-server depending on
+// @cedarjs/internal
+export const findApiDistFunctions = (params: {
+  cwd: string
+  options?: FastGlobOptions
+  discoverfunctionsGlob?: string | string[]
+}) => {
+  const {
+    cwd = getPaths().api.base,
+    options = {},
+    discoverfunctionsGlob = 'dist/functions/**/*.{ts,js}',
+  } = params
+  return fg.sync(discoverfunctionsGlob, {
     cwd,
-    deep: 2, // We don't support deeply nested api functions, to maximise compatibility with deployment providers
+    // We don't support deeply nested api functions, to maximise compatibility
+    // with deployment providers
+    deep: 2,
     absolute: true,
+    ...options,
   })
 }
 


### PR DESCRIPTION
For function discovery in createServer and related modules.

Allows overriding the glob used to discover functions, which is required when a different bundler is used, or the directory structure is not the default `dist/functions/`

Defaults to: `'dist/functions/**/*.{ts,js}'`

All credit for this one goes to @richard-stafflink who created the original PR over at https://github.com/redwoodjs/graphql/pull/12063