### PR TITLE
chore(ci): cli smoke tests: Switch to `cedar` (mostly)

### DIFF
--- a/.github/workflows/cli-smoke-tests.yml
+++ b/.github/workflows/cli-smoke-tests.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Nested script | Run `cedar exec`
         # Using -f to overwrite script that already exists in the test-project
-        run: yarn cedar g script -f i/am/nested && yarn rw exec i/am/nested
+        run: yarn cedar g script -f i/am/nested && yarn cedar exec i/am/nested
         working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
 
       - name: Nested script | Run `cedar exec` in /scripts


### PR DESCRIPTION
Moving the CI cli smoke tests over to `yarn cedar`, except for one `yarn rw` and one `yarn redwood`, so that I get a failure if I accidentally remove the `rw` or `redwood` bins