### PR TITLE
chore(deps): Upgrade klaw-sync to v7.0.0

### DIFF
--- a/packages/create-cedar-app/package.json
+++ b/packages/create-cedar-app/package.json
@@ -40,7 +40,7 @@
     "envinfo": "7.14.0",
     "execa": "5.1.1",
     "fs-extra": "11.2.0",
-    "klaw-sync": "6.0.0",
+    "klaw-sync": "7.0.0",
     "semver": "7.6.3",
     "systeminformation": "5.23.8",
     "termi-link": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14951,7 +14951,7 @@ __metadata:
     envinfo: "npm:7.14.0"
     execa: "npm:5.1.1"
     fs-extra: "npm:11.2.0"
-    klaw-sync: "npm:6.0.0"
+    klaw-sync: "npm:7.0.0"
     semver: "npm:7.6.3"
     systeminformation: "npm:5.23.8"
     termi-link: "npm:1.1.0"
@@ -21453,12 +21453,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"klaw-sync@npm:6.0.0":
-  version: 6.0.0
-  resolution: "klaw-sync@npm:6.0.0"
+"klaw-sync@npm:7.0.0":
+  version: 7.0.0
+  resolution: "klaw-sync@npm:7.0.0"
   dependencies:
     graceful-fs: "npm:^4.1.11"
-  checksum: 10c0/00d8e4c48d0d699b743b3b028e807295ea0b225caf6179f51029e19783a93ad8bb9bccde617d169659fbe99559d73fb35f796214de031d0023c26b906cecd70a
+    memfs: "npm:^4.17.0"
+  checksum: 10c0/b3b811520be082b3c1e0912d37ea515f9ec9f72e10add409b5a418c4601be4ab7f9e5e245dd9c2ab41088fd2371b70d467b0899deefff69cfdfdeeee2aa7afd6
   languageName: node
   linkType: hard
 
@@ -22536,6 +22537,18 @@ __metadata:
     tree-dump: "npm:^1.0.1"
     tslib: "npm:^2.0.0"
   checksum: 10c0/9cce5886a10e590887cd63271ba6198f037e537a8ee84048cfe27f851adfc9b7fd3e5b49ac5d31fe8d9c753ffa57ac4d1f8eb4a27a3927047945bd420a4cc38a
+  languageName: node
+  linkType: hard
+
+"memfs@npm:^4.17.0":
+  version: 4.36.0
+  resolution: "memfs@npm:4.36.0"
+  dependencies:
+    "@jsonjoy.com/json-pack": "npm:^1.0.3"
+    "@jsonjoy.com/util": "npm:^1.3.0"
+    tree-dump: "npm:^1.0.1"
+    tslib: "npm:^2.0.0"
+  checksum: 10c0/1ba2b507dde155568612737eadc0070c7709a05e7c7d720bf53866c3a68ef265ee5f4e27328c9566c6be4498563ee9afd081d8542be8ec885abd182d2df92e75
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Even though this is a major version bump of a dependency from v6 to v7, it's only used as a devDep and has no impact on user's apps. So this is just a chore commit

(klaw-sync had to do a major version bump because they changed how they handle symlinks, but that doesn't affect us)