### PR TITLE
docs(auth): Fix syntax in Netlify Identity docs

### DIFF
--- a/docs/docs/auth/netlify.md
+++ b/docs/docs/auth/netlify.md
@@ -19,7 +19,7 @@ If this's a deal breaker for you, there are [other great auth providers to choos
 But here we'll assume it's not and that your app is already deployed.
 (If it isn't, do that first, then come back. And yes, there's a setup command for that: `yarn rw setup deploy netlify`.)
 
-Once you've deployed your app, go to its overview, click "Projects" in the nav on the side, click on the name of your project. You should now be at "app.netlify.com/projects/<name-of-your-app>/overview". Look for "Project configuration" on the side menu. Scroll down and find "Identity". Search for Netlify Identity, enable it, and copy the API endpoint in the Identity card.
+Once you've deployed your app, go to its overview, click "Projects" in the nav on the side, click on the name of your project. You should now be at `app.netlify.com/projects/<name-of-your-app>/overview`. Look for "Project configuration" on the side menu. Scroll down and find "Identity". Search for Netlify Identity, enable it, and copy the API endpoint in the Identity card.
 (It should look something like `https://my-redwood-app.netlify.app/.netlify/identity`.)
 
 Let's do one more thing while we're here to make signing up later a little easier.


### PR DESCRIPTION
Fix for this build error introduced in #532 

```
6:03:22 AM: [success] [webpackbar] Client: Compiled with some errors in 26.85s
6:03:22 AM: [ERROR] Client bundle compiled with errors therefore further build is impossible.
6:03:22 AM: Error: MDX compilation failed for file "/opt/build/repo/docs/docs/auth/netlify.md"
6:03:22 AM: Cause: Expected a closing tag for `<name-of-your-app>` (22:175-22:193) before the end of `paragraph`
6:03:22 AM: Details:
6:03:22 AM: {
6:03:22 AM:   "column": 1,
6:03:22 AM:   "message": "Expected a closing tag for `<name-of-your-app>` (22:175-22:193) before the end of `paragraph`",
6:03:22 AM:   "line": 22,
6:03:22 AM:   "name": "22:1-23:88",
6:03:22 AM:   "place": {
```