### PR TITLE
chore(api-server): Increase test timeout on Windows

### DIFF
--- a/packages/api-server/vitest.config.mts
+++ b/packages/api-server/vitest.config.mts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     exclude: [...configDefaults.exclude, '**/fixtures'],
     pool: 'threads',
+    hookTimeout: process.platform === 'win32' ? 30_000 : 10_000,
   },
 })


### PR DESCRIPTION
The test started being flaky on Windows, so I'm increasing the timeout from 10s to 30s for Windows
Example of failing run: https://github.com/cedarjs/cedar/actions/runs/16549745453/job/46802880280?pr=300