### PR TITLE
chore(deps): Update `@cedarjs` package versions and deps

### DIFF
--- a/__fixtures__/esm-test-project/api/package.json
+++ b/__fixtures__/esm-test-project/api/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@cedarjs/api": "0.10.0",
-    "@cedarjs/auth-dbauth-api": "0.10.0",
-    "@cedarjs/graphql-server": "0.10.0"
+    "@cedarjs/api": "2.0.2",
+    "@cedarjs/auth-dbauth-api": "2.0.2",
+    "@cedarjs/graphql-server": "2.0.2"
   }
 }

--- a/__fixtures__/esm-test-project/package.json
+++ b/__fixtures__/esm-test-project/package.json
@@ -8,9 +8,9 @@
     ]
   },
   "devDependencies": {
-    "@cedarjs/core": "0.10.0",
-    "@cedarjs/project-config": "0.10.0",
-    "@cedarjs/testing": "0.10.0",
+    "@cedarjs/core": "2.0.2",
+    "@cedarjs/project-config": "2.0.2",
+    "@cedarjs/testing": "2.0.2",
     "vitest": "3.2.4",
     "prettier-plugin-tailwindcss": "^0.5.12"
   },

--- a/__fixtures__/esm-test-project/web/package.json
+++ b/__fixtures__/esm-test-project/web/package.json
@@ -12,16 +12,16 @@
     ]
   },
   "dependencies": {
-    "@cedarjs/auth-dbauth-web": "0.10.0",
-    "@cedarjs/forms": "0.10.0",
-    "@cedarjs/router": "0.10.0",
-    "@cedarjs/web": "0.10.0",
+    "@cedarjs/auth-dbauth-web": "2.0.2",
+    "@cedarjs/forms": "2.0.2",
+    "@cedarjs/router": "2.0.2",
+    "@cedarjs/web": "2.0.2",
     "humanize-string": "2.1.0",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
   "devDependencies": {
-    "@cedarjs/vite": "0.10.0",
+    "@cedarjs/vite": "2.0.2",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10.4.22",

--- a/__fixtures__/rsc-caching/api/package.json
+++ b/__fixtures__/rsc-caching/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@cedarjs/api": "9.0.0-canary.620",
-    "@cedarjs/graphql-server": "9.0.0-canary.620"
+    "@cedarjs/api": "1.0.0-canary.12868",
+    "@cedarjs/graphql-server": "1.0.0-canary.12868"
   }
 }

--- a/__fixtures__/rsc-caching/package.json
+++ b/__fixtures__/rsc-caching/package.json
@@ -7,8 +7,8 @@
     ]
   },
   "devDependencies": {
-    "@cedarjs/core": "9.0.0-canary.620",
-    "@cedarjs/project-config": "9.0.0-canary.620"
+    "@cedarjs/core": "1.0.0-canary.12868",
+    "@cedarjs/project-config": "1.0.0-canary.12868"
   },
   "eslintConfig": {
     "extends": "@cedarjs/eslint-config",

--- a/__fixtures__/rsc-caching/web/package.json
+++ b/__fixtures__/rsc-caching/web/package.json
@@ -13,18 +13,18 @@
   "dependencies": {
     "@apollo/client-react-streaming": "0.10.0",
     "@jtoar/throw-on-client": "0.0.1",
-    "@cedarjs/auth-dbauth-middleware": "9.0.0-canary.620",
-    "@cedarjs/auth-dbauth-web": "9.0.0-canary.620",
-    "@cedarjs/forms": "9.0.0-canary.620",
-    "@cedarjs/router": "9.0.0-canary.620",
-    "@cedarjs/web": "9.0.0-canary.620",
+    "@cedarjs/auth-dbauth-middleware": "1.0.0-canary.12868",
+    "@cedarjs/auth-dbauth-web": "1.0.0-canary.12868",
+    "@cedarjs/forms": "1.0.0-canary.12868",
+    "@cedarjs/router": "1.0.0-canary.12868",
+    "@cedarjs/web": "1.0.0-canary.12868",
     "@tobbe.dev/rsc-test": "0.0.5",
     "client-only": "0.0.1",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
   "devDependencies": {
-    "@cedarjs/vite": "9.0.0-canary.620",
+    "@cedarjs/vite": "1.0.0-canary.12868",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"
   }

--- a/__fixtures__/test-project-rsa/api/package.json
+++ b/__fixtures__/test-project-rsa/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@cedarjs/api": "9.0.0-canary.620",
-    "@cedarjs/graphql-server": "9.0.0-canary.620"
+    "@cedarjs/api": "1.0.0-canary.12868",
+    "@cedarjs/graphql-server": "1.0.0-canary.12868"
   }
 }

--- a/__fixtures__/test-project-rsa/package.json
+++ b/__fixtures__/test-project-rsa/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "devDependencies": {
-    "@cedarjs/core": "9.0.0-canary.620"
+    "@cedarjs/core": "1.0.0-canary.12868"
   },
   "eslintConfig": {
     "extends": "@cedarjs/eslint-config",

--- a/__fixtures__/test-project-rsa/web/package.json
+++ b/__fixtures__/test-project-rsa/web/package.json
@@ -12,14 +12,14 @@
   },
   "dependencies": {
     "@apollo/client-react-streaming": "0.10.0",
-    "@cedarjs/forms": "9.0.0-canary.620",
-    "@cedarjs/router": "9.0.0-canary.620",
-    "@cedarjs/web": "9.0.0-canary.620",
+    "@cedarjs/forms": "1.0.0-canary.12868",
+    "@cedarjs/router": "1.0.0-canary.12868",
+    "@cedarjs/web": "1.0.0-canary.12868",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
   "devDependencies": {
-    "@cedarjs/vite": "9.0.0-canary.620",
+    "@cedarjs/vite": "1.0.0-canary.12868",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"
   }

--- a/__fixtures__/test-project-rsc-kitchen-sink/api/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@cedarjs/api": "9.0.0-canary.620",
-    "@cedarjs/graphql-server": "9.0.0-canary.620"
+    "@cedarjs/api": "1.0.0-canary.12868",
+    "@cedarjs/graphql-server": "1.0.0-canary.12868"
   }
 }

--- a/__fixtures__/test-project-rsc-kitchen-sink/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/package.json
@@ -7,8 +7,8 @@
     ]
   },
   "devDependencies": {
-    "@cedarjs/core": "9.0.0-canary.620",
-    "@cedarjs/project-config": "9.0.0-canary.620"
+    "@cedarjs/core": "1.0.0-canary.12868",
+    "@cedarjs/project-config": "1.0.0-canary.12868"
   },
   "eslintConfig": {
     "extends": "@cedarjs/eslint-config",

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/package.json
@@ -13,18 +13,18 @@
   "dependencies": {
     "@apollo/client-react-streaming": "0.10.0",
     "@jtoar/throw-on-client": "0.0.1",
-    "@cedarjs/auth-dbauth-middleware": "9.0.0-canary.620",
-    "@cedarjs/auth-dbauth-web": "9.0.0-canary.620",
-    "@cedarjs/forms": "9.0.0-canary.620",
-    "@cedarjs/router": "9.0.0-canary.620",
-    "@cedarjs/web": "9.0.0-canary.620",
+    "@cedarjs/auth-dbauth-middleware": "1.0.0-canary.12868",
+    "@cedarjs/auth-dbauth-web": "1.0.0-canary.12868",
+    "@cedarjs/forms": "1.0.0-canary.12868",
+    "@cedarjs/router": "1.0.0-canary.12868",
+    "@cedarjs/web": "1.0.0-canary.12868",
     "@tobbe.dev/rsc-test": "0.0.5",
     "client-only": "0.0.1",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
   "devDependencies": {
-    "@cedarjs/vite": "9.0.0-canary.620",
+    "@cedarjs/vite": "1.0.0-canary.12868",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"
   }

--- a/__fixtures__/test-project/api/package.json
+++ b/__fixtures__/test-project/api/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@cedarjs/api": "0.10.0",
-    "@cedarjs/auth-dbauth-api": "0.10.0",
-    "@cedarjs/graphql-server": "0.10.0"
+    "@cedarjs/api": "2.0.2",
+    "@cedarjs/auth-dbauth-api": "2.0.2",
+    "@cedarjs/graphql-server": "2.0.2"
   }
 }

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -7,9 +7,9 @@
     ]
   },
   "devDependencies": {
-    "@cedarjs/core": "0.10.0",
-    "@cedarjs/project-config": "0.10.0",
-    "@cedarjs/testing": "0.10.0",
+    "@cedarjs/core": "2.0.2",
+    "@cedarjs/project-config": "2.0.2",
+    "@cedarjs/testing": "2.0.2",
     "prettier-plugin-tailwindcss": "^0.5.12"
   },
   "engines": {

--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -11,16 +11,16 @@
     ]
   },
   "dependencies": {
-    "@cedarjs/auth-dbauth-web": "0.10.0",
-    "@cedarjs/forms": "0.10.0",
-    "@cedarjs/router": "0.10.0",
-    "@cedarjs/web": "0.10.0",
+    "@cedarjs/auth-dbauth-web": "2.0.2",
+    "@cedarjs/forms": "2.0.2",
+    "@cedarjs/router": "2.0.2",
+    "@cedarjs/web": "2.0.2",
     "humanize-string": "2.1.0",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
   "devDependencies": {
-    "@cedarjs/vite": "0.10.0",
+    "@cedarjs/vite": "2.0.2",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10.4.22",

--- a/packages/adapters/fastify/web/package.json
+++ b/packages/adapters/fastify/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/fastify-web",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/api-server",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "description": "CedarJS's HTTP server for Serverless Functions",
   "repository": {
     "type": "git",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/api",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/auth0/api/package.json
+++ b/packages/auth-providers/auth0/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-auth0-api",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/auth0/setup/package.json
+++ b/packages/auth-providers/auth0/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-auth0-setup",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/auth0/web/package.json
+++ b/packages/auth-providers/auth0/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-auth0-web",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/azureActiveDirectory/api/package.json
+++ b/packages/auth-providers/azureActiveDirectory/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-azure-active-directory-api",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/azureActiveDirectory/setup/package.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-azure-active-directory-setup",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/azureActiveDirectory/web/package.json
+++ b/packages/auth-providers/azureActiveDirectory/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-azure-active-directory-web",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/clerk/api/package.json
+++ b/packages/auth-providers/clerk/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-clerk-api",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/clerk/setup/package.json
+++ b/packages/auth-providers/clerk/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-clerk-setup",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/clerk/web/package.json
+++ b/packages/auth-providers/clerk/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-clerk-web",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/custom/setup/package.json
+++ b/packages/auth-providers/custom/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-custom-setup",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/dbAuth/api/package.json
+++ b/packages/auth-providers/dbAuth/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-dbauth-api",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-dbauth-middleware",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-dbauth-setup",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-dbauth-web",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/firebase/api/package.json
+++ b/packages/auth-providers/firebase/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-firebase-api",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/firebase/setup/package.json
+++ b/packages/auth-providers/firebase/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-firebase-setup",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/firebase/web/package.json
+++ b/packages/auth-providers/firebase/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-firebase-web",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/netlify/api/package.json
+++ b/packages/auth-providers/netlify/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-netlify-api",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/netlify/setup/package.json
+++ b/packages/auth-providers/netlify/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-netlify-setup",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/netlify/web/package.json
+++ b/packages/auth-providers/netlify/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-netlify-web",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/supabase/api/package.json
+++ b/packages/auth-providers/supabase/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-supabase-api",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/supabase/middleware/package.json
+++ b/packages/auth-providers/supabase/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-supabase-middleware",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/supabase/setup/package.json
+++ b/packages/auth-providers/supabase/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-supabase-setup",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/supabase/web/package.json
+++ b/packages/auth-providers/supabase/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-supabase-web",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/supertokens/api/package.json
+++ b/packages/auth-providers/supertokens/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-supertokens-api",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/supertokens/setup/package.json
+++ b/packages/auth-providers/supertokens/setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-supertokens-setup",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth-providers/supertokens/web/package.json
+++ b/packages/auth-providers/supertokens/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth-supertokens-web",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/auth",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/babel-config",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/cli-helpers",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/cli-data-migrate",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/cli-packages/storybook-vite/package.json
+++ b/packages/cli-packages/storybook-vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/cli-storybook-vite",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/cli",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "description": "The CedarJS Command Line",
   "repository": {
     "type": "git",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/codemods",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "description": "Codemods to ease upgrading a CedarJS Project",
   "repository": {
     "type": "git",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/context",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/cookie-jar/package.json
+++ b/packages/cookie-jar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/cookie-jar",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/core",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "description": "Foundational packages and config required to build CedarJS",
   "repository": {
     "type": "git",

--- a/packages/create-cedar-app/package.json
+++ b/packages/create-cedar-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-cedar-app",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/create-cedar-app/templates/esm-js/api/package.json
+++ b/packages/create-cedar-app/templates/esm-js/api/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@cedarjs/api": "0.10.0",
-    "@cedarjs/graphql-server": "0.10.0"
+    "@cedarjs/api": "2.0.2",
+    "@cedarjs/graphql-server": "2.0.2"
   }
 }

--- a/packages/create-cedar-app/templates/esm-js/package.json
+++ b/packages/create-cedar-app/templates/esm-js/package.json
@@ -8,9 +8,9 @@
     ]
   },
   "devDependencies": {
-    "@cedarjs/core": "0.10.0",
-    "@cedarjs/project-config": "0.10.0",
-    "@cedarjs/testing": "0.10.0",
+    "@cedarjs/core": "2.0.2",
+    "@cedarjs/project-config": "2.0.2",
+    "@cedarjs/testing": "2.0.2",
     "vitest": "3.2.4"
   },
   "engines": {

--- a/packages/create-cedar-app/templates/esm-js/web/package.json
+++ b/packages/create-cedar-app/templates/esm-js/web/package.json
@@ -12,14 +12,14 @@
     ]
   },
   "dependencies": {
-    "@cedarjs/forms": "0.10.0",
-    "@cedarjs/router": "0.10.0",
-    "@cedarjs/web": "0.10.0",
+    "@cedarjs/forms": "2.0.2",
+    "@cedarjs/router": "2.0.2",
+    "@cedarjs/web": "2.0.2",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
   "devDependencies": {
-    "@cedarjs/vite": "0.10.0",
+    "@cedarjs/vite": "2.0.2",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"
   }

--- a/packages/create-cedar-app/templates/esm-ts/api/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/api/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@cedarjs/api": "0.10.0",
-    "@cedarjs/graphql-server": "0.10.0"
+    "@cedarjs/api": "2.0.2",
+    "@cedarjs/graphql-server": "2.0.2"
   }
 }

--- a/packages/create-cedar-app/templates/esm-ts/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/package.json
@@ -8,9 +8,9 @@
     ]
   },
   "devDependencies": {
-    "@cedarjs/core": "0.10.0",
-    "@cedarjs/project-config": "0.10.0",
-    "@cedarjs/testing": "0.10.0",
+    "@cedarjs/core": "2.0.2",
+    "@cedarjs/project-config": "2.0.2",
+    "@cedarjs/testing": "2.0.2",
     "vitest": "3.2.4"
   },
   "engines": {

--- a/packages/create-cedar-app/templates/esm-ts/web/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/web/package.json
@@ -12,14 +12,14 @@
     ]
   },
   "dependencies": {
-    "@cedarjs/forms": "0.10.0",
-    "@cedarjs/router": "0.10.0",
-    "@cedarjs/web": "0.10.0",
+    "@cedarjs/forms": "2.0.2",
+    "@cedarjs/router": "2.0.2",
+    "@cedarjs/web": "2.0.2",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
   "devDependencies": {
-    "@cedarjs/vite": "0.10.0",
+    "@cedarjs/vite": "2.0.2",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"
   }

--- a/packages/create-cedar-app/templates/js/api/package.json
+++ b/packages/create-cedar-app/templates/js/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@cedarjs/api": "0.10.0",
-    "@cedarjs/graphql-server": "0.10.0"
+    "@cedarjs/api": "2.0.2",
+    "@cedarjs/graphql-server": "2.0.2"
   }
 }

--- a/packages/create-cedar-app/templates/js/package.json
+++ b/packages/create-cedar-app/templates/js/package.json
@@ -7,9 +7,9 @@
     ]
   },
   "devDependencies": {
-    "@cedarjs/core": "0.10.0",
-    "@cedarjs/project-config": "0.10.0",
-    "@cedarjs/testing": "0.10.0"
+    "@cedarjs/core": "2.0.2",
+    "@cedarjs/project-config": "2.0.2",
+    "@cedarjs/testing": "2.0.2"
   },
   "engines": {
     "node": "=24.x"

--- a/packages/create-cedar-app/templates/js/web/package.json
+++ b/packages/create-cedar-app/templates/js/web/package.json
@@ -11,14 +11,14 @@
     ]
   },
   "dependencies": {
-    "@cedarjs/forms": "0.10.0",
-    "@cedarjs/router": "0.10.0",
-    "@cedarjs/web": "0.10.0",
+    "@cedarjs/forms": "2.0.2",
+    "@cedarjs/router": "2.0.2",
+    "@cedarjs/web": "2.0.2",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
   "devDependencies": {
-    "@cedarjs/vite": "0.10.0",
+    "@cedarjs/vite": "2.0.2",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"
   }

--- a/packages/create-cedar-app/templates/ts/api/package.json
+++ b/packages/create-cedar-app/templates/ts/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@cedarjs/api": "0.10.0",
-    "@cedarjs/graphql-server": "0.10.0"
+    "@cedarjs/api": "2.0.2",
+    "@cedarjs/graphql-server": "2.0.2"
   }
 }

--- a/packages/create-cedar-app/templates/ts/package.json
+++ b/packages/create-cedar-app/templates/ts/package.json
@@ -7,9 +7,9 @@
     ]
   },
   "devDependencies": {
-    "@cedarjs/core": "0.10.0",
-    "@cedarjs/project-config": "0.10.0",
-    "@cedarjs/testing": "0.10.0"
+    "@cedarjs/core": "2.0.2",
+    "@cedarjs/project-config": "2.0.2",
+    "@cedarjs/testing": "2.0.2"
   },
   "engines": {
     "node": "=24.x"

--- a/packages/create-cedar-app/templates/ts/web/package.json
+++ b/packages/create-cedar-app/templates/ts/web/package.json
@@ -11,14 +11,14 @@
     ]
   },
   "dependencies": {
-    "@cedarjs/forms": "0.10.0",
-    "@cedarjs/router": "0.10.0",
-    "@cedarjs/web": "0.10.0",
+    "@cedarjs/forms": "2.0.2",
+    "@cedarjs/router": "2.0.2",
+    "@cedarjs/web": "2.0.2",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
   "devDependencies": {
-    "@cedarjs/vite": "0.10.0",
+    "@cedarjs/vite": "2.0.2",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"
   }

--- a/packages/create-cedar-rsc-app/package.json
+++ b/packages/create-cedar-rsc-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-cedar-rsc-app",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "description": "Quickstart for a Cedar React Server Components App",
   "repository": {
     "type": "git",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/eslint-config",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/eslint-plugin",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/forms",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/framework-tools/package.json
+++ b/packages/framework-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/framework-tools",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/graphql-server",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/internal",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/jobs",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/mailer/core/package.json
+++ b/packages/mailer/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/mailer-core",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/mailer/handlers/in-memory/package.json
+++ b/packages/mailer/handlers/in-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/mailer-handler-in-memory",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/mailer/handlers/nodemailer/package.json
+++ b/packages/mailer/handlers/nodemailer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/mailer-handler-nodemailer",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/mailer/handlers/resend/package.json
+++ b/packages/mailer/handlers/resend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/mailer-handler-resend",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/mailer/handlers/studio/package.json
+++ b/packages/mailer/handlers/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/mailer-handler-studio",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/mailer/renderers/mjml-react/package.json
+++ b/packages/mailer/renderers/mjml-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/mailer-renderer-mjml-react",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/mailer/renderers/react-email/package.json
+++ b/packages/mailer/renderers/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/mailer-renderer-react-email",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/ogimage-gen",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/prerender",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "description": "CedarJS prerender",
   "repository": {
     "type": "git",

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/project-config",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/realtime",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/record",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/router",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/server-store/package.json
+++ b/packages/server-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/server-store",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/storage",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook-framework-cedarjs",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "description": "Storybook for CedarJS",
   "keywords": [
     "Storybook",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/structure",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "description": "noun: the arrangement of and relations between the parts or elements of something complex",
   "repository": {
     "type": "git",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/telemetry",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/testing",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "description": "Tools, wrappers and configuration for testing a Cedar project.",
   "repository": {
     "type": "git",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/tui",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/vite",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "description": "Vite configuration package for CedarJS",
   "repository": {
     "type": "git",

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/web-server",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "description": "CedarJS's server for the Web side",
   "repository": {
     "type": "git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedarjs/web",
-  "version": "0.10.0",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cedarjs/cedar.git",


### PR DESCRIPTION
Updates internal package version from 0.10.0 to 2.0.2, which is the latest released stable version
For the RSC test related packages I bumped to the latest canary version instead.

This should also fix the `build:test-project` command