### PR TITLE
feat(gql): Trusted Documents support for CedarJS Mailer

### DIFF
--- a/packages/graphql-server/src/plugins/useRedwoodTrustedDocuments.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodTrustedDocuments.ts
@@ -60,14 +60,22 @@ const allowRedwoodAuthCurrentUserQuery = async (request: Request) => {
 
 /**
  * When using Studio, we want to allow the `resyncMailRenderers` and `resyncMailTemplate` mutations to be
- * executed without a persisted operation.
+ * executed without a persisted operation. This is only allowed in local development, ensure you have NODE_ENV=development set.
  *
  * This is because the `resyncMailRenderers` mutation is a special case that is used by
  * Studio to sync mail renderers from the mailer configuration.
  *
  * This function checks if the request is for the `resyncMailRenderers` or `resyncMailTemplate` mutations and has the correct headers.
+ *
+ * If you need Studio in production, you just have to add the above mutations to your
+ * SDL schema and as dummy resolvers so Trusted Documents can pick them up.
  */
 const allowRedwoodStudioResyncMailMutations = async (request: Request) => {
+  const isLocalDevelopment = process.env.NODE_ENV === 'development'
+  if (!isLocalDevelopment) {
+    return false
+  }
+
   const headers = request.headers
   const hasContentType = headers.get('content-type') === 'application/json'
 
@@ -76,7 +84,7 @@ const allowRedwoodStudioResyncMailMutations = async (request: Request) => {
     query === REDWOOD__STUDIO_RESYNC_MAIL_RENDERERS_MUTATION ||
     query === REDWOOD__STUDIO_TEMPLATE_MUTATION
 
-  return hasContentType && hasAllowedQuery
+  return hasContentType && hasAllowedQuery && isLocalDevelopment
 }
 
 export const useRedwoodTrustedDocuments = (

--- a/packages/graphql-server/src/plugins/useRedwoodTrustedDocuments.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodTrustedDocuments.ts
@@ -26,6 +26,10 @@ export type RedwoodTrustedDocumentOptions = Omit<
 
 const REDWOOD__AUTH_GET_CURRENT_USER_QUERY =
   '{"query":"query __REDWOOD__AUTH_GET_CURRENT_USER { redwood { currentUser } }"}'
+const REDWOOD__STUDIO_RESYNC_MAIL_RENDERERS_MUTATION =
+  '{"query":"mutation { resyncMailRenderers }"}'
+const REDWOOD__STUDIO_TEMPLATE_MUTATION =
+  '{"query":"mutation { resyncMailTemplate }"}'
 
 /**
  * When using Redwood Auth, we want to allow the known, trusted `redwood.currentUser` query to be
@@ -54,6 +58,27 @@ const allowRedwoodAuthCurrentUserQuery = async (request: Request) => {
   return hasAllowedHeaders && hasAllowedQuery
 }
 
+/**
+ * When using Studio, we want to allow the `resyncMailRenderers` and `resyncMailTemplate` mutations to be
+ * executed without a persisted operation.
+ *
+ * This is because the `resyncMailRenderers` mutation is a special case that is used by
+ * Studio to sync mail renderers from the mailer configuration.
+ *
+ * This function checks if the request is for the `resyncMailRenderers` or `resyncMailTemplate` mutations and has the correct headers.
+ */
+const allowRedwoodStudioResyncMailMutations = async (request: Request) => {
+  const headers = request.headers
+  const hasContentType = headers.get('content-type') === 'application/json'
+
+  const query = await request.text()
+  const hasAllowedQuery =
+    query === REDWOOD__STUDIO_RESYNC_MAIL_RENDERERS_MUTATION ||
+    query === REDWOOD__STUDIO_TEMPLATE_MUTATION
+
+  return hasContentType && hasAllowedQuery
+}
+
 export const useRedwoodTrustedDocuments = (
   options: RedwoodTrustedDocumentOptions,
 ): Plugin<RedwoodGraphQLContext> => {
@@ -80,7 +105,7 @@ export const useRedwoodTrustedDocuments = (
           }
         }
       }
-      return allowRedwoodAuthCurrentUserQuery(request)
+      return allowRedwoodAuthCurrentUserQuery(request) || allowRedwoodStudioResyncMailMutations(request)
     },
   })
 }

--- a/packages/graphql-server/src/plugins/useRedwoodTrustedDocuments.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodTrustedDocuments.ts
@@ -26,9 +26,9 @@ export type RedwoodTrustedDocumentOptions = Omit<
 
 const REDWOOD__AUTH_GET_CURRENT_USER_QUERY =
   '{"query":"query __REDWOOD__AUTH_GET_CURRENT_USER { redwood { currentUser } }"}'
-const REDWOOD__STUDIO_RESYNC_MAIL_RENDERERS_MUTATION =
+const CEDAR__STUDIO_RESYNC_MAIL_RENDERERS_MUTATION =
   '{"query":"mutation { resyncMailRenderers }"}'
-const REDWOOD__STUDIO_TEMPLATE_MUTATION =
+const CEDAR__STUDIO_TEMPLATE_MUTATION =
   '{"query":"mutation { resyncMailTemplate }"}'
 
 /**
@@ -59,18 +59,21 @@ const allowRedwoodAuthCurrentUserQuery = async (request: Request) => {
 }
 
 /**
- * When using Studio, we want to allow the `resyncMailRenderers` and `resyncMailTemplate` mutations to be
- * executed without a persisted operation. This is only allowed in local development, ensure you have NODE_ENV=development set.
+ * When using Studio, we want to allow the `resyncMailRenderers` and
+ * `resyncMailTemplate` mutations to be executed without a persisted operation.
+ * This is only allowed in local development, ensure you have
+ * NODE_ENV=development set.
  *
- * This is because the `resyncMailRenderers` mutation is a special case that is used by
- * Studio to sync mail renderers from the mailer configuration.
+ * This is because the `resyncMailRenderers` mutation is a special case that is
+ * used by Studio to sync mail renderers from the mailer configuration.
  *
- * This function checks if the request is for the `resyncMailRenderers` or `resyncMailTemplate` mutations and has the correct headers.
+ * This function checks if the request is for the `resyncMailRenderers` or
+ * `resyncMailTemplate` mutations and has the correct headers.
  *
- * If you need Studio in production, you just have to add the above mutations to your
- * SDL schema and as dummy resolvers so Trusted Documents can pick them up.
+ * If you need Studio in production, you just have to add the above mutations to
+ * your SDL schema and as dummy resolvers so Trusted Documents can pick them up.
  */
-const allowRedwoodStudioResyncMailMutations = async (request: Request) => {
+const allowCedarStudioResyncMailMutations = async (request: Request) => {
   const isLocalDevelopment = process.env.NODE_ENV === 'development'
   if (!isLocalDevelopment) {
     return false
@@ -80,11 +83,11 @@ const allowRedwoodStudioResyncMailMutations = async (request: Request) => {
   const hasContentType = headers.get('content-type') === 'application/json'
 
   const query = await request.text()
-  const hasAllowedQuery =
-    query === REDWOOD__STUDIO_RESYNC_MAIL_RENDERERS_MUTATION ||
-    query === REDWOOD__STUDIO_TEMPLATE_MUTATION
+  const isAllowedQuery =
+    query === CEDAR__STUDIO_RESYNC_MAIL_RENDERERS_MUTATION ||
+    query === CEDAR__STUDIO_TEMPLATE_MUTATION
 
-  return hasContentType && hasAllowedQuery && isLocalDevelopment
+  return hasContentType && isAllowedQuery
 }
 
 export const useRedwoodTrustedDocuments = (
@@ -113,7 +116,10 @@ export const useRedwoodTrustedDocuments = (
           }
         }
       }
-      return allowRedwoodAuthCurrentUserQuery(request) || allowRedwoodStudioResyncMailMutations(request)
+      return (
+        allowRedwoodAuthCurrentUserQuery(request) ||
+        allowCedarStudioResyncMailMutations(request)
+      )
     },
   })
 }


### PR DESCRIPTION
Studio is broken for the mail feature if trusted documents store is enabled. See https://github.com/redwoodjs/studio/issues/75

This fixes the issue:

![Not Working](https://github.com/user-attachments/assets/bb6f25c3-3196-4bc0-99a4-933dd4a9a973)
This was the first initialization of studio with a test project, as you can see the second example is not showing and there's a copy remnant there. With trusted documents it's not synchronizing effectively.

![Fixed](https://github.com/user-attachments/assets/e82fcb88-0491-408b-9bf2-e978b2cf7c62)
This shows that studio synchronizes effectively after the changes in this PR.

EDIT by Tobbe:
I wanted to surface this really informative code comment:
```js
/**
 * When using Studio, we want to allow the `resyncMailRenderers` and
 * `resyncMailTemplate` mutations to be executed without a persisted operation.
 * This is only allowed in local development, ensure you have
 * NODE_ENV=development set.
 *
 * This is because the `resyncMailRenderers` mutation is a special case that is
 * used by Studio to sync mail renderers from the mailer configuration.
 *
 * This function checks if the request is for the `resyncMailRenderers` or
 * `resyncMailTemplate` mutations and has the correct headers.
 *
 * If you need Studio in production, you just have to add the above mutations to
 * your SDL schema and as dummy resolvers so Trusted Documents can pick them up.
 */
```