### PR TITLE
chore(cli): Workaround for codemod CI test failures

### DIFF
--- a/packages/cli/src/commands/setup/graphql/features/fragments/__codemod_tests__/appGqlConfigTransform.test.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__codemod_tests__/appGqlConfigTransform.test.ts
@@ -1,11 +1,20 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { describe, test } from 'vitest'
+import { beforeAll, describe, test } from 'vitest'
 
 import { findUp } from '@cedarjs/project-config'
 
 describe('fragments graphQLClientConfig', () => {
+  beforeAll(async () => {
+    // Was running into this issue
+    // https://github.com/vitest-dev/vitest/discussions/6511
+    //   Error: [vitest-worker]: Timeout calling "onTaskUpdate"
+    // One workaround that was posted there was this:
+    // TODO: Remove this workaround once the issue is fixed
+    await new Promise((res) => setImmediate(res))
+  })
+
   test('App.tsx with no graphQLClientConfig', async () => {
     await matchFolderTransform('appGqlConfigTransform', 'config-simple', {
       useJsCodeshift: true,

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__codemod_tests__/appImportTransform.test.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__codemod_tests__/appImportTransform.test.ts
@@ -1,6 +1,15 @@
-import { describe, test } from 'vitest'
+import { beforeAll, describe, test } from 'vitest'
 
 describe('fragments possibleTypes import', () => {
+  beforeAll(async () => {
+    // Was running into this issue
+    // https://github.com/vitest-dev/vitest/discussions/6511
+    //   Error: [vitest-worker]: Timeout calling "onTaskUpdate"
+    // One workaround that was posted there was this:
+    // TODO: Remove this workaround once the issue is fixed
+    await new Promise((res) => setImmediate(res))
+  })
+
   test('Default App.tsx', async () => {
     await matchFolderTransform('appImportTransform', 'import-simple', {
       useJsCodeshift: true,

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__codemod_tests__/grapqlTransform.test.ts
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__codemod_tests__/grapqlTransform.test.ts
@@ -1,6 +1,15 @@
-import { describe, test } from 'vitest'
+import { beforeAll, describe, test } from 'vitest'
 
 describe('trusted-documents graphql handler transform', () => {
+  beforeAll(async () => {
+    // Was running into this issue
+    // https://github.com/vitest-dev/vitest/discussions/6511
+    //   Error: [vitest-worker]: Timeout calling "onTaskUpdate"
+    // One workaround that was posted there was this:
+    // TODO: Remove this workaround once the issue is fixed
+    await new Promise((res) => setImmediate(res))
+  })
+
   test('Default handler', async () => {
     await matchFolderTransform('graphqlTransform', 'graphql', {
       useJsCodeshift: true,

--- a/packages/cli/src/commands/setup/middleware/ogImage/__codemod_tests__/middleware.ts
+++ b/packages/cli/src/commands/setup/middleware/ogImage/__codemod_tests__/middleware.ts
@@ -1,6 +1,15 @@
-import { describe, it } from 'vitest'
+import { beforeAll, describe, it } from 'vitest'
 
 describe('Middleware codemod', () => {
+  beforeAll(async () => {
+    // Was running into this issue
+    // https://github.com/vitest-dev/vitest/discussions/6511
+    //   Error: [vitest-worker]: Timeout calling "onTaskUpdate"
+    // One workaround that was posted there was this:
+    // TODO: Remove this workaround once the issue is fixed
+    await new Promise((res) => setImmediate(res))
+  })
+
   it('Handles the default TSX case', async () => {
     await matchTransformSnapshot('codemodMiddleware', 'defaultTsx')
   })

--- a/packages/cli/src/commands/setup/middleware/ogImage/__codemod_tests__/vitePlugin.ts
+++ b/packages/cli/src/commands/setup/middleware/ogImage/__codemod_tests__/vitePlugin.ts
@@ -4,6 +4,15 @@ describe('Vite plugin codemod', () => {
   beforeAll(async () => {
     // Was running into this issue
     // https://github.com/vitest-dev/vitest/discussions/6511
+    //   Error: [vitest-worker]: Timeout calling "onTaskUpdate"
+    // One workaround that was posted there was this:
+    // TODO: Remove this workaround once the issue is fixed
+    await new Promise((res) => setImmediate(res))
+  })
+
+  beforeAll(async () => {
+    // Was running into this issue
+    // https://github.com/vitest-dev/vitest/discussions/6511
     // One workaround that was posted there was this:
     // TODO: Remove this workaround once the issue is fixed
     await new Promise((res) => setImmediate(res))

--- a/packages/cli/src/commands/setup/uploads/__codemod_tests__/dbCodemod.test.ts
+++ b/packages/cli/src/commands/setup/uploads/__codemod_tests__/dbCodemod.test.ts
@@ -1,10 +1,19 @@
 import path from 'node:path'
 
-import { describe, it, expect } from 'vitest'
+import { beforeAll, describe, it, expect } from 'vitest'
 
 import { runTransform } from '../../../../lib/runTransform.js'
 
 describe('Db codemod', () => {
+  beforeAll(async () => {
+    // Was running into this issue
+    // https://github.com/vitest-dev/vitest/discussions/6511
+    //   Error: [vitest-worker]: Timeout calling "onTaskUpdate"
+    // One workaround that was posted there was this:
+    // TODO: Remove this workaround once the issue is fixed
+    await new Promise((res) => setImmediate(res))
+  })
+
   it('Handles the default db case', async () => {
     await matchTransformSnapshot('dbCodemod', 'defaultDb')
   })


### PR DESCRIPTION
Adding this workaround to more tests: https://github.com/cedarjs/cedar/pull/174