### PR TITLE
fix(graphql-server): Point towards correct context import

### DIFF
--- a/packages/graphql-server/src/plugins/useRedwoodGlobalContextSetter.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodGlobalContextSetter.ts
@@ -5,16 +5,15 @@ import { setContext } from '@cedarjs/context'
 import type { RedwoodGraphQLContext } from '../types'
 
 /**
- * This Envelop plugin waits until the GraphQL context is done building and sets the
- * Redwood global context which can be imported with:
- * // import { context } from '@cedarjs/graphql-server'
- * @returns
+ * This Envelop plugin waits until the GraphQL context is done building and sets
+ * the CedarJS global context which can be imported with:
+ * `import { context } from '@cedarjs/context'`
  */
 export const useRedwoodGlobalContextSetter =
   (): Plugin<RedwoodGraphQLContext> => ({
     onContextBuilding() {
-      return ({ context: redwoodGraphqlContext }) => {
-        setContext(redwoodGraphqlContext)
+      return ({ context }) => {
+        setContext(context)
       }
     },
   })


### PR DESCRIPTION
Our context implementation has moved to `@cedarjs/context` (from graphql-server where it used to live). This happened a while ago, but this jsdoc comment was still pointing towards the old location