### PR TITLE
fix(cli): Destroy command: Correct import of cellFiles

### DIFF
--- a/packages/cli/src/commands/deploy.js
+++ b/packages/cli/src/commands/deploy.js
@@ -1,5 +1,3 @@
-export const command = 'deploy <target>'
-export const description = 'Deploy your Redwood project'
 import { terminalLink } from 'termi-link'
 
 import * as deployBaremetal from './deploy/baremetal.js'
@@ -9,6 +7,8 @@ import * as deployRender from './deploy/render.js'
 import * as deployServerless from './deploy/serverless.js'
 import * as deployVercel from './deploy/vercel.js'
 
+export const command = 'deploy <target>'
+export const description = 'Deploy your Redwood project'
 export const builder = (yargs) =>
   yargs
     .command(deployBaremetal)

--- a/packages/cli/src/commands/destroy.js
+++ b/packages/cli/src/commands/destroy.js
@@ -1,6 +1,3 @@
-export const command = 'destroy <type>'
-export const aliases = ['d']
-export const description = 'Rollback changes made by the generate command'
 import { terminalLink } from 'termi-link'
 
 import * as destroyCell from './destroy/cell/cell.js'
@@ -13,6 +10,9 @@ import * as destroyScaffold from './destroy/scaffold/scaffold.js'
 import * as destroySdl from './destroy/sdl/sdl.js'
 import * as destroyService from './destroy/service/service.js'
 
+export const command = 'destroy <type>'
+export const aliases = ['d']
+export const description = 'Rollback changes made by the generate command'
 export const builder = (yargs) =>
   yargs
     .command(destroyCell)

--- a/packages/cli/src/commands/destroy/cell/cell.js
+++ b/packages/cli/src/commands/destroy/cell/cell.js
@@ -1,7 +1,6 @@
-import { files as cellFiles } from '../../generate/cell/cellHandler.js'
 import { createYargsForComponentDestroy, createHandler } from '../helpers.js'
 
 export const { command, description, builder } = createYargsForComponentDestroy(
-  { componentName: 'cell', filesFn: cellFiles },
+  { componentName: 'cell' },
 )
 export const handler = createHandler('cell')

--- a/packages/cli/src/commands/destroy/cell/cellHandler.js
+++ b/packages/cli/src/commands/destroy/cell/cellHandler.js
@@ -1,4 +1,4 @@
-import { files as cellFiles } from '../../generate/cell/cell.js'
+import { files as cellFiles } from '../../generate/cell/cellHandler.js'
 import { createHandler } from '../handlerHelpers.js'
 
 export const { handler, tasks } = createHandler({

--- a/packages/cli/src/commands/destroy/component/component.js
+++ b/packages/cli/src/commands/destroy/component/component.js
@@ -1,10 +1,7 @@
-import { files as componentFiles } from '../../generate/component/componentHandler.js'
 import { createHandler, createYargsForComponentDestroy } from '../helpers.js'
 
 export const description = 'Destroy a component'
-
 export const { command, builder, tasks } = createYargsForComponentDestroy({
   componentName: 'component',
-  filesFn: componentFiles,
 })
 export const handler = createHandler('component')


### PR DESCRIPTION
- `cellFiles` should be imported from `cellHandler`
- The main `cell.js` file should *not* import from any handler file as that will also include a bunch of extra modules we only want to load on-demand when actually running the command