### PR TITLE
chore(testing): Debug yarn pack issue - disable cache

### DIFF
--- a/.github/actions/set-up-test-project/setUpTestProject.mjs
+++ b/.github/actions/set-up-test-project/setUpTestProject.mjs
@@ -28,13 +28,11 @@ console.log()
  * @returns {Promise<void>}
  */
 async function main() {
-  await setUpTestProject({
-    canary: true,
-  })
+  await setUpTestProject({ canary: true })
 }
 
 /**
- *  *@param {{canary: boolean}} options
+ * @param {{ canary: boolean }} options
  * @returns {Promise<void>}
  */
 async function setUpTestProject({ canary }) {

--- a/tasks/framework-tools/tarsync/bin.mts
+++ b/tasks/framework-tools/tarsync/bin.mts
@@ -8,13 +8,7 @@ import { tarsync } from './tarsync.mjs'
 async function main() {
   const { projectPath, watch, verbose } = await getOptions()
 
-  await tarsync(
-    {
-      projectPath,
-      verbose,
-    },
-    'CLI invocation',
-  )
+  await tarsync({ projectPath, verbose }, 'CLI invocation')
 
   if (!watch) {
     return

--- a/tasks/framework-tools/tarsync/lib.mts
+++ b/tasks/framework-tools/tarsync/lib.mts
@@ -98,7 +98,7 @@ export async function getOptions(): Promise<Options> {
 }
 
 export async function buildTarballs() {
-  await $`yarn nx run-many -t build:pack --exclude create-cedar-app`
+  await $`yarn nx run-many -t build:pack --exclude create-cedar-app --skipNxCache --skipRemoteCache`
 }
 
 export async function moveTarballs(projectPath: string) {

--- a/tasks/framework-tools/tarsync/tarsync.mts
+++ b/tasks/framework-tools/tarsync/tarsync.mts
@@ -18,12 +18,9 @@ export async function tarsync(
   const verboseOutput = verbose || !isTTY
   $.verbose = verboseOutput
 
-  const outputManager = new OutputManager({
-    disabled: verboseOutput,
-  })
-  outputManager.start({
-    triggeredBy,
-  })
+  const outputManager = new OutputManager({ disabled: verboseOutput })
+
+  outputManager.start({ triggeredBy })
 
   cd(FRAMEWORK_PATH)
 


### PR DESCRIPTION
When setting up the test project in CI we run `yarn project:tarsync`, which in turn runs `yarn nx run-many -t build:pack`. nx is configured to have `build:pack` depend on `build`. So first it'll run `yarn build`, and then `yarn build:pack`.

I have `yarn build` setup to do some debug logging when building the `@cedarjs/testing` package. With this logging I have confirmed that the build step produces the expected files. For the next step, `yarn build:pack`, I've also added some debug logging by simply running `ls -la` before executing the actual command. And this output for some reason does *not* have some of the files listed at the end of the build step. And so things fail.

How can files disappear between the two steps? 