### PR TITLE
docs(rw-to-cedar): Point out that latest RW-compatible version is v1.x

### DIFF
--- a/docs/docs/upgrade-guides/redwood-to-cedar.md
+++ b/docs/docs/upgrade-guides/redwood-to-cedar.md
@@ -4,6 +4,11 @@ description: How to switch from RedwoodJS/RedwoodGraphQL to CedarJS
 
 # Migrating from RedwoodJS to CedarJS
 
+The latest version of Cedar that's fully compatible with RedwoodJS is CedarJS
+v1.x. Newer versions of Cedar, like v2, have breaking changes compared to RW.
+Please migrate to Cedar v1 first, and make sure that's working, before migrating
+to v2 or newer.
+
 ## Required Steps
 
 1. Search and replace all instances of `"@redwoodjs/(.*)": "\d+\.\d+\.\d+"`

--- a/docs/versioned_docs/version-1.x/upgrade-guides/redwood-to-cedar.md
+++ b/docs/versioned_docs/version-1.x/upgrade-guides/redwood-to-cedar.md
@@ -4,6 +4,11 @@ description: How to switch from RedwoodJS/RedwoodGraphQL to CedarJS
 
 # Migrating from RedwoodJS to CedarJS
 
+The latest version of Cedar that's fully compatible with RedwoodJS is CedarJS
+v1.x. Newer versions of Cedar, like v2, have breaking changes compared to RW.
+Please migrate to Cedar v1 first, and make sure that's working, before migrating
+to v2 or newer.
+
 ## Required Steps
 
 1. Search and replace all instances of `"@redwoodjs/(.*)": "\d+\.\d+\.\d+"`

--- a/docs/versioned_docs/version-2.0/upgrade-guides/redwood-to-cedar.md
+++ b/docs/versioned_docs/version-2.0/upgrade-guides/redwood-to-cedar.md
@@ -4,6 +4,11 @@ description: How to switch from RedwoodJS/RedwoodGraphQL to CedarJS
 
 # Migrating from RedwoodJS to CedarJS
 
+The latest version of Cedar that's fully compatible with RedwoodJS is CedarJS
+v1.x. Newer versions of Cedar, like v2, have breaking changes compared to RW.
+Please migrate to Cedar v1 first, and make sure that's working, before migrating
+to v2 or newer.
+
 ## Required Steps
 
 1. Search and replace all instances of `"@redwoodjs/(.*)": "\d+\.\d+\.\d+"`

--- a/docs/versioned_docs/version-8.x/upgrade-guides/redwood-to-cedar.md
+++ b/docs/versioned_docs/version-8.x/upgrade-guides/redwood-to-cedar.md
@@ -4,6 +4,11 @@ description: How to switch from RedwoodJS/RedwoodGraphQL to CedarJS
 
 # Migrating from RedwoodJS to CedarJS
 
+The latest version of Cedar that's fully compatible with RedwoodJS is CedarJS
+v1.x. Newer versions of Cedar, like v2, have breaking changes compared to RW.
+Please migrate to Cedar v1 first, and make sure that's working, before migrating
+to v2 or newer.
+
 ## Required Steps
 
 1. Search and replace all instances of `"@redwoodjs/(.*)": "\d+\.\d+\.\d+"`


### PR DESCRIPTION
Add a paragraph urging users to first upgrade to v1 of Cedar before moving on to v2 or newer