### PR TITLE
feat(cli): upgrade command: Link to Discord instead of forums

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -185,14 +185,20 @@ export const handler = async ({ dryRun, tag, verbose, dedupe, yes }) => {
           ]
           // Show links when switching to 'latest' or 'rc', undefined is essentially an alias of 'latest'
           if ([undefined, 'latest', 'rc'].includes(tag)) {
+            const ghReleasesLink = terminalLink(
+              `GitHub Release notes`,
+              `https://github.com/cedarjs/cedar/releases`, // intentionally not linking to specific version
+            )
+            const discordLink = terminalLink(
+              `Discord`,
+              `https://cedarjs.com/discord`,
+            )
+
             messageSections.push(
-              `   Please review the release notes for any manual steps: \n   ❖ ${terminalLink(
-                `Redwood community discussion`,
-                `https://community.redwoodjs.com/c/announcements/releases-and-upgrade-guides/`,
-              )}\n   ❖ ${terminalLink(
-                `GitHub Release notes`,
-                `https://github.com/cedarjs/cedar/releases`, // intentionally not linking to specific version
-              )} \n\n`,
+              '   Please review the release notes for any manual steps:\n' +
+                `   ❖ ${ghReleasesLink}\n` +
+                '   Join our Discord community if you have any questions or need support:\n' +
+                `   ❖ ${discordLink}\n`,
             )
           }
           // @MARK


### PR DESCRIPTION
CedarJS doesn't have any forums, so it's better to just direct people to our Discord