### PR TITLE
fix(storybook): Add package.json keyword for Storybook's addon catalog

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -4,7 +4,9 @@
   "description": "Storybook for CedarJS",
   "keywords": [
     "Storybook",
+    "storybook-addon",
     "Cedar",
+    "CedarJS",
     "React",
     "Vite"
   ],


### PR DESCRIPTION
Adding the `storybook-addon` keyword needed for the package to be picked up by Storybook's automatic tooling, as pointed out in #489 