### PR TITLE
fix(api-server): Use dotenv-defaults in watch bin

### DIFF
--- a/packages/api-server/ambient.d.ts
+++ b/packages/api-server/ambient.d.ts
@@ -1,1 +1,15 @@
-declare module 'dotenv-defaults'
+// `@types/dotenv-defaults` depends on dotenv v8, but dotenv-defaults uses
+// dotenv v14, so I have to manually fix the types here
+
+declare module 'dotenv-defaults' {
+  import type { config as Config } from 'dotenv-defaults/index.js'
+
+  type BrokenConfigOptions = Exclude<Parameters<typeof Config>[0], undefined>
+  type ConfigOutput = ReturnType<typeof Config>
+
+  interface ConfigOptions extends BrokenConfigOptions {
+    multiline?: boolean
+  }
+
+  export function config(options?: ConfigOptions): ConfigOutput
+}

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
     "@types/aws-lambda": "8.10.152",
+    "@types/dotenv-defaults": "^2.0.4",
     "@types/qs": "6.9.16",
     "@types/split2": "4.2.3",
     "@types/yargs": "17.0.33",

--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -2,7 +2,7 @@ import path from 'path'
 
 import ansis from 'ansis'
 import chokidar from 'chokidar'
-import dotenv from 'dotenv'
+import { config } from 'dotenv-defaults'
 
 import {
   buildApi,
@@ -19,9 +19,8 @@ import { serverManager } from './serverManager.js'
 const rwjsPaths = getPaths()
 
 if (!process.env.REDWOOD_ENV_FILES_LOADED) {
-  dotenv.config({
+  config({
     path: path.join(rwjsPaths.base, '.env'),
-    // @ts-expect-error The types for dotenv-defaults are using an outdated version of dotenv
     defaults: path.join(rwjsPaths.base, '.env.defaults'),
     multiline: true,
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1994,6 +1994,7 @@ __metadata:
     "@fastify/multipart": "npm:9.0.3"
     "@fastify/url-data": "npm:6.0.3"
     "@types/aws-lambda": "npm:8.10.152"
+    "@types/dotenv-defaults": "npm:^2.0.4"
     "@types/qs": "npm:6.9.16"
     "@types/split2": "npm:4.2.3"
     "@types/yargs": "npm:17.0.33"


### PR DESCRIPTION
We use `dotenv-defaults` to support an additional `.env.defaults` file. But the `watch` bin in `@cedarjs/api-server` incorrectly used the standard `dotenv` page

This PR also provides better types for the `dotenv-defaults` package