### PR TITLE
feat(cli): Add format option to lint command

### DIFF
--- a/packages/cli/src/commands/lint.js
+++ b/packages/cli/src/commands/lint.js
@@ -23,7 +23,7 @@ export const builder = (yargs) => {
     })
     .option('format', {
       default: 'stylish',
-      description: 'Use a specific output format - default: stylish',
+      description: 'Use a specific output format',
       type: 'string',
     })
     .epilogue(

--- a/packages/cli/src/commands/lint.js
+++ b/packages/cli/src/commands/lint.js
@@ -35,10 +35,7 @@ export const builder = (yargs) => {
 }
 
 export const handler = async ({ path, fix, format }) => {
-  recordTelemetryAttributes({
-    command: 'lint',
-    fix,
-  })
+  recordTelemetryAttributes({ command: 'lint', fix, format })
 
   try {
     const pathString = path?.join(' ')

--- a/packages/cli/src/commands/lint.js
+++ b/packages/cli/src/commands/lint.js
@@ -1,5 +1,6 @@
+import fs from 'node:fs'
+
 import execa from 'execa'
-import fs from 'fs-extra'
 import { terminalLink } from 'termi-link'
 
 import { recordTelemetryAttributes } from '@cedarjs/cli-helpers'
@@ -20,6 +21,11 @@ export const builder = (yargs) => {
       description: 'Try to fix errors',
       type: 'boolean',
     })
+    .option('format', {
+      default: 'stylish',
+      description: 'Use a specific output format - default: stylish',
+      type: 'string',
+    })
     .epilogue(
       `Also see the ${terminalLink(
         'CedarJS CLI Reference',
@@ -28,7 +34,7 @@ export const builder = (yargs) => {
     )
 }
 
-export const handler = async ({ path, fix }) => {
+export const handler = async ({ path, fix, format }) => {
   recordTelemetryAttributes({
     command: 'lint',
     fix,
@@ -36,15 +42,15 @@ export const handler = async ({ path, fix }) => {
 
   try {
     const pathString = path?.join(' ')
+    const sbPath = getPaths().web.storybook
     const result = await execa(
       'yarn eslint',
       [
         fix && '--fix',
+        `--format ${format}`,
         !pathString && fs.existsSync(getPaths().web.src) && 'web/src',
         !pathString && fs.existsSync(getPaths().web.config) && 'web/config',
-        !pathString &&
-          fs.existsSync(getPaths().web.storybook) &&
-          'web/.storybook',
+        !pathString && fs.existsSync(sbPath) && 'web/.storybook',
         !pathString && fs.existsSync(getPaths().scripts) && 'scripts',
         !pathString && fs.existsSync(getPaths().api.src) && 'api/src',
         pathString,


### PR DESCRIPTION
Adds support for `--format`, allowing you to pass a formatter for eslint to use

Fixes https://github.com/cedarjs/cedar/issues/451