### PR TITLE
chore(prerender): Remove forPrerender arg as it was always true

### DIFF
--- a/packages/prerender/src/build-and-import/buildAndImport.ts
+++ b/packages/prerender/src/build-and-import/buildAndImport.ts
@@ -118,7 +118,7 @@ export async function buildAndImport(
       }),
       ignoreHtmlAndCssImportsPlugin(),
       cellTransformPlugin(),
-      cedarjsRoutesAutoLoaderPlugin({ forPrerender: true }),
+      cedarjsRoutesAutoLoaderPlugin(),
       cedarjsDirectoryNamedImportPlugin(),
       cedarjsPrerenderMediaImportsPlugin(),
       commonjs(),

--- a/packages/prerender/src/build-and-import/rollupPlugins/__tests__/rollup-plugin-cedarjs-routes-auto-loader.test.ts
+++ b/packages/prerender/src/build-and-import/rollupPlugins/__tests__/rollup-plugin-cedarjs-routes-auto-loader.test.ts
@@ -8,9 +8,9 @@ import { getPaths } from '@cedarjs/project-config'
 import { cedarjsRoutesAutoLoaderPlugin } from '../rollup-plugin-cedarjs-routes-auto-loader'
 import { dedent } from '../utils'
 
-const transform = (filename: string, forPrerender = false) => {
+const transform = (filename: string) => {
   const code = fs.readFileSync(filename, 'utf-8')
-  const plugin = cedarjsRoutesAutoLoaderPlugin({ forPrerender })
+  const plugin = cedarjsRoutesAutoLoaderPlugin()
   const pluginTransform = plugin.transform
 
   if (typeof pluginTransform !== 'function') {
@@ -68,7 +68,7 @@ describe('page auto loader correctly imports pages', () => {
 
   beforeAll(() => {
     process.env.RWJS_CWD = FIXTURE_PATH
-    result = transform(getPaths().web.routes, true)
+    result = transform(getPaths().web.routes)
   })
 
   afterAll(() => {
@@ -76,21 +76,6 @@ describe('page auto loader correctly imports pages', () => {
   })
 
   test('Pages get both a LazyComponent and a prerenderLoader', () => {
-    const clientBuildResult = transform(getPaths().web.routes)
-    expect(clientBuildResult?.code).toContain(
-      dedent(6)`const AboutPage = {
-        name: "AboutPage",
-        prerenderLoader: (name) => ({
-          default: globalThis.__REDWOOD__PRERENDER_PAGES[name]
-        }),
-        LazyComponent: lazy(() => import("./pages/AboutPage/AboutPage"))
-      }`,
-    )
-  })
-
-  test('Pages get both a LazyComponent and a prerenderLoader for prerender', () => {
-    result = transform(getPaths().web.routes, true)
-
     expect(result?.code).toContain(
       dedent(6)`const AboutPage = {
         name: "AboutPage",

--- a/packages/prerender/src/build-and-import/rollupPlugins/rollup-plugin-cedarjs-routes-auto-loader.ts
+++ b/packages/prerender/src/build-and-import/rollupPlugins/rollup-plugin-cedarjs-routes-auto-loader.ts
@@ -38,28 +38,14 @@ function withRelativeImports(page: PagesDependency) {
   }
 }
 
-function prerenderLoaderImpl(forPrerender: boolean, relativeImport: string) {
-  if (forPrerender) {
-    return dedent(2)`{
-      const chunkId = './${relativeImport.split('/').at(-1)}-__PRERENDER_CHUNK_ID.js';
-      return require(chunkId);
-    }`
-  }
-
-  // This code will be output when building the web side (i.e. not when
-  // prerendering)
-  // active-route-loader will use this code for auto-imported pages, for the
-  // first load of a prerendered page
-  // Manually imported pages will be bundled in the main bundle and will be
-  // loaded by the code in `normalizePage` in util.ts
-  return `({
-    default: globalThis.__REDWOOD__PRERENDER_PAGES[name]
-  })`
+function prerenderLoaderImpl(relativeImport: string) {
+  return `{
+    const chunkId = './${relativeImport.split('/').at(-1)}-__PRERENDER_CHUNK_ID.js';
+    return require(chunkId);
+  }`
 }
 
-export function cedarjsRoutesAutoLoaderPlugin({
-  forPrerender = false,
-}: PluginOptions = {}): Plugin {
+export function cedarjsRoutesAutoLoaderPlugin(): Plugin {
   // @NOTE: This var gets mutated inside the transform function
   let pages = processPagesDir().map(withRelativeImports)
 
@@ -187,7 +173,7 @@ export function cedarjsRoutesAutoLoaderPlugin({
 
         const declaration = dedent(8)`const ${importName} = {
           name: "${importName}",
-          prerenderLoader: (name) => ${prerenderLoaderImpl(forPrerender, relativeImport)},
+          prerenderLoader: (name) => ${prerenderLoaderImpl(relativeImport)},
           LazyComponent: lazy(() => import("${relativeImport}"))
         }`
         declarations.push(declaration)


### PR DESCRIPTION
This code only ever runs in the context of prerendering, so no need to ever support anything else than that