### PR TITLE
chore(ci): Fix eslint and TS for github actions

### DIFF
--- a/.github/actions/require-milestone/requireMilestone.mjs
+++ b/.github/actions/require-milestone/requireMilestone.mjs
@@ -1,17 +1,6 @@
 // @ts-check
 
 /**
- * @typedef {Object} ProcessEnv
- * @property {string} GITHUB_EVENT_PATH - `GITHUB_EVENT_PATH` is set in the
- *   GitHub Actions runner.
- *   It's the path to the file on the runner that contains the full event
- *   webhook payload.
- *   @see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables.
- * @property {string} GITHUB_TOKEN - GitHub token for API requests.
- * @property {string} GITHUB_REPOSITORY - The owner and repository name.
- */
-
-/**
  * @typedef {Object} PullRequest
  * @property {string} title - The title of the pull request.
  * @property {number} number - The pull request number.
@@ -26,10 +15,18 @@
  * @property {{ login: string }} sender - The user who triggered the event.
  */
 
-/** @type {ProcessEnv} */
+/** Environment variables needed for the script. */
 const env = {
+  /**
+   * `GITHUB_EVENT_PATH` - This is set by the GitHub Actions runner.
+   * It's the path to the file on the runner that contains the full event
+   * webhook payload.
+   * @see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables.
+   */
   GITHUB_EVENT_PATH: process.env.GITHUB_EVENT_PATH || '',
+  /** `GITHUB_TOKEN` - GitHub token for API requests */
   GITHUB_TOKEN: process.env.GITHUB_TOKEN || '',
+  /** `GITHUB_REPOSITORY` - The owner and repository name */
   GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY || '',
 }
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -394,6 +394,7 @@ export default [
       'packages/cli-packages/**/*.mjs',
       'packages/codemods/tasks/**',
       'packages/ogimage-gen/cjsWrappers/**',
+      '.github/**',
     ],
     languageOptions: {
       globals: {


### PR DESCRIPTION
Tell eslint that the github actions run in a node context, so that it knows that `console.log` etc is available.

Also fix a few TS errors in `requireMilestone.mjs`