### PR TITLE
chore(lefthook): No NX tui when building

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@ pre-push:
     - ref: next
     - ref: release/*
   jobs:
-    - run: yarn build
+    - run: NX_TUI=false yarn build
     - run: yarn lint
     - run: yarn prettier --check --log-level=silent .
     - run: yarn check


### PR DESCRIPTION
After the upgrade to NX v22 in #503 I started seeing this in the console when running `git push`

<img width="438" height="171" alt="image" src="https://github.com/user-attachments/assets/37ed5407-c737-442f-8e82-6ebe0f3cc0fd" />

NX has introduced a new default TUI that seems to leak terminal control characters/codes when used in lefthook the way I use it. So I turn of the new TUI there.