### PR TITLE
feat(esm): Create ESM Cedar App using hidden --esm flag

### DIFF
--- a/packages/create-cedar-app/src/create-cedar-app.js
+++ b/packages/create-cedar-app/src/create-cedar-app.js
@@ -434,6 +434,36 @@ async function handleTypescriptPreference(typescriptFlag) {
   }
 }
 
+async function handleEsmPreference(esmFlag) {
+  // Handle case where flag is set
+  if (esmFlag !== null) {
+    tui.drawText(
+      `${RedwoodStyling.green('✔')} Setting up ${
+        esmFlag ? 'an ESM' : 'a CJS'
+      } project based on command line flag`,
+    )
+    return esmFlag
+  }
+
+  return false
+  // Disable this for now, while the ESM flag is hidden
+  // Prompt user for preference
+  // try {
+  //   const response = await tui.prompt({
+  //     type: 'Select',
+  //     name: 'esm',
+  //     choices: ['CJS', 'ESM'],
+  //     message: 'Select your preferred project type',
+  //     initial: 'CJS',
+  //   })
+  //   return response.esm === 'ESM'
+  // } catch (_error) {
+  //   recordErrorViaTelemetry('User cancelled install at esm prompt')
+  //   await shutdownTelemetry()
+  //   process.exit(1)
+  // }
+}
+
 async function handleGitPreference(gitInitFlag) {
   // Handle case where flag is set
   if (gitInitFlag !== null) {
@@ -657,6 +687,12 @@ async function createRedwoodApp() {
       type: 'boolean',
       describe: 'Generate a TypeScript project',
     })
+    .option('esm', {
+      hidden: true,
+      default: null,
+      type: 'boolean',
+      describe: 'Generate an ESM project',
+    })
     .option('git-init', {
       alias: 'git',
       default: null,
@@ -708,6 +744,7 @@ async function createRedwoodApp() {
     parsedFlags['yarn-install'] ??
     (_isYarnBerryOrNewer ? parsedFlags.yes : null)
   const typescriptFlag = parsedFlags.typescript ?? parsedFlags.yes
+  const esmFlag = parsedFlags.esm // TODO: ?? parsedFlags.yes
   const overwrite = parsedFlags.overwrite
   const gitInitFlag = parsedFlags['git-init'] ?? parsedFlags.yes
   const commitMessageFlag =
@@ -732,7 +769,14 @@ async function createRedwoodApp() {
   const useTypescript = await handleTypescriptPreference(typescriptFlag)
   trace.getActiveSpan()?.setAttribute('typescript', useTypescript)
 
-  const templateDir = path.join(templatesDir, useTypescript ? 'ts' : 'js')
+  // Determine ESM or not
+  const useEsm = await handleEsmPreference(esmFlag)
+  trace.getActiveSpan()?.setAttribute('esm', useEsm)
+
+  const templateDir = path.join(
+    templatesDir,
+    useTypescript ? (useEsm ? 'esm-ts' : 'ts') : useEsm ? 'esm-js' : 'js',
+  )
 
   // Determine git preference
   const useGit = await handleGitPreference(gitInitFlag)

--- a/packages/create-cedar-app/tests/e2e.test.ts
+++ b/packages/create-cedar-app/tests/e2e.test.ts
@@ -1,5 +1,8 @@
 /* eslint-env node */
 
+// To run these tests locally, go to ~/cedarjs-fw/packages/create-cedar-app
+// Then run `PROJECT_PATH=./ yarn test:e2e`
+
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 


### PR DESCRIPTION
With this PR I add support for a hidden `--esm` flag you can pass to `yarn create cedar-app` to generate an app based on our ESM template

Until #80 is merged, the ESM app will not have full functionality. So for now, generation works, but you can't run it

PR 15/n in the #349 series