### PR TITLE
feat(docs): Add note about gql import in ESM apps

### DIFF
--- a/docs/docs/directives.md
+++ b/docs/docs/directives.md
@@ -159,7 +159,11 @@ const requireAuth = createValidatorDirective(schema, validate)
 export default requireAuth
 ```
 
-All Redwood apps come with two built-in validator directives: `@requireAuth` and `@skipAuth`.
+(Note that the `gql` import should be `import { gql } from 'graphql-tag'` in
+apps that use ESM)
+
+All Cedar apps come with two built-in validator directives: `@requireAuth` and
+`@skipAuth`.
 The `@requireAuth` directive takes optional roles.
 You may use these to protect against unwanted GraphQL access to your data.
 Or explicitly allow public access.


### PR DESCRIPTION
Keeping the CJS way of doing things as the default for now, with just a note on how to update to the ESM way. Once ESM becomes the default I should switch it to be the other way around