### PR TITLE
fix(vite): Special handling for auth requests in proxy server during startup

### DIFF
--- a/packages/vite/src/lib/getMergedConfig.ts
+++ b/packages/vite/src/lib/getMergedConfig.ts
@@ -94,7 +94,7 @@ export function getMergedConfig(rwConfig: Config, rwPaths: Paths) {
                 // This heuristic isn't perfect. It's written to handle dbAuth.
                 // But it's very unlikely the user would have code that does
                 // this exact request without it being a auth token request.
-                // We need this special handling because we don't the error
+                // We need this special handling because we don't want the error
                 // message below to be used as the auth token.
                 const isAuthTokenRequest =
                   isWaiting && req.url === '/auth?method=getToken'


### PR DESCRIPTION
Fixes this error:

```
Error: Failed to execute 'fetch' on 'Window': Failed to read the 'headers' property from 'RequestInit': String contains non ISO-8859-1 code point.
```

That would be seen if the user had dbAuth setup and a graphql request was made while the api server was still starting up.

The reason was that the error message contains a utf-8 character (⌛), and the message was sent as the auth token to the auth provider, which tried to set it as a header value. And utf-8 characters aren't allowed as header values.