### PR TITLE
feat(cli): cedarjs and cj bins

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -64,6 +64,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
+    "cedarjs": "./dist/cjs/bins/redwood.js",
+    "cj": "./dist/cjs/bins/redwood.js",
     "redwood": "./dist/cjs/bins/redwood.js",
     "rw": "./dist/cjs/bins/redwood.js",
     "rwfw": "./dist/cjs/bins/rwfw.js",

--- a/packages/api/src/bins/cedarjs.ts
+++ b/packages/api/src/bins/cedarjs.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+/**
+ * This file lets users run the Cedar CLI commands inside the /api directory
+ * in their projects.
+ * This works because of the "bin" field in the @cedarjs/api package.json file
+ * that points to this file.
+ */
+
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+const cliPackageJsonFileUrl = pathToFileURL(
+  require.resolve('@cedarjs/cli/package.json'),
+)
+
+const requireFromCli = createRequire(cliPackageJsonFileUrl)
+const bins = requireFromCli('./package.json')['bin']
+const cliEntryPointUrl = new URL(bins['cedarjs'], cliPackageJsonFileUrl)
+
+// If this is defined, we're running through yarn and need to change the cwd.
+// See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.
+if (process.env.PROJECT_CWD) {
+  process.chdir(process.env.PROJECT_CWD)
+}
+
+import(cliEntryPointUrl.toString())

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,6 +10,8 @@
   "license": "MIT",
   "type": "module",
   "bin": {
+    "cedarjs": "./dist/index.js",
+    "cj": "./dist/index.js",
     "redwood": "./dist/index.js",
     "rw": "./dist/index.js",
     "rwfw": "./dist/rwfw.js"

--- a/packages/core/src/bins/cedarjs.ts
+++ b/packages/core/src/bins/cedarjs.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+// A proxy for running the "redwood" @cedarjs/cli bin (`yarn redwood`, or
+// `yarn rw`) from @cedarjs/core.
+//
+// createRequire is for ES modules. require literally doesn't exist in ES
+// modules, so if you want to use it, you have to create it.
+//
+// But that's not why we're using it here. We're using it here to require files
+// from other packages for yarn 3 reasons:
+//
+// > If your package is something that automatically loads plugins (for example
+// > eslint), peer dependencies obviously aren't an option as you can't
+// > reasonably list all plugins. Instead, you should use the createRequire
+// > function to load plugins on behalf of the configuration file that lists the
+// > plugins to load, be it the package.json or a custom one like the
+// > .eslintrc.js file.
+//
+// See:
+// - https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies
+// - https://yarnpkg.com/advanced/rulebook#modules-shouldnt-hardcode-node_modules-paths-to-access-other-modules
+
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+// You can think about the argument we're passing to `createRequire` as being
+// kinda like setting the `cwd`:
+//
+// > It's using the path/URL to resolve relative paths (e.g.:
+// > createRequire('/foo/bar')('./baz') may load /foo/bar/baz/index.js)
+//
+// Example import.meta.url value:
+// file:///Users/tobbe/tmp/rx-create-app/node_modules/@cedarjs/core/dist/bins/redwood.js
+//
+// See https://github.com/nodejs/node/issues/40567#issuecomment-949825461.
+const require = createRequire(import.meta.url)
+
+// Example value:
+// file:///Users/tobbe/tmp/rx-create-app/node_modules/@cedarjs/cli/package.json
+const cliPackageJsonFileUrl = pathToFileURL(
+  require.resolve('@cedarjs/cli/package.json'),
+)
+
+const requireFromCli = createRequire(cliPackageJsonFileUrl)
+const bins = requireFromCli('./package.json')['bin']
+const cliEntryPointUrl = new URL(bins['cedarjs'], cliPackageJsonFileUrl)
+
+import(cliEntryPointUrl.toString())

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -114,6 +114,8 @@
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
+    "cedarjs": "./dist/cjs/bins/cedarjs.js",
+    "cj": "./dist/cjs/bins/cedarjs.js",
     "cross-env": "./dist/cjs/bins/cross-env.js",
     "msw": "./dist/cjs/bins/msw.js",
     "redwood": "./dist/cjs/bins/redwood.js",

--- a/packages/web/src/bins/cedarjs.ts
+++ b/packages/web/src/bins/cedarjs.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+/**
+ * This file lets users run the Cedar CLI commands inside the /web directory
+ * in their projects.
+ * This works because of the "bin" field in the @cedarjs/web package.json file
+ * that points to this file.
+ */
+
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+const cliPackageJsonFileUrl = pathToFileURL(
+  require.resolve('@cedarjs/cli/package.json'),
+)
+
+const requireFromCli = createRequire(cliPackageJsonFileUrl)
+const bins = requireFromCli('./package.json')['bin']
+const cliEntryPointUrl = new URL(bins['cedarjs'], cliPackageJsonFileUrl)
+
+// If this is defined, we're running through yarn and need to change the cwd.
+// See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.
+if (process.env.PROJECT_CWD) {
+  process.chdir(process.env.PROJECT_CWD)
+}
+
+import(cliEntryPointUrl.toString())

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,6 +2045,8 @@ __metadata:
     redis:
       optional: true
   bin:
+    cedarjs: ./dist/cjs/bins/redwood.js
+    cj: ./dist/cjs/bins/redwood.js
     redwood: ./dist/cjs/bins/redwood.js
     rw: ./dist/cjs/bins/redwood.js
     rwfw: ./dist/cjs/bins/rwfw.js
@@ -2755,6 +2757,8 @@ __metadata:
     vitest: "npm:3.2.4"
     yargs: "npm:17.7.2"
   bin:
+    cedarjs: ./dist/index.js
+    cj: ./dist/index.js
     redwood: ./dist/index.js
     rw: ./dist/index.js
     rwfw: ./dist/rwfw.js
@@ -3623,6 +3627,8 @@ __metadata:
     react: 19.0.0-rc-f2df5694-20240916
     react-dom: 19.0.0-rc-f2df5694-20240916
   bin:
+    cedarjs: ./dist/cjs/bins/cedarjs.js
+    cj: ./dist/cjs/bins/cedarjs.js
     cross-env: ./dist/cjs/bins/cross-env.js
     msw: ./dist/cjs/bins/msw.js
     redwood: ./dist/cjs/bins/redwood.js


### PR DESCRIPTION
Added `cedarjs` and `cj` bins in addition to the existing `redwood` and `rw` bins. So you can do things like `yarn cj info` or `yarn cj g page about`