### PR TITLE
chore(ci): use skipIf to skip codemod tests on Windows CI

### DIFF
--- a/packages/cli/src/commands/setup/graphql/features/fragments/__codemod_tests__/appGqlConfigTransform.test.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__codemod_tests__/appGqlConfigTransform.test.ts
@@ -5,72 +5,75 @@ import { describe, test } from 'vitest'
 
 import { findUp } from '@cedarjs/project-config'
 
-describe('fragments graphQLClientConfig', (context) => {
-  if (process.env.CI && process.platform === 'win32') {
-    // See my comments in this thread:
-    // https://github.com/vitest-dev/vitest/discussions/6511
-    context.skip('Skipping CI tests on Windows')
-  }
-
-  test('App.tsx with no graphQLClientConfig', async () => {
-    await matchFolderTransform('appGqlConfigTransform', 'config-simple', {
-      useJsCodeshift: true,
+// Skipping CI tests on Windows
+// See my comments in this thread:
+// https://github.com/vitest-dev/vitest/discussions/6511
+describe.skipIf(process.env.CI && process.platform === 'win32')(
+  'fragments graphQLClientConfig',
+  () => {
+    test('App.tsx with no graphQLClientConfig', async () => {
+      await matchFolderTransform('appGqlConfigTransform', 'config-simple', {
+        useJsCodeshift: true,
+      })
     })
-  })
 
-  test('App.tsx with existing inline graphQLClientConfig', async () => {
-    await matchFolderTransform('appGqlConfigTransform', 'existingPropInline', {
-      useJsCodeshift: true,
+    test('App.tsx with existing inline graphQLClientConfig', async () => {
+      await matchFolderTransform(
+        'appGqlConfigTransform',
+        'existingPropInline',
+        {
+          useJsCodeshift: true,
+        },
+      )
     })
-  })
 
-  test('App.tsx with existing graphQLClientConfig in separate variable', async () => {
-    await matchFolderTransform(
-      'appGqlConfigTransform',
-      'existingPropVariable',
-      {
-        useJsCodeshift: true,
-      },
-    )
-  })
+    test('App.tsx with existing graphQLClientConfig in separate variable', async () => {
+      await matchFolderTransform(
+        'appGqlConfigTransform',
+        'existingPropVariable',
+        {
+          useJsCodeshift: true,
+        },
+      )
+    })
 
-  test('App.tsx with existing graphQLClientConfig in separate variable, without cacheConfig property', async () => {
-    await matchFolderTransform(
-      'appGqlConfigTransform',
-      'existingPropVariableNoCacheConfig',
-      {
-        useJsCodeshift: true,
-      },
-    )
-  })
+    test('App.tsx with existing graphQLClientConfig in separate variable, without cacheConfig property', async () => {
+      await matchFolderTransform(
+        'appGqlConfigTransform',
+        'existingPropVariableNoCacheConfig',
+        {
+          useJsCodeshift: true,
+        },
+      )
+    })
 
-  test('App.tsx with existing graphQLClientConfig in separate variable with non-standard name', async () => {
-    await matchFolderTransform(
-      'appGqlConfigTransform',
-      'existingPropVariableCustomName',
-      {
-        useJsCodeshift: true,
-      },
-    )
-  })
+    test('App.tsx with existing graphQLClientConfig in separate variable with non-standard name', async () => {
+      await matchFolderTransform(
+        'appGqlConfigTransform',
+        'existingPropVariableCustomName',
+        {
+          useJsCodeshift: true,
+        },
+      )
+    })
 
-  test('test-project App.tsx', async () => {
-    const rootFwPath = path.dirname(findUp('lerna.json') || '')
-    const testProjectAppTsx = fs.readFileSync(
-      path.join(
-        rootFwPath,
-        '__fixtures__',
-        'test-project',
-        'web',
-        'src',
-        'App.tsx',
-      ),
-      'utf-8',
-    )
-    await matchInlineTransformSnapshot(
-      'appGqlConfigTransform',
-      testProjectAppTsx,
-      `import type { ReactNode } from 'react'
+    test('test-project App.tsx', async () => {
+      const rootFwPath = path.dirname(findUp('lerna.json') || '')
+      const testProjectAppTsx = fs.readFileSync(
+        path.join(
+          rootFwPath,
+          '__fixtures__',
+          'test-project',
+          'web',
+          'src',
+          'App.tsx',
+        ),
+        'utf-8',
+      )
+      await matchInlineTransformSnapshot(
+        'appGqlConfigTransform',
+        testProjectAppTsx,
+        `import type { ReactNode } from 'react'
 
       import { FatalErrorBoundary, RedwoodProvider } from \"@cedarjs/web\";
       import { RedwoodApolloProvider } from \"@cedarjs/web/apollo\";
@@ -109,6 +112,7 @@ describe('fragments graphQLClientConfig', (context) => {
 
       export default App;
       `,
-    )
-  })
-})
+      )
+    })
+  },
+)

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__codemod_tests__/appImportTransform.test.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__codemod_tests__/appImportTransform.test.ts
@@ -1,21 +1,21 @@
 import { describe, test } from 'vitest'
 
-describe('fragments possibleTypes import', (context) => {
-  if (process.env.CI && process.platform === 'win32') {
-    // See my comments in this thread:
-    // https://github.com/vitest-dev/vitest/discussions/6511
-    context.skip('Skipping CI tests on Windows')
-  }
-
-  test('Default App.tsx', async () => {
-    await matchFolderTransform('appImportTransform', 'import-simple', {
-      useJsCodeshift: true,
+// Skipping CI tests on Windows
+// See my comments in this thread:
+// https://github.com/vitest-dev/vitest/discussions/6511
+describe.skipIf(process.env.CI && process.platform === 'win32')(
+  'fragments possibleTypes import',
+  () => {
+    test('Default App.tsx', async () => {
+      await matchFolderTransform('appImportTransform', 'import-simple', {
+        useJsCodeshift: true,
+      })
     })
-  })
 
-  test('App.tsx with existing import', async () => {
-    await matchFolderTransform('appImportTransform', 'existingImport', {
-      useJsCodeshift: true,
+    test('App.tsx with existing import', async () => {
+      await matchFolderTransform('appImportTransform', 'existingImport', {
+        useJsCodeshift: true,
+      })
     })
-  })
-})
+  },
+)

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__codemod_tests__/grapqlTransform.test.ts
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__codemod_tests__/grapqlTransform.test.ts
@@ -1,21 +1,21 @@
 import { describe, test } from 'vitest'
 
-describe('trusted-documents graphql handler transform', (context) => {
-  if (process.env.CI && process.platform === 'win32') {
-    // See my comments in this thread:
-    // https://github.com/vitest-dev/vitest/discussions/6511
-    context.skip('Skipping CI tests on Windows')
-  }
-
-  test('Default handler', async () => {
-    await matchFolderTransform('graphqlTransform', 'graphql', {
-      useJsCodeshift: true,
+// Skipping CI tests on Windows
+// See my comments in this thread:
+// https://github.com/vitest-dev/vitest/discussions/6511
+describe.skipIf(process.env.CI && process.platform === 'win32')(
+  'trusted-documents graphql handler transform',
+  () => {
+    test('Default handler', async () => {
+      await matchFolderTransform('graphqlTransform', 'graphql', {
+        useJsCodeshift: true,
+      })
     })
-  })
 
-  test('Handler with the store already set up', async () => {
-    await matchFolderTransform('graphqlTransform', 'alreadySetUp', {
-      useJsCodeshift: true,
+    test('Handler with the store already set up', async () => {
+      await matchFolderTransform('graphqlTransform', 'alreadySetUp', {
+        useJsCodeshift: true,
+      })
     })
-  })
-})
+  },
+)

--- a/packages/cli/src/commands/setup/middleware/ogImage/__codemod_tests__/middleware.ts
+++ b/packages/cli/src/commands/setup/middleware/ogImage/__codemod_tests__/middleware.ts
@@ -1,24 +1,24 @@
 import { describe, it } from 'vitest'
 
-describe('Middleware codemod', (context) => {
-  if (process.env.CI && process.platform === 'win32') {
-    // See my comments in this thread:
-    // https://github.com/vitest-dev/vitest/discussions/6511
-    context.skip('Skipping CI tests on Windows')
-  }
+// Skipping CI tests on Windows.
+// See my comments in this thread:
+// https://github.com/vitest-dev/vitest/discussions/6511
+describe.skipIf(process.env.CI && process.platform === 'win32')(
+  'Middleware codemod',
+  () => {
+    it('Handles the default TSX case', async () => {
+      await matchTransformSnapshot('codemodMiddleware', 'defaultTsx')
+    })
 
-  it('Handles the default TSX case', async () => {
-    await matchTransformSnapshot('codemodMiddleware', 'defaultTsx')
-  })
+    it('Handles when OgImageMiddleware is already imported', async () => {
+      await matchTransformSnapshot('codemodMiddleware', 'alreadyContainsImport')
+    })
 
-  it('Handles when OgImageMiddleware is already imported', async () => {
-    await matchTransformSnapshot('codemodMiddleware', 'alreadyContainsImport')
-  })
-
-  it('Handles when registerMiddleware function is already defined', async () => {
-    await matchTransformSnapshot(
-      'codemodMiddleware',
-      'registerFunctionAlreadyDefined',
-    )
-  })
-})
+    it('Handles when registerMiddleware function is already defined', async () => {
+      await matchTransformSnapshot(
+        'codemodMiddleware',
+        'registerFunctionAlreadyDefined',
+      )
+    })
+  },
+)

--- a/packages/cli/src/commands/setup/middleware/ogImage/__codemod_tests__/vitePlugin.ts
+++ b/packages/cli/src/commands/setup/middleware/ogImage/__codemod_tests__/vitePlugin.ts
@@ -1,13 +1,13 @@
 import { describe, it } from 'vitest'
 
-describe('Vite plugin codemod', (context) => {
-  if (process.env.CI && process.platform === 'win32') {
-    // See my comments in this thread:
-    // https://github.com/vitest-dev/vitest/discussions/6511
-    context.skip('Skipping CI tests on Windows')
-  }
-
-  it('Handles the default vite config case', async () => {
-    await matchTransformSnapshot('codemodVitePlugin', 'defaultViteConfig')
-  })
-})
+// Skipping CI tests on Windows.
+// See my comments in this thread:
+// https://github.com/vitest-dev/vitest/discussions/6511
+describe.skipIf(process.env.CI && process.platform === 'win32')(
+  'Vite plugin codemod',
+  () => {
+    it('Handles the default vite config case', async () => {
+      await matchTransformSnapshot('codemodVitePlugin', 'defaultViteConfig')
+    })
+  },
+)

--- a/packages/cli/src/commands/setup/uploads/__codemod_tests__/dbCodemod.test.ts
+++ b/packages/cli/src/commands/setup/uploads/__codemod_tests__/dbCodemod.test.ts
@@ -4,25 +4,25 @@ import { describe, it, expect } from 'vitest'
 
 import { runTransform } from '../../../../lib/runTransform.js'
 
-describe('Db codemod', (context) => {
-  if (process.env.CI && process.platform === 'win32') {
-    // See my comments in this thread:
-    // https://github.com/vitest-dev/vitest/discussions/6511
-    context.skip('Skipping CI tests on Windows')
-  }
-
-  it('Handles the default db case', async () => {
-    await matchTransformSnapshot('dbCodemod', 'defaultDb')
-  })
-
-  it('will throw an error if the db file has the old format', async () => {
-    const transformResult = await runTransform({
-      transformPath: path.join(__dirname, '../dbCodemod.ts'), // Use TS here!
-      targetPaths: [
-        path.join(__dirname, '../__testfixtures__/oldFormat.input.ts'),
-      ],
+// Skipping CI tests on Windows
+// See my comments in this thread:
+// https://github.com/vitest-dev/vitest/discussions/6511
+describe.skipIf(process.env.CI && process.platform === 'win32')(
+  'Db codemod',
+  () => {
+    it('Handles the default db case', async () => {
+      await matchTransformSnapshot('dbCodemod', 'defaultDb')
     })
 
-    expect(transformResult.error).toContain('ERR_OLD_FORMAT')
-  })
-})
+    it('will throw an error if the db file has the old format', async () => {
+      const transformResult = await runTransform({
+        transformPath: path.join(__dirname, '../dbCodemod.ts'), // Use TS here!
+        targetPaths: [
+          path.join(__dirname, '../__testfixtures__/oldFormat.input.ts'),
+        ],
+      })
+
+      expect(transformResult.error).toContain('ERR_OLD_FORMAT')
+    })
+  },
+)


### PR DESCRIPTION
This is a re-implementation of #254, so I'm going to copy the description from there:

The cli package codemod tests are flaky on Windows CI, blocking all the dependabot PRs that could otherwise be automatically merged.

I hate doing this, but right now I don't know how to make them non-flaky. 

See this discussion thread for a bit more context https://github.com/vitest-dev/vitest/discussions/6511
And here's a previous attempt at fixing this issue: https://github.com/cedarjs/cedar/pull/235