### PR TITLE
feat(esm): packages/vite api side vitest support

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -21,6 +21,10 @@
         "default": "./dist/cjs/index.js"
       }
     },
+    "./api": {
+      "types": "./dist/api/vite-plugin-cedar-vitest-api-preset.d.ts",
+      "default": "./dist/api/vite-plugin-cedar-vitest-api-preset.js"
+    },
     "./client": {
       "require": "./dist/cjs/client.js",
       "import": "./dist/client.js"
@@ -66,6 +70,7 @@
     "@cedarjs/internal": "workspace:*",
     "@cedarjs/project-config": "workspace:*",
     "@cedarjs/server-store": "workspace:*",
+    "@cedarjs/testing": "workspace:*",
     "@cedarjs/web": "workspace:*",
     "@swc/core": "1.13.3",
     "@vitejs/plugin-react": "4.3.4",

--- a/packages/vite/src/api/vite-plugin-cedar-vitest-api-preset.ts
+++ b/packages/vite/src/api/vite-plugin-cedar-vitest-api-preset.ts
@@ -1,0 +1,16 @@
+import {
+  autoImportsPlugin,
+  cedarVitestApiConfigPlugin,
+  trackDbImportsPlugin,
+} from '@cedarjs/testing/api/vitest'
+
+import { cedarjsDirectoryNamedImportPlugin } from '../plugins/vite-plugin-cedarjs-directory-named-import.js'
+
+export function cedarVitestPreset() {
+  return [
+    cedarVitestApiConfigPlugin(),
+    autoImportsPlugin(),
+    cedarjsDirectoryNamedImportPlugin(),
+    trackDbImportsPlugin(),
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3635,6 +3635,7 @@ __metadata:
     "@cedarjs/internal": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
     "@cedarjs/server-store": "workspace:*"
+    "@cedarjs/testing": "workspace:*"
     "@cedarjs/web": "workspace:*"
     "@hyrious/esbuild-plugin-commonjs": "npm:0.2.6"
     "@swc/core": "npm:1.13.3"


### PR DESCRIPTION
Bringing over the last `packages/vite` changes from #80 to the `main` branch