### PR TITLE
chore(deps): Upgrade to Lefthook v2.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "human-id": "^4.1.1",
     "jest": "29.7.0",
     "jscodeshift": "17.0.0",
-    "lefthook": "^1.11.14",
+    "lefthook": "2.0.11",
     "lerna": "9.0.3",
     "listr2": "7.0.2",
     "make-dir-cli": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22272,90 +22272,90 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lefthook-darwin-arm64@npm:1.13.6":
-  version: 1.13.6
-  resolution: "lefthook-darwin-arm64@npm:1.13.6"
+"lefthook-darwin-arm64@npm:2.0.11":
+  version: 2.0.11
+  resolution: "lefthook-darwin-arm64@npm:2.0.11"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"lefthook-darwin-x64@npm:1.13.6":
-  version: 1.13.6
-  resolution: "lefthook-darwin-x64@npm:1.13.6"
+"lefthook-darwin-x64@npm:2.0.11":
+  version: 2.0.11
+  resolution: "lefthook-darwin-x64@npm:2.0.11"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"lefthook-freebsd-arm64@npm:1.13.6":
-  version: 1.13.6
-  resolution: "lefthook-freebsd-arm64@npm:1.13.6"
+"lefthook-freebsd-arm64@npm:2.0.11":
+  version: 2.0.11
+  resolution: "lefthook-freebsd-arm64@npm:2.0.11"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"lefthook-freebsd-x64@npm:1.13.6":
-  version: 1.13.6
-  resolution: "lefthook-freebsd-x64@npm:1.13.6"
+"lefthook-freebsd-x64@npm:2.0.11":
+  version: 2.0.11
+  resolution: "lefthook-freebsd-x64@npm:2.0.11"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"lefthook-linux-arm64@npm:1.13.6":
-  version: 1.13.6
-  resolution: "lefthook-linux-arm64@npm:1.13.6"
+"lefthook-linux-arm64@npm:2.0.11":
+  version: 2.0.11
+  resolution: "lefthook-linux-arm64@npm:2.0.11"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"lefthook-linux-x64@npm:1.13.6":
-  version: 1.13.6
-  resolution: "lefthook-linux-x64@npm:1.13.6"
+"lefthook-linux-x64@npm:2.0.11":
+  version: 2.0.11
+  resolution: "lefthook-linux-x64@npm:2.0.11"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"lefthook-openbsd-arm64@npm:1.13.6":
-  version: 1.13.6
-  resolution: "lefthook-openbsd-arm64@npm:1.13.6"
+"lefthook-openbsd-arm64@npm:2.0.11":
+  version: 2.0.11
+  resolution: "lefthook-openbsd-arm64@npm:2.0.11"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"lefthook-openbsd-x64@npm:1.13.6":
-  version: 1.13.6
-  resolution: "lefthook-openbsd-x64@npm:1.13.6"
+"lefthook-openbsd-x64@npm:2.0.11":
+  version: 2.0.11
+  resolution: "lefthook-openbsd-x64@npm:2.0.11"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"lefthook-windows-arm64@npm:1.13.6":
-  version: 1.13.6
-  resolution: "lefthook-windows-arm64@npm:1.13.6"
+"lefthook-windows-arm64@npm:2.0.11":
+  version: 2.0.11
+  resolution: "lefthook-windows-arm64@npm:2.0.11"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"lefthook-windows-x64@npm:1.13.6":
-  version: 1.13.6
-  resolution: "lefthook-windows-x64@npm:1.13.6"
+"lefthook-windows-x64@npm:2.0.11":
+  version: 2.0.11
+  resolution: "lefthook-windows-x64@npm:2.0.11"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"lefthook@npm:^1.11.14":
-  version: 1.13.6
-  resolution: "lefthook@npm:1.13.6"
+"lefthook@npm:2.0.11":
+  version: 2.0.11
+  resolution: "lefthook@npm:2.0.11"
   dependencies:
-    lefthook-darwin-arm64: "npm:1.13.6"
-    lefthook-darwin-x64: "npm:1.13.6"
-    lefthook-freebsd-arm64: "npm:1.13.6"
-    lefthook-freebsd-x64: "npm:1.13.6"
-    lefthook-linux-arm64: "npm:1.13.6"
-    lefthook-linux-x64: "npm:1.13.6"
-    lefthook-openbsd-arm64: "npm:1.13.6"
-    lefthook-openbsd-x64: "npm:1.13.6"
-    lefthook-windows-arm64: "npm:1.13.6"
-    lefthook-windows-x64: "npm:1.13.6"
+    lefthook-darwin-arm64: "npm:2.0.11"
+    lefthook-darwin-x64: "npm:2.0.11"
+    lefthook-freebsd-arm64: "npm:2.0.11"
+    lefthook-freebsd-x64: "npm:2.0.11"
+    lefthook-linux-arm64: "npm:2.0.11"
+    lefthook-linux-x64: "npm:2.0.11"
+    lefthook-openbsd-arm64: "npm:2.0.11"
+    lefthook-openbsd-x64: "npm:2.0.11"
+    lefthook-windows-arm64: "npm:2.0.11"
+    lefthook-windows-x64: "npm:2.0.11"
   dependenciesMeta:
     lefthook-darwin-arm64:
       optional: true
@@ -22379,7 +22379,7 @@ __metadata:
       optional: true
   bin:
     lefthook: bin/index.js
-  checksum: 10c0/c1919d60708be7e12e705f3a583755b959931ef09c9d8e2e453fb96889a9aa74f803196ceb375b3ce775abe5f4948ec86859b736357d6dc0be312f455a82f0aa
+  checksum: 10c0/6be293eb26e2d9a77fca5814f39b0fef4f33bcf68b391966d89b2efc3cd57bb28f4cf1ab33113df14b627a98760275f5bb66884912d86da34b86e3f7a7e6f487
   languageName: node
   linkType: hard
 
@@ -28052,7 +28052,7 @@ __metadata:
     human-id: "npm:^4.1.1"
     jest: "npm:29.7.0"
     jscodeshift: "npm:17.0.0"
-    lefthook: "npm:^1.11.14"
+    lefthook: "npm:2.0.11"
     lerna: "npm:9.0.3"
     listr2: "npm:7.0.2"
     make-dir-cli: "npm:4.0.0"


### PR DESCRIPTION
v2 had three breaking changes, but none that affected us https://github.com/evilmartians/lefthook/releases/tag/v2.0.0