### PR TITLE
chore(ci): Include dbAuth in SSR change detection

### DIFF
--- a/.github/actions/detect-changes/cases/ssr.mjs
+++ b/.github/actions/detect-changes/cases/ssr.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Detects if there are SSR changes
  *
@@ -16,7 +18,8 @@ export function ssrChanged(changedFiles) {
       changedFile.startsWith('packages/router/') ||
       changedFile.startsWith('packages/web-server/') ||
       changedFile.startsWith('packages/vite/') ||
-      changedFile.startsWith('packages/cookie-jar/')
+      changedFile.startsWith('packages/cookie-jar/') ||
+      changedFile.startsWith('packages/auth-providers/dbAuth')
     ) {
       console.log('SSR change detected:', changedFile)
       return true

--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -1,9 +1,7 @@
 // @ts-check
 
-// @ts-expect-error types
 import fs from 'node:fs'
 
-// @ts-expect-error types
 import core from '@actions/core'
 import { codeChanges } from './cases/code_changes.mjs'
 import { rscChanged } from './cases/rsc.mjs'
@@ -167,7 +165,7 @@ async function fetchJson(url, retries = 0) {
   try {
     const res = await fetch(url, {
       headers: {
-        Authorization: githubToken ? `Bearer ${githubToken}` : undefined,
+        ...(githubToken ? { Authorization: `Bearer ${githubToken}` } : {}),
         ['X-GitHub-Api-Version']: '2022-11-28',
         Accept: 'application/vnd.github+json',
       },


### PR DESCRIPTION
The SSR test project uses dbAuth, so we should make sure the SSR tests still pass after making changes to dbAuth 
(This would have prevented the regression introduced in #245 and later fixed in #257)