### PR TITLE
chore(prerender): Lift import of pages to top level

### DIFF
--- a/packages/prerender/src/build-and-import/rollupPlugins/__tests__/rollup-plugin-cedarjs-routes-auto-loader.test.ts
+++ b/packages/prerender/src/build-and-import/rollupPlugins/__tests__/rollup-plugin-cedarjs-routes-auto-loader.test.ts
@@ -79,10 +79,7 @@ describe('page auto loader correctly imports pages', () => {
     expect(result?.code).toContain(
       dedent(6)`const AboutPage = {
         name: "AboutPage",
-        prerenderLoader: (name) => {
-          const chunkId = './AboutPage-__PRERENDER_CHUNK_ID.js';
-          return require(chunkId);
-        },
+        prerenderLoader: (name) => ({ default: __cedarjs_prerender__AboutPage }),
         LazyComponent: lazy(() => import("./pages/AboutPage/AboutPage"))
       }`,
     )
@@ -93,10 +90,7 @@ describe('page auto loader correctly imports pages', () => {
     expect(result?.code).toContain(
       dedent(6)`const ContactNewContactPage = {
         name: "ContactNewContactPage",
-        prerenderLoader: (name) => {
-          const chunkId = './NewContactPage-__PRERENDER_CHUNK_ID.js';
-          return require(chunkId);
-        },
+        prerenderLoader: (name) => ({ default: __cedarjs_prerender__ContactNewContactPage }),
         LazyComponent: lazy(() => import("./pages/Contact/NewContactPage/NewContactPage"))
       }`,
     )

--- a/packages/prerender/src/build-and-import/rollupPlugins/rollup-plugin-cedarjs-routes-auto-loader.ts
+++ b/packages/prerender/src/build-and-import/rollupPlugins/rollup-plugin-cedarjs-routes-auto-loader.ts
@@ -38,13 +38,6 @@ function withRelativeImports(page: PagesDependency) {
   }
 }
 
-function prerenderLoaderImpl(relativeImport: string) {
-  return `{
-    const chunkId = './${relativeImport.split('/').at(-1)}-__PRERENDER_CHUNK_ID.js';
-    return require(chunkId);
-  }`
-}
-
 export function cedarjsRoutesAutoLoaderPlugin(): Plugin {
   // @NOTE: This var gets mutated inside the transform function
   let pages = processPagesDir().map(withRelativeImports)
@@ -171,9 +164,12 @@ export function cedarjsRoutesAutoLoaderPlugin(): Plugin {
           continue
         }
 
+        imports.push(
+          `import __cedarjs_prerender__${importName} from '${relativeImport}';`,
+        )
         const declaration = dedent(8)`const ${importName} = {
           name: "${importName}",
-          prerenderLoader: (name) => ${prerenderLoaderImpl(relativeImport)},
+          prerenderLoader: (name) => ({ default: __cedarjs_prerender__${importName} }),
           LazyComponent: lazy(() => import("${relativeImport}"))
         }`
         declarations.push(declaration)


### PR DESCRIPTION
When prerendering we don't want to lazy load any pages. The previous implementation achieved this by calling `require(chunkId)` inside a function that we'd generate the body for

Now I instead generate a regular `import` and let the bundler handle that, and the Spec for the page can now simply return the imported page. The page import will be a top level import, just as if the user had manually imported the page in the first place. And the bundler will then often just inline the page component.

This should also work much better (hopefully without any changes at all!) for ESM projects