### PR TITLE
chore(tasks): Use the bin field in api-server instead of assuming a path

### DIFF
--- a/tasks/k6-test/run-k6-tests.mts
+++ b/tasks/k6-test/run-k6-tests.mts
@@ -26,6 +26,31 @@ import {
 // useful consts
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
+// Utility function to find bin path from package.json
+function findBinPath(appPath: string, packageName: string, binName: string) {
+  try {
+    const packageJsonPath = path.join(
+      appPath,
+      'node_modules',
+      packageName,
+      'package.json',
+    )
+    const packageJson = fs.readJsonSync(packageJsonPath)
+
+    if (packageJson.bin?.[binName]) {
+      return path.resolve(
+        path.dirname(packageJsonPath),
+        packageJson.bin[binName],
+      )
+    }
+
+    throw new Error(`Bin '${binName}' not found in ${packageName} package.json`)
+  } catch (error) {
+    console.error(`Error finding bin path for ${packageName}:`, error)
+    throw error
+  }
+}
+
 // Parse input
 const args = yargs(hideBin(process.argv))
   .positional('project-directory', {
@@ -52,16 +77,27 @@ const REDWOOD_PROJECT_DIRECTORY =
 
 const SETUPS_DIR = path.join(__dirname, 'setups')
 const TESTS_DIR = path.join(__dirname, 'tests')
-const API_SERVER_COMMANDS = [
-  {
-    cmd: `node ${path.resolve(REDWOOD_PROJECT_DIRECTORY, 'node_modules/@cedarjs/cli/dist/index.js')} serve api`,
-    host: 'http://localhost:8911',
-  },
-  {
-    cmd: `node ${path.resolve(REDWOOD_PROJECT_DIRECTORY, 'node_modules/@cedarjs/api-server/dist/bin.js')} api`,
-    host: 'http://localhost:8911',
-  },
-]
+
+// Function to get API server commands with dynamic bin paths
+function getApiServerCommands(projectPath: string) {
+  const cliPath = findBinPath(projectPath, '@cedarjs/cli', 'rw')
+  const apiServerPath = findBinPath(
+    projectPath,
+    '@cedarjs/api-server',
+    'rw-server',
+  )
+
+  return [
+    {
+      cmd: `node ${cliPath} serve api`,
+      host: 'http://localhost:8911',
+    },
+    {
+      cmd: `node ${apiServerPath} api`,
+      host: 'http://localhost:8911',
+    },
+  ]
+}
 let cleanUpExecuted = false
 
 let serverSubprocess: ExecaChildProcess | undefined
@@ -79,7 +115,7 @@ const stopServer = async () => {
   serverSubprocess.cancel()
   try {
     await serverSubprocess
-  } catch (_error) {
+  } catch {
     // ignore
   }
 }
@@ -171,11 +207,11 @@ async function main() {
   })
 
   // Results collection
-  const results = {}
+  const results: Record<string, Record<string, any>> = {}
 
   console.log('The following setups will be run:')
-  for (let i = 0; i < setups.length; i++) {
-    console.log(`- ${setups[i]}`)
+  for (const setup of setups) {
+    console.log('-', setup)
   }
 
   for (const setup of setups) {
@@ -218,20 +254,23 @@ async function main() {
       stdio: args.verbose ? 'inherit' : 'ignore',
     })
 
+    // Get API server commands with dynamic paths
+    const apiServerCommands = getApiServerCommands(REDWOOD_PROJECT_DIRECTORY)
+
     // Run the tests
     for (let i = 0; i < runForTests.length; i++) {
       // Run for different server commands
-      for (let j = 0; j < API_SERVER_COMMANDS.length; j++) {
+      for (let j = 0; j < apiServerCommands.length; j++) {
         console.log(`\n${divider}`)
         console.log(
-          `Running test ${i * API_SERVER_COMMANDS.length + j + 1}/${runForTests.length * API_SERVER_COMMANDS.length}: ${runForTests[i]}`,
+          `Running test ${i * apiServerCommands.length + j + 1}/${runForTests.length * apiServerCommands.length}: ${runForTests[i]}`,
         )
-        console.log(ansis.dim(API_SERVER_COMMANDS[j].cmd))
+        console.log(ansis.dim(apiServerCommands[j].cmd))
         console.log(`${divider}`)
 
         // Start the server
         await startServer(
-          API_SERVER_COMMANDS[j].cmd,
+          apiServerCommands[j].cmd,
           setupModule.startupGracePeriod,
         )
 
@@ -244,7 +283,7 @@ async function main() {
               'run',
               path.join(TESTS_DIR, `${runForTests[i]}.js`),
               '--env',
-              `TEST_HOST=${API_SERVER_COMMANDS[j].host}`,
+              `TEST_HOST=${apiServerCommands[j].host}`,
             ],
             {
               cwd: REDWOOD_PROJECT_DIRECTORY,
@@ -252,13 +291,13 @@ async function main() {
             },
           )
           passed = true
-        } catch (_error) {
+        } catch {
           // ignore
         }
 
         results[setup] ??= {}
         results[setup][runForTests[i]] ??= {}
-        results[setup][runForTests[i]][API_SERVER_COMMANDS[j].cmd] =
+        results[setup][runForTests[i]][apiServerCommands[j].cmd] =
           fs.readJSONSync(
             path.join(REDWOOD_PROJECT_DIRECTORY, 'summary.json'),
             {
@@ -267,8 +306,7 @@ async function main() {
               encoding: 'utf-8',
             },
           ) ?? {}
-        results[setup][runForTests[i]][API_SERVER_COMMANDS[j].cmd].passed =
-          passed
+        results[setup][runForTests[i]][apiServerCommands[j].cmd].passed = passed
 
         // Stop the server
         await stopServer()

--- a/tasks/server-tests/vitest.setup.mts
+++ b/tasks/server-tests/vitest.setup.mts
@@ -6,6 +6,31 @@ import type { ProcessPromise } from 'zx'
 
 import { getConfig } from '@cedarjs/project-config'
 
+/** Utility function to find bin path from package.json */
+function findBinPath(appPath: string, packageName: string, binName: string) {
+  try {
+    const packageJsonPath = path.join(
+      appPath,
+      'node_modules',
+      packageName,
+      'package.json',
+    )
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+
+    if (packageJson.bin?.[binName]) {
+      return path.resolve(
+        path.dirname(packageJsonPath),
+        packageJson.bin[binName],
+      )
+    }
+
+    throw new Error(`Bin '${binName}' not found in ${packageName} package.json`)
+  } catch (error) {
+    console.error(`Error finding bin path for ${packageName}`, error)
+    throw error
+  }
+}
+
 $.verbose = !!process.env.VERBOSE
 
 type TestContext = {
@@ -20,24 +45,35 @@ export const testContext: TestContext = {
   projectConfig: {} as ReturnType<typeof getConfig>,
 }
 
-const __dirname = fileURLToPath(new URL('./', import.meta.url))
+// Function to get bin paths dynamically
+function getBinPaths() {
+  const appUrl = new URL('./fixtures/redwood-app', import.meta.url)
+  const appPath = fileURLToPath(appUrl)
+
+  return {
+    rw: findBinPath(appPath, '@cedarjs/cli', 'rw'),
+    rwServer: findBinPath(appPath, '@cedarjs/api-server', 'rw-server'),
+    rwWebServer: findBinPath(appPath, '@cedarjs/web-server', 'rw-web-server'),
+  }
+}
+
+const binPaths = getBinPaths()
 
 // @cedarjs/cli (yarn rw)
-export const rw = path.resolve(__dirname, '../../packages/cli/dist/index.js')
+export const rw = binPaths.rw
 
 // @cedarjs/api-server (yarn rw-server)
-export const rwServer = path.resolve(
-  __dirname,
-  '../../packages/api-server/dist/bin.js',
-)
+export const rwServer = binPaths.rwServer
 
 // @cedarjs/web-server (yarn rw-web-server)
-export const rwWebServer = path.resolve(
-  __dirname,
-  '../../packages/web-server/dist/bin.js',
-)
+export const rwWebServer = binPaths.rwWebServer
 
 let original_RWJS_CWD: string | undefined
+
+declare global {
+  // eslint-disable-next-line no-var
+  var loggedBinPaths: boolean
+}
 
 beforeAll(() => {
   original_RWJS_CWD = process.env.RWJS_CWD
@@ -119,13 +155,13 @@ export async function test({
   const webRes = await fetch(url)
   const webBody = await webRes.text()
 
-  expect(webRes.status).toEqual(200)
-  expect(webBody).toEqual(
-    fs.readFileSync(
-      path.join(__dirname, './fixtures/redwood-app/web/dist/about.html'),
-      'utf-8',
-    ),
+  const aboutHtmlPath = path.join(
+    import.meta.dirname,
+    './fixtures/redwood-app/web/dist/about.html',
   )
+
+  expect(webRes.status).toEqual(200)
+  expect(webBody).toEqual(fs.readFileSync(aboutHtmlPath, 'utf-8'))
 
   apiHost ??= '::'
   if (apiHost.includes(':')) {


### PR DESCRIPTION
Instead of directly reaching for `node_modules/@cedarjs/api-server/dist/bin.js` I now look up the `bin` field in api-server's `package.json` and get the path from there. So if I change the path those scripts still keep working.
And the paths might change as I work on making the api-server package build for ESM (or even CJS+ESM) in #300 