### PR TITLE
feat(project-config): Allow for both .js and .mjs dist SSR files

### DIFF
--- a/packages/project-config/src/__tests__/paths.test.ts
+++ b/packages/project-config/src/__tests__/paths.test.ts
@@ -76,8 +76,8 @@ const DEFAULT_PATHS = {
     distBrowser: ['web', 'dist', 'browser'],
     distRsc: ['web', 'dist', 'rsc'],
     distSsr: ['web', 'dist', 'ssr'],
-    distSsrDocument: ['web', 'dist', 'ssr', 'Document.mjs'],
-    distSsrEntryServer: ['web', 'dist', 'ssr', 'entry.server.mjs'],
+    distSsrDocument: ['web', 'dist', 'ssr', 'Document'],
+    distSsrEntryServer: ['web', 'dist', 'ssr', 'entry.server'],
     distRouteHooks: ['web', 'dist', 'ssr', 'routeHooks'],
     distRscEntries: ['web', 'dist', 'rsc', 'entries.mjs'],
     routeManifest: ['web', 'dist', 'ssr', 'route-manifest.json'],
@@ -154,6 +154,8 @@ describe('paths', () => {
         storybookPreviewConfig: null,
         // Vite paths ~ not configured in empty-project
         viteConfig: null,
+        distSsrDocument: null,
+        distSsrEntryServer: null,
         entryClient: null,
         entryServer: null,
       })
@@ -290,6 +292,8 @@ describe('paths', () => {
         logger: null,
       })
       Object.assign(pathTemplate.web, {
+        distSsrDocument: null, // SSR isn't setup for example-todo-main
+        distSsrEntryServer: null, // SSR isn't setup for example-todo-main
         document: null, // this fixture doesn't have a document
         entryClient: null, // doesn't exist in example-todo-main
         entryServer: null, // doesn't exist in example-todo-main
@@ -477,6 +481,8 @@ describe('paths', () => {
       Object.assign(pathTemplate.web, {
         app: null,
         document: null, // this fixture doesnt have a document
+        distSsrDocument: null,
+        distSsrEntryServer: null,
         entryClient: null,
         entryServer: null,
         viteConfig: null, // no vite config in example-todo-main-with-errors
@@ -624,6 +630,8 @@ describe('paths', () => {
         document: null, // this fixture doesn't have a document
         storybookPreviewConfig: null,
         entryServer: null,
+        distSsrDocument: null,
+        distSsrEntryServer: null,
       })
 
       const expectedPaths = getExpectedPaths(FIXTURE_BASEDIR, pathTemplate)

--- a/packages/project-config/src/paths.ts
+++ b/packages/project-config/src/paths.ts
@@ -54,8 +54,8 @@ export interface WebPaths {
   distBrowser: string
   distRsc: string
   distSsr: string
-  distSsrDocument: string
-  distSsrEntryServer: string
+  distSsrDocument: string | null
+  distSsrEntryServer: string | null
   distRouteHooks: string
   distRscEntries: string
   routeManifest: string
@@ -133,8 +133,8 @@ const PATH_WEB_DIR_DIST_BROWSER = 'web/dist/browser'
 const PATH_WEB_DIR_DIST_RSC = 'web/dist/rsc'
 const PATH_WEB_DIR_DIST_SSR = 'web/dist/ssr'
 
-const PATH_WEB_DIR_DIST_SSR_ENTRY_SERVER = 'web/dist/ssr/entry.server.mjs'
-const PATH_WEB_DIR_DIST_SSR_DOCUMENT = 'web/dist/ssr/Document.mjs'
+const PATH_WEB_DIR_DIST_SSR_ENTRY_SERVER = 'web/dist/ssr/entry.server'
+const PATH_WEB_DIR_DIST_SSR_DOCUMENT = 'web/dist/ssr/Document'
 const PATH_WEB_DIR_DIST_SSR_ROUTEHOOKS = 'web/dist/ssr/routeHooks'
 const PATH_WEB_DIR_DIST_RSC_ENTRIES = 'web/dist/rsc/entries.mjs'
 const PATH_WEB_DIR_ROUTE_MANIFEST = 'web/dist/ssr/route-manifest.json'
@@ -257,10 +257,11 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
       distBrowser: path.join(BASE_DIR, PATH_WEB_DIR_DIST_BROWSER),
       distRsc: path.join(BASE_DIR, PATH_WEB_DIR_DIST_RSC),
       distSsr: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SSR),
-      distSsrDocument: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SSR_DOCUMENT),
-      distSsrEntryServer: path.join(
-        BASE_DIR,
-        PATH_WEB_DIR_DIST_SSR_ENTRY_SERVER,
+      distSsrDocument: resolveFile(
+        path.join(BASE_DIR, PATH_WEB_DIR_DIST_SSR_DOCUMENT),
+      ),
+      distSsrEntryServer: resolveFile(
+        path.join(BASE_DIR, PATH_WEB_DIR_DIST_SSR_ENTRY_SERVER),
       ),
       distRouteHooks: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SSR_ROUTEHOOKS),
       distRscEntries: path.join(BASE_DIR, PATH_WEB_DIR_DIST_RSC_ENTRIES),
@@ -330,6 +331,34 @@ export const getAppRouteHook = (forProd = false) => {
   }
 
   return resolveFile(path.join(rwPaths.web.src, 'App.routeHooks'))
+}
+
+/**
+ * Gets the built server entry file path.
+ * Throws an error if the file does not exist.
+ */
+export function getBuiltServerEntryFile(): string {
+  const entryServer = getPaths().web.distSsrEntryServer
+
+  if (!entryServer) {
+    throw new Error('Server entry file not found (' + entryServer + ')')
+  }
+
+  return entryServer
+}
+
+/**
+ * Gets the built Document file path.
+ * Throws an error if the file does not exist.
+ */
+export function getBuiltDocumentFile(): string {
+  const document = getPaths().web.distSsrDocument
+
+  if (!document) {
+    throw new Error('Document file not found (' + document + ')')
+  }
+
+  return document
 }
 
 /**

--- a/packages/vite/src/middleware/register.ts
+++ b/packages/vite/src/middleware/register.ts
@@ -2,7 +2,7 @@ import fmw from 'find-my-way'
 import type Router from 'find-my-way'
 import type { ViteDevServer } from 'vite'
 
-import { getPaths } from '@cedarjs/project-config'
+import { getBuiltServerEntryFile } from '@cedarjs/project-config'
 import { MiddlewareResponse } from '@cedarjs/web/middleware'
 import type {
   Middleware,
@@ -103,11 +103,9 @@ export const addMiddlewareHandlers = (mwRegList: MiddlewareReg = []) => {
 export const createMiddlewareRouter = async (
   vite?: ViteDevServer,
 ): Promise<Router.Instance<any>> => {
-  const rwPaths = getPaths()
-
   const entryServerImport: EntryServer = vite
     ? await ssrLoadEntryServer(vite)
-    : await import(makeFilePath(rwPaths.web.distSsrEntryServer))
+    : await import(makeFilePath(getBuiltServerEntryFile()))
 
   const { registerMiddleware } = entryServerImport
 

--- a/packages/vite/src/rsc/rscBuildForSsr.ts
+++ b/packages/vite/src/rsc/rscBuildForSsr.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import { build as viteBuild } from 'vite'
 import { cjsInterop } from 'vite-plugin-cjs-interop'
 
-import { getPaths } from '@cedarjs/project-config'
+import { getBuiltServerEntryFile, getPaths } from '@cedarjs/project-config'
 
 import { onWarn } from '../lib/onWarn.js'
 import { rscRoutesAutoLoader } from '../plugins/vite-plugin-rsc-routes-auto-loader.js'
@@ -147,13 +147,10 @@ export async function rscBuildForSsr({
 
   // TODO (RSC): This is horrible. Please help me find a better way to do this.
   // Really should not be search/replacing in the built files like this.
-  const entryServerMjs = fs.readFileSync(
-    rwPaths.web.distSsrEntryServer,
-    'utf-8',
-  )
+  const entryServerMjs = fs.readFileSync(getBuiltServerEntryFile(), 'utf-8')
 
   fs.writeFileSync(
-    rwPaths.web.distSsrEntryServer,
+    getBuiltServerEntryFile(),
     entryServerMjs.replace(
       /import (require\S+) from "graphql-scalars";/,
       'import * as $1 from "graphql-scalars";',

--- a/packages/vite/src/streaming/createReactStreamingHandler.ts
+++ b/packages/vite/src/streaming/createReactStreamingHandler.ts
@@ -9,7 +9,13 @@ import type { ViteDevServer } from 'vite'
 import { middlewareDefaultAuthProviderState } from '@cedarjs/auth/dist/AuthProvider/AuthProviderState.js'
 import type { ServerAuthState } from '@cedarjs/auth/dist/AuthProvider/ServerAuthProvider.js'
 import type { RouteSpec, RWRouteManifestItem } from '@cedarjs/internal'
-import { getAppRouteHook, getConfig, getPaths } from '@cedarjs/project-config'
+import {
+  getAppRouteHook,
+  getConfig,
+  getPaths,
+  getBuiltServerEntryFile,
+  getBuiltDocumentFile,
+} from '@cedarjs/project-config'
 import { matchPath } from '@cedarjs/router/util'
 import type { TagDescriptor } from '@cedarjs/web'
 import { MiddlewareResponse } from '@cedarjs/web/middleware'
@@ -55,18 +61,12 @@ export const createReactStreamingHandler = async (
   // Dev is the opposite, we load it every time to pick up changes
   if (isProd) {
     if (rscEnabled) {
-      entryServerImport = await import(
-        makeFilePath(rwPaths.web.distSsrEntryServer)
-      )
+      entryServerImport = await import(makeFilePath(getBuiltServerEntryFile()))
     } else {
-      entryServerImport = await import(
-        makeFilePath(rwPaths.web.distSsrEntryServer)
-      )
+      entryServerImport = await import(makeFilePath(getBuiltServerEntryFile()))
     }
 
-    fallbackDocumentImport = await import(
-      makeFilePath(rwPaths.web.distSsrDocument)
-    )
+    fallbackDocumentImport = await import(makeFilePath(getBuiltDocumentFile()))
   }
 
   // @NOTE: we are returning a FetchAPI handler


### PR DESCRIPTION
Add support for built files to have both `.js` and `.mjs` extensions (and more, like `.cjs`).
Vite doesn't always output the same file extension. It depends on the project configuration. See https://vite.dev/guide/build#:~:text=%7D%0A%7D-,File%20Extensions,-If%20the%20package