### PR TITLE
fix(testing): Use correct jest types

### DIFF
--- a/packages/testing/src/config/jest/api/jest.setup.ts
+++ b/packages/testing/src/config/jest/api/jest.setup.ts
@@ -3,6 +3,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+type JestIt = typeof global.it
+type JestDescribe = typeof global.describe
+
 // @NOTE without these imports in the setup file, mockCurrentUser
 // will remain undefined in the user's tests
 import { defineScenario } from '../../../api/scenario.js'
@@ -136,7 +139,7 @@ const getProjectDb = async () => {
  * Wraps "it" or "test", to seed and teardown the scenario after each test
  * This one passes scenario data to the test function
  */
-function buildScenario(itFunc: jest.It, testPath: string) {
+function buildScenario(itFunc: JestIt, testPath: string) {
   const scenarioFunc = (...args: any[]) => {
     let scenarioName: string, testName: string, testFunc: ScenarioTestFunction
 
@@ -173,7 +176,7 @@ function buildScenario(itFunc: jest.It, testPath: string) {
  * This creates a describe() block that will seed the scenario ONCE before all tests in the block
  * Note that you need to use the getScenario() function to get the data.
  */
-function buildDescribeScenario(describeFunc: jest.Describe, testPath: string) {
+function buildDescribeScenario(describeFunc: JestDescribe, testPath: string) {
   const describeScenarioFunc = (
     ...args:
       | [string, string, (getScenario: () => any) => any]


### PR DESCRIPTION
The important thing to know here is that there's a mismatch between jest's internal types that it actually uses, and the types provided by `@types/jest`. We use `@types/jest` because that's the only way to have types for globally available methods `describe`, `test`, `it` etc. It's somewhat of a legacy config to have those be magically available, but it's what was in vogue when RW was created.
See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73007#issuecomment-2977672418