### PR TITLE
feat(deps): Switch to `@dr.pogodin/react-helmet`

### DIFF
--- a/docs/docs/seo-head.md
+++ b/docs/docs/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-0.0.1/seo-head.md
+++ b/docs/versioned_docs/version-0.0.1/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-0.0.2/seo-head.md
+++ b/docs/versioned_docs/version-0.0.2/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-0.0.3/seo-head.md
+++ b/docs/versioned_docs/version-0.0.3/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-0.0.4/seo-head.md
+++ b/docs/versioned_docs/version-0.0.4/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-0.0.5/seo-head.md
+++ b/docs/versioned_docs/version-0.0.5/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-0.1/seo-head.md
+++ b/docs/versioned_docs/version-0.1/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-0.2/seo-head.md
+++ b/docs/versioned_docs/version-0.2/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-0.3/seo-head.md
+++ b/docs/versioned_docs/version-0.3/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-0.4/seo-head.md
+++ b/docs/versioned_docs/version-0.4/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-8.0/seo-head.md
+++ b/docs/versioned_docs/version-8.0/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-8.1/seo-head.md
+++ b/docs/versioned_docs/version-8.1/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-8.2/seo-head.md
+++ b/docs/versioned_docs/version-8.2/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-8.3/seo-head.md
+++ b/docs/versioned_docs/version-8.3/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-8.4/seo-head.md
+++ b/docs/versioned_docs/version-8.4/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-8.5/seo-head.md
+++ b/docs/versioned_docs/version-8.5/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/docs/versioned_docs/version-8.6/seo-head.md
+++ b/docs/versioned_docs/version-8.6/seo-head.md
@@ -72,7 +72,7 @@ Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several sp
 
 ### What About Nested Tags?
 
-Redwood uses [react-helmet-async](https://github.com/staylor/react-helmet-async) underneath, which will use the tags furthest down your component tree.
+Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helmet) underneath, which will use the tags furthest down your component tree.
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 

--- a/packages/prerender/ambient.d.ts
+++ b/packages/prerender/ambient.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-import type { HelmetServerState } from 'react-helmet-async'
+import type { HelmetServerState } from '@dr.pogodin/react-helmet'
 
 declare global {
   var RWJS_ENV: {

--- a/packages/vite/ambient.d.ts
+++ b/packages/vite/ambient.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-var */
 /// <reference types="react/experimental" />
-import type { HelmetServerState } from 'react-helmet-async'
+import type { HelmetServerState } from '@dr.pogodin/react-helmet'
 import type { ViteRuntime } from 'vite/runtime'
 
 declare global {

--- a/packages/web/ambient.d.ts
+++ b/packages/web/ambient.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-var */
 import type { NormalizedCacheObject } from '@apollo/client'
-import type { HelmetServerState } from 'react-helmet-async'
+import type { HelmetServerState } from '@dr.pogodin/react-helmet'
 
 declare global {
   var __REDWOOD__PRERENDERING: boolean

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -147,6 +147,7 @@
     "@babel/runtime-corejs3": "7.27.6",
     "@cedarjs/auth": "workspace:*",
     "@cedarjs/server-store": "workspace:*",
+    "@dr.pogodin/react-helmet": "2.0.4",
     "@whatwg-node/fetch": "0.9.21",
     "apollo-upload-client": "18.0.1",
     "cookie": "1.0.2",
@@ -154,7 +155,6 @@
     "graphql": "16.9.0",
     "graphql-sse": "2.5.4",
     "graphql-tag": "2.12.6",
-    "react-helmet-async": "2.0.5",
     "react-hot-toast": "2.4.1",
     "stacktracey": "2.1.8",
     "ts-toolbelt": "9.6.0"

--- a/packages/web/src/components/MetaTags.tsx
+++ b/packages/web/src/components/MetaTags.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import * as helmetPkg from 'react-helmet-async'
+import * as helmetPkg from '@dr.pogodin/react-helmet'
 
 const { Helmet: HelmetHead } = helmetPkg
 // Ideally we wouldn't include this for non experiment builds

--- a/packages/web/src/components/Metadata.tsx
+++ b/packages/web/src/components/Metadata.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 
-import * as helmetPkg from 'react-helmet-async'
+import * as helmetPkg from '@dr.pogodin/react-helmet'
 
 const { Helmet: HelmetHead } = helmetPkg
 

--- a/packages/web/src/components/RedwoodProvider.tsx
+++ b/packages/web/src/components/RedwoodProvider.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 // @NOTE: Helmet is not used in SSR & RSC
-import * as helmetPkg from 'react-helmet-async'
+import * as helmetPkg from '@dr.pogodin/react-helmet'
 const { Helmet, HelmetProvider } = helmetPkg
 
 interface RedwoodProviderProps {

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -32,7 +32,7 @@ export * from './components/RedwoodProvider.js'
 
 export * from './components/MetaTags.js'
 export * from './components/Metadata.js'
-import * as helmetPkg from 'react-helmet-async'
+import * as helmetPkg from '@dr.pogodin/react-helmet'
 
 const { Helmet } = helmetPkg
 export { Helmet as Head, Helmet }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3627,6 +3627,7 @@ __metadata:
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/internal": "workspace:*"
     "@cedarjs/server-store": "workspace:*"
+    "@dr.pogodin/react-helmet": "npm:2.0.4"
     "@rollup/plugin-babel": "npm:6.0.4"
     "@testing-library/jest-dom": "npm:6.5.0"
     "@testing-library/react": "npm:14.3.1"
@@ -3645,7 +3646,6 @@ __metadata:
     publint: "npm:0.3.12"
     react: "npm:19.0.0-rc-f2df5694-20240916"
     react-dom: "npm:19.0.0-rc-f2df5694-20240916"
-    react-helmet-async: "npm:2.0.5"
     react-hot-toast: "npm:2.4.1"
     stacktracey: "npm:2.1.8"
     ts-toolbelt: "npm:9.6.0"
@@ -3832,6 +3832,19 @@ __metadata:
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
   checksum: 10c0/e10f1b02b78e4812646ddf289b7d9f2cb567d336c363b266bd50cd223cf3de7c2c74018d91cd2613041568397ef3a4a2b500aba588c6e5bd78c38374ba68f38c
+  languageName: node
+  linkType: hard
+
+"@dr.pogodin/react-helmet@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@dr.pogodin/react-helmet@npm:2.0.4"
+  dependencies:
+    invariant: "npm:^2.2.4"
+    react-fast-compare: "npm:^3.2.2"
+    shallowequal: "npm:^1.1.0"
+  peerDependencies:
+    react: 19
+  checksum: 10c0/f92b58108f6382e94a940d4b176bf2f5a7f659edd472e7a42ab998a37582cbdad008dc0bd1ba16fe55eb6e6e30663c29461906418b50c72d9bb662cf5d55630e
   languageName: node
   linkType: hard
 
@@ -25885,19 +25898,6 @@ __metadata:
   version: 3.2.2
   resolution: "react-fast-compare@npm:3.2.2"
   checksum: 10c0/0bbd2f3eb41ab2ff7380daaa55105db698d965c396df73e6874831dbafec8c4b5b08ba36ff09df01526caa3c61595247e3269558c284e37646241cba2b90a367
-  languageName: node
-  linkType: hard
-
-"react-helmet-async@npm:2.0.5":
-  version: 2.0.5
-  resolution: "react-helmet-async@npm:2.0.5"
-  dependencies:
-    invariant: "npm:^2.2.4"
-    react-fast-compare: "npm:^3.2.2"
-    shallowequal: "npm:^1.1.0"
-  peerDependencies:
-    react: ^16.6.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/f390ea8bf13c2681850e5f8eb5b73d8613f407c245a5fd23e9db9b2cc14a3700dd1ce992d3966632886d1d613083294c2aeee009193f49dfa7d145d9f13ea2b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We need something that's actually maintained instead of react-helmet-async, so switching to https://github.com/birdofpreyru/react-helmet. See also https://github.com/staylor/react-helmet-async/issues/254

This new library should be a 1:1 match with the old as far as features goes with version I've picked here. So there should be no change needed for user's apps.

In the future I can upgrade to newer version with more features and capabilities 

This was needed for https://github.com/cedarjs/cedar/pull/80