### PR TITLE
chore(ci): Refactor ci.yml for easier reading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -834,76 +834,8 @@ jobs:
 
   create-cedar-app:
     needs: check
-
     name: 🌲 Create Cedar App
-    runs-on: ubuntu-latest
-
-    env:
-      REDWOOD_CI: 1
-      REDWOOD_DISABLE_TELEMETRY: 1
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Set up job
-        uses: ./.github/actions/set-up-job
-
-      - name: Set up test project
-        run: |
-          yarn build:pack
-          PROJECT_PATH=$(yarn set-up-test-project)
-          echo "PROJECT_PATH=$PROJECT_PATH" >> $GITHUB_ENV
-        working-directory: ./packages/create-cedar-app
-        env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
-      - name: Set up git
-        run: |
-          git config --global user.email "you@example.com"
-          git config --global user.name "Your Name"
-
-      - name: e2e test
-        run: yarn test:e2e
-        working-directory: ./packages/create-cedar-app
-        env:
-          PROJECT_PATH: ${{ env.PROJECT_PATH }}
-
-      - name: Install expect
-        run: |
-          sudo apt-get update
-          sudo apt-get install expect
-
-      - name: Prompt tests
-        run: |
-          ./tests/e2e_prompts.sh
-          ./tests/e2e_prompts_git.sh
-          ./tests/e2e_prompts_m.sh
-          ./tests/e2e_prompts_ts.sh
-          ./tests/e2e_prompts_overwrite.sh
-        working-directory: ./packages/create-cedar-app
-        env:
-          PROJECT_PATH: ${{ env.PROJECT_PATH }}
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 18
-
-      - name: Prompt tests
-        run: ./tests/e2e_prompts_node_less.sh
-        working-directory: ./packages/create-cedar-app
-        env:
-          PROJECT_PATH: ${{ env.PROJECT_PATH }}
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 21
-
-      - name: Prompt tests
-        run: ./tests/e2e_prompts_node_greater.sh
-        working-directory: ./packages/create-cedar-app
-        env:
-          PROJECT_PATH: ${{ env.PROJECT_PATH }}
+    uses: ./.github/workflows/create-cedar-app-test.yml
 
   create-cedar-app-skip:
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,92 +210,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     name: 🔄 Smoke tests / ${{ matrix.os }} / node 20 latest
-    runs-on: ${{ matrix.os }}
-
-    env:
-      REDWOOD_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
-
-    steps:
-      - name: Checkout the framework code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: Set up job
-        uses: ./.github/actions/set-up-job
-
-      - name: 🌲 Set up test project
-        id: set-up-test-project
-        uses: ./.github/actions/set-up-test-project
-        env:
-          REDWOOD_DISABLE_TELEMETRY: 1
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
-      - name: 🎭 Install playwright dependencies
-        run: npx playwright install --with-deps chromium
-
-      - name: 🧑‍💻 Run dev smoke tests
-        working-directory: ./tasks/smoke-tests/dev
-        run: npx playwright test
-        env:
-          REDWOOD_TEST_PROJECT_PATH: '${{ steps.set-up-test-project.outputs.test-project-path }}'
-          REDWOOD_DISABLE_TELEMETRY: 1
-
-      - name: 🔐 Run auth smoke tests
-        working-directory: ./tasks/smoke-tests/auth
-        run: npx playwright test
-        env:
-          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
-          REDWOOD_DISABLE_TELEMETRY: 1
-
-      - name: Run `rw build --no-prerender`
-        run: |
-          yarn rw build --no-prerender
-        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
-
-      - name: Run `rw prerender`
-        run: |
-          yarn rw prerender --verbose
-        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
-
-      - name: Run `rw test web`
-        run: |
-          yarn rw test web --no-watch
-        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
-
-      - name: Run `rw test api`
-        run: |
-          yarn rw test api --no-watch
-        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
-
-      - name: Run db import tracking tests
-        shell: bash
-        run: |
-          # Only run this for ESM projects where the vitest config file exists
-          if test -f ./vitest-sort.config.ts; then
-            npx vitest --config ./vitest-sort.config.ts run
-          fi
-        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}/api
-
-      - name: 🖥️ Run serve smoke tests
-        working-directory: tasks/smoke-tests/serve
-        run: npx playwright test
-        env:
-          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
-          REDWOOD_DISABLE_TELEMETRY: 1
-
-      - name: 📄 Run prerender smoke tests
-        working-directory: tasks/smoke-tests/prerender
-        run: npx playwright test
-        env:
-          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
-          REDWOOD_DISABLE_TELEMETRY: 1
-
-      - name: 📕 Run Storybook smoke tests
-        working-directory: tasks/smoke-tests/storybook
-        run: npx playwright test
-        env:
-          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
-          REDWOOD_DISABLE_TELEMETRY: 1
+    uses: ./.github/workflows/smoke-tests-test.yml
+    with:
+      os: ${{ matrix.os }}
 
   smoke-tests-skip:
     needs: detect-changes
@@ -319,92 +236,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     name: 🔄 Smoke tests React 18 / ${{ matrix.os }} / node 20 latest
-    runs-on: ${{ matrix.os }}
-
-    env:
-      REDWOOD_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
-
-    steps:
-      - name: Checkout the framework code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: Set up job
-        uses: ./.github/actions/set-up-job
-        with:
-          build: false
-
-      - name: Downgrade to React 18
-        run: |
-          yarn tsx ./tasks/downgradeToReact18.mts
-
-      # One of our dependencies is on GitHub instead of NPM and without authentication
-      # we'll get rate limited and this step becomes flaky.
-      - name: 🐈 Yarn install
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
-        run: yarn install --inline-builds
-
-      - name: 🏗️ Build
-        shell: bash
-        run: yarn build
-
-      - name: 🌲 Set up test project for React 18
-        id: set-up-test-project-react-18
-        uses: ./.github/actions/set-up-test-project
-        env:
-          REDWOOD_DISABLE_TELEMETRY: 1
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
-
-      - name: 🎭 Install playwright dependencies
-        run: npx playwright install --with-deps chromium
-
-      - name: 🧑‍💻 Run dev smoke tests
-        working-directory: ./tasks/smoke-tests/dev
-        run: npx playwright test
-        env:
-          REDWOOD_TEST_PROJECT_PATH: '${{ steps.set-up-test-project-react-18.outputs.test-project-path }}'
-          REDWOOD_DISABLE_TELEMETRY: 1
-
-      - name: 🔐 Run auth smoke tests
-        working-directory: ./tasks/smoke-tests/auth
-        run: npx playwright test
-        env:
-          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
-          REDWOOD_DISABLE_TELEMETRY: 1
-
-      - name: Run `rw build --no-prerender`
-        run: |
-          yarn rw build --no-prerender
-        working-directory: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
-
-      - name: Run `rw prerender`
-        run: |
-          yarn rw prerender --verbose
-        working-directory: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
-
-      - name: 🖥️ Run serve smoke tests
-        working-directory: tasks/smoke-tests/serve
-        run: npx playwright test
-        env:
-          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
-          REDWOOD_DISABLE_TELEMETRY: 1
-
-      - name: 📄 Run prerender smoke tests
-        working-directory: tasks/smoke-tests/prerender
-        run: npx playwright test
-        env:
-          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
-          REDWOOD_DISABLE_TELEMETRY: 1
-
-      - name: 📕 Run Storybook smoke tests
-        working-directory: tasks/smoke-tests/storybook
-        run: npx playwright test
-        env:
-          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
-          REDWOOD_DISABLE_TELEMETRY: 1
+    uses: ./.github/workflows/smoke-tests-react-18-test.yml
+    with:
+      os: ${{ matrix.os }}
 
   smoke-tests-react-18-skip:
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -832,7 +832,7 @@ jobs:
     steps:
       - run: echo "Skipped"
 
-  crwa:
+  create-cedar-app:
     needs: check
 
     name: 🌲 Create Cedar App
@@ -905,7 +905,7 @@ jobs:
         env:
           PROJECT_PATH: ${{ env.PROJECT_PATH }}
 
-  crwa-skip:
+  create-cedar-app-skip:
     needs: detect-changes
     if: needs.detect-changes.outputs.code == 'false'
 

--- a/.github/workflows/create-cedar-app-test.yml
+++ b/.github/workflows/create-cedar-app-test.yml
@@ -1,0 +1,76 @@
+name: 🌲 Create Cedar App Test
+
+on:
+  workflow_call:
+
+jobs:
+  create-cedar-app-test:
+    name: 🌲 Create Cedar App
+    runs-on: ubuntu-latest
+
+    env:
+      REDWOOD_CI: 1
+      REDWOOD_DISABLE_TELEMETRY: 1
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
+
+      - name: Set up test project
+        run: |
+          yarn build:pack
+          PROJECT_PATH=$(yarn set-up-test-project)
+          echo "PROJECT_PATH=$PROJECT_PATH" >> $GITHUB_ENV
+        working-directory: ./packages/create-cedar-app
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
+      - name: Set up git
+        run: |
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+
+      - name: e2e test
+        run: yarn test:e2e
+        working-directory: ./packages/create-cedar-app
+        env:
+          PROJECT_PATH: ${{ env.PROJECT_PATH }}
+
+      - name: Install expect
+        run: |
+          sudo apt-get update
+          sudo apt-get install expect
+
+      - name: Prompt tests
+        run: |
+          ./tests/e2e_prompts.sh
+          ./tests/e2e_prompts_git.sh
+          ./tests/e2e_prompts_m.sh
+          ./tests/e2e_prompts_ts.sh
+          ./tests/e2e_prompts_overwrite.sh
+        working-directory: ./packages/create-cedar-app
+        env:
+          PROJECT_PATH: ${{ env.PROJECT_PATH }}
+
+      - name: ⬢ Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 18
+
+      - name: Prompt tests
+        run: ./tests/e2e_prompts_node_less.sh
+        working-directory: ./packages/create-cedar-app
+        env:
+          PROJECT_PATH: ${{ env.PROJECT_PATH }}
+
+      - name: ⬢ Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 21
+
+      - name: Prompt tests
+        run: ./tests/e2e_prompts_node_greater.sh
+        working-directory: ./packages/create-cedar-app
+        env:
+          PROJECT_PATH: ${{ env.PROJECT_PATH }}

--- a/.github/workflows/smoke-tests-react-18-test.yml
+++ b/.github/workflows/smoke-tests-react-18-test.yml
@@ -1,0 +1,98 @@
+name: 🔄 Smoke Tests React 18 Test
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+
+jobs:
+  smoke-tests-react-18-test:
+    name: 🔄 Smoke tests React 18 / ${{ inputs.os }} / node 20 latest
+    runs-on: ${{ inputs.os }}
+
+    env:
+      REDWOOD_CI: 1
+      REDWOOD_VERBOSE_TELEMETRY: 1
+
+    steps:
+      - name: Checkout the framework code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
+        with:
+          build: false
+
+      - name: Downgrade to React 18
+        run: |
+          yarn tsx ./tasks/downgradeToReact18.mts
+
+      # One of our dependencies is on GitHub instead of NPM and without authentication
+      # we'll get rate limited and this step becomes flaky.
+      - name: 🐈 Yarn install
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+        run: yarn install --inline-builds
+
+      - name: 🏗️ Build
+        shell: bash
+        run: yarn build
+
+      - name: 🌲 Set up test project for React 18
+        id: set-up-test-project-react-18
+        uses: ./.github/actions/set-up-test-project
+        env:
+          REDWOOD_DISABLE_TELEMETRY: 1
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
+      - name: 🎭 Install playwright dependencies
+        run: npx playwright install --with-deps chromium
+
+      - name: 🧑‍💻 Run dev smoke tests
+        working-directory: ./tasks/smoke-tests/dev
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: '${{ steps.set-up-test-project-react-18.outputs.test-project-path }}'
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 🔐 Run auth smoke tests
+        working-directory: ./tasks/smoke-tests/auth
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: Run `rw build --no-prerender`
+        run: |
+          yarn rw build --no-prerender
+        working-directory: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
+
+      - name: Run `rw prerender`
+        run: |
+          yarn rw prerender --verbose
+        working-directory: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
+
+      - name: 🖥️ Run serve smoke tests
+        working-directory: tasks/smoke-tests/serve
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 📄 Run prerender smoke tests
+        working-directory: tasks/smoke-tests/prerender
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 📕 Run Storybook smoke tests
+        working-directory: tasks/smoke-tests/storybook
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1

--- a/.github/workflows/smoke-tests-test.yml
+++ b/.github/workflows/smoke-tests-test.yml
@@ -1,0 +1,98 @@
+name: 🔄 Smoke Tests Test
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+
+jobs:
+  smoke-tests-test:
+    name: 🔄 Smoke tests / ${{ inputs.os }} / node 20 latest
+    runs-on: ${{ inputs.os }}
+
+    env:
+      REDWOOD_CI: 1
+      REDWOOD_VERBOSE_TELEMETRY: 1
+
+    steps:
+      - name: Checkout the framework code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
+
+      - name: 🌲 Set up test project
+        id: set-up-test-project
+        uses: ./.github/actions/set-up-test-project
+        env:
+          REDWOOD_DISABLE_TELEMETRY: 1
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
+      - name: 🎭 Install playwright dependencies
+        run: npx playwright install --with-deps chromium
+
+      - name: 🧑‍💻 Run dev smoke tests
+        working-directory: ./tasks/smoke-tests/dev
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: '${{ steps.set-up-test-project.outputs.test-project-path }}'
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 🔐 Run auth smoke tests
+        working-directory: ./tasks/smoke-tests/auth
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: Run `rw build --no-prerender`
+        run: |
+          yarn rw build --no-prerender
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
+
+      - name: Run `rw prerender`
+        run: |
+          yarn rw prerender --verbose
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
+
+      - name: Run `rw test web`
+        run: |
+          yarn rw test web --no-watch
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
+
+      - name: Run `rw test api`
+        run: |
+          yarn rw test api --no-watch
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
+
+      - name: Run db import tracking tests
+        shell: bash
+        run: |
+          # Only run this for ESM projects where the vitest config file exists
+          if test -f ./vitest-sort.config.ts; then
+            npx vitest --config ./vitest-sort.config.ts run
+          fi
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}/api
+
+      - name: 🖥️ Run serve smoke tests
+        working-directory: tasks/smoke-tests/serve
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 📄 Run prerender smoke tests
+        working-directory: tasks/smoke-tests/prerender
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 📕 Run Storybook smoke tests
+        working-directory: tasks/smoke-tests/storybook
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1


### PR DESCRIPTION
The ci.yml file was getting too unwieldy. I need to add a couple more jobs to it, and I just couldn't get a good overview of what was going on. 

So I'm trying to extract out the logic for a few jobs into reusable workflows (that I'll actually only "reuse" in one place)

If this works I'll keep doing it with more jobs