### PR TITLE
chore(cli): Remove unused runScriptFunction() from execBabel

### DIFF
--- a/packages/cli/src/lib/execBabel.js
+++ b/packages/cli/src/lib/execBabel.js
@@ -1,31 +1,8 @@
-import { createRequire } from 'node:module'
-import path from 'node:path'
-
 import {
   getWebSideDefaultBabelConfig,
   registerApiSideBabelHook,
 } from '@cedarjs/babel-config'
 import { getPaths } from '@cedarjs/project-config'
-
-// This function is used both by the "exec" and "prerender" commands
-export async function runScriptFunction({
-  path: scriptPath,
-  functionName,
-  args,
-}) {
-  const createdRequire = createRequire(import.meta.url)
-  const script = createdRequire(scriptPath)
-  const returnValue = await script[functionName](args)
-
-  try {
-    const { db } = createdRequire(path.join(getPaths().api.lib, 'db'))
-    db.$disconnect()
-  } catch (e) {
-    // silence
-  }
-
-  return returnValue
-}
 
 export function configureBabel() {
   const {


### PR DESCRIPTION
From a quick search through the code we're not using this anywhere anymore, so it should be safe to remove