### PR TITLE
chore(ci): Cypress: Fix eslint, RW->Cedar and remove commented code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
 
-          ./tasks/run-e2e "$project_path" \
+          ./tasks/run-e2e.cjs "$project_path" \
             --no-build-framework \
             --no-start
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "check": "cross-env yarn constraints && yarn dedupe --check",
     "check:package": "nx run-many -t check:package --output-style static",
     "clean:prisma": "rimraf node_modules/.prisma/client && node node_modules/@prisma/client/scripts/postinstall.js",
-    "e2e": "node ./tasks/run-e2e",
+    "e2e": "node ./tasks/run-e2e.cjs",
     "e2e:background-jobs": "tsx ./tasks/e2e-background-jobs/run.mts",
     "format": "prettier . --write",
     "format:check": "prettier . --check",

--- a/tasks/e2e/cypress.config.js
+++ b/tasks/e2e/cypress.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({

--- a/tasks/e2e/cypress/e2e/01-tutorial/sharedTests.js
+++ b/tasks/e2e/cypress/e2e/01-tutorial/sharedTests.js
@@ -49,7 +49,7 @@ export function waitForApiSide() {
             'content-type': 'application/json',
           },
           body: JSON.stringify({
-            query: 'query Q { redwood { version } }',
+            query: 'query Q { cedarjs { version } }',
           }),
           failOnStatusCode: false,
         })
@@ -62,7 +62,7 @@ export function waitForApiSide() {
 
 export const test_first_page = () =>
   it('1. Our First Page', () => {
-    //redwoodjs.com/docs/tutorial/chapter1/first-page
+    // https://cedarjs.com/docs/tutorial/chapter1/first-page
     cy.visit('http://localhost:8910')
     cy.exec(`cd ${BASE_DIR}; yarn redwood generate page home / --force`)
     cy.get('h1').should('contain', 'HomePage')
@@ -70,7 +70,7 @@ export const test_first_page = () =>
 
 export const test_pages = () =>
   it('2. A Second Page and a Link', () => {
-    // https://redwoodjs.com/docs/tutorial/chapter1/second-page
+    // https://cedarjs.com/docs/tutorial/chapter1/second-page
     cy.exec(`cd ${BASE_DIR}; yarn redwood generate page about --force`)
     cy.writeFile(
       path.join(BASE_DIR, 'web/src/pages/HomePage/HomePage.jsx'),

--- a/tasks/e2e/cypress/e2e/01-tutorial/tutorial.cy.js
+++ b/tasks/e2e/cypress/e2e/01-tutorial/tutorial.cy.js
@@ -24,7 +24,7 @@ import {
 
 const BASE_DIR = Cypress.env('RW_PATH')
 
-describe('The Redwood Tutorial - Golden path edition', () => {
+describe('The Cedar Tutorial - Golden path edition', () => {
   // TODO: https://redwoodjs.com/docs/tutorial/chapter3/saving-data
   // TODO: https://redwoodjs.com/docs/tutorial/chapter4/administration
   after(() => {

--- a/tasks/run-e2e.cjs
+++ b/tasks/run-e2e.cjs
@@ -17,7 +17,7 @@ const yargs = require('yargs/yargs')
 //
 // The steps are composable, so that it can work for the GitHub Workflow, and
 // us contributors.
-//
+
 const makeDirectory = () => {
   console.log('mkdir', REDWOOD_PROJECT_DIRECTORY)
   fs.mkdirSync(REDWOOD_PROJECT_DIRECTORY, { recursive: true })
@@ -231,7 +231,7 @@ makeDirectory(REDWOOD_PROJECT_DIRECTORY)
 console.log()
 console.log('-'.repeat(80))
 
-let {
+const {
   buildFramework,
   copyFramework,
   createProject,
@@ -243,9 +243,6 @@ const tasks = [
   buildFramework && buildRedwoodFramework,
   createProject && (() => createRedwoodJSApp({ typescript })),
   copyFramework && runTarsync,
-  // copyFramework && addFrameworkDepsToProject,
-  // copyFramework && runYarnInstall,
-  // copyFramework && copyFrameworkPackages,
   autoStart && runDevServerInBackground,
   autoStart && initGit,
   autoStart && runCypress,


### PR DESCRIPTION
I had to run Cypress locally to debug an issue with https://github.com/cedarjs/cedar/pull/316
And in doing so I wanted to fix a few code warnings, code style things, and move more of the code from mentioning RW to Cedar instead.