### PR TITLE
chore(dbAuth): Await vitest expect promise

### DIFF
--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.fetch.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.fetch.test.js
@@ -2690,9 +2690,9 @@ describe('dbAuth', () => {
       const dbAuth = new DbAuthHandler(req, context, options)
       await dbAuth.init()
 
-      expect(async () => {
-        await dbAuth._validateCsrf()
-      }).rejects.toThrow(dbAuthError.CsrfTokenMismatchError)
+      await expect(dbAuth._validateCsrf()).rejects.toThrow(
+        dbAuthError.CsrfTokenMismatchError,
+      )
     })
   })
 

--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
@@ -2502,9 +2502,9 @@ describe('dbAuth', () => {
       const dbAuth = new DbAuthHandler(event, context, options)
       await dbAuth.init()
 
-      expect(async () => {
-        await dbAuth._validateCsrf()
-      }).rejects.toThrow(dbAuthError.CsrfTokenMismatchError)
+      await expect(dbAuth._validateCsrf()).rejects.toThrow(
+        dbAuthError.CsrfTokenMismatchError,
+      )
     })
   })
 


### PR DESCRIPTION
Preventing error logs like these
```
Promise returned by `expect(actual).rejects.toThrow(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
    at /Users/tobbe/dev/cedarjs/cedar/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.fetch.test.js:2693:36
```