### PR TITLE
chore(test-project): Remove deprecated arg from build:test-project

### DIFF
--- a/tasks/test-project/test-project
+++ b/tasks/test-project/test-project
@@ -17,6 +17,7 @@ const { getExecaOptions, confirmNoFixtureNoLink } = require('./util')
 
 const args = yargs(hideBin(process.argv))
   .usage('Usage: $0 <project directory> [option]')
+  .demandCommand(1, 'Please provide a project directory')
   .option('link', {
     default: false,
     type: 'boolean',
@@ -37,12 +38,6 @@ const args = yargs(hideBin(process.argv))
     default: false,
     type: 'boolean',
     describe: 'Enable streaming-ssr experiment (RW v7)',
-  })
-  .option('rebuildFixture', {
-    default: false,
-    hidden: true,
-    type: 'boolean',
-    describe: 'Rebuild __fixtures__/test-project',
   })
   .option('clean', {
     default: false,
@@ -69,23 +64,10 @@ const {
   verbose,
   clean,
   copyFromFixture,
-  rebuildFixture,
   javascript,
   streamingSsr,
 } = args
 
-if (rebuildFixture) {
-  console.log(
-    ansis.red.bold(
-      `
-      --rebuildFixture is deprecated. Please run \`yarn rebuild-test-project-fixture\` instead.
-      `,
-    ),
-  )
-}
-
-// Do not use demandCommand because rebuildFixture doesn't require <project directory>
-// Require 1 and only 1 arg if not rebuildFixture
 if (args._.length > 1) {
   console.log(
     ansis.red.bold(
@@ -97,25 +79,17 @@ if (args._.length > 1) {
     ),
   )
   process.exit(1)
-} else if (args._.length < 1) {
-  console.log(
-    ansis.red.bold(
-      `
-      Missing <project directory> argument
-      Specify a project directory outside the framework directory
-      EXAMPLE: 'yarn build:test-project ../test-project'
-      `,
-    ),
-  )
-  process.exit(1)
 }
 
 const OUTPUT_PROJECT_PATH = path.resolve(String(args._))
-
-const RW_FRAMEWORKPATH = path.join(__dirname, '../../')
+const CEDAR_FRAMEWORK_PATH = path.join(__dirname, '../../')
 
 // Project Directory path check: must not be a subdirectory or Yarn will error
-const relativePathCheck = path.relative(RW_FRAMEWORKPATH, OUTPUT_PROJECT_PATH)
+const relativePathCheck = path.relative(
+  CEDAR_FRAMEWORK_PATH,
+  OUTPUT_PROJECT_PATH,
+)
+
 if (
   relativePathCheck &&
   !relativePathCheck.startsWith('..') &&
@@ -124,12 +98,13 @@ if (
   console.log(
     ansis.red.bold(
       `
-      Project Directory CANNOT be a subdirectory of '${RW_FRAMEWORKPATH}'
+      Project Directory CANNOT be a subdirectory of '${CEDAR_FRAMEWORK_PATH}'
       Specify a project directory outside the framework directory
       EXAMPLE: 'yarn build:test-project ../test-project'
       `,
     ),
   )
+
   process.exit(1)
 }
 
@@ -144,7 +119,7 @@ const createProject = async () => {
   return execa(
     cmd,
     ['--no-yarn-install', '--typescript', '--overwrite', '--no-git'],
-    getExecaOptions(RW_FRAMEWORKPATH),
+    getExecaOptions(CEDAR_FRAMEWORK_PATH),
   )
 }
 
@@ -154,7 +129,7 @@ const copyProject = async () => {
   }
 
   const FIXTURE_TESTPROJ_PATH = path.join(
-    RW_FRAMEWORKPATH,
+    CEDAR_FRAMEWORK_PATH,
     '__fixtures__/test-project',
   )
 


### PR DESCRIPTION
There `--rebuildFixture` argument has been deprecated for more than two years. Time to remove it.
This is just an internal tool, so this is a safe chore PR