### PR TITLE
feat(cca): Use modern workspace config

### DIFF
--- a/__fixtures__/esm-test-project/package.json
+++ b/__fixtures__/esm-test-project/package.json
@@ -1,12 +1,10 @@
 {
   "private": true,
   "type": "module",
-  "workspaces": {
-    "packages": [
-      "api",
-      "web"
-    ]
-  },
+  "workspaces": [
+    "api",
+    "web"
+  ],
   "devDependencies": {
     "@cedarjs/core": "2.0.2",
     "@cedarjs/project-config": "2.0.2",

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -1,11 +1,9 @@
 {
   "private": true,
-  "workspaces": {
-    "packages": [
-      "api",
-      "web"
-    ]
-  },
+  "workspaces": [
+    "api",
+    "web"
+  ],
   "devDependencies": {
     "@cedarjs/core": "2.0.2",
     "@cedarjs/project-config": "2.0.2",

--- a/docs/docs/graphql.md
+++ b/docs/docs/graphql.md
@@ -2399,14 +2399,13 @@ npx create-docusaurus@latest docs classic
 Add `docs` to your `workspaces` in the project's `package.json`:
 
 ```
-  "workspaces": {
-    "packages": [
-      "docs",
-      "api",
-      "web",
-      "packages/*"
-    ]
-  },
+  "workspaces": [
+    "docs",
+    "api",
+    "web",
+    "packages/*"
+  ],
+
 ```
 
 2. Ensure a `docs` directory exists at the root of your project

--- a/packages/create-cedar-app/templates/esm-js/package.json
+++ b/packages/create-cedar-app/templates/esm-js/package.json
@@ -1,12 +1,10 @@
 {
   "private": true,
   "type": "module",
-  "workspaces": {
-    "packages": [
-      "api",
-      "web"
-    ]
-  },
+  "workspaces": [
+    "api",
+    "web"
+  ],
   "devDependencies": {
     "@cedarjs/core": "2.0.2",
     "@cedarjs/project-config": "2.0.2",

--- a/packages/create-cedar-app/templates/esm-ts/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/package.json
@@ -1,12 +1,10 @@
 {
   "private": true,
   "type": "module",
-  "workspaces": {
-    "packages": [
-      "api",
-      "web"
-    ]
-  },
+  "workspaces": [
+    "api",
+    "web"
+  ],
   "devDependencies": {
     "@cedarjs/core": "2.0.2",
     "@cedarjs/project-config": "2.0.2",

--- a/packages/create-cedar-app/templates/js/package.json
+++ b/packages/create-cedar-app/templates/js/package.json
@@ -1,11 +1,9 @@
 {
   "private": true,
-  "workspaces": {
-    "packages": [
-      "api",
-      "web"
-    ]
-  },
+  "workspaces": [
+    "api",
+    "web"
+  ],
   "devDependencies": {
     "@cedarjs/core": "2.0.2",
     "@cedarjs/project-config": "2.0.2",

--- a/packages/create-cedar-app/templates/ts/package.json
+++ b/packages/create-cedar-app/templates/ts/package.json
@@ -1,11 +1,9 @@
 {
   "private": true,
-  "workspaces": {
-    "packages": [
-      "api",
-      "web"
-    ]
-  },
+  "workspaces": [
+    "api",
+    "web"
+  ],
   "devDependencies": {
     "@cedarjs/core": "2.0.2",
     "@cedarjs/project-config": "2.0.2",

--- a/tasks/server-tests/fixtures/redwood-app/package.json
+++ b/tasks/server-tests/fixtures/redwood-app/package.json
@@ -1,11 +1,9 @@
 {
   "private": true,
-  "workspaces": {
-    "packages": [
-      "api",
-      "web"
-    ]
-  },
+  "workspaces": [
+    "api",
+    "web"
+  ],
   "eslintConfig": {
     "extends": "@cedarjs/eslint-config",
     "root": true


### PR DESCRIPTION
Cedar apps have always shipped with the following workspace config

```json
  "workspaces": {
    "packages": [
      "api",
      "web"
    ]
  },
```

If you read [yarn's docs on workspaces](https://yarnpkg.com/configuration/manifest#workspaces) they say the "workspaces" value should be an array, but here it was an object. 
It's very difficult to find any kind of documentation for this object notation. Even going back to the [yarn v1.x docs](https://classic.yarnpkg.com/en/docs/workspaces#toc-how-to-use-it) it says it should be an array.
Here are their introduction blog post when they added workspaces support: https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/
That blog post also only mentions the array syntax.

Even more digging lead me to this blog post from 2018 https://classic.yarnpkg.com/blog/2018/02/15/nohoist/
Yarn introduced a `nohoist` option for workspaces. And this is where they also added support for `workspaces` being an object with a `packages` key.

So, from yarn v1.4.2 `workspaces` could be an object.

With yarn v2 the `hoisted` option in the `workspaces` config was replaced by their `nmHoistingLimits` config as seen in their [migration docs](https://yarnpkg.com/migration/guide#replace-nohoist-by-nmhoistinglimits). But, and this is only my guess, they decided to keep support for the `workspaces.packages` syntax to be less disruptive and make it easier for projects to upgrade.

So the reason we use the object notation is that the template in Redwood was set up to use that syntax when Redwood still used yarn v1 >v1.4 and it just hasn't changed since then. This is where Redwood introduced that config: https://github.com/redwoodjs/create-redwood-app/commit/3651cb0b2a6b44e049f541ec4202d8a99d9360b6

Switching to the array syntax also make the config work with npm and pnpm, making it easier for users to switch to another package manager if they want.