### PR TITLE
feat(esm): Add ESM test project to CI

### DIFF
--- a/.github/actions/set-up-test-project-esm/action.yaml
+++ b/.github/actions/set-up-test-project-esm/action.yaml
@@ -1,0 +1,15 @@
+name: Set up test project
+description: Sets up the test project fixture in CI for smoke tests and CLI checks
+
+runs:
+  using: node20
+  main: 'setUpTestProjectEsm.mjs'
+
+inputs:
+  canary:
+    description: Upgrade the project to canary?
+    default: 'false'
+
+outputs:
+  test-project-path:
+    description: Path to the test project

--- a/.github/actions/set-up-test-project-esm/setUpTestProjectEsm.mjs
+++ b/.github/actions/set-up-test-project-esm/setUpTestProjectEsm.mjs
@@ -1,0 +1,89 @@
+/* eslint-env node */
+// @ts-check
+
+import path from 'node:path'
+
+import core from '@actions/core'
+
+import fs from 'fs-extra'
+
+import {
+  createExecWithEnvInCwd,
+  execInFramework,
+  REDWOOD_FRAMEWORK_PATH,
+} from '../actionsLib.mjs'
+
+const TEST_PROJECT_PATH = path.join(
+  path.dirname(process.cwd()),
+  'esm-test-project',
+)
+
+core.setOutput('test-project-path', TEST_PROJECT_PATH)
+
+const canary = core.getInput('canary') === 'true'
+console.log({
+  canary,
+})
+
+console.log()
+
+/**
+ * @returns {Promise<void>}
+ */
+async function main() {
+  await setUpTestProject({
+    canary: true,
+  })
+}
+
+/**
+ * @param {{canary: boolean}} options
+ * @returns {Promise<void>}
+ */
+async function setUpTestProject({ canary }) {
+  const TEST_PROJECT_FIXTURE_PATH = path.join(
+    REDWOOD_FRAMEWORK_PATH,
+    '__fixtures__',
+    'esm-test-project',
+  )
+
+  console.log(`Creating project at ${TEST_PROJECT_PATH}`)
+  console.log()
+  await fs.copy(TEST_PROJECT_FIXTURE_PATH, TEST_PROJECT_PATH)
+
+  await execInFramework('yarn project:tarsync --verbose', {
+    env: { RWJS_CWD: TEST_PROJECT_PATH },
+  })
+
+  if (canary) {
+    console.log(`Upgrading project to canary`)
+    await execInProject('yarn rw upgrade -t canary', {
+      input: Buffer.from('Y'),
+    })
+    console.log()
+  }
+
+  await sharedTasks()
+}
+
+const execInProject = createExecWithEnvInCwd(TEST_PROJECT_PATH)
+
+/**
+ * @returns {Promise<void>}
+ */
+async function sharedTasks() {
+  console.log('Generating dbAuth secret')
+  const { stdout } = await execInProject('yarn rw g secret --raw', {
+    silent: true,
+  })
+  fs.appendFileSync(
+    path.join(TEST_PROJECT_PATH, '.env'),
+    `SESSION_SECRET='${stdout}'`,
+  )
+  console.log()
+
+  console.log('Running prisma migrate reset')
+  await execInProject('yarn rw prisma migrate reset --force')
+}
+
+main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,18 @@ jobs:
     with:
       os: ${{ matrix.os }}
 
+  smoke-tests-esm:
+    needs: check
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    name: 🔄 Smoke tests ESM / ${{ matrix.os }} / node 20 latest
+    uses: ./.github/workflows/smoke-tests-test-esm.yml
+    with:
+      os: ${{ matrix.os }}
+
   cli-smoke-tests:
     needs: check
 

--- a/.github/workflows/smoke-tests-test-esm.yml
+++ b/.github/workflows/smoke-tests-test-esm.yml
@@ -1,0 +1,97 @@
+name: 🔄 Smoke Tests Test
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+
+jobs:
+  smoke-tests:
+    runs-on: ${{ inputs.os }}
+
+    env:
+      REDWOOD_CI: 1
+      REDWOOD_VERBOSE_TELEMETRY: 1
+
+    steps:
+      - name: Checkout the framework code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
+
+      - name: 🌲 Set up test project
+        id: set-up-test-project
+        uses: ./.github/actions/set-up-test-project-esm
+        env:
+          REDWOOD_DISABLE_TELEMETRY: 1
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
+      - name: 🎭 Install playwright dependencies
+        run: npx playwright install --with-deps chromium
+
+      - name: 🧑‍💻 Run dev smoke tests
+        working-directory: ./tasks/smoke-tests/dev
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: '${{ steps.set-up-test-project.outputs.test-project-path }}'
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 🔐 Run auth smoke tests
+        working-directory: ./tasks/smoke-tests/auth
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: Run `rw build --no-prerender`
+        run: |
+          yarn rw build --no-prerender
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
+
+      - name: Run `rw prerender`
+        run: |
+          yarn rw prerender --verbose
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
+
+      - name: Run `rw test web`
+        run: |
+          yarn rw test web --no-watch
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
+
+      - name: Run `rw test api`
+        run: |
+          yarn rw test api --no-watch
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
+
+      - name: Run db import tracking tests
+        shell: bash
+        run: |
+          # Only run this for ESM projects where the vitest config file exists
+          if test -f ./vitest-sort.config.ts; then
+            npx vitest --config ./vitest-sort.config.ts run
+          fi
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}/api
+
+      - name: 🖥️ Run serve smoke tests
+        working-directory: tasks/smoke-tests/serve
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 📄 Run prerender smoke tests
+        working-directory: tasks/smoke-tests/prerender
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 📕 Run Storybook smoke tests
+        working-directory: tasks/smoke-tests/storybook
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1


### PR DESCRIPTION
Adds running basic smoke tests towards the ESM project to our CI pipeline

Still want to also add CLI smoke tests, and possibly React 18 smoke tests as well, but I'll do that as separate PRs