### PR TITLE
chore(jobs): Fix timing issue in flaky forever loop unit test

### DIFF
--- a/packages/jobs/src/core/__tests__/Worker.test.ts
+++ b/packages/jobs/src/core/__tests__/Worker.test.ts
@@ -295,8 +295,8 @@ describe('run', async () => {
     })
 
     worker.run()
-    // just enough delay to run through the loop twice
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    // enough delay to run through the loop twice, but not three times
+    await new Promise((resolve) => setTimeout(resolve, 15))
     worker.forever = false
     expect(adapter.find).toHaveBeenCalledTimes(2)
   })


### PR DESCRIPTION
I'd sometimes see this in CI, for example here https://github.com/cedarjs/cedar/actions/runs/20233105073/job/58080880976?pr=698

```
   FAIL  src/core/__tests__/Worker.test.ts > run > will try to find jobs in a loop until `forever` is set to `false`
  AssertionError: expected "spy" to be called 2 times, but got 3 times
   ❯ src/core/__tests__/Worker.test.ts:301:26
      299|     await new Promise((resolve) => setTimeout(resolve, 20))
      300|     worker.forever = false
      301|     expect(adapter.find).toHaveBeenCalledTimes(2)
         |                          ^
      302|   })
      303| 
  
  ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
  
  
   Test Files  1 failed | 9 passed (10)
        Tests  1 failed | 120 passed (121)
  Type Errors  no errors
     Start at  13:14:50
     Duration  12.93s (transform 2.89s, setup 0ms, collect 4.26s, tests 390ms, environment 3ms, prepare 3.96s, typecheck 12.33s)
  
  
  Error: AssertionError: expected "spy" to be called 2 times, but got 3 times
   ❯ src/core/__tests__/Worker.test.ts:301:26
```