### PR TITLE
chore(nx): Fix TS error in debug tooling

### DIFF
--- a/tasks/framework-tools/tarsync/debug-task-scheduling.mts
+++ b/tasks/framework-tools/tarsync/debug-task-scheduling.mts
@@ -130,7 +130,10 @@ class TaskSchedulingDebugger {
       this.parseNxOutput(combinedOutput, captureStart)
     } catch (error) {
       // Even if the build fails, we want to analyze what happened
-      const errorOutput = error.stdout + '\n' + error.stderr
+      const errorOutput =
+        (error as { stdout?: string }).stdout +
+        '\n' +
+        (error as { stderr?: string }).stderr
       this.executionLog.push(`ERROR: ${errorOutput}`)
       this.parseNxOutput(errorOutput, captureStart)
     }


### PR DESCRIPTION
Typecasting to get rid of TS error. It's just for the error reporting, so this is good enough for now. If I need better errors I'll come back to this later