### PR TITLE
chore(prerender): Don't guess project format - read from package.json

### DIFF
--- a/packages/prerender/src/build-and-import/buildAndImport.ts
+++ b/packages/prerender/src/build-and-import/buildAndImport.ts
@@ -26,7 +26,7 @@ import { cedarjsRoutesAutoLoaderPlugin } from './rollupPlugins/rollup-plugin-ced
 import { typescriptPlugin } from './rollupPlugins/rollup-plugin-cedarjs-typescript'
 import type { Options } from './types'
 import {
-  guessFormat,
+  getPkgType,
   isValidJsFile,
   makeFilePath,
   setPrerenderChunkIds,
@@ -142,11 +142,9 @@ export async function buildAndImport(
   })
 
   try {
-    const format = options.format ?? guessFormat(options.filepath)
-
     const { output } = await build.generate({
       dir: outDir,
-      format: format === 'esm' ? 'es' : 'cjs',
+      format: getPkgType() === 'module' ? 'es' : 'cjs',
       exports: 'auto',
       sourcemap: 'inline',
     })

--- a/packages/prerender/src/build-and-import/utils.ts
+++ b/packages/prerender/src/build-and-import/utils.ts
@@ -10,7 +10,7 @@ export type RequireFunction = (
   ctx: { format: 'cjs' | 'esm' },
 ) => any
 
-function getPkgType() {
+export function getPkgType() {
   try {
     const pkg = JSON.parse(
       fs.readFileSync(path.resolve('package.json'), 'utf-8'),
@@ -22,19 +22,6 @@ function getPkgType() {
   }
 
   return undefined
-}
-
-export function guessFormat(inputFile: string): 'esm' | 'cjs' {
-  const ext = path.extname(inputFile)
-  const type = getPkgType()
-  if (ext === '.js') {
-    return type === 'module' ? 'esm' : 'cjs'
-  } else if (ext === '.ts' || ext === '.mts') {
-    return 'esm'
-  } else if (ext === '.mjs') {
-    return 'esm'
-  }
-  return 'cjs'
 }
 
 export const getRandomId = () => {


### PR DESCRIPTION
For Cedar projects we can always just read the info we need from package.json files. No need to have fancy guessing in place. So this is a quick refactor to clean up the code a bit