### PR TITLE
feat(dbAuth): Dual mode ESM+CJS dbAuth web package

### DIFF
--- a/packages/auth-providers/dbAuth/web/.babelrc.js
+++ b/packages/auth-providers/dbAuth/web/.babelrc.js
@@ -1,1 +1,0 @@
-module.exports = { extends: '../../../../babel.config.js' }

--- a/packages/auth-providers/dbAuth/web/build.ts
+++ b/packages/auth-providers/dbAuth/web/build.ts
@@ -1,4 +1,4 @@
-import { buildCjs, buildEsm } from '@cedarjs/framework-tools'
+import { buildExternalEsm, buildExternalCjs } from '@cedarjs/framework-tools'
 import {
   generateTypesCjs,
   generateTypesEsm,
@@ -6,11 +6,11 @@ import {
 } from '@cedarjs/framework-tools/generateTypes'
 
 // ESM build and type generation
-await buildEsm()
+await buildExternalEsm()
 await generateTypesEsm()
 
 // CJS build, type generation, and package.json insert
-await buildCjs()
+await buildExternalCjs()
 await generateTypesCjs()
 await insertCommonJsPackageJson({
   buildFileUrl: import.meta.url,

--- a/packages/auth-providers/dbAuth/web/build.ts
+++ b/packages/auth-providers/dbAuth/web/build.ts
@@ -1,0 +1,17 @@
+import { buildCjs, buildEsm } from '@cedarjs/framework-tools'
+import {
+  generateTypesCjs,
+  generateTypesEsm,
+  insertCommonJsPackageJson,
+} from '@cedarjs/framework-tools/generateTypes'
+
+// ESM build and type generation
+await buildEsm()
+await generateTypesEsm()
+
+// CJS build, type generation, and package.json insert
+await buildCjs()
+await generateTypesCjs()
+await insertCommonJsPackageJson({
+  buildFileUrl: import.meta.url,
+})

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -7,34 +7,51 @@
     "directory": "packages/auth-providers/dbAuth/web"
   },
   "license": "MIT",
-  "main": "./dist/index.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "default": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
     "webAuthn"
   ],
   "scripts": {
-    "build": "yarn build:js && yarn build:types",
-    "build:js": "babel src -d dist --extensions \".js,.jsx,.ts,.tsx\" --copy-files --no-copy-ignored",
+    "build": "tsx ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-dbauth-web.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
+    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
+    "check:attw": "yarn rw-fwtools-attw",
+    "check:package": "concurrently npm:check:attw yarn:publint",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "yarn vitest run src",
-    "test:watch": "yarn test --watch"
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "7.27.6",
     "@cedarjs/auth": "workspace:*",
-    "@simplewebauthn/browser": "9.0.1",
-    "core-js": "3.42.0"
+    "@simplewebauthn/browser": "9.0.1"
   },
   "devDependencies": {
-    "@babel/cli": "7.27.2",
-    "@babel/core": "^7.26.10",
+    "@arethetypeswrong/cli": "0.18.2",
+    "@cedarjs/framework-tools": "workspace:*",
     "@simplewebauthn/types": "9.0.1",
     "@types/react": "^18.2.55",
+    "concurrently": "8.2.2",
+    "publint": "0.3.12",
     "react": "19.0.0-rc-f2df5694-20240916",
+    "tsx": "4.20.3",
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },

--- a/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.middleware.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.middleware.test.ts
@@ -3,10 +3,10 @@ import { vi, beforeAll, afterAll, describe, it, expect } from 'vitest'
 
 import type { CustomProviderHooks } from '@cedarjs/auth'
 
-import type { DbAuthClientArgs } from '../dbAuth'
-import { createDbAuthClient, createAuth } from '../dbAuth'
+import type { DbAuthClientArgs } from '../dbAuth.js'
+import { createDbAuthClient, createAuth } from '../dbAuth.js'
 
-import { fetchMock } from './dbAuth.test'
+import { fetchMock } from './dbAuth.test.js'
 
 const defaultArgs = {
   fetchConfig: {

--- a/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
@@ -3,14 +3,14 @@ import { vi, beforeAll, beforeEach, describe, it, expect } from 'vitest'
 
 import type { CustomProviderHooks, CurrentUser } from '@cedarjs/auth'
 
-import type { DbAuthClientArgs } from '../dbAuth'
-import { createDbAuthClient, createAuth } from '../dbAuth'
+import type { DbAuthClientArgs } from '../dbAuth.js'
+import { createDbAuthClient, createAuth } from '../dbAuth.js'
 
 globalThis.RWJS_API_URL = '/.redwood/functions'
 globalThis.RWJS_API_GRAPHQL_URL = '/.redwood/functions/graphql'
 
 vi.mock('@whatwg-node/fetch', () => {
-  return
+  return ''
 })
 
 interface User {

--- a/packages/auth-providers/dbAuth/web/src/__tests__/webAuthn.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/webAuthn.test.ts
@@ -1,6 +1,6 @@
 import { vi, beforeEach, describe, it, expect } from 'vitest'
 
-import WebAuthnClient from '../webAuthn'
+import WebAuthnClient from '../webAuthn.js'
 
 globalThis.RWJS_API_URL = '/.redwood/functions'
 
@@ -13,7 +13,7 @@ vi.mock('@simplewebauthn/browser', () => {
 })
 
 vi.mock('@whatwg-node/fetch', () => {
-  return
+  return ''
 })
 
 const mockOpen = vi.fn()

--- a/packages/auth-providers/dbAuth/web/src/dbAuth.ts
+++ b/packages/auth-providers/dbAuth/web/src/dbAuth.ts
@@ -4,7 +4,7 @@ import {
   getCurrentUserFromMiddleware,
 } from '@cedarjs/auth'
 
-import type { WebAuthnClientType } from './webAuthn'
+import type { WebAuthnClientType } from './webAuthn.js'
 
 export interface LoginAttributes {
   username: string

--- a/packages/auth-providers/dbAuth/web/src/index.ts
+++ b/packages/auth-providers/dbAuth/web/src/index.ts
@@ -1,1 +1,1 @@
-export * from './dbAuth'
+export * from './dbAuth.js'

--- a/packages/auth-providers/dbAuth/web/src/webAuthn.ts
+++ b/packages/auth-providers/dbAuth/web/src/webAuthn.ts
@@ -39,7 +39,7 @@ export default class WebAuthnClient {
   authApiUrl = ''
 
   private getAuthApiUrl() {
-    return this.authApiUrl || `${globalThis.RWJS_API_URL}/auth`
+    return this.authApiUrl || `${RWJS_API_URL}/auth`
   }
 
   setAuthApiUrl(authApiUrl?: string) {

--- a/packages/auth-providers/dbAuth/web/src/webAuthn.ts
+++ b/packages/auth-providers/dbAuth/web/src/webAuthn.ts
@@ -39,7 +39,7 @@ export default class WebAuthnClient {
   authApiUrl = ''
 
   private getAuthApiUrl() {
-    return this.authApiUrl || `${RWJS_API_URL}/auth`
+    return this.authApiUrl || `${globalThis.RWJS_API_URL}/auth`
   }
 
   setAuthApiUrl(authApiUrl?: string) {

--- a/packages/auth-providers/dbAuth/web/tsconfig.build.json
+++ b/packages/auth-providers/dbAuth/web/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src", "ambient.d.ts"]
+}

--- a/packages/auth-providers/dbAuth/web/tsconfig.cjs.json
+++ b/packages/auth-providers/dbAuth/web/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+  }
+}

--- a/packages/auth-providers/dbAuth/web/tsconfig.json
+++ b/packages/auth-providers/dbAuth/web/tsconfig.json
@@ -2,9 +2,11 @@
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
     "strict": true,
-    "rootDir": "src",
+    "isolatedModules": true,
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
     "outDir": "dist"
   },
-  "include": ["src", "ambient.d.ts"],
+  "include": ["."],
   "references": [{ "path": "../../../auth/tsconfig.build.json" }]
 }

--- a/packages/auth-providers/dbAuth/web/webAuthn/index.js
+++ b/packages/auth-providers/dbAuth/web/webAuthn/index.js
@@ -1,2 +1,3 @@
 /* eslint-env es6, commonjs */
-module.exports = require('../dist/webAuthn')
+// For CommonJS environments, point to the CJS build
+module.exports = require('../dist/cjs/webAuthn')

--- a/packages/auth-providers/dbAuth/web/webAuthn/package.json
+++ b/packages/auth-providers/dbAuth/web/webAuthn/package.json
@@ -1,4 +1,4 @@
 {
   "main": "./index.js",
-  "types": "../dist/webAuthn.d.ts"
+  "types": "../dist/cjs/webAuthn.d.ts"
 }

--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -166,7 +166,7 @@ async function createServer() {
           '@cedarjs/forms',
           '@cedarjs/prerender/*',
           '@cedarjs/auth-*-api',
-          '@cedarjs/auth-*-web',
+          '@cedarjs/auth-!(dbauth)-web',
         ],
       }),
       rscEnabled && rscRoutesAutoLoader(),

--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -166,6 +166,9 @@ async function createServer() {
           '@cedarjs/forms',
           '@cedarjs/prerender/*',
           '@cedarjs/auth-*-api',
+          // Add more to the pattern below as they're converted to dual ESM/CJS
+          // modules
+          // '@cedarjs/auth-!(dbauth|auth0|clerk)-web',
           '@cedarjs/auth-!(dbauth)-web',
         ],
       }),

--- a/packages/vite/src/rsc/rscBuildForSsr.ts
+++ b/packages/vite/src/rsc/rscBuildForSsr.ts
@@ -67,7 +67,7 @@ export async function rscBuildForSsr({
           '@cedarjs/forms',
           '@cedarjs/prerender/*',
           '@cedarjs/auth-*-api',
-          '@cedarjs/auth-*-web',
+          '@cedarjs/auth-!(dbauth)-web',
         ],
       }),
       rscRoutesAutoLoader(),

--- a/packages/vite/src/streaming/buildForStreamingServer.ts
+++ b/packages/vite/src/streaming/buildForStreamingServer.ts
@@ -24,7 +24,7 @@ export async function buildForStreamingServer({
           '@cedarjs/forms',
           '@cedarjs/prerender/*',
           '@cedarjs/auth-*-api',
-          '@cedarjs/auth-*-web',
+          '@cedarjs/auth-!(dbauth)-web',
         ],
       }),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,15 +2315,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-dbauth-web@workspace:packages/auth-providers/dbAuth/web"
   dependencies:
-    "@babel/cli": "npm:7.27.2"
-    "@babel/core": "npm:^7.26.10"
-    "@babel/runtime-corejs3": "npm:7.27.6"
+    "@arethetypeswrong/cli": "npm:0.18.2"
     "@cedarjs/auth": "workspace:*"
+    "@cedarjs/framework-tools": "workspace:*"
     "@simplewebauthn/browser": "npm:9.0.1"
     "@simplewebauthn/types": "npm:9.0.1"
     "@types/react": "npm:^18.2.55"
-    core-js: "npm:3.42.0"
+    concurrently: "npm:8.2.2"
+    publint: "npm:0.3.12"
     react: "npm:19.0.0-rc-f2df5694-20240916"
+    tsx: "npm:4.20.3"
     typescript: "npm:5.6.2"
     vitest: "npm:3.2.4"
   languageName: unknown


### PR DESCRIPTION
Need this to get full ESM support in Cedar apps with `"type": "module"`

I tried this in #245, but had a regression for SSR and RSC. This PR includes updated vite config to fix that regression