### PR TITLE
chore(prerender): Use readFile instead of require for json file

### DIFF
--- a/packages/prerender/src/build-and-import/rollupPlugins/rollup-plugin-cedarjs-prerender-media-imports.ts
+++ b/packages/prerender/src/build-and-import/rollupPlugins/rollup-plugin-cedarjs-prerender-media-imports.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import { extname, join, relative, dirname } from 'node:path'
 
 import type { Plugin } from 'rollup'
@@ -66,8 +67,7 @@ export function cedarjsPrerenderMediaImportsPlugin(
           getPaths().web.dist,
           'client-build-manifest.json',
         )
-        delete require.cache[require.resolve(manifestPath)]
-        buildManifest = require(manifestPath)
+        buildManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
       } catch {
         // Manifest not found, all imports will fallback to data URLs
         buildManifest = {}

--- a/packages/prerender/src/graphql/graphql.ts
+++ b/packages/prerender/src/graphql/graphql.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises'
 import path from 'path'
 
 import type { DocumentNode } from 'graphql'
@@ -45,7 +46,8 @@ export async function executeQuery(
   // generated on the web side)
   if (config.graphql.trustedDocuments) {
     const documentsPath = path.join(getPaths().web.graphql, 'graphql')
-    const documents: Record<string, any> | undefined = require(documentsPath)
+    const documentsText = await fs.readFile(documentsPath, 'utf8')
+    const documents = JSON.parse(documentsText)
     const documentName =
       operationName[0].toUpperCase() + operationName.slice(1) + 'Document'
     const queryHash = documents?.[documentName]?.__meta__?.hash

--- a/packages/prerender/src/graphql/graphql.ts
+++ b/packages/prerender/src/graphql/graphql.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs/promises'
 import path from 'path'
 
 import type { DocumentNode } from 'graphql'
@@ -46,8 +45,7 @@ export async function executeQuery(
   // generated on the web side)
   if (config.graphql.trustedDocuments) {
     const documentsPath = path.join(getPaths().web.graphql, 'graphql')
-    const documentsText = await fs.readFile(documentsPath, 'utf8')
-    const documents = JSON.parse(documentsText)
+    const documents = require(documentsPath)
     const documentName =
       operationName[0].toUpperCase() + operationName.slice(1) + 'Document'
     const queryHash = documents?.[documentName]?.__meta__?.hash

--- a/packages/prerender/src/graphql/graphql.ts
+++ b/packages/prerender/src/graphql/graphql.ts
@@ -45,7 +45,7 @@ export async function executeQuery(
   // generated on the web side)
   if (config.graphql.trustedDocuments) {
     const documentsPath = path.join(getPaths().web.graphql, 'graphql')
-    const documents = require(documentsPath)
+    const documents: Record<string, any> | undefined = require(documentsPath)
     const documentName =
       operationName[0].toUpperCase() + operationName.slice(1) + 'Document'
     const queryHash = documents?.[documentName]?.__meta__?.hash


### PR DESCRIPTION
Using `readFile` instead of `require()` makes the code compatible with ESM