### PR TITLE
docs(docusaurus): Give the 8.x docs a Redwood label

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -234,6 +234,9 @@ const config: Config = {
               path: 'canary',
               banner: 'unreleased',
             },
+            '8.x': {
+              label: 'Redwood 8.x',
+            },
           },
         },
         blog: false,


### PR DESCRIPTION
<img width="273" height="215" alt="image" src="https://github.com/user-attachments/assets/ce484bf6-4d2d-4337-843e-7497afa83d93" />

At the end of the list you can see that the old Redwood docs I copied over just to safekeep them are now explicitly labeled "Redwood"