### PR TITLE
docs(vite-configuration): Add note about Tailwind CSS setup command versions

### DIFF
--- a/docs/docs/vite-configuration.md
+++ b/docs/docs/vite-configuration.md
@@ -42,10 +42,10 @@ yarn workspace web add -D sass sass-loader
 And if you want to use Tailwind CSS, just run the setup command:
 
 ```
-yarn rw setup ui tailwindcss
+yarn cedar setup ui tailwindcss
 ```
 
-> Note: The setup command `yarn rw setup ui tailwindcss` installs Tailwind CSS v3.x by default. Cedar also works with Tailwind v4.x, but the setup helper does not currently install that version or its configuration.
+> Note: The setup command `yarn cedar setup ui tailwindcss` installs Tailwind CSS v3.x by default. Cedar also works with Tailwind v4.x, but the setup helper does not currently install that version or its configuration.
 
 ## Vite Dev Server
 


### PR DESCRIPTION
This pull request adds a clarifying note to the documentation regarding Tailwind CSS support in the setup process. It informs users that the setup command installs Tailwind CSS v3.x by default, and while Cedar supports Tailwind v4.x, the setup helper does not yet install or configure it.

Documentation updates:

* Added a note to `docs/docs/vite-configuration.md` explaining that `yarn cedar setup ui tailwindcss` installs Tailwind CSS v3.x by default, and that while Cedar supports Tailwind v4.x, the setup helper does not currently install or configure v4.x.