### PR TITLE
fix(web): Fix TS strict mode error in App.tsx

### DIFF
--- a/packages/web/src/components/DevFatalErrorPage.tsx
+++ b/packages/web/src/components/DevFatalErrorPage.tsx
@@ -38,7 +38,7 @@ interface EnhancedGqlError extends GraphQLError {
 // Allow APIs client to attach response/request
 type ErrorWithRequestMeta = Error & {
   mostRecentRequest?: RequestDetails
-  graphQLErrors: EnhancedGqlError[]
+  graphQLErrors?: EnhancedGqlError[]
   mostRecentResponse?: any
 }
 


### PR DESCRIPTION
If you enable strict mode in your TS config for the web side you'd see this in `App.tsx`

<img width="405" height="121" alt="image" src="https://github.com/user-attachments/assets/572d830c-e357-4b57-8655-9df1a750fb82" />

The error is:

```
No overload matches this call.
Overload 1 of 2, '(props: PropsFatalErrorBoundary): FatalErrorBoundary', gave the following error.
Type '(props: { error?: ErrorWithRequestMeta | undefined; }) => Element' is not assignable to type 'ComponentType<{ error?: Error | undefined; }>'.
Type '(props: { error?: ErrorWithRequestMeta | undefined; }) => Element' is not assignable to type 'FunctionComponent<{ error?: Error | undefined; }>'.
Types of parameters 'props' and 'props' are incompatible.
Type '{ error?: Error | undefined; }' is not assignable to type '{ error?: ErrorWithRequestMeta | undefined; }'.
Types of property 'error' are incompatible.
Type 'Error | undefined' is not assignable to type 'ErrorWithRequestMeta | undefined'.
Type 'Error' is not assignable to type 'ErrorWithRequestMeta'.
Property 'graphQLErrors' is missing in type 'Error' but required in type '{ mostRecentRequest?: RequestDetails | undefined; graphQLErrors: EnhancedGqlError[]; mostRecentResponse?: any; }'.
Overload 2 of 2, '(props: PropsFatalErrorBoundary, context: any): FatalErrorBoundary', gave the following error.
Type '(props: { error?: ErrorWithRequestMeta | undefined; }) => Element' is not assignable to type 'ComponentType<{ error?: Error | undefined; }>'.
Type '(props: { error?: ErrorWithRequestMeta | undefined; }) => Element' is not assignable to type 'FunctionComponent<{ error?: Error | undefined; }>'.
Types of parameters 'props' and 'props' are incompatible.
Type '{ error?: Error | undefined; }' is not assignable to type '{ error?: ErrorWithRequestMeta | undefined; }'.
Types of property 'error' are incompatible.
Type 'Error | undefined' is not assignable to type 'ErrorWithRequestMeta | undefined'.
Type 'Error' is not assignable to type 'ErrorWithRequestMeta'.
Property 'graphQLErrors' is missing in type 'Error' but required in type '{ mostRecentRequest?: RequestDetails | undefined; graphQLErrors: EnhancedGqlError[]; mostRecentResponse?: any; }'. (ts 2769
```

And, as the case usually is, the relevant part is the last few lines:

```
Type 'Error' is not assignable to type 'ErrorWithRequestMeta'.
Property 'graphQLErrors' is missing in type 'Error' but required in type '
{
  mostRecentRequest?: RequestDetails | undefined;
  graphQLErrors: EnhancedGqlError[];
  mostRecentResponse?: any;
}
'.
```

The fix is to just make `graphQLErrors` optional.
The code already handled it being undefined by optional chaining: `props.error.graphQLErrors?.find((gqlErr) => gqlErr.__RedwoodEnhancedError)`