### PR TITLE
chore(internal): Fix possibleTypes test

### DIFF
--- a/packages/internal/src/__tests__/fixtures/.redwood/schema.graphql
+++ b/packages/internal/src/__tests__/fixtures/.redwood/schema.graphql
@@ -1,31 +1,40 @@
 scalar BigInt
 
+scalar Byte
+
 scalar Date
 
 scalar DateTime
+
+scalar File
 
 scalar JSON
 
 scalar JSONObject
 
-type Mutation {
-  createTodo(body: String!): Todo
-}
-
+"""About the Redwood queries."""
 type Query {
+  """Fetches the CedarJS root schema."""
+  cedarjs: Redwood
+
+  """Fetches the Redwood root schema."""
   redwood: Redwood
 }
 
+"""
+The Cedar Root Schema
+
+Defines details about Cedar such as the current user and version information.
+"""
 type Redwood {
+  """The current user."""
   currentUser: JSON
+
+  """The version of Prisma."""
   prismaVersion: String
+
+  """The version of CedarJS."""
   version: String
 }
 
 scalar Time
-
-type Todo {
-  body: String!
-  id: Int!
-  status: String!
-}

--- a/packages/internal/src/__tests__/fixtures/fragment-test-project/.redwood/schema.graphql
+++ b/packages/internal/src/__tests__/fixtures/fragment-test-project/.redwood/schema.graphql
@@ -1,0 +1,160 @@
+scalar BigInt
+
+scalar Byte
+
+input CreateProduceInput {
+  isPickled: Boolean
+  isSeedless: Boolean
+  name: String!
+  nutrients: String
+  price: Int!
+  quantity: Int!
+  region: String!
+  ripenessIndicators: String
+  stallId: String!
+  vegetableFamily: String
+}
+
+input CreateStallInput {
+  name: String!
+  stallNumber: String!
+}
+
+scalar Date
+
+scalar DateTime
+
+scalar File
+
+type Fruit implements Grocery {
+  id: ID!
+
+  """Seedless is only for fruits"""
+  isSeedless: Boolean
+  name: String!
+  nutrients: String
+  price: Int!
+  quantity: Int!
+  region: String!
+
+  """Ripeness is only for fruits"""
+  ripenessIndicators: String
+  stall: Stall!
+}
+
+union Groceries = Fruit | Vegetable
+
+interface Grocery {
+  id: ID!
+  name: String!
+  nutrients: String
+  price: Int!
+  quantity: Int!
+  region: String!
+  stall: Stall!
+}
+
+scalar JSON
+
+scalar JSONObject
+
+type Mutation {
+  createProduce(input: CreateProduceInput!): Produce!
+  createStall(input: CreateStallInput!): Stall!
+  deleteProduce(id: String!): Produce!
+  deleteStall(id: String!): Stall!
+  updateProduce(id: String!, input: UpdateProduceInput!): Produce!
+  updateStall(id: String!, input: UpdateStallInput!): Stall!
+}
+
+type Produce {
+  id: String!
+  isPickled: Boolean
+  isSeedless: Boolean
+  name: String!
+  nutrients: String
+  price: Int!
+  quantity: Int!
+  region: String!
+  ripenessIndicators: String
+  stall: Stall!
+  stallId: String!
+  vegetableFamily: String
+}
+
+"""About the Redwood queries."""
+type Query {
+  """Fetches the CedarJS root schema."""
+  cedarjs: Redwood
+  fruitById(id: ID!): Fruit
+  fruits: [Fruit!]!
+  groceries: [Groceries!]!
+  produce(id: String!): Produce
+  produces: [Produce!]!
+
+  """Fetches the Redwood root schema."""
+  redwood: Redwood
+  stall(id: String!): Stall
+  stalls: [Stall!]!
+  vegetableById(id: ID!): Vegetable
+  vegetables: [Vegetable!]!
+}
+
+"""
+The Cedar Root Schema
+
+Defines details about Cedar such as the current user and version information.
+"""
+type Redwood {
+  """The current user."""
+  currentUser: JSON
+
+  """The version of Prisma."""
+  prismaVersion: String
+
+  """The version of CedarJS."""
+  version: String
+}
+
+type Stall {
+  id: String!
+  name: String!
+  produce: [Produce]!
+  stallNumber: String!
+}
+
+scalar Time
+
+input UpdateProduceInput {
+  isPickled: Boolean
+  isSeedless: Boolean
+  name: String
+  nutrients: String
+  price: Int
+  quantity: Int
+  region: String
+  ripenessIndicators: String
+  stallId: String
+  vegetableFamily: String
+}
+
+input UpdateStallInput {
+  name: String
+  stallNumber: String
+}
+
+type Vegetable implements Grocery {
+  id: ID!
+
+  """Pickled is only for vegetables"""
+  isPickled: Boolean
+  name: String!
+  nutrients: String
+  price: Int!
+  quantity: Int!
+  region: String!
+  stall: Stall!
+
+  """Veggie Family is only for vegetables"""
+  vegetableFamily: String
+}

--- a/packages/internal/src/__tests__/fixtures/fragment-test-project/api/db/schema.prisma
+++ b/packages/internal/src/__tests__/fixtures/fragment-test-project/api/db/schema.prisma
@@ -1,0 +1,14 @@
+// Don't forget to tell Prisma about your edits to this file using
+// `yarn rw prisma migrate dev` or `yarn rw prisma db push`.
+// `migrate` is like committing while `push` is for prototyping.
+// Read more about both here:
+// https://www.prisma.io/docs/orm/prisma-migrate
+
+datasource db {
+  provider = "sqlite"
+}
+
+generator client {
+  provider      = "prisma-client-js"
+  binaryTargets = "native"
+}

--- a/packages/internal/src/__tests__/fixtures/fragment-test-project/api/src/graphql/groceries.sdl.ts
+++ b/packages/internal/src/__tests__/fixtures/fragment-test-project/api/src/graphql/groceries.sdl.ts
@@ -1,0 +1,49 @@
+export const schema = gql`
+  interface Grocery {
+    id: ID!
+    name: String!
+    quantity: Int!
+    price: Int!
+    nutrients: String
+    stall: Stall!
+    region: String!
+  }
+
+  type Fruit implements Grocery {
+    id: ID!
+    name: String!
+    quantity: Int!
+    price: Int!
+    nutrients: String
+    stall: Stall!
+    region: String!
+    "Seedless is only for fruits"
+    isSeedless: Boolean
+    "Ripeness is only for fruits"
+    ripenessIndicators: String
+  }
+
+  type Vegetable implements Grocery {
+    id: ID!
+    name: String!
+    quantity: Int!
+    price: Int!
+    nutrients: String
+    stall: Stall!
+    region: String!
+    "Veggie Family is only for vegetables"
+    vegetableFamily: String
+    "Pickled is only for vegetables"
+    isPickled: Boolean
+  }
+
+  union Groceries = Fruit | Vegetable
+
+  type Query {
+    groceries: [Groceries!]! @skipAuth
+    fruits: [Fruit!]! @skipAuth
+    fruitById(id: ID!): Fruit @skipAuth
+    vegetables: [Vegetable!]! @skipAuth
+    vegetableById(id: ID!): Vegetable @skipAuth
+  }
+`

--- a/packages/internal/src/__tests__/fixtures/fragment-test-project/api/src/graphql/produces.sdl.ts
+++ b/packages/internal/src/__tests__/fixtures/fragment-test-project/api/src/graphql/produces.sdl.ts
@@ -1,0 +1,54 @@
+export const schema = gql`
+  type Produce {
+    id: String!
+    name: String!
+    quantity: Int!
+    price: Int!
+    nutrients: String
+    region: String!
+    isSeedless: Boolean
+    ripenessIndicators: String
+    vegetableFamily: String
+    isPickled: Boolean
+    stall: Stall!
+    stallId: String!
+  }
+
+  type Query {
+    produces: [Produce!]! @skipAuth
+    produce(id: String!): Produce @skipAuth
+  }
+
+  input CreateProduceInput {
+    name: String!
+    quantity: Int!
+    price: Int!
+    nutrients: String
+    region: String!
+    isSeedless: Boolean
+    ripenessIndicators: String
+    vegetableFamily: String
+    isPickled: Boolean
+    stallId: String!
+  }
+
+  input UpdateProduceInput {
+    name: String
+    quantity: Int
+    price: Int
+    nutrients: String
+    region: String
+    isSeedless: Boolean
+    ripenessIndicators: String
+    vegetableFamily: String
+    isPickled: Boolean
+    stallId: String
+  }
+
+  type Mutation {
+    createProduce(input: CreateProduceInput!): Produce! @skipAuth
+    updateProduce(id: String!, input: UpdateProduceInput!): Produce!
+      @skipAuth
+    deleteProduce(id: String!): Produce! @skipAuth
+  }
+`

--- a/packages/internal/src/__tests__/fixtures/fragment-test-project/redwood.toml
+++ b/packages/internal/src/__tests__/fixtures/fragment-test-project/redwood.toml
@@ -1,0 +1,5 @@
+[web]
+port = "8910"
+
+[graphql]
+fragments = true

--- a/packages/internal/src/__tests__/fixtures/fragment-test-project/web/src/graphql/possibleTypes.ts
+++ b/packages/internal/src/__tests__/fixtures/fragment-test-project/web/src/graphql/possibleTypes.ts
@@ -1,0 +1,12 @@
+export interface PossibleTypesResultData {
+  possibleTypes: {
+    [key: string]: string[]
+  }
+}
+const result: PossibleTypesResultData = {
+  possibleTypes: {
+    Groceries: ['Fruit', 'Vegetable'],
+    Grocery: ['Fruit', 'Vegetable'],
+  },
+}
+export default result

--- a/packages/internal/src/__tests__/fixtures/fragment-test-project/web/src/pages/GroceriesPage.tsx
+++ b/packages/internal/src/__tests__/fixtures/fragment-test-project/web/src/pages/GroceriesPage.tsx
@@ -1,0 +1,58 @@
+import { Metadata, useQuery } from '@cedarjs/web';
+
+const GET_GROCERIES = gql`
+  query GetGroceries {
+    groceries {
+      ...Fruit_info
+      ...Vegetable_info
+    }
+  }
+`;
+
+const GET_PRODUCE = gql`
+  query GetProduce {
+    produces {
+      ...Produce_info
+    }
+  }
+`;
+
+const GroceriesPage = () => {
+  const { data: groceryData, loading: groceryLoading } =
+    useQuery(GET_GROCERIES)
+  const { data: produceData, loading: produceLoading } =
+    useQuery(GET_PRODUCE)
+
+  return (
+    <div className="m-12">
+      <Metadata title="Groceries" description="Groceries page" og />
+
+      <div className="grid auto-cols-auto gap-4 grid-cols-4">
+        {!groceryLoading &&
+          groceryData.groceries.map((fruit: { id: string, name: string }) => (
+            <div key={fruit.id}>
+              {fruit.id} {fruit.name}
+            </div>
+          ))}
+
+        {!groceryLoading &&
+          groceryData.groceries.map(
+            (vegetable: { id: string, name: string }) => (
+              <div key={vegetable.id}>
+                {vegetable.id} {vegetable.name}
+              </div>
+            )
+          )}
+
+        {!produceLoading &&
+          produceData.produces?.map((produce: { id: string, name: string }) => (
+            <div key={produce.id}>
+              {produce.id} {produce.name}
+            </div>
+          ))}
+      </div>
+    </div>
+  )
+}
+
+export default GroceriesPage

--- a/packages/internal/src/__tests__/possibleTypes.test.ts
+++ b/packages/internal/src/__tests__/possibleTypes.test.ts
@@ -16,10 +16,7 @@ afterEach(() => {
 describe('Generate gql possible types web from the GraphQL Schema', () => {
   describe('when toml has graphql possible types turned off', () => {
     test('when there are *no* union types', async () => {
-      const FIXTURE_PATH = path.resolve(
-        __dirname,
-        '../../../../__fixtures__/example-todo-main',
-      )
+      const FIXTURE_PATH = path.resolve(__dirname, './fixtures')
 
       process.env.RWJS_CWD = FIXTURE_PATH
 
@@ -44,7 +41,7 @@ describe('Generate gql possible types web from the GraphQL Schema', () => {
     test('when there are union types ', async () => {
       const FIXTURE_PATH = path.resolve(
         __dirname,
-        '../../../../__fixtures__/fragment-test-project',
+        './fixtures/fragment-test-project',
       )
 
       process.env.RWJS_CWD = FIXTURE_PATH


### PR DESCRIPTION
This test broke when I removed the fragment test fixture in #551 
Didn't notice until the next PR after started failing on CI.

The test now use fixtures closer to where the tests are defined to make it easier to see what's used where, and to make it less likely to break some random test because a global fixture is changed.