### PR TITLE
chore(ci): Skip tests that'd fail on unreleased package versions during release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: ⚙️ CI
 
 on:
-  pull_request:
+  # Run on all pull requests
+  pull_request: {}
+  # Run on pushes to the 'next' branch and to release branches
   push:
     branches: ['next', 'release/**']
 
@@ -144,6 +146,11 @@ jobs:
   telemetry-check:
     needs: check
 
+    # When releasing a new version of Cedar this check would try to install
+    # @cedar/* package versions that aren't published yet, so it would always
+    # fail. That's why we skip it on release branches.
+    if: github.event_name == 'pull_request' || !startsWith(github.ref, 'refs/heads/release/')
+
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -194,6 +201,11 @@ jobs:
 
   create-cedar-app:
     needs: check
+
+    # When releasing a new version of Cedar this check would try to install
+    # @cedar/* package versions that aren't published yet, so it would always
+    # fail. That's why we skip it on release branches.
+    if: github.event_name == 'pull_request' || !startsWith(github.ref, 'refs/heads/release/')
     name: 🌲 Create Cedar App
     uses: ./.github/workflows/create-cedar-app-test.yml
 


### PR DESCRIPTION
When we push new package versions during the release process two CI checks would try to install the yet-to-be-released packages. They'd both fail with a message similar to this:

```
Run yarn build:pack
/home/runner/work/cedar/cedar/node_modules/zx/build/core.cjs:587
          const output = new ProcessOutput({
                         ^

Error: sOutput [Error]: 
    at file:///home/runner/work/cedar/cedar/packages/create-cedar-app/scripts/buildPack.js:18:10
    exit code: 1
    details: 
➤ YN0000: · Yarn 4.12.0
➤ YN0000: ┌ Resolution step
Resolution step
➤ YN0082: @cedarjs/api@npm:2.1.0: No candidates found
➤ YN0000: └ Completed in 0s 822ms
➤ YN0000: · Failed with errors in 0s 832ms
    at EventEmitter.end (/home/runner/work/cedar/cedar/node_modules/zx/build/core.cjs:587:26)
    at EventEmitter.emit (node:events:520:35)
    at ChildProcess.<anonymous> (/home/runner/work/cedar/cedar/node_modules/zx/build/vendor-core.cjs:1170:16)
    at Object.onceWrapper (node:events:623:26)
    at ChildProcess.emit (node:events:508:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5) {
  [cause]: [Getter]
}

Node.js v24.11.1
Error: Process completed with exit code 1.
```

This PR skips the tests that'd always fail