### PR TITLE
fix(docs): 'cedar' instead of 'cedarjs' as the bin name

### DIFF
--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -7,7 +7,7 @@ services:
         # Ensure corepack is enabled in service environment
         corepack enable
         cd /workspaces/cdr-test-app
-        NODE_ENV=development corepack yarn cedarjs dev
+        NODE_ENV=development corepack yarn cedar dev
 
 tasks:
   setup-environment:

--- a/docs/docs/background-jobs.md
+++ b/docs/docs/background-jobs.md
@@ -377,7 +377,7 @@ that sort of thing. We call these recurring jobs.
 CedarJS's job system has native support for these kinds of jobs by specifying a
 `cron` schedule when scheduling a job. The easiest way to schedule a cron job
 locally is probably to have a script do it. So first generate a script:
-`yarn cedarjs generate script ScheduleCronJobs`. Then update the script to look
+`yarn cedar generate script ScheduleCronJobs`. Then update the script to look
 something like this:
 
 ```ts
@@ -392,7 +392,7 @@ export default async () => {
 ```
 
 Now you can just run that script and the job will be scheduled:
-`yarn cedarjs exec ScheduleCronJobs`
+`yarn cedar exec ScheduleCronJobs`
 
 CedarJS uses https://github.com/harrisiirak/cron-parser under the hood for
 parsing the `cron` schedule. So all the syntax supported by `cron-parser` is

--- a/docs/docs/realtime.md
+++ b/docs/docs/realtime.md
@@ -110,8 +110,8 @@ Regardless of the implementation chosen, **a stateful server and store are neede
 
 To setup realtime in an existing Cedar project, run the following commands:
 
-- `yarn cedarjs setup server-file`
-- `yarn cedarjs setup realtime`
+- `yarn cedar setup server-file`
+- `yarn cedar setup realtime`
 
 You'll get:
 

--- a/docs/docs/tutorial/chapter0/what-is-cedarjs.md
+++ b/docs/docs/tutorial/chapter0/what-is-cedarjs.md
@@ -21,7 +21,7 @@ One of the core principles behind CedarJS was that getting data from the backend
 
 A CedarJS app is actually two apps: a frontend (that's the React part) and a backend, which is your server and talks to a database and other third party systems. Your app is technically a monorepo with two top-level directories: `web` containing the frontend code and `api` containing the backend.
 
-You can start them both with a single command: `yarn cedarjs dev`
+You can start them both with a single command: `yarn cedar dev`
 
 ## The Frontend
 

--- a/docs/docs/tutorial/intermission.md
+++ b/docs/docs/tutorial/intermission.md
@@ -44,11 +44,11 @@ If you want to complete the tutorial in TypeScript, continue with your own repo,
 git clone https://github.com/cedarjs/cedar-tutorial
 cd cedar-tutorial
 yarn install
-yarn cedarjs prisma migrate dev
-yarn cedarjs g secret
+yarn cedar prisma migrate dev
+yarn cedar g secret
 ```
 
-That'll check out the repo, install all the dependencies, create your local database (SQLite) and fill it with a few blog posts. After that last command (`yarn cedarjs g secret`) you'll need to copy the string that's output and add it to a file `.env` in the root of your project:
+That'll check out the repo, install all the dependencies, create your local database (SQLite) and fill it with a few blog posts. After that last command (`yarn cedar g secret`) you'll need to copy the string that's output and add it to a file `.env` in the root of your project:
 
 ```bash title=".env"
 SESSION_SECRET=JV2kA48ZU4FnLHwqaydy9beJ99qy4VgWXPkvsaw3xE2LGyuSur2dVq2PsPkPfygr
@@ -56,7 +56,7 @@ SESSION_SECRET=JV2kA48ZU4FnLHwqaydy9beJ99qy4VgWXPkvsaw3xE2LGyuSur2dVq2PsPkPfygr
 
 This is the encryption key for the secure cookies used in [dbAuth](/docs/tutorial/chapter4/authentication#session-secret).
 
-Now just run `yarn cedarjs dev` to start your development server. Your browser should open to a fresh new blog app:
+Now just run `yarn cedar dev` to start your development server. Your browser should open to a fresh new blog app:
 
 ![image](https://user-images.githubusercontent.com/300/101423176-54e93780-38ad-11eb-9230-ba8557764eb4.png)
 

--- a/docs/implementation-docs/api-extensionless-imports.md
+++ b/docs/implementation-docs/api-extensionless-imports.md
@@ -9,7 +9,7 @@ First step was setting the correct tsconfig options:
 ```
 
 Next step was to decide if I wanted to fix `dev` or `build` first. I decided to
-go with `dev`. `yarn cedarjs dev` is handled by
+go with `dev`. `yarn cedar dev` is handled by
 `packages/cli/src/commands/devHandler.js`, which in turn calls
 `cedarjs-api-server-watch` for ESM projects. `cedarjs-api-server-watch` is the
 name I've given `packages/api-server/src/watch.ts` when it's built for ESM. (The

--- a/packages/cli/src/commands/experimental/util.js
+++ b/packages/cli/src/commands/experimental/util.js
@@ -67,7 +67,7 @@ export const isRealtimeSetup = () => {
   if (!realtimeExists()) {
     throw new Error(
       'Adding realtime events requires that CedarJS Realtime is setup. ' +
-        'Please run `yarn cedarjs setup realtime` first.',
+        'Please run `yarn cedar setup realtime` first.',
     )
   }
 

--- a/packages/cli/src/commands/generate/realtime/__tests__/realtimeHandler.test.ts
+++ b/packages/cli/src/commands/generate/realtime/__tests__/realtimeHandler.test.ts
@@ -108,7 +108,7 @@ describe('realtimeHandler', () => {
     expect(vi.mocked(console).error).toHaveBeenCalledWith(
       expect.stringMatching(
         'Adding realtime events requires that CedarJS Realtime is setup. ' +
-          'Please run `yarn cedarjs setup realtime` first.',
+          'Please run `yarn cedar setup realtime` first.',
       ),
     )
     expect(vi.mocked(process).exit).toHaveBeenCalledWith(1)

--- a/packages/create-cedar-app/README.md
+++ b/packages/create-cedar-app/README.md
@@ -28,7 +28,7 @@ CedarJS requires Node.js =20.x.
 yarn create cedar-app my-cedar-app
 cd my-cedar-app
 yarn install
-yarn cedarjs dev
+yarn cedar dev
 ```
 
 <h3>Resources</h3>


### PR DESCRIPTION
Align on advertising `yarn cedar` everywhere instead of `yarn cedarjs`.

Still a lot of `yarn rw` and `yarn redwood` to switch over