### PR TITLE
chore(ci): Remove unneeded awaits in specs

### DIFF
--- a/tasks/smoke-tests/auth/tests/authChecks.spec.ts
+++ b/tasks/smoke-tests/auth/tests/authChecks.spec.ts
@@ -29,21 +29,19 @@ test('useAuth hook, auth redirects checks', async ({ page }) => {
   await page.goto('/profile')
 
   const usernameRow = await page.waitForSelector('*css=tr >> text=EMAIL')
-  await expect(await usernameRow.innerHTML()).toBe(
+  expect(await usernameRow.innerHTML()).toBe(
     '<td>EMAIL</td><td>testuser@bazinga.com</td>',
   )
 
   const isAuthenticatedRow = await page.waitForSelector(
     '*css=tr >> text=isAuthenticated',
   )
-  await expect(await isAuthenticatedRow.innerHTML()).toBe(
+  expect(await isAuthenticatedRow.innerHTML()).toBe(
     '<td>isAuthenticated</td><td>true</td>',
   )
 
   const isAdminRow = await page.waitForSelector('*css=tr >> text=Is Admin')
-  await expect(await isAdminRow.innerHTML()).toBe(
-    '<td>Is Admin</td><td>false</td>',
-  )
+  expect(await isAdminRow.innerHTML()).toBe('<td>Is Admin</td><td>false</td>')
 
   await page.goto('/')
   await page.getByText('Log Out').click()
@@ -60,7 +58,7 @@ test('requireAuth graphql checks', async ({ page }) => {
   // Try to create a post as an anonymous user.
   await createNewPost({ page })
 
-  await expect(
+  expect(
     page
       .locator('.rw-form-error-title')
       .locator("text=You don't have permission to do that"),

--- a/tasks/smoke-tests/auth/tests/rbacChecks.spec.ts
+++ b/tasks/smoke-tests/auth/tests/rbacChecks.spec.ts
@@ -65,7 +65,7 @@ test('RBAC: Should not be able to delete contact as non-admin user', async ({
 
   await page.locator('text=Delete').first().click()
 
-  await expect(
+  expect(
     page
       .locator('.rw-scaffold')
       .locator("text=You don't have permission to do that"),
@@ -77,7 +77,7 @@ test('RBAC: Should not be able to delete contact as non-admin user', async ({
     page.locator('.rw-scaffold').locator('text=Contact deleted'),
   ).toBeHidden()
 
-  await expect(
+  expect(
     await page.locator('text=charlie@chimichanga.com').count(),
   ).toBeGreaterThan(0)
 })
@@ -137,7 +137,7 @@ export default async ({ args }) => {
     page.locator('.rw-scaffold').locator('text=Contact deleted'),
   ).toBeVisible()
 
-  await expect(await page.locator('text=charlie@chimichanga.com').count()).toBe(
+  expect(await page.locator('text=charlie@chimichanga.com').count()).toBe(
     contactCountBefore - 1,
   )
 })


### PR DESCRIPTION
Fixing errors like these
<img width="459" height="114" alt="image" src="https://github.com/user-attachments/assets/a9a80453-dd82-4681-aa2f-e743ef372ebc" />
> Unexpected `await` of a non-Promise (non-"Thenable") value. (eslint @typescript-eslint/await-thenable)