### PR TITLE
chore(test-project): Update indentation for easier visual scanning

### DIFF
--- a/tasks/test-project/tasks.js
+++ b/tasks/test-project/tasks.js
@@ -493,29 +493,29 @@ async function apiTasks(outputPath, { verbose, linkWithLatestFwBuild }) {
 
           const doublePageContent = `import { Metadata } from '@cedarjs/web'
 
-const DoublePage = () => {
-  return (
-    <>
-      <Metadata title="Double" description="Double page" og />
+            const DoublePage = () => {
+              return (
+                <>
+                  <Metadata title="Double" description="Double page" og />
 
-      <h1 className="mb-1 mt-2 text-xl font-semibold">DoublePage</h1>
-      <p>
-        This page exists to make sure we don&apos;t regress on{' '}
-        <a
-          href="https://github.com/redwoodjs/redwood/issues/7757"
-          className="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
-          target="_blank"
-          rel="noreferrer"
-        >
-          #7757
-        </a>
-      </p>
-      <p>It needs to be a page that is not wrapped in a Set</p>
-    </>
-  )
-}
+                  <h1 className="mb-1 mt-2 text-xl font-semibold">DoublePage</h1>
+                  <p>
+                    This page exists to make sure we don&apos;t regress on{' '}
+                    <a
+                      href="https://github.com/redwoodjs/redwood/issues/7757"
+                      className="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      #7757
+                    </a>
+                  </p>
+                  <p>It needs to be a page that is not wrapped in a Set</p>
+                </>
+              )
+            }
 
-export default DoublePage`
+            export default DoublePage`
 
           fs.writeFileSync(
             fullPath('web/src/pages/DoublePage/DoublePage'),
@@ -560,17 +560,17 @@ export default DoublePage`
 
           const blogPostRouteHooks = `import { db } from '$api/src/lib/db.js'
 
-      export async function routeParameters() {
-        return (await db.post.findMany({ take: 7 })).map((post) => ({ id: post.id }))
-      }
-      `.replaceAll(/ {6}/g, '')
+            export async function routeParameters() {
+              return (await db.post.findMany({ take: 7 })).map((post) => ({ id: post.id }))
+            }
+            `.replaceAll(/ {6}/g, '')
           const blogPostRouteHooksPath = `${OUTPUT_PATH}/web/src/pages/BlogPostPage/BlogPostPage.routeHooks.ts`
           fs.writeFileSync(blogPostRouteHooksPath, blogPostRouteHooks)
 
           const waterfallRouteHooks = `export async function routeParameters() {
-        return [{ id: 2 }]
-      }
-      `.replaceAll(/ {6}/g, '')
+              return [{ id: 2 }]
+            }
+            `.replaceAll(/ {6}/g, '')
           const waterfallRouteHooksPath = `${OUTPUT_PATH}/web/src/pages/WaterfallPage/WaterfallPage.routeHooks.ts`
           fs.writeFileSync(waterfallRouteHooksPath, waterfallRouteHooks)
         },

--- a/tasks/test-project/tui-tasks.ts
+++ b/tasks/test-project/tui-tasks.ts
@@ -602,29 +602,29 @@ export async function apiTasks(
 
           const doublePageContent = `import { Metadata } from '@cedarjs/web'
 
-const DoublePage = () => {
-  return (
-    <>
-      <Metadata title="Double" description="Double page" og />
+            const DoublePage = () => {
+              return (
+                <>
+                  <Metadata title="Double" description="Double page" og />
 
-      <h1 className="mb-1 mt-2 text-xl font-semibold">DoublePage</h1>
-      <p>
-        This page exists to make sure we don&apos;t regress on{' '}
-        <a
-          href="https://github.com/redwoodjs/redwood/issues/7757"
-          className="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
-          target="_blank"
-          rel="noreferrer"
-        >
-          #7757
-        </a>
-      </p>
-      <p>It needs to be a page that is not wrapped in a Set</p>
-    </>
-  )
-}
+                  <h1 className="mb-1 mt-2 text-xl font-semibold">DoublePage</h1>
+                  <p>
+                    This page exists to make sure we don&apos;t regress on{' '}
+                    <a
+                      href="https://github.com/redwoodjs/redwood/issues/7757"
+                      className="text-blue-600 underline visited:text-purple-600 hover:text-blue-800"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      #7757
+                    </a>
+                  </p>
+                  <p>It needs to be a page that is not wrapped in a Set</p>
+                </>
+              )
+            }
 
-export default DoublePage`
+            export default DoublePage`
 
           fs.writeFileSync(
             fullPath('web/src/pages/DoublePage/DoublePage'),
@@ -669,17 +669,17 @@ export default DoublePage`
 
           const blogPostRouteHooks = `import { db } from '$api/src/lib/db.js'
 
-      export async function routeParameters() {
-        return (await db.post.findMany({ take: 7 })).map((post) => ({ id: post.id }))
-      }
-      `.replaceAll(/ {6}/g, '')
+            export async function routeParameters() {
+              return (await db.post.findMany({ take: 7 })).map((post) => ({ id: post.id }))
+            }
+            `.replaceAll(/ {6}/g, '')
           const blogPostRouteHooksPath = `${OUTPUT_PATH}/web/src/pages/BlogPostPage/BlogPostPage.routeHooks.ts`
           fs.writeFileSync(blogPostRouteHooksPath, blogPostRouteHooks)
 
           const waterfallRouteHooks = `export async function routeParameters() {
-        return [{ id: 2 }]
-      }
-      `.replaceAll(/ {6}/g, '')
+              return [{ id: 2 }]
+            }
+            `.replaceAll(/ {6}/g, '')
           const waterfallRouteHooksPath = `${OUTPUT_PATH}/web/src/pages/WaterfallPage/WaterfallPage.routeHooks.ts`
           fs.writeFileSync(waterfallRouteHooksPath, waterfallRouteHooks)
         },


### PR DESCRIPTION
Indenting code snippets inline with the code around them makes it quicker and easier to visually scan where methods and other control blocks start and end