### PR TITLE
feat(ccdra): Support different engines for different templates

### DIFF
--- a/packages/create-cedar-app/src/create-cedar-app.js
+++ b/packages/create-cedar-app/src/create-cedar-app.js
@@ -167,8 +167,8 @@ async function executeCompatibilityCheck(templateDir) {
 }
 
 /**
- *
- * This type has to be updated if the engines field in the create redwood app template package.json is updated.
+ * This type has to be updated if the engines field in the create cedar app
+ * template package.json is updated.
  * @returns [boolean, Record<'node' | 'yarn', any>]
  */
 function checkNodeVersion(templateDir) {
@@ -760,9 +760,6 @@ async function createRedwoodApp() {
 
   const templatesDir = fileURLToPath(new URL('../templates', import.meta.url))
 
-  // Engine check
-  await executeCompatibilityCheck(path.join(templatesDir, 'ts'))
-
   targetDir = await handleTargetDirPreference(targetDir)
 
   // Determine ts/js preference
@@ -777,6 +774,9 @@ async function createRedwoodApp() {
     templatesDir,
     useTypescript ? (useEsm ? 'esm-ts' : 'ts') : useEsm ? 'esm-js' : 'js',
   )
+
+  // Engine check
+  await executeCompatibilityCheck(templateDir)
 
   // Determine git preference
   const useGit = await handleGitPreference(gitInitFlag)

--- a/packages/create-cedar-app/templates/esm-js/package.json
+++ b/packages/create-cedar-app/templates/esm-js/package.json
@@ -18,7 +18,7 @@
     "root": true
   },
   "engines": {
-    "node": "=20.x"
+    "node": ">=20.19 < 21"
   },
   "prisma": {
     "seed": "yarn rw exec seed"

--- a/packages/create-cedar-app/templates/esm-ts/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/package.json
@@ -18,7 +18,7 @@
     "root": true
   },
   "engines": {
-    "node": "=20.x"
+    "node": ">=20.19 < 21"
   },
   "prisma": {
     "seed": "yarn rw exec seed"


### PR DESCRIPTION
This is more of an internal feature than a user-facing feature, so I'm releasing this in a patch version

Prior to this change the engine (node version) check that we do in create-cedar-app only/always looked at the range specified in the TS template. Now, with this PR, we look at the range for the specific template the user wants to install