### PR TITLE
chore(router): Fix unit tests throwing/catching on undefined url

### DIFF
--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -234,6 +234,7 @@ describe('test params escaping', () => {
 
   const TestRouter = () => (
     <Router>
+      <Route path="/" page={HomePage} name="home" />
       <Route path="/redirect2/{value}" redirect="/param-test/{value}" />
       <Route path="/param-test/{value}" page={ParamPage} name="params" />
       <Route notfound page={NotFoundPage} />
@@ -337,6 +338,7 @@ describe('query params should not override path params', () => {
 
   const TestRouter = () => (
     <Router>
+      <Route path="/" page={HomePage} name="home" />
       <Route
         path="/user/{id:Int}/contact/{contactId:Int}"
         page={ParamPage}
@@ -1128,8 +1130,8 @@ test('params should be updated if navigated to different route with same page', 
     </Router>
   )
 
-  const screen = render(<TestRouter />)
   act(() => navigate('/user'))
+  const screen = render(<TestRouter />)
   // Wait for page load
   await waitFor(() => screen.getByText('param no-id'))
   act(() => navigate('/user/99'))
@@ -1152,8 +1154,8 @@ test('should handle ref and key as search params', async () => {
     </Router>
   )
 
-  const screen = render(<TestRouter />)
   act(() => navigate('/params?ref=1&key=2'))
+  const screen = render(<TestRouter />)
 
   await waitFor(() => {
     expect(screen.queryByText(`{"ref":"1","key":"2"}`)).toBeInTheDocument()


### PR DESCRIPTION
In Cedar we have a splash page that's displayed in Cedar apps when someone navigates to `/` but the app doesn't have a route defined for `/` (aka root or home route). This splash page displays the current Cedar version by doing a gql request to the backend. The URL to use for that request is read from the `RWJS_API_GRAPHQL_URL` env var.
When running the router unit tests that env var is `undefined`, and so the `fetch()` request would throw an error, which we'd catch and print to the console.

It'd look like this

```
stderr | src/__tests__/router.test.tsx > should handle ref and key as search params
Unable to get CedarJS version:  TypeError: Failed to parse URL from undefined
    at node:internal/deps/undici/undici:15845:13
    at fetchVersion (/Users/tobbe/dev/cedarjs/cedar/packages/router/src/splash-page.tsx:519:26) {
  [cause]: TypeError: Invalid URL: undefined
      at new URLImpl (/Users/tobbe/dev/cedarjs/cedar/node_modules/jsdom/node_modules/whatwg-url/lib/URL-impl.js:23:13)
      at Object.exports.setup (/Users/tobbe/dev/cedarjs/cedar/node_modules/jsdom/node_modules/whatwg-url/lib/URL.js:54:12)
      at new URL (/Users/tobbe/dev/cedarjs/cedar/node_modules/jsdom/node_modules/whatwg-url/lib/URL.js:115:22)
      at new Request (node:internal/deps/undici/undici:10413:25)
      at fetch (node:internal/deps/undici/undici:11325:25)
      at fetch (node:internal/deps/undici/undici:15843:10)
      at fetch (node:internal/bootstrap/web/exposed-window-or-worker:83:12)
      at fetchVersion (/Users/tobbe/dev/cedarjs/cedar/packages/router/src/splash-page.tsx:519:43)
      at /Users/tobbe/dev/cedarjs/cedar/packages/router/src/splash-page.tsx:543:5
      at Object.react_stack_bottom_frame (/Users/tobbe/dev/cedarjs/cedar/node_modules/react-dom/cjs/react-dom-client.development.js:25989:20)
}
```

So there are a few ways to fix this

 1. Make sure the env var is defined, and that the `fetch()` call returns a version value to display on the splash page
 2. Make sure the tests all have a route defined for `/`
 3. Make sure the tests don't navigate to `/`

I started implementing fix 2, and that worked. But then I remembered that fix 3 would also work, and how to implement that, so I switched to that fix for later test cases. 
Since both are valid use cases the router should support, I decided I didn't mind having two different fixes in use.

I chose not to try to implement fix 1 because it'd mean I'd either have to mock `fetch()`, or spin up a (mock) server to intercept the fetch calls. This sounded like more work than it was worth.