### PR TITLE
chore(release): Add publishConfig to package.jsons

### DIFF
--- a/packages/adapters/fastify/web/package.json
+++ b/packages/adapters/fastify/web/package.json
@@ -34,5 +34,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -138,5 +138,8 @@
       "optional": true
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -125,5 +125,8 @@
       "optional": true
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/auth0/api/package.json
+++ b/packages/auth-providers/auth0/api/package.json
@@ -53,5 +53,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/auth0/setup/package.json
+++ b/packages/auth-providers/auth0/setup/package.json
@@ -51,5 +51,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/auth0/web/package.json
+++ b/packages/auth-providers/auth0/web/package.json
@@ -65,5 +65,8 @@
   "peerDependencies": {
     "@auth0/auth0-spa-js": "2.3.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/azureActiveDirectory/api/package.json
+++ b/packages/auth-providers/azureActiveDirectory/api/package.json
@@ -54,5 +54,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/azureActiveDirectory/setup/package.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/package.json
@@ -51,5 +51,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/azureActiveDirectory/web/package.json
+++ b/packages/auth-providers/azureActiveDirectory/web/package.json
@@ -66,5 +66,8 @@
   "peerDependencies": {
     "@azure/msal-browser": "2.39.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/clerk/api/package.json
+++ b/packages/auth-providers/clerk/api/package.json
@@ -52,5 +52,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/clerk/setup/package.json
+++ b/packages/auth-providers/clerk/setup/package.json
@@ -48,5 +48,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/clerk/web/package.json
+++ b/packages/auth-providers/clerk/web/package.json
@@ -66,5 +66,8 @@
   "peerDependencies": {
     "@clerk/clerk-react": "5.43.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/custom/setup/package.json
+++ b/packages/auth-providers/custom/setup/package.json
@@ -51,5 +51,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/dbAuth/api/package.json
+++ b/packages/auth-providers/dbAuth/api/package.json
@@ -75,5 +75,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -53,5 +53,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -40,5 +40,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -55,5 +55,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/firebase/api/package.json
+++ b/packages/auth-providers/firebase/api/package.json
@@ -52,5 +52,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/firebase/setup/package.json
+++ b/packages/auth-providers/firebase/setup/package.json
@@ -51,5 +51,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/firebase/web/package.json
+++ b/packages/auth-providers/firebase/web/package.json
@@ -65,5 +65,8 @@
   "peerDependencies": {
     "firebase": "10.14.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/netlify/api/package.json
+++ b/packages/auth-providers/netlify/api/package.json
@@ -53,5 +53,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/netlify/setup/package.json
+++ b/packages/auth-providers/netlify/setup/package.json
@@ -51,5 +51,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/netlify/web/package.json
+++ b/packages/auth-providers/netlify/web/package.json
@@ -65,5 +65,8 @@
   "peerDependencies": {
     "netlify-identity-widget": "1.9.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/supabase/api/package.json
+++ b/packages/auth-providers/supabase/api/package.json
@@ -54,5 +54,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/supabase/middleware/package.json
+++ b/packages/auth-providers/supabase/middleware/package.json
@@ -56,5 +56,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/supabase/setup/package.json
+++ b/packages/auth-providers/supabase/setup/package.json
@@ -48,5 +48,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/supabase/web/package.json
+++ b/packages/auth-providers/supabase/web/package.json
@@ -66,5 +66,8 @@
   "peerDependencies": {
     "@supabase/supabase-js": "2.45.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/supertokens/api/package.json
+++ b/packages/auth-providers/supertokens/api/package.json
@@ -56,5 +56,8 @@
   "peerDependencies": {
     "supertokens-node": "15.2.3"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/supertokens/setup/package.json
+++ b/packages/auth-providers/supertokens/setup/package.json
@@ -52,5 +52,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/supertokens/web/package.json
+++ b/packages/auth-providers/supertokens/web/package.json
@@ -65,5 +65,8 @@
   "peerDependencies": {
     "supertokens-auth-react": "0.39.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -103,5 +103,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -54,5 +54,8 @@
     "tsx": "4.20.4",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -85,5 +85,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -46,5 +46,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/cli-packages/storybook-vite/package.json
+++ b/packages/cli-packages/storybook-vite/package.json
@@ -41,5 +41,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -99,5 +99,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -60,5 +60,8 @@
     "tsx": "4.20.4",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -64,5 +64,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/cookie-jar/package.json
+++ b/packages/cookie-jar/package.json
@@ -35,5 +35,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,5 +65,8 @@
     "publint": "0.3.12",
     "tsx": "4.20.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/create-cedar-app/package.json
+++ b/packages/create-cedar-app/package.json
@@ -51,5 +51,8 @@
     "vitest": "3.2.4",
     "yargs": "17.7.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/create-cedar-app/package.json
+++ b/packages/create-cedar-app/package.json
@@ -51,8 +51,5 @@
     "vitest": "3.2.4",
     "yargs": "17.7.2"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -37,5 +37,8 @@
     "@babel/cli": "7.27.2",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -35,5 +35,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -58,5 +58,8 @@
   "peerDependencies": {
     "react": "19.0.0-rc-f2df5694-20240916"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -79,5 +79,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -184,5 +184,8 @@
     "tsx": "4.20.4",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -51,5 +51,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2",
     "vitest": "3.2.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/mailer/core/package.json
+++ b/packages/mailer/core/package.json
@@ -28,5 +28,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/mailer/handlers/in-memory/package.json
+++ b/packages/mailer/handlers/in-memory/package.json
@@ -27,5 +27,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/mailer/handlers/nodemailer/package.json
+++ b/packages/mailer/handlers/nodemailer/package.json
@@ -29,5 +29,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/mailer/handlers/resend/package.json
+++ b/packages/mailer/handlers/resend/package.json
@@ -28,5 +28,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/mailer/handlers/studio/package.json
+++ b/packages/mailer/handlers/studio/package.json
@@ -29,5 +29,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/mailer/renderers/mjml-react/package.json
+++ b/packages/mailer/renderers/mjml-react/package.json
@@ -30,5 +30,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/mailer/renderers/react-email/package.json
+++ b/packages/mailer/renderers/react-email/package.json
@@ -28,5 +28,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -58,5 +58,8 @@
     "vite": "5.4.19",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -109,6 +109,9 @@
     "react": "19.0.0-rc-f2df5694-20240916",
     "react-dom": "19.0.0-rc-f2df5694-20240916"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "externals": {
     "react": "react",
     "react-dom": "react-dom"

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -51,5 +51,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -52,5 +52,8 @@
       "optional": true
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -42,5 +42,8 @@
     "tsx": "4.20.4",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -121,5 +121,8 @@
     "react": "19.0.0-rc-f2df5694-20240916",
     "react-dom": "19.0.0-rc-f2df5694-20240916"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/server-store/package.json
+++ b/packages/server-store/package.json
@@ -34,5 +34,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -70,5 +70,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -60,5 +60,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -38,5 +38,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -163,5 +163,8 @@
       "optional": true
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -30,5 +30,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -115,5 +115,8 @@
     "typescript": "5.6.2",
     "vitest": "3.2.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -38,5 +38,8 @@
     "tsx": "4.20.4",
     "typescript": "5.6.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -188,5 +188,8 @@
     "react": "19.0.0-rc-f2df5694-20240916",
     "react-dom": "19.0.0-rc-f2df5694-20240916"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }


### PR DESCRIPTION
Already had this on the `next` branch. No reason not to have it on `main` as well. I want the two branches to be as similar as possible