### PR TITLE
feat(esm): Update templates to use extensionless aliased imports

### DIFF
--- a/__fixtures__/test-project/api/src/functions/auth.ts
+++ b/__fixtures__/test-project/api/src/functions/auth.ts
@@ -3,8 +3,8 @@ import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 import { DbAuthHandler } from '@cedarjs/auth-dbauth-api'
 import type { DbAuthHandlerOptions, UserType } from '@cedarjs/auth-dbauth-api'
 
-import { cookieName } from 'src/lib/auth.js'
-import { db } from 'src/lib/db.js'
+import { cookieName } from 'src/lib/auth'
+import { db } from 'src/lib/db'
 
 export const handler = async (
   event: APIGatewayProxyEvent,

--- a/__fixtures__/test-project/api/src/functions/graphql.ts
+++ b/__fixtures__/test-project/api/src/functions/graphql.ts
@@ -5,9 +5,9 @@ import directives from 'src/directives/**/*.{js,ts}'
 import sdls from 'src/graphql/**/*.sdl.{js,ts}'
 import services from 'src/services/**/*.{js,ts}'
 
-import { cookieName, getCurrentUser } from 'src/lib/auth.js'
-import { db } from 'src/lib/db.js'
-import { logger } from 'src/lib/logger.js'
+import { cookieName, getCurrentUser } from 'src/lib/auth'
+import { db } from 'src/lib/db'
+import { logger } from 'src/lib/logger'
 
 const authDecoder = createAuthDecoder(cookieName)
 

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.ts.template
@@ -3,8 +3,8 @@ import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 import { DbAuthHandler } from '@cedarjs/auth-dbauth-api'
 import type { DbAuthHandlerOptions, UserType } from '@cedarjs/auth-dbauth-api'
 
-import { cookieName } from 'src/lib/auth.js'
-import { db } from 'src/lib/db.js'
+import { cookieName } from 'src/lib/auth'
+import { db } from 'src/lib/db'
 
 export const handler = async (
   event: APIGatewayProxyEvent,

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.webAuthn.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.webAuthn.ts.template
@@ -3,8 +3,8 @@ import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 import { DbAuthHandler } from '@cedarjs/auth-providers-api/dist/dbAuth'
 import type { DbAuthHandlerOptions, UserType } from '@cedarjs/auth-dbauth-api'
 
-import { cookieName } from 'src/lib/auth.js'
-import { db } from 'src/lib/db.js'
+import { cookieName } from 'src/lib/auth'
+import { db } from 'src/lib/db'
 
 export const handler = async (
   event: APIGatewayProxyEvent,

--- a/packages/create-cedar-app/templates/ts/api/src/directives/requireAuth/requireAuth.ts
+++ b/packages/create-cedar-app/templates/ts/api/src/directives/requireAuth/requireAuth.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag'
 import type { ValidatorDirectiveFunc } from '@cedarjs/graphql-server'
 import { createValidatorDirective } from '@cedarjs/graphql-server'
 
-import { requireAuth as applicationRequireAuth } from 'src/lib/auth.js'
+import { requireAuth as applicationRequireAuth } from 'src/lib/auth'
 
 export const schema = gql`
   """

--- a/packages/create-cedar-app/templates/ts/api/src/functions/graphql.ts
+++ b/packages/create-cedar-app/templates/ts/api/src/functions/graphql.ts
@@ -4,8 +4,8 @@ import directives from 'src/directives/**/*.{js,ts}'
 import sdls from 'src/graphql/**/*.sdl.{js,ts}'
 import services from 'src/services/**/*.{js,ts}'
 
-import { db } from 'src/lib/db.js'
-import { logger } from 'src/lib/logger.js'
+import { db } from 'src/lib/db'
+import { logger } from 'src/lib/logger'
 
 export const handler = createGraphQLHandler({
   loggerConfig: { logger, options: {} },


### PR DESCRIPTION
Continuation of the work started in #463. Use imports like `import { db } from 'src/lib/db'`.