### PR TITLE
fix(api-server): lambdaLoader: improve handler import logic

### DIFF
--- a/.changesets/190.md
+++ b/.changesets/190.md
@@ -1,0 +1,8 @@
+- fix(api-server): lambdaLoader: improve handler import logic (#190) by @Tobbe
+
+For ESModule and CommonJS compatibility.
+When using a bundler like Rollup, the handler function is exported as `default`.
+
+This change defaults to a named `handler` export, just like before. But if an export like that can't be found it'll now also look for a `default` export with a `handler` property on it.
+
+All credit for this one goes to @richard-stafflink who created the original PR over at https://github.com/redwoodjs/graphql/pull/12064

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -31,18 +31,26 @@ export const setLambdaFunctions = async (foundFunctions: string[]) => {
     const fnImport = await import(`file://${fnPath}`)
     const handler: Handler = (() => {
       if ('handler' in fnImport) {
-        // ESModule export of handler - when using `export const handler = ...` - most common case
+        // ESModule export of handler - when using
+        // `export const handler = ...` - most common case
         return fnImport.handler
       }
+
       if ('default' in fnImport) {
         if ('handler' in fnImport.default) {
-          // CommonJS export of handler - when using `module.exports.handler = ...` or `export default { handler: ... }`
-          // This is less common, but required for bundling tools that export a default object, like esbuild or rollup
+          // CommonJS export of handler - when using
+          // `module.exports.handler = ...` or `export default { handler: ... }`
+          // This is less common, but required for bundling tools that export a
+          // default object, like esbuild and rollup
           return fnImport.default.handler
         }
+
         // Default export is not expected, so skip it
       }
-      // If no handler is found, return undefined - we do not want to throw an error
+
+      // If no handler is found, return undefined - we do not want to throw an
+      // error
+      return undefined
     })()
 
     LAMBDA_FUNCTIONS[routeName] = handler


### PR DESCRIPTION
For ESModule and CommonJS compatibility.
When using a bundler like Rollup, the handler function is exported as `default`.

This change defaults to a named `handler` export, just like before. But if an export like that can't be found it'll now also look for a `default` export with a `handler` property on it.

All credit for this one goes to @richard-stafflink who created the original PR over at https://github.com/redwoodjs/graphql/pull/12064