### PR TITLE
docs(quick-start): Mention cdr in tip admonition

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -34,7 +34,7 @@ Then change into that directory, yarn install, and start the development server:
 ```
 cd my-cedar-project
 yarn install
-yarn cdr dev
+yarn cedarjs dev
 ```
 
 Your browser should automatically open to [http://localhost:8910](http://localhost:8910) where you'll see the Welcome Page, which links out to many great resources:
@@ -48,7 +48,7 @@ From dev to deploy, the CLI is with you the whole way.
 And there's quite a few commands at your disposal:
 
 ```
-yarn cdr --help
+yarn cedarjs --help
 ```
 
 For all the details, see the [CLI reference](cli-commands.md).
@@ -81,7 +81,7 @@ defining your app's data models. And Prisma
 migrations hassle-free:
 
 ```
-yarn cdr prisma migrate dev
+yarn cedarjs prisma migrate dev
 
 # ...
 
@@ -90,7 +90,14 @@ yarn cdr prisma migrate dev
 
 :::tip
 
-`rw` is short for `redwood`
+If you feel `cedarjs` is too long to type out all the time, you can use `cdr` as
+an alias:
+
+```
+yarn cdr prisma migrate dev
+yarn cdr dev
+# etc
+```
 
 :::
 
@@ -99,14 +106,14 @@ You'll be prompted for the name of your migration. `create posts` will do.
 Now let's generate everything we need to perform all the CRUD (Create, Retrieve, Update, Delete) actions on our `Post` model:
 
 ```
-yarn cdr generate scaffold post
+yarn cedarjs generate scaffold post
 ```
 
 Navigate to [http://localhost:8910/posts/new](http://localhost:8910/posts/new), fill in the title and body, and click "Save":
 
 <img src="https://user-images.githubusercontent.com/300/73028004-72262c00-3de9-11ea-8924-66d1cc1fceb6.png" alt="Create a new post" />
 
-Did we just create a post in the database? Yup! With `yarn cdr generate scaffold <model>`, Cedar created all the pages, components, and services necessary to perform all CRUD actions on our posts table.
+Did we just create a post in the database? Yup! With `yarn cedarjs generate scaffold <model>`, Cedar created all the pages, components, and services necessary to perform all CRUD actions on our posts table.
 
 ## Frontend first with Storybook
 
@@ -115,7 +122,7 @@ That's more than ok — Cedar integrates Storybook so that you can work on desig
 Mockup, build, and verify your React components, even in complete isolation from the backend:
 
 ```
-yarn cdr storybook
+yarn cedarjs storybook
 ```
 
 Seeing "Couldn't find any stories"?
@@ -123,7 +130,7 @@ That's because you need a `*.stories.{tsx,jsx}` file.
 The CedarJS CLI makes getting one easy enough — try generating a [Cell](./cells), CedarJS's data-fetching abstraction:
 
 ```
-yarn cdr generate cell examplePosts
+yarn cedarjs generate cell examplePosts
 ```
 
 The Storybook server should hot reload and now you'll have four stories to work with.
@@ -131,7 +138,7 @@ They'll probably look a little bland since there's no styling.
 See if the CedarJS CLI's `setup ui` command has your favorite styling library:
 
 ```
-yarn cdr setup ui --help
+yarn cedarjs setup ui --help
 ```
 
 ## Testing with Vitest
@@ -140,7 +147,7 @@ It'd be hard to scale from side project to startup without a few tests.
 Cedar fully integrates Vitest with both the front- and back-ends, and makes it easy to keep your whole app covered by generating test files with all your components and services:
 
 ```
-yarn cdr test
+yarn cedarjs test
 ```
 
 To make the integration even more seamless, CedarJS augments Vitest with database [scenarios](testing.md#scenarios) and [GraphQL mocking](testing.md#mocking-graphql-calls).
@@ -150,7 +157,7 @@ To make the integration even more seamless, CedarJS augments Vitest with databas
 CedarJS is designed for both serverless deploy targets like Netlify and Vercel and serverful deploy targets like Render and AWS:
 
 ```
-yarn cdr setup deploy --help
+yarn cedarjs setup deploy --help
 ```
 
 Don't go live without auth!
@@ -158,7 +165,7 @@ Lock down your app with CedarJS's built-in, database-backed authentication syste
 the most popular third-party auth providers:
 
 ```
-yarn cdr setup auth --help
+yarn cedarjs setup auth --help
 ```
 
 ## Next Steps


### PR DESCRIPTION
Now that #473 added `cdr` as a bin name I'm also updating the quick start guide to use this new bin name.

*EDIT:* Starting to second-guess myself as I write this... I really like my own setup where I have `cedar` as an alias for `yarn cedarjs`. Maybe I should spike on adding that to the create-cedar-app setup process... I'll leave this as a draft for now

*EDIT 2:* Staying with `cedarjs` for now, but updating the "tip" admonition to mention `cdr`