### PR TITLE
docs(coc): Add a Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# CedarJS Code of Conduct
+
+## Purpose
+
+CedarJS is committed to fostering a welcoming, safe, and inclusive environment for everyone. Our Code of Conduct outlines our values and expectations for behavior, ensuring all contributors, users, and team members are treated with respect and dignity.
+
+## Our Values
+
+- **People First:** We treat each other with empathy, kindness, and respect.
+- **Openness:** We encourage collaboration, honest communication, and the sharing of ideas.
+- **Inclusion:** We celebrate diversity and strive to create an environment where everyone feels valued and heard.
+- **Integrity:** We act ethically and take responsibility for our actions.
+
+## Scope
+
+This Code of Conduct applies to all CedarJS spaces, including the workplace, online platforms, events, and work-related social activities. It covers all contributors, maintainers, users, partners, and vendors.
+
+We do not tolerate discrimination or harassment based on race, color, national origin, religion, sex, age, disability, sexual orientation, gender identity or expression, marital status, medical or genetic condition, or any other characteristic.
+
+## Expected Behavior
+
+- Be respectful and considerate in all interactions.
+- Communicate openly and constructively.
+- Value differing perspectives and experiences.
+- Use inclusive language and avoid jargon.
+- Respect privacy and confidentiality.
+
+## Unacceptable Behavior
+
+- Harassment, intimidation, or discrimination in any form.
+- Abusive, derogatory, or demeaning language or behavior.
+- Unwelcome sexual attention or advances.
+- Bullying, threats, or deliberate intimidation.
+- Inappropriate use of company property or assets.
+- Retaliation against anyone who reports a violation.
+
+## Reporting and Enforcement
+
+If you experience or witness a violation of this Code of Conduct, you are encouraged to report it as soon as possible. You may report incidents to any core team member.
+
+All reports will be handled promptly, confidentially, and with respect for all parties involved. Retaliation against reporters is strictly prohibited. Consequences for violations may include warnings, removal from projects or events, or further action as appropriate.
+
+## Review and Feedback
+
+This Code of Conduct is reviewed and updated as needed. Feedback is welcome at any time via direct communication.
+
+Together, we build CedarJS as a community where everyone can thrive.


### PR DESCRIPTION
Adding a Code of Conduct, as required by https://www.netlify.com/legal/open-source-policy/