### PR TITLE
fix(cli): Remove cdr bin

### DIFF
--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -6,7 +6,7 @@ services:
       start: |
         # Ensure corepack is enabled in service environment
         corepack enable
-        cd /workspaces/cdr-test-app
+        cd /workspaces/cedar-test-app
         NODE_ENV=development corepack yarn cedar dev
 
 tasks:
@@ -19,7 +19,7 @@ tasks:
       export RWFW_PATH="/workspaces/cedar"
       export REDWOOD_DISABLE_TELEMETRY=1
       echo "Setting up CedarJS development environment..."
-      mkdir -p /workspaces/cdr-test-app
+      mkdir -p /workspaces/cedar-test-app
       cd /workspaces/cedar
       echo "Cleaning up existing symlinks and cache..."
       rm -rf node_modules/@cedarjs
@@ -29,10 +29,10 @@ tasks:
       echo "Installing framework dependencies..."
       corepack yarn install
       echo "Building test project..."
-      corepack yarn run build:test-project ../cdr-test-app --typescript --link --verbose
-      cd /workspaces/cdr-test-app
+      corepack yarn run build:test-project ../cedar-test-app --typescript --link --verbose
+      cd /workspaces/cedar-test-app
       sed -i "s/\(open *= *\).*/\1false/" redwood.toml
-      echo -e "\n\n\033[94m ======================================================\n\033[33m ⌛ CedarJS development environment is ready!\n Test app \"cdr-test-app\" has been generated & linked with framework code.\n\n If you make changes to the framework:\n 1. \033[33mEnsure env vars are set \033[92mexport RWFW_PATH=\"/workspaces/cedar\"\033[33m\n 2. \033[33mRun \033[92mcorepack yarn rwfw project:sync\033[33m to sync changes\n 3. \033[33mOr use the \033[92mSync Framework Changes\033[33m task from Ona dashboard\n\033[94m ======================================================\n\n"
+      echo -e "\n\n\033[94m ======================================================\n\033[33m ⌛ CedarJS development environment is ready!\n Test app \"cedar-test-app\" has been generated & linked with framework code.\n\n If you make changes to the framework:\n 1. \033[33mEnsure env vars are set \033[92mexport RWFW_PATH=\"/workspaces/cedar\"\033[33m\n 2. \033[33mRun \033[92mcorepack yarn rwfw project:sync\033[33m to sync changes\n 3. \033[33mOr use the \033[92mSync Framework Changes\033[33m task from Ona dashboard\n\033[94m ======================================================\n\n"
       # Open ports for CedarJS development servers
       echo "Opening ports for development servers..."
       gitpod environment port open 8910 --name "CedarJS Web Server" --protocol https
@@ -67,7 +67,7 @@ tasks:
       - manual
     command: |
       export RWFW_PATH="/workspaces/cedar"
-      cd /workspaces/cdr-test-app
+      cd /workspaces/cedar-test-app
       corepack yarn rwfw project:sync
       echo "Framework changes synced to test project"
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -64,7 +64,6 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "cdr": "./dist/cjs/bins/cedar.js",
     "cedar": "./dist/cjs/bins/cedar.js",
     "cedarjs": "./dist/cjs/bins/cedar.js",
     "redwood": "./dist/cjs/bins/redwood.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,6 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "cdr": "./dist/index.js",
     "cedarjs": "./dist/index.js",
     "redwood": "./dist/index.js",
     "rw": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,6 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "cdr": "./dist/bins/cedar.js",
     "cedar": "./dist/bins/cedar.js",
     "cedarjs": "./dist/bins/cedar.js",
     "cedarjs-api-server-watch": "./dist/bins/cedarjs-api-server-watch.js",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -114,7 +114,6 @@
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "cdr": "./dist/cjs/bins/cedar.js",
     "cedar": "./dist/cjs/bins/cedar.js",
     "cedarjs": "./dist/cjs/bins/cedar.js",
     "cross-env": "./dist/cjs/bins/cross-env.js",

--- a/tasks/e2e-background-jobs/run.mts
+++ b/tasks/e2e-background-jobs/run.mts
@@ -24,7 +24,7 @@ import {
 //     "name":"SampleJob",
 //     "path":"SampleJob/SampleJob",
 //     "args":[
-//       "/Users/tobbe/tmp/cdr-test-project-e2e-cron/BACKGROUND_JOB_TEST.txt",
+//       "/Users/tobbe/tmp/cedar-test-project-e2e-cron/BACKGROUND_JOB_TEST.txt",
 //       "0049550"
 //     ]
 //   }`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2641,7 +2641,6 @@ __metadata:
     redis:
       optional: true
   bin:
-    cdr: ./dist/cjs/bins/cedar.js
     cedar: ./dist/cjs/bins/cedar.js
     cedarjs: ./dist/cjs/bins/cedar.js
     redwood: ./dist/cjs/bins/redwood.js
@@ -3357,7 +3356,6 @@ __metadata:
     vitest: "npm:3.2.4"
     yargs: "npm:17.7.2"
   bin:
-    cdr: ./dist/index.js
     cedarjs: ./dist/index.js
     redwood: ./dist/index.js
     rw: ./dist/index.js
@@ -3459,7 +3457,6 @@ __metadata:
     tsx: "npm:4.20.5"
     typescript: "npm:5.9.2"
   bin:
-    cdr: ./dist/bins/cedar.js
     cedar: ./dist/bins/cedar.js
     cedarjs: ./dist/bins/cedar.js
     cedarjs-api-server-watch: ./dist/bins/cedarjs-api-server-watch.js
@@ -4252,7 +4249,6 @@ __metadata:
     react: 19.0.0-rc-f2df5694-20240916
     react-dom: 19.0.0-rc-f2df5694-20240916
   bin:
-    cdr: ./dist/cjs/bins/cedar.js
     cedar: ./dist/cjs/bins/cedar.js
     cedarjs: ./dist/cjs/bins/cedar.js
     cross-env: ./dist/cjs/bins/cross-env.js


### PR DESCRIPTION
Standardize on only using `yarn cedar` by removing the `cdr` bin