### PR TITLE
chore(router): Workaround for failing pageLoadingContext test

### DIFF
--- a/packages/router/src/__tests__/pageLoadingContext.test.tsx
+++ b/packages/router/src/__tests__/pageLoadingContext.test.tsx
@@ -540,9 +540,14 @@ test(
     // After 700ms 'Page Loading Context Page' should be rendered
     await waitFor(() => screen.getByText('Page Loading Context Page'))
 
-    // This shouldn't show up, because the page shouldn't render before it's
-    // fully loaded
+    // This is a workaround for a router compatibility issue with React 19.
+    // See https://github.com/cedarjs/cedar/issues/682
+    // See https://github.com/cedarjs/cedar/pull/690
+    // TODO: Update the router to properly support React 19, and then remove the
+    // waitFor() workaround
     await waitFor(() => {
+      // This shouldn't show up, because the page shouldn't render before it's
+      // fully loaded
       expect(screen.queryByText('loading in page...')).not.toBeInTheDocument()
     })
 


### PR DESCRIPTION
This is the `waitFor` workaround from https://github.com/cedarjs/cedar/issues/682