### PR TITLE
fix(jobs): Fix the eslint command that's run when generating new jobs

### DIFF
--- a/packages/cli/src/commands/generate/job/jobHandler.js
+++ b/packages/cli/src/commands/generate/job/jobHandler.js
@@ -125,24 +125,26 @@ export const handler = async ({ name, force, ...rest }) => {
     // We don't care if this fails because we'll fall back to 'default'
   }
 
+  let jobFiles = {}
   const tasks = new Listr(
     [
       {
         title: 'Generating job files...',
         task: async () => {
-          const jobFiles = await files({ name, queueName, ...rest })
+          jobFiles = await files({ name, queueName, ...rest })
           return writeFilesTask(jobFiles, { overwriteExisting: force })
         },
       },
       {
         title: 'Cleaning up...',
         task: () => {
-          execa.commandSync('yarn', [
+          execa.sync('yarn', [
             'eslint',
             '--fix',
             '--config',
             `${getPaths().base}/node_modules/@cedarjs/eslint-config/shared.js`,
             `${getPaths().api.jobsConfig}`,
+            ...Object.keys(jobFiles),
           ])
         },
       },


### PR DESCRIPTION
Properly use eslint to format all generated files when running `yarn cedarjs g job NewJobName`