### PR TITLE
chore(internal): Fix structure import for proper types

### DIFF
--- a/packages/internal/src/routes.ts
+++ b/packages/internal/src/routes.ts
@@ -8,8 +8,8 @@ import ansis from 'ansis'
 
 import { getPaths, getRouteHookForPage } from '@cedarjs/project-config'
 import { getRouteRegexAndParams } from '@cedarjs/router/dist/util'
-import { getProject } from '@cedarjs/structure/dist/index.js'
-import type { RWRoute } from '@cedarjs/structure/dist/model/RWRoute.js'
+import { getProject } from '@cedarjs/structure'
+import type { RWRoute } from '@cedarjs/structure'
 
 export interface RouteInformation {
   name?: string

--- a/packages/structure/src/index.ts
+++ b/packages/structure/src/index.ts
@@ -1,6 +1,6 @@
 export { DiagnosticSeverity } from 'vscode-languageserver-types'
 export { DefaultHost, Host } from './hosts'
-export { RWProject } from './model'
+export { RWProject, RWRoute } from './model'
 export { URL_file } from './x/URL'
 import { DefaultHost } from './hosts'
 import { RWProject } from './model'

--- a/packages/structure/src/model/index.ts
+++ b/packages/structure/src/model/index.ts
@@ -1,1 +1,2 @@
 export { RWProject } from './RWProject'
+export { RWRoute } from './RWRoute'


### PR DESCRIPTION
Fixes https://github.com/cedarjs/cedar/issues/590 

At least, that's what I'm hoping. I was never able to reproduce the error locally