### PR TITLE
fix(jobs): Restore simpler types

### DIFF
--- a/packages/jobs/src/core/JobManager.ts
+++ b/packages/jobs/src/core/JobManager.ts
@@ -5,7 +5,6 @@ import type {
   CreateSchedulerArgs,
   CreateSchedulerConfig,
   Job,
-  JobComputedProperties,
   JobDefinition,
   JobManagerConfig,
   QueueNames,
@@ -68,13 +67,13 @@ export class JobManager<
     }
   }
 
-  createJob<TArgs extends any[], TJobDef extends JobDefinition<TQueues, TArgs>>(
-    jobDefinition: TJobDef,
-  ): TJobDef & JobComputedProperties {
+  createJob<TArgs extends unknown[]>(
+    jobDefinition: JobDefinition<TQueues, TArgs>,
+  ): Job<TQueues, TArgs> {
     // The cast is necessary because the JobDefinition type lacks the `name` and
     // `path` properties that are required by the Job type. These properties are
     // added to the job at build time by a plugin in the build process.
-    return jobDefinition as TJobDef & JobComputedProperties
+    return jobDefinition as Job<TQueues, TArgs>
   }
 
   createWorker({ index, workoff, clear, processName }: CreateWorkerArgs) {

--- a/packages/jobs/src/core/__tests__/JobManager.test-d.ts
+++ b/packages/jobs/src/core/__tests__/JobManager.test-d.ts
@@ -81,6 +81,12 @@ describe('JobManager Type Tests', () => {
     it('should accept no arguments at all', () => {
       expectTypeOf(scheduler(jobWithNoArgs)).toEqualTypeOf<Promise<boolean>>()
     })
+
+    it('should accept no arguments, but with options', () => {
+      expectTypeOf(scheduler(jobWithNoArgs, { wait: 30 })).toEqualTypeOf<
+        Promise<boolean>
+      >()
+    })
   })
 
   describe('scheduler with optional arguments', () => {
@@ -97,6 +103,19 @@ describe('JobManager Type Tests', () => {
       expectTypeOf(
         scheduler(jobWithOptionalArgs, ['1st', '2nd']),
       ).toEqualTypeOf<Promise<boolean>>()
+    })
+
+    it('should accept only one argument', () => {
+      expectTypeOf(scheduler(jobWithOptionalArgs, ['1st'])).toEqualTypeOf<
+        Promise<boolean>
+      >()
+    })
+
+    it('should require array even for just one argument', () => {
+      // @ts-expect-error - array required
+      expectTypeOf(scheduler(jobWithOptionalArgs, '1st')).toEqualTypeOf<
+        Promise<boolean>
+      >()
     })
 
     it('should accept empty array', () => {

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -242,7 +242,7 @@ type PriorityValue = IntRange<1, 101>
  * If the job has arguments:
  *  - you must pass the arguments and then optionally pass the scheduler options
  */
-export type CreateSchedulerArgs<TJob extends Job<QueueNames, any[]>> =
+export type CreateSchedulerArgs<TJob extends Job<QueueNames>> =
   Parameters<TJob['perform']> extends []
     ? [ScheduleJobOptions?] | [[], ScheduleJobOptions?]
     : [Parameters<TJob['perform']>, ScheduleJobOptions?]


### PR DESCRIPTION
Restore `createJob()` and `CreateScheduleArgs` types to what they were before cron jobs, as that was simpler, and is enough now that the cron schedule is specified when scheduling a job (vs defining one)