### PR TITLE
chore(cli): Fix silencing of console.log in flightcontrol test

### DIFF
--- a/packages/cli/src/commands/deploy/__tests__/flightcontrol.test.ts
+++ b/packages/cli/src/commands/deploy/__tests__/flightcontrol.test.ts
@@ -27,8 +27,6 @@ vi.mock('@cedarjs/cli-helpers', async (importOriginal) => {
   }
 })
 
-vi.spyOn(console, 'log').mockImplementation(() => {})
-
 afterAll(() => {
   vi.restoreAllMocks()
 })
@@ -66,6 +64,7 @@ describe('builder', () => {
 describe('handler', () => {
   beforeEach(async () => {
     vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
 
     const execa = await import('execa')
     const cmdMock = execa.command as unknown as Mock
@@ -87,8 +86,11 @@ describe('handler', () => {
 
     it('should have non-zero exit code when build fails', async () => {
       const execa = await import('execa')
-      const cmdMock = execa.command as unknown as Mock
-      cmdMock.mockImplementation(() => Promise.resolve({ failed: true }))
+      const cmdMock = execa.command
+      vi.mocked(cmdMock).mockImplementation(() =>
+        // @ts-expect-error - only partially mocked
+        Promise.resolve({ failed: true }),
+      )
 
       await expect(
         handler({


### PR DESCRIPTION
Follow-up on this ancient commit: 74a51548363d75f83ab2f60b8dcb8b49a2bcba12
It tried to silence the "Building web..." messages, but failed to do so because the stubbed out console.log would be reset before running the test. This PR fixes that.

It also gets rid of a `as unknown as` type cast