### PR TITLE
fix(codemods): Link to git tag on GitHub for graphql config download

### DIFF
--- a/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/updateGraphqlConfig.ts
+++ b/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/updateGraphqlConfig.ts
@@ -7,10 +7,7 @@ import { getPaths } from '@cedarjs/project-config'
 
 export const updateGraphqlConfig = async () => {
   const res = await fetch(
-    // TODO: Have to come back here to update the URL when we have a more
-    // stable location than main
-    // 'https://raw.githubusercontent.com/redwoodjs/redwood/release/major/v7.0.0/packages/create-cedar-app/templates/ts/graphql.config.js'
-    'https://raw.githubusercontent.com/cedarjs/cedar/main/packages/create-cedar-app/templates/ts/graphql.config.js',
+    'https://raw.githubusercontent.com/cedarjs/cedar/refs/tags/v0.4.0/packages/create-cedar-app/templates/ts/graphql.config.js',
   )
   const text = await res.text()
   fs.writeFileSync(path.join(getPaths().base, 'graphql.config.js'), text)


### PR DESCRIPTION
Now that we have stable releases of CedarJS to link to, we should do that (just as the TODO told us!)