### PR TITLE
chore(docs): Remove unused .eslintrc.js file

### DIFF
--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  env: {
-    commonjs: true,
-    node: true,
-  },
-}


### PR DESCRIPTION
We don't run eslint for our docs, only for code in packages/