### PR TITLE
feat(auth): Optional lambda context

### DIFF
--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -110,7 +110,7 @@ export const getAuthenticationContext = async ({
 }: {
   authDecoder?: Decoder | Decoder[]
   event: APIGatewayProxyEvent | Request
-  context: LambdaContext
+  context?: LambdaContext
 }): Promise<undefined | AuthContextPayload> => {
   const cookieHeader = parseAuthorizationCookie(event)
   const typeFromHeader = getAuthProviderHeader(event)

--- a/packages/graphql-server/src/functions/__tests__/fixtures/auth.ts
+++ b/packages/graphql-server/src/functions/__tests__/fixtures/auth.ts
@@ -1,8 +1,5 @@
-import { parseJWT } from '@cedarjs/api'
+import { Decoded, parseJWT } from '@cedarjs/api'
 import { AuthenticationError, ForbiddenError } from '@cedarjs/graphql-server'
-import type { APIGatewayEvent } from 'aws-lambda'
-
-interface Context extends Record<string, any> {}
 
 import { context } from '@cedarjs/context'
 
@@ -18,9 +15,15 @@ type RedwoodUser = Record<string, unknown> & { roles?: string[] }
  * if the user is authenticated or has role-based access
  *
  * @param decoded - The decoded access token containing user info and JWT claims like `sub`. Note could be null.
- * @param { token, SupportedAuthTypes type } - The access token itself as well as the auth provider type
- * @param { APIGatewayEvent event, Context context } - An object which contains information from the invoker
- * such as headers and cookies, and the context information about the invocation such as IP Address
+ * @param authInfo
+ * @param authInfo.token - The access token itself
+ * @param authInfo.type - The auth provider type
+ * @param req - An object which contains information from the invoker such as
+ * headers and cookies, and the context information about the invocation such as
+ * IP Address
+ * @param req.event - Standard API Gateway event object that's compatible with
+ * AWS Lambda
+ * @param req.context - AWS Lambda context object
  *
  * !! BEWARE !! Anything returned from this function will be available to the
  * client--it becomes the content of `currentUser` on the web side (as well as
@@ -33,11 +36,8 @@ type RedwoodUser = Record<string, unknown> & { roles?: string[] }
  * @returns RedwoodUser
  */
 export const getCurrentUser = async (
-  decoded,
-  /* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-  { token, type },
-  /* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-  req?: { event: APIGatewayEvent, context: Context }
+  decoded: Decoded,
+  { token: _token, type: _type }: { token: string; type: string },
 ): Promise<RedwoodUser | null> => {
   if (!decoded) {
     return null

--- a/packages/graphql-server/src/functions/__tests__/useRequireAuth.test.ts
+++ b/packages/graphql-server/src/functions/__tests__/useRequireAuth.test.ts
@@ -61,7 +61,7 @@ export const mockedAuthenticationEvent = ({
 
 const handler = async (
   _event: APIGatewayEvent,
-  _context: Context,
+  _context?: Context,
 ): Promise<any> => {
   // @MARK
   // Don't use globalContext until beforeAll runs
@@ -142,8 +142,8 @@ const handlerWithError = async (
 }
 
 const getCurrentUserWithError = async (
-  _decoded,
-  { token: _token },
+  _decoded: unknown,
+  { token: _token }: { token: string },
 ): Promise<RedwoodUser> => {
   throw Error('Something went wrong getting the user info')
 }
@@ -163,7 +163,7 @@ describe('useRequireAuth', () => {
       authDecoder: async (
         token: string,
         _type: string,
-        _req: { event: APIGatewayEvent; context: Context },
+        _req: { event: APIGatewayEvent; context?: Context },
       ) => {
         return { token }
       },
@@ -197,7 +197,7 @@ describe('useRequireAuth', () => {
       authDecoder: async (
         token: string,
         _type: string,
-        _req: { event: APIGatewayEvent; context: Context },
+        _req: { event: APIGatewayEvent; context?: Context },
       ) => {
         return jwt.decode(token) as Record<string, any>
       },

--- a/packages/graphql-server/src/functions/useRequireAuth.ts
+++ b/packages/graphql-server/src/functions/useRequireAuth.ts
@@ -12,7 +12,7 @@ interface Args {
   authDecoder?: Decoder | Decoder[]
   handlerFn: (
     event: APIGatewayEvent,
-    context: LambdaContext,
+    context?: LambdaContext,
     ...others: any
   ) => any
   getCurrentUser?: GetCurrentUser
@@ -23,7 +23,7 @@ export type UseRequireAuth = (
   args: Args,
 ) => (
   event: APIGatewayEvent,
-  context: LambdaContext,
+  context?: LambdaContext,
   ...rest: any
 ) => Promise<ReturnType<Args['handlerFn']>>
 
@@ -34,7 +34,7 @@ export const useRequireAuth: UseRequireAuth = ({
 }) => {
   return async (
     event: APIGatewayEvent,
-    context: LambdaContext,
+    context?: LambdaContext,
     ...rest: any
   ) => {
     const authEnrichedFunction = async () => {


### PR DESCRIPTION
auth handlers often don't care about the lambda context. And looking at `packages/api/src/auth/index.ts` `context` was already optional in a lot of places. This PR just continues that by making the context optional in more places. This makes it easier to implement auth related functionality without getting TypeScript errors when you don't pass a context.