### PR TITLE
chore(deps): Bump Axios to v1.8.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13119,13 +13119,13 @@ __metadata:
   linkType: hard
 
 "axios@npm:^1.7.4":
-  version: 1.7.7
-  resolution: "axios@npm:1.7.7"
+  version: 1.10.0
+  resolution: "axios@npm:1.10.0"
   dependencies:
     follow-redirects: "npm:^1.15.6"
     form-data: "npm:^4.0.0"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/4499efc89e86b0b49ffddc018798de05fab26e3bf57913818266be73279a6418c3ce8f9e934c7d2d707ab8c095e837fc6c90608fb7715b94d357720b5f568af7
+  checksum: 10c0/2239cb269cc789eac22f5d1aabd58e1a83f8f364c92c2caa97b6f5cbb4ab2903d2e557d9dc670b5813e9bcdebfb149e783fb8ab3e45098635cd2f559b06bd5d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes this security alert
<img width="1251" height="539" alt="image" src="https://github.com/user-attachments/assets/79475e6f-abf1-4ea2-b424-badd93633e7d" />

axios is a transitive dependency because of nx