### PR TITLE
fix(prerender): Use built LocationProvider

### DIFF
--- a/packages/prerender/src/build-and-import/buildAndImport.ts
+++ b/packages/prerender/src/build-and-import/buildAndImport.ts
@@ -49,14 +49,7 @@ export async function buildAndImport(
     throw new Error(`${options.filepath} is not a valid JS file`)
   }
 
-  console.log('options', options)
-
   const tsConfigs = parseTypeScriptConfigFiles()
-
-  console.log(
-    'tsConfigs.web?.data.compilerOptions',
-    tsConfigs.web?.compilerOptions,
-  )
 
   const resolvePaths = tsconfigPathsToRegExp(
     tsConfigs.web?.compilerOptions?.paths || {},


### PR DESCRIPTION
Use the built components to make sure we don't end up with multiple versions of modules in memory. Especially critical for React that compares objects with `===` to check if they're the same