### PR TITLE
feat(esm): packages/internal: Update test fixtures to use ESM style gql imports

### DIFF
--- a/packages/internal/src/__tests__/fixtures/graphqlCodeGen/bookshelf/api/src/directives/requireAuth/requireAuth.js
+++ b/packages/internal/src/__tests__/fixtures/graphqlCodeGen/bookshelf/api/src/directives/requireAuth/requireAuth.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import { gql } from 'graphql-tag'
 
 import { createValidatorDirective } from '@cedarjs/graphql-server'
 

--- a/packages/internal/src/__tests__/fixtures/graphqlCodeGen/bookshelf/api/src/directives/skipAuth/skipAuth.js
+++ b/packages/internal/src/__tests__/fixtures/graphqlCodeGen/bookshelf/api/src/directives/skipAuth/skipAuth.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import { gql } from 'graphql-tag'
 
 import { createValidatorDirective } from '@cedarjs/graphql-server'
 

--- a/packages/internal/src/__tests__/fixtures/graphqlCodeGen/realtime/api/src/directives/requireAuth/requireAuth.js
+++ b/packages/internal/src/__tests__/fixtures/graphqlCodeGen/realtime/api/src/directives/requireAuth/requireAuth.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import { gql } from 'graphql-tag'
 
 import { createValidatorDirective } from '@cedarjs/graphql-server'
 

--- a/packages/internal/src/__tests__/fixtures/graphqlCodeGen/realtime/api/src/directives/skipAuth/skipAuth.js
+++ b/packages/internal/src/__tests__/fixtures/graphqlCodeGen/realtime/api/src/directives/skipAuth/skipAuth.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import { gql } from 'graphql-tag'
 
 import { createValidatorDirective } from '@cedarjs/graphql-server'
 


### PR DESCRIPTION
Pulling these changes over from #80. It seems it doesn't really matter for the tests that use these fixtures how `gql` is imported, but now at least they match what it will soon look like in all new Cedar apps