### PR TITLE
fix(core): Add missing bin fields to core/package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,8 @@
   "license": "MIT",
   "type": "module",
   "bin": {
+    "cedarjs": "./dist/bins/cedarjs.js",
+    "cj": "./dist/bins/cedarjs.js",
     "cross-env": "./dist/bins/cross-env.js",
     "eslint": "./dist/bins/eslint.js",
     "jest": "./dist/bins/jest.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2859,6 +2859,8 @@ __metadata:
     tsx: "npm:4.19.4"
     typescript: "npm:5.6.2"
   bin:
+    cedarjs: ./dist/bins/cedarjs.js
+    cj: ./dist/bins/cedarjs.js
     cross-env: ./dist/bins/cross-env.js
     eslint: ./dist/bins/eslint.js
     jest: ./dist/bins/jest.js


### PR DESCRIPTION
This should have been part of https://github.com/cedarjs/cedar/pull/195

`cedarjs` and `cj` needs to be part of the core package, because that's the package that the root package.json in a CedarJS app has installed