### PR TITLE
feat(jobs): Updated Cron Jobs API

### DIFF
--- a/packages/jobs/src/core/Executor.ts
+++ b/packages/jobs/src/core/Executor.ts
@@ -71,8 +71,8 @@ export class Executor {
       const job = await loadJob({ name: this.job.name, path: this.job.path })
       await job.perform(...this.job.args)
 
-      const runAt = job.cron
-        ? CronExpressionParser.parse(job.cron).next().toDate()
+      const runAt = this.job.cron
+        ? CronExpressionParser.parse(this.job.cron).next().toDate()
         : undefined
 
       await this.adapter.success({

--- a/packages/jobs/src/core/JobManager.ts
+++ b/packages/jobs/src/core/JobManager.ts
@@ -54,7 +54,7 @@ export class JobManager<
       logger: schedulerConfig.logger ?? this.logger,
     })
 
-    return <TJob extends Job<TQueues, any[], any>>(
+    return <TJob extends Job<TQueues, any[]>>(
       job: TJob,
       ...argsAndOptions: CreateSchedulerArgs<TJob>
     ) => {
@@ -68,11 +68,9 @@ export class JobManager<
     }
   }
 
-  createJob<
-    TArgs extends any[],
-    TCron extends string | undefined,
-    TJobDef extends JobDefinition<TQueues, TArgs, TCron> & { cron?: TCron },
-  >(jobDefinition: TJobDef): TJobDef & JobComputedProperties {
+  createJob<TArgs extends any[], TJobDef extends JobDefinition<TQueues, TArgs>>(
+    jobDefinition: TJobDef,
+  ): TJobDef & JobComputedProperties {
     // The cast is necessary because the JobDefinition type lacks the `name` and
     // `path` properties that are required by the Job type. These properties are
     // added to the job at build time by a plugin in the build process.

--- a/packages/jobs/src/core/Scheduler.ts
+++ b/packages/jobs/src/core/Scheduler.ts
@@ -61,12 +61,13 @@ export class Scheduler<TAdapter extends BaseAdapter> {
     const priority = job.priority ?? DEFAULT_PRIORITY
     const wait = options?.wait ?? DEFAULT_WAIT
     const waitUntil = options?.waitUntil ?? DEFAULT_WAIT_UNTIL
+    const cron = options?.cron
 
     if (!queue) {
       throw new QueueNotDefinedError()
     }
 
-    if (job.cron && (wait || waitUntil)) {
+    if (cron && (wait || waitUntil)) {
       throw new Error(
         'Cannot schedule a cron job with wait or waitUntil options',
       )
@@ -76,10 +77,10 @@ export class Scheduler<TAdapter extends BaseAdapter> {
       name: job.name,
       path: job.path,
       args: args ?? [],
-      cron: job.cron,
+      cron,
       runAt: this.computeRunAt({ wait, waitUntil }),
-      queue: queue,
-      priority: priority,
+      queue,
+      priority,
     }
   }
 

--- a/packages/jobs/src/core/__tests__/JobManager.test.ts
+++ b/packages/jobs/src/core/__tests__/JobManager.test.ts
@@ -165,24 +165,6 @@ describe('createJob()', () => {
 
     expect(job).toEqual(jobDefinition)
   })
-
-  it('allows you to specify a cron schedule to run the job at', () => {
-    const manager = new JobManager({
-      adapters: {},
-      queues: ['default'] as const,
-      logger: mockLogger,
-      workers: [],
-    })
-    const jobDefinition: JobDefinition<['default'], unknown[]> = {
-      queue: 'default',
-      cron: '0 0 * * *',
-      perform: vi.fn(),
-    }
-
-    const job = manager.createJob(jobDefinition)
-
-    expect(job).toEqual(jobDefinition)
-  })
 })
 
 describe('createWorker()', () => {

--- a/packages/jobs/src/core/__tests__/Scheduler.test.ts
+++ b/packages/jobs/src/core/__tests__/Scheduler.test.ts
@@ -162,6 +162,70 @@ describe('buildPayload()', () => {
     expect(payload.runAt).toEqual(options.waitUntil)
   })
 
+  it('takes into account a `cron` schedule', () => {
+    const scheduler = new Scheduler({
+      adapter: mockAdapter,
+      logger: mockLogger,
+    })
+    const job = {
+      id: 1,
+      name: 'JobName',
+      path: 'JobPath/JobPath',
+      queue: 'default',
+      priority: 25 as const,
+
+      perform: vi.fn(),
+    }
+    const options = { cron: '0 0 * * *' }
+    const payload = scheduler.buildPayload({ job, args: [], options })
+
+    expect(payload.cron).toEqual(options.cron)
+  })
+
+  it('throws an error if cron is used with wait option', () => {
+    const scheduler = new Scheduler({
+      adapter: mockAdapter,
+      logger: mockLogger,
+    })
+    const job = {
+      id: 1,
+      name: 'JobName',
+      path: 'JobPath/JobPath',
+      queue: 'default',
+      priority: 25 as const,
+
+      perform: vi.fn(),
+    }
+    const options = { cron: '0 0 * * *', wait: 10 }
+
+    // @ts-expect-error testing error case with mutually exclusive options
+    expect(() => scheduler.buildPayload({ job, args: [], options })).toThrow(
+      'Cannot schedule a cron job with wait or waitUntil options',
+    )
+  })
+
+  it('throws an error if cron is used with waitUntil option', () => {
+    const scheduler = new Scheduler({
+      adapter: mockAdapter,
+      logger: mockLogger,
+    })
+    const job = {
+      id: 1,
+      name: 'JobName',
+      path: 'JobPath/JobPath',
+      queue: 'default',
+      priority: 25 as const,
+
+      perform: vi.fn(),
+    }
+    const options = { cron: '0 0 * * *', waitUntil: new Date(2030, 0, 1) }
+
+    // @ts-expect-error testing error case with mutually exclusive options
+    expect(() => scheduler.buildPayload({ job, args: [], options })).toThrow(
+      'Cannot schedule a cron job with wait or waitUntil options',
+    )
+  })
+
   it('throws an error if no queue set', async () => {
     const scheduler = new Scheduler({
       adapter: mockAdapter,

--- a/tasks/e2e-background-jobs/fixtures.mts
+++ b/tasks/e2e-background-jobs/fixtures.mts
@@ -60,7 +60,6 @@ import { jobs } from 'src/lib/jobs'
 
 export const SampleCronJob = jobs.createJob({
   queue: 'default',
-  cron: '* * * * * *',
   perform: async () => {
     const timestamp = new Date().toISOString().replace(/:/g, '_')
     const fileName = \`report-\${timestamp}.txt\`
@@ -77,7 +76,7 @@ import { SampleCronJob } from 'api/src/jobs/SampleCronJob/SampleCronJob'
 import { later } from 'api/src/lib/jobs'
 
 export default async () => {
-  await later(SampleCronJob)
+  await later(SampleCronJob, [], { cron: '* * * * * *' })
 }
 
 `


### PR DESCRIPTION
# Before

```ts
// Job definition with cron schedule
const cronJob = manager.createJob({
  queue: 'default',
  cron: '0 0 * * *', // Schedule defined here
  perform: () => {
    console.log('Running daily at midnight')
  }
})

// Scheduling (no options allowed)
const scheduler = manager.createScheduler({ adapter: 'prisma' })
// Schedule is set. This can only ever be scheduled as a cron
// job with the fixed schedule
scheduler(cronJob) 
```

# After
```ts
// Job definition without cron schedule
const job = manager.createJob({
  queue: 'default',
  perform: () => {
    console.log('Running as scheduled')
  }
})

// Scheduling with cron option
const scheduler = manager.createScheduler({ adapter: 'prisma' })
scheduler(job, [], { cron: '0 0 * * *' })        // Daily at midnight
scheduler(job, [], { cron: '0 */6 * * *' })      // Every 6 hours
scheduler(job, [], { wait: 300 })                // Or wait 5 minutes
scheduler(job, [], { waitUntil: new Date(...) }) // Or specific time
```