### PR TITLE
fix(prerender): Fix FooPage bug

### DIFF
--- a/packages/prerender/src/build-and-import/buildAndImport.ts
+++ b/packages/prerender/src/build-and-import/buildAndImport.ts
@@ -118,7 +118,7 @@ export async function buildAndImport(
       }),
       ignoreHtmlAndCssImportsPlugin(),
       cellTransformPlugin(),
-      cedarjsRoutesAutoLoaderPlugin({ forPrerender: true }),
+      cedarjsRoutesAutoLoaderPlugin(),
       cedarjsDirectoryNamedImportPlugin(),
       cedarjsPrerenderMediaImportsPlugin(),
       commonjs(),

--- a/packages/prerender/src/build-and-import/buildAndImport.ts
+++ b/packages/prerender/src/build-and-import/buildAndImport.ts
@@ -118,7 +118,7 @@ export async function buildAndImport(
       }),
       ignoreHtmlAndCssImportsPlugin(),
       cellTransformPlugin(),
-      cedarjsRoutesAutoLoaderPlugin(),
+      cedarjsRoutesAutoLoaderPlugin({ forPrerender: true }),
       cedarjsDirectoryNamedImportPlugin(),
       cedarjsPrerenderMediaImportsPlugin(),
       commonjs(),

--- a/packages/prerender/src/build-and-import/rollupPlugins/__tests__/rollup-plugin-cedarjs-routes-auto-loader.test.ts
+++ b/packages/prerender/src/build-and-import/rollupPlugins/__tests__/rollup-plugin-cedarjs-routes-auto-loader.test.ts
@@ -6,10 +6,11 @@ import type { TransformPluginContext } from 'rollup'
 import { getPaths } from '@cedarjs/project-config'
 
 import { cedarjsRoutesAutoLoaderPlugin } from '../rollup-plugin-cedarjs-routes-auto-loader'
+import { dedent } from '../utils'
 
-const transform = (filename: string, forPrerender = false) => {
+const transform = (filename: string) => {
   const code = fs.readFileSync(filename, 'utf-8')
-  const plugin = cedarjsRoutesAutoLoaderPlugin({ forPrerender })
+  const plugin = cedarjsRoutesAutoLoaderPlugin()
   const pluginTransform = plugin.transform
 
   if (typeof pluginTransform !== 'function') {
@@ -77,34 +78,14 @@ describe('page auto loader correctly imports pages', () => {
     result = transform(getPaths().web.routes)
 
     expect(result?.code).toContain(
-      `const HomePage = {
-        name: "HomePage",
-        prerenderLoader: (name) => ({
-          default: globalThis.__REDWOOD__PRERENDER_PAGES[name]
-        }),
-        LazyComponent: lazy(() => import("./pages/HomePage/HomePage"))
-      }`
-        .split('\n')
-        .map((line) => line.replace(/^\s{6}/, ''))
-        .join('\n'),
-    )
-  })
-
-  test('Pages get both a LazyComponent and a prerenderLoader for prerender', () => {
-    result = transform(getPaths().web.routes, true)
-
-    expect(result?.code).toContain(
-      `const HomePage = {
+      dedent(6)`const HomePage = {
         name: "HomePage",
         prerenderLoader: (name) => {
-            const chunkId = './HomePage-__PRERENDER_CHUNK_ID.js';
-            return require(chunkId);
-          },
+          const chunkId = './HomePage-__PRERENDER_CHUNK_ID.js';
+          return require(chunkId);
+        },
         LazyComponent: lazy(() => import("./pages/HomePage/HomePage"))
-      }`
-        .split('\n')
-        .map((line) => line.replace(/^\s{6}/, ''))
-        .join('\n'),
+      }`,
     )
   })
 

--- a/packages/prerender/src/build-and-import/rollupPlugins/__tests__/rollup-plugin-cedarjs-routes-auto-loader.test.ts
+++ b/packages/prerender/src/build-and-import/rollupPlugins/__tests__/rollup-plugin-cedarjs-routes-auto-loader.test.ts
@@ -8,9 +8,9 @@ import { getPaths } from '@cedarjs/project-config'
 import { cedarjsRoutesAutoLoaderPlugin } from '../rollup-plugin-cedarjs-routes-auto-loader'
 import { dedent } from '../utils'
 
-const transform = (filename: string) => {
+const transform = (filename: string, forPrerender = false) => {
   const code = fs.readFileSync(filename, 'utf-8')
-  const plugin = cedarjsRoutesAutoLoaderPlugin()
+  const plugin = cedarjsRoutesAutoLoaderPlugin({ forPrerender })
   const pluginTransform = plugin.transform
 
   if (typeof pluginTransform !== 'function') {
@@ -61,13 +61,14 @@ describe('mulitiple files ending in Page.{js,jsx,ts,tsx}', () => {
 describe('page auto loader correctly imports pages', () => {
   const FIXTURE_PATH = path.resolve(
     __dirname,
-    '../../../../../../__fixtures__/example-todo-main/',
+    '../../../../../../__fixtures__/test-project/',
   )
 
   let result: { code?: string } | null
 
   beforeAll(() => {
     process.env.RWJS_CWD = FIXTURE_PATH
+    result = transform(getPaths().web.routes, true)
   })
 
   afterAll(() => {
@@ -75,26 +76,38 @@ describe('page auto loader correctly imports pages', () => {
   })
 
   test('Pages get both a LazyComponent and a prerenderLoader', () => {
-    result = transform(getPaths().web.routes)
-
     expect(result?.code).toContain(
-      dedent(6)`const HomePage = {
-        name: "HomePage",
+      dedent(6)`const AboutPage = {
+        name: "AboutPage",
         prerenderLoader: (name) => {
-          const chunkId = './HomePage-__PRERENDER_CHUNK_ID.js';
+          const chunkId = './AboutPage-__PRERENDER_CHUNK_ID.js';
           return require(chunkId);
         },
-        LazyComponent: lazy(() => import("./pages/HomePage/HomePage"))
+        LazyComponent: lazy(() => import("./pages/AboutPage/AboutPage"))
+      }`,
+    )
+  })
+
+  // See packages/router/src/page.ts for what a Spec is
+  test('Nested pages get the correct Spec', () => {
+    expect(result?.code).toContain(
+      dedent(6)`const ContactNewContactPage = {
+        name: "ContactNewContactPage",
+        prerenderLoader: (name) => {
+          const chunkId = './NewContactPage-__PRERENDER_CHUNK_ID.js';
+          return require(chunkId);
+        },
+        LazyComponent: lazy(() => import("./pages/Contact/NewContactPage/NewContactPage"))
       }`,
     )
   })
 
   test('Already imported pages are left alone.', () => {
-    expect(result?.code).toContain(`import FooPage from 'src/pages/FooPage'`)
+    expect(result?.code).toContain(`import HomePage from 'src/pages/HomePage'`)
   })
 
   test('Already imported pages are not lazy loaded', () => {
-    expect(result?.code).not.toContain('const FooPage')
+    expect(result?.code).not.toContain('const HomePage')
   })
 
   test('RSC specific code should not be added', () => {

--- a/packages/prerender/src/build-and-import/rollupPlugins/__tests__/rollup-plugin-cedarjs-routes-auto-loader.test.ts
+++ b/packages/prerender/src/build-and-import/rollupPlugins/__tests__/rollup-plugin-cedarjs-routes-auto-loader.test.ts
@@ -76,6 +76,21 @@ describe('page auto loader correctly imports pages', () => {
   })
 
   test('Pages get both a LazyComponent and a prerenderLoader', () => {
+    const clientBuildResult = transform(getPaths().web.routes)
+    expect(clientBuildResult?.code).toContain(
+      dedent(6)`const AboutPage = {
+        name: "AboutPage",
+        prerenderLoader: (name) => ({
+          default: globalThis.__REDWOOD__PRERENDER_PAGES[name]
+        }),
+        LazyComponent: lazy(() => import("./pages/AboutPage/AboutPage"))
+      }`,
+    )
+  })
+
+  test('Pages get both a LazyComponent and a prerenderLoader for prerender', () => {
+    result = transform(getPaths().web.routes, true)
+
     expect(result?.code).toContain(
       dedent(6)`const AboutPage = {
         name: "AboutPage",

--- a/packages/prerender/src/build-and-import/rollupPlugins/utils.ts
+++ b/packages/prerender/src/build-and-import/rollupPlugins/utils.ts
@@ -16,3 +16,45 @@ export function convertToDataUrl(assetPath: string) {
     return ''
   }
 }
+
+export function dedent(indentLevel: number) {
+  return (strings: TemplateStringsArray, ...values: any[]) => {
+    // Reconstruct the full string from template literal parts
+    let result = strings[0]
+
+    for (let i = 0; i < values.length; i++) {
+      result += values[i] + strings[i + 1]
+    }
+
+    // Split into lines
+    const lines = result.split('\n')
+
+    // Remove leading/trailing empty lines
+    while (lines.length > 0 && lines[0].trim() === '') {
+      lines.shift()
+    }
+    while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+      lines.pop()
+    }
+
+    const minIndent = indentLevel
+
+    // Remove the specified indentation from lines that have enough indentation
+    const dedentedLines = lines.map((line) => {
+      if (line.trim() === '') {
+        return ''
+      }
+
+      // Check if line has enough indentation to remove
+      const match = line.match(/^(\s*)/)
+      if (match && match[1].length >= minIndent) {
+        return line.slice(minIndent)
+      }
+
+      // Return line as-is if it doesn't have enough indentation
+      return line
+    })
+
+    return dedentedLines.join('\n')
+  }
+}


### PR DESCRIPTION
Fix a bug where you couldn't lazy load a page called "FooPage" when prerendering

Also added a `dedent` utility function to clean up both the actual implementation and the tests
Plus added an extra test for nested pages