### PR TITLE
chore(jobs): Fix timing issue in flaky forever loop unit test by mocking timers

### DIFF
--- a/packages/jobs/src/core/__tests__/Worker.test.ts
+++ b/packages/jobs/src/core/__tests__/Worker.test.ts
@@ -1,3 +1,5 @@
+import type timers from 'node:timers'
+
 import { beforeEach, describe, expect, vi, it } from 'vitest'
 
 import { DEFAULT_LOGGER } from '../../consts.js'
@@ -10,6 +12,34 @@ import { mockLogger, MockAdapter } from './mocks.js'
 // don't execute any code inside Executor, just spy on whether functions are
 // called
 vi.mock('../Executor')
+
+// Mock node:timers to forward to global timers so fake timers work
+// Hopefully this won't be needed when we upgrade to Vitest v4
+vi.mock('node:timers', async () => {
+  const actual = await vi.importActual<typeof timers>('node:timers')
+
+  return {
+    ...actual,
+    setTimeout: (callback: TimerHandler, ms?: number, ...args: any[]) =>
+      // The "Implied eval" warnings are about the fact that `setTimeout` can
+      // technically accept strings (which would be eval'd), but that's a
+      // limitation of the `TimerHandler` type and not something we need to fix
+      // in our mock - we're just forwarding the arguments correctly.
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      globalThis.setTimeout(callback, ms, ...args),
+    clearTimeout: (id: number | NodeJS.Timeout | undefined) =>
+      globalThis.clearTimeout(id),
+    setInterval: (callback: TimerHandler, ms?: number, ...args: any[]) =>
+      // The "Implied eval" warnings are about the fact that `setTimeout` can
+      // technically accept strings (which would be eval'd), but that's a
+      // limitation of the `TimerHandler` type and not something we need to fix
+      // in our mock - we're just forwarding the arguments correctly.
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      globalThis.setInterval(callback, ms, ...args),
+    clearInterval: (id: number | NodeJS.Timeout | undefined) =>
+      globalThis.clearInterval(id),
+  }
+})
 
 describe('constructor', () => {
   it('saves options', () => {
@@ -284,21 +314,39 @@ describe('run', async () => {
   })
 
   it('will try to find jobs in a loop until `forever` is set to `false`', async () => {
+    // Use fake timers so we can test with a 60-second sleep delay but the test
+    // completes in milliseconds instead of waiting 60+ seconds of real time
+    vi.useFakeTimers()
+
     const adapter = new MockAdapter()
     const worker = new Worker({
       adapter,
       logger: mockLogger,
       processName: 'mockProcessName',
       queues: ['*'],
-      sleepDelay: 0.01,
+      sleepDelay: 60,
       forever: true,
     })
 
-    worker.run()
-    // enough delay to run through the loop twice, but not three times
-    await new Promise((resolve) => setTimeout(resolve, 15))
+    const runPromise = worker.run()
+
+    // First loop iteration happens immediately
+    await vi.waitFor(() => expect(adapter.find).toHaveBeenCalledTimes(1))
+
+    // Advance fake time by 60 seconds to trigger second iteration
+    await vi.advanceTimersByTimeAsync(60000)
+    await vi.waitFor(() => expect(adapter.find).toHaveBeenCalledTimes(2))
+
+    // Stop the worker before third iteration
     worker.forever = false
+    await vi.advanceTimersByTimeAsync(60000)
+
+    await runPromise
+
+    // Should still be 2, not 3
     expect(adapter.find).toHaveBeenCalledTimes(2)
+
+    vi.useRealTimers()
   })
 
   it('does nothing if no job found and forever=false', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10190,11 +10190,11 @@ __metadata:
   linkType: hard
 
 "@sinonjs/commons@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@sinonjs/commons@npm:3.0.0"
+  version: 3.0.1
+  resolution: "@sinonjs/commons@npm:3.0.1"
   dependencies:
     type-detect: "npm:4.0.8"
-  checksum: 10c0/1df9cd257942f4e4960dfb9fd339d9e97b6a3da135f3d5b8646562918e863809cb8e00268535f4f4723535d2097881c8fc03d545c414d8555183376cfc54ee84
+  checksum: 10c0/1227a7b5bd6c6f9584274db996d7f8cee2c8c350534b9d0141fc662eaf1f292ea0ae3ed19e5e5271c8fd390d27e492ca2803acd31a1978be2cdc6be0da711403
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow-up on https://github.com/cedarjs/cedar/pull/704

Making the test not be flaky by mocking timers.

Just like @scamden notes in https://github.com/vitest-dev/vitest/pull/7097#issuecomment-2885209928, I also couldn't get vitest to properly mock node's timers, even though they should be using `@sinonjs/fake-timers` v14, which does support mocking node:timers