### PR TITLE
feat(storybook): Node 24 and ESM compatibility

### DIFF
--- a/packages/storybook/src/preset.ts
+++ b/packages/storybook/src/preset.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import type { PresetProperty } from '@storybook/types'
@@ -12,8 +13,14 @@ import { mockRouter } from './plugins/mock-router.js'
 import { reactDocgen } from './plugins/react-docgen.js'
 import type { StorybookConfig } from './types.js'
 
-const getAbsolutePath = (input: string) =>
-  path.dirname(require.resolve(path.join(input, 'package.json')))
+function getAbsolutePath(input: string) {
+  const createdRequire = createRequire(import.meta.url)
+  return path.dirname(
+    createdRequire.resolve(path.join(input, 'package.json'), {
+      paths: [getPaths().base],
+    }),
+  )
+}
 
 export const core: PresetProperty<'core'> = {
   builder: getAbsolutePath('@storybook/builder-vite'),
@@ -23,7 +30,8 @@ export const core: PresetProperty<'core'> = {
 export const previewAnnotations: StorybookConfig['previewAnnotations'] = (
   entry,
 ) => {
-  return [...entry, require.resolve('./preview.js')]
+  const createdRequire = createRequire(import.meta.url)
+  return [...entry, createdRequire.resolve('./preview.js')]
 }
 
 const redwoodProjectPaths = getPaths()


### PR DESCRIPTION
Getting rid of `require()` usage to prep for Node 24 and ESM

Was specifically seeing this error when running Storybook

```
[WebServer] SB_CORE-SERVER_0002 (CriticalPresetLoadError): Storybook failed to load the following preset: storybook-framework-cedarjs/preset.
[WebServer] 
[WebServer] Please check whether your setup is correct, the Storybook dependencies (and their peer dependencies) are installed correctly and there are no package version clashes.
[WebServer] 
[WebServer] If you believe this is a bug, please open an issue on Github.
[WebServer] 
[WebServer] ReferenceError: require is not defined
[WebServer]     at getAbsolutePath (file://./node_modules/storybook-framework-cedarjs/dist/preset.js:9:49)
[WebServer]     at file://./node_modules/storybook-framework-cedarjs/dist/preset.js:11:12
[WebServer]     at ModuleJobSync.runSync (node:internal/modules/esm/module_job:514:37)
[WebServer]     at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:449:47)
[WebServer]     at loadESMFromCJS (node:internal/modules/cjs/loader:1577:24)
[WebServer]     at Module._compile (node:internal/modules/cjs/loader:1742:5)
[WebServer]     at node:internal/modules/cjs/loader:1893:10
[WebServer]     at Object.newLoader (./node_modules/esbuild-register/dist/node.js:2262:9)
[WebServer]     at extensions..js (./node_modules/esbuild-register/dist/node.js:4833:24)
[WebServer]     at Module.load (node:internal/modules/cjs/loader:1480:32)
[WebServer]     at loadPreset (./node_modules/@storybook/core-common/dist/index.js:15:82)
[WebServer] 
[WebServer] WARN[WebServer]  Broken build, fix the error above.
```