### PR TITLE
fix(deps): Update react-server-dom-webpack to address CVE

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -100,7 +100,7 @@
     "core-js": "3.42.0",
     "react": "19.0.0-rc-f2df5694-20240916",
     "react-dom": "19.0.0-rc-f2df5694-20240916",
-    "react-server-dom-webpack": "19.2.1"
+    "react-server-dom-webpack": "19.0.1"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -89,7 +89,7 @@
     "http-proxy-middleware": "3.0.5",
     "isbot": "5.1.32",
     "react": "19.0.0-rc-f2df5694-20240916",
-    "react-server-dom-webpack": "19.2.1",
+    "react-server-dom-webpack": "19.0.1",
     "rimraf": "6.0.1",
     "vite": "5.4.19",
     "vite-plugin-cjs-interop": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3974,7 +3974,7 @@ __metadata:
     publint: "npm:0.3.15"
     react: "npm:19.0.0-rc-f2df5694-20240916"
     react-dom: "npm:19.0.0-rc-f2df5694-20240916"
-    react-server-dom-webpack: "npm:19.2.1"
+    react-server-dom-webpack: "npm:19.0.1"
     tstyche: "npm:3.0.0"
     tsx: "npm:4.20.6"
     typescript: "npm:5.9.3"
@@ -4184,7 +4184,7 @@ __metadata:
     memfs: "npm:4.51.1"
     publint: "npm:0.3.15"
     react: "npm:19.0.0-rc-f2df5694-20240916"
-    react-server-dom-webpack: "npm:19.2.1"
+    react-server-dom-webpack: "npm:19.0.1"
     rimraf: "npm:6.0.1"
     rollup: "npm:4.24.0"
     tsx: "npm:4.20.6"
@@ -27125,18 +27125,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-server-dom-webpack@npm:19.2.1":
-  version: 19.2.1
-  resolution: "react-server-dom-webpack@npm:19.2.1"
+"react-server-dom-webpack@npm:19.0.1":
+  version: 19.0.1
+  resolution: "react-server-dom-webpack@npm:19.0.1"
   dependencies:
     acorn-loose: "npm:^8.3.0"
     neo-async: "npm:^2.6.1"
     webpack-sources: "npm:^3.2.0"
   peerDependencies:
-    react: ^19.2.1
-    react-dom: ^19.2.1
+    react: ^19.0.1
+    react-dom: ^19.0.1
     webpack: ^5.59.0
-  checksum: 10c0/71adb91488ff0e8cb9290bd0d88521dc185f4adc1754ef89b4816e155f73acc420d18a5700a64517c42d5894d0c51e7380c410df4fd61b48e5aa1c6359e1e911
+  checksum: 10c0/19833a18466e24f36857bdc85da64b32e5140e866215fbd4f59f915470446a2cb064ef4f594952ac480c13d8c4b54d1385e9b19de726c88c5580bbcde707b26a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
For the experimental RSC support Cedar was using a version of react-server-dom-webpack that was vulnerable to https://www.cve.org/CVERecord?id=CVE-2025-55182 (more info on the CVE here: https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components)

RSC support in Cedar was only ever available in `@canary` releases, and only if you had the experimental support turned on in your `redwood.toml`. Stable version releases of Cedar, like v1.1.1 and v2.0.2 etc did still have react-server-dom-webpack as a dependency, but it was not used in a way that would make Cedar vulnerable to the exploit detailed in the CVE