### PR TITLE
chore(ci): Use new CCA flag --no-node-check

### DIFF
--- a/.github/actions/set-up-rsc-project/setUpRscProject.mjs
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mjs
@@ -68,7 +68,7 @@ async function setUpRscProject(rscProjectPath, exec, execInProject) {
     rscProjectPath,
   ])
   await execInProject('yarn install')
-  await execInProject('yarn cedar upgrade -t canary')
+  await execInProject('yarn cedar upgrade --yes --tag canary')
 
   console.log(`Setting up Streaming/SSR in ${rscProjectPath}`)
   const cmdSetupStreamingSSR = `node ${rwBinPath} experimental setup-streaming-ssr -f`


### PR DESCRIPTION
Allow creating a new app, that still wants Node 20, even though CI now uses Node 24, by using the new `--no-node-check` flag to `yarn create cedar-app`

Also switching to `npx`, so that I can use the canary version of cca, as I haven't made a release on npm yet of cca with support for the new flag