### PR TITLE
fix(api): Fix SupportedVerifierTypes import

### DIFF
--- a/packages/api/src/webhooks/index.ts
+++ b/packages/api/src/webhooks/index.ts
@@ -3,7 +3,7 @@ import type { APIGatewayProxyEvent } from 'aws-lambda'
 import type {
   VerifyOptions,
   SupportedVerifierTypes,
-} from '../auth/verifiers/index.js'
+} from '../auth/verifiers/common.js'
 import {
   createVerifier,
   WebhookVerificationError,


### PR DESCRIPTION
I was getting errors like these:
```
 FAIL   api  src/directives/requireAuth/requireAuth.test.ts [ api/src/directives/requireAuth/requireAuth.test.ts ]
SyntaxError: The requested module '../auth/verifiers/index.js' does not provide an export named 'SupportedVerifierTypes'
 ❯ src/directives/requireAuth/requireAuth.test.ts:1:1
      1| import { mockRedwoodDirective, getDirectiveName } from '@cedarjs/testing/api'
       | ^
      2|
      3| import requireAuth from './requireAuth.js'
```

This PR should fix that by making sure `SupportedVerifyerTypes` is properly imported from the correct location