### PR TITLE
chore(deps): Remove react-is resolution

### DIFF
--- a/__fixtures__/esm-test-project/package.json
+++ b/__fixtures__/esm-test-project/package.json
@@ -23,7 +23,6 @@
   },
   "packageManager": "yarn@4.9.4",
   "resolutions": {
-    "react-is": "19.0.1",
     "vite": "5.4.19"
   }
 }

--- a/__fixtures__/rsc-caching/package.json
+++ b/__fixtures__/rsc-caching/package.json
@@ -19,7 +19,6 @@
   },
   "packageManager": "yarn@4.6.0",
   "resolutions": {
-    "@apollo/client-react-streaming/superjson": "^1.12.2",
-    "react-is": "19.0.1"
+    "@apollo/client-react-streaming/superjson": "^1.12.2"
   }
 }

--- a/__fixtures__/test-project-rsa/package.json
+++ b/__fixtures__/test-project-rsa/package.json
@@ -18,7 +18,6 @@
   },
   "packageManager": "yarn@4.6.0",
   "resolutions": {
-    "@apollo/client-react-streaming/superjson": "^1.12.2",
-    "react-is": "19.0.1"
+    "@apollo/client-react-streaming/superjson": "^1.12.2"
   }
 }

--- a/__fixtures__/test-project-rsc-kitchen-sink/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/package.json
@@ -19,7 +19,6 @@
   },
   "packageManager": "yarn@4.6.0",
   "resolutions": {
-    "@apollo/client-react-streaming/superjson": "^1.12.2",
-    "react-is": "19.0.1"
+    "@apollo/client-react-streaming/superjson": "^1.12.2"
   }
 }

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -15,8 +15,5 @@
   "engines": {
     "node": "=24.x"
   },
-  "packageManager": "yarn@4.9.4",
-  "resolutions": {
-    "react-is": "19.0.1"
-  }
+  "packageManager": "yarn@4.9.4"
 }

--- a/packages/create-cedar-app/templates/esm-js/package.json
+++ b/packages/create-cedar-app/templates/esm-js/package.json
@@ -18,7 +18,6 @@
   },
   "packageManager": "yarn@4.9.4",
   "resolutions": {
-    "react-is": "19.0.1",
     "vite": "5.4.19"
   }
 }

--- a/packages/create-cedar-app/templates/esm-ts/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/package.json
@@ -18,7 +18,6 @@
   },
   "packageManager": "yarn@4.9.4",
   "resolutions": {
-    "react-is": "19.0.1",
     "vite": "5.4.19"
   }
 }

--- a/packages/create-cedar-app/templates/js/package.json
+++ b/packages/create-cedar-app/templates/js/package.json
@@ -14,8 +14,5 @@
   "engines": {
     "node": "=24.x"
   },
-  "packageManager": "yarn@4.9.4",
-  "resolutions": {
-    "react-is": "19.0.1"
-  }
+  "packageManager": "yarn@4.9.4"
 }

--- a/packages/create-cedar-app/templates/ts/package.json
+++ b/packages/create-cedar-app/templates/ts/package.json
@@ -14,8 +14,5 @@
   "engines": {
     "node": "=24.x"
   },
-  "packageManager": "yarn@4.9.4",
-  "resolutions": {
-    "react-is": "19.0.1"
-  }
+  "packageManager": "yarn@4.9.4"
 }

--- a/tasks/downgradeToReact18.mts
+++ b/tasks/downgradeToReact18.mts
@@ -72,14 +72,6 @@ async function downgradeReactVersion(packageJsonArray: PackageJson[]) {
   }
 }
 
-async function removeReactIsResolution(packageJsonArray: PackageJson[]) {
-  for (const packageJson of packageJsonArray) {
-    if (packageJson.resolutions?.['react-is']) {
-      delete packageJson.resolutions['react-is']
-    }
-  }
-}
-
 async function writePackageJsonFiles(
   packageJsonMap: Record<string, PackageJson>,
 ) {
@@ -102,6 +94,5 @@ const packageJsonMap = await parsePackageJsonFiles(packageJsonFilePaths)
 const packageJsonArray = Object.values(packageJsonMap)
 
 await downgradeReactVersion(packageJsonArray)
-await removeReactIsResolution(packageJsonArray)
 
 await writePackageJsonFiles(packageJsonMap)

--- a/tasks/server-tests/fixtures/redwood-app/package.json
+++ b/tasks/server-tests/fixtures/redwood-app/package.json
@@ -10,9 +10,6 @@
     "extends": "@cedarjs/eslint-config",
     "root": true
   },
-  "resolutions": {
-    "react-is": "19.0.1"
-  },
   "devDependencies": {
     "@cedarjs/core": "0.0.5",
     "@cedarjs/project-config": "0.0.5",

--- a/tasks/test-project/rebuild-test-project-fixture.ts
+++ b/tasks/test-project/rebuild-test-project-fixture.ts
@@ -585,7 +585,7 @@ async function runCommand() {
         rootPackageJson.devDependencies['prettier-plugin-tailwindcss']
       fs.writeFileSync(
         path.join(OUTPUT_PROJECT_PATH, 'package.json'),
-        JSON.stringify(newRootPackageJson, null, 2),
+        JSON.stringify(newRootPackageJson, null, 2) + '\n',
       )
 
       // removes existing Fixture and replaces with newly built project,


### PR DESCRIPTION
For the release notes: If you have a resolution for react-is in your root package.json you can now remove that

I forgot why we did this. I thought it was because we were on a canary version of React 19. But it's because of jest. See https://github.com/jestjs/jest/issues/15402

So until we've fully switched to Vitest we're going to have to keep this around