### PR TITLE
feat(esm): Add missing dependency to `packages/testing`

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -113,7 +113,7 @@
     "build": "tsx ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-testing.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose tsconfig.cjs.json",
+    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext 'js,jsx,ts,tsx' --ignore dist --exec 'yarn build'",
     "check:attw": "yarn rw-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",
@@ -143,6 +143,7 @@
     "jest-watch-typeahead": "2.2.2",
     "msw": "1.3.5",
     "ts-toolbelt": "9.6.0",
+    "unplugin-auto-import": "19.3.0",
     "whatwg-fetch": "3.6.20"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3601,6 +3601,7 @@ __metadata:
     ts-toolbelt: "npm:9.6.0"
     tsx: "npm:4.20.3"
     typescript: "npm:5.6.2"
+    unplugin-auto-import: "npm:19.3.0"
     vitest: "npm:3.2.4"
     whatwg-fetch: "npm:3.6.20"
   languageName: unknown


### PR DESCRIPTION
`unplugin-auto-import` is used in vite plugins that we added in #355 

PR (7/n) for adding ESM support. See #349 for PR 1/n in the series