### PR TITLE
feat(esm): Make vitest an optional peerDep in packages/testing

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -155,5 +155,13 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "peerDependencies": {
+    "vitest": "3.2.4"
+  },
+  "peerDependenciesMeta": {
+    "vitest": {
+      "optional": true
+    }
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }


### PR DESCRIPTION
When https://github.com/cedarjs/cedar/pull/355 added vitest support to the testing package it should also have made 