### PR TITLE
feat(cli): cedar upgrade command: Skip confirmation if tag is provided

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -54,7 +54,7 @@ export const builder = (yargs) => {
     })
     .option('yes', {
       alias: 'y',
-      describe: 'Skip prompts and use defaults.',
+      describe: 'Skip prompts and use defaults',
       default: false,
       type: 'boolean',
     })


### PR DESCRIPTION
If the user has passed a tag to upgrade to I now assume they know what they're doing and that they actually want to upgrade. Therefore I skip the confirmation prompt