### PR TITLE
fix(cedar): Update all docs links to point to https://cedarjs.com/docs

### DIFF
--- a/.changesets/11540.md
+++ b/.changesets/11540.md
@@ -2,4 +2,4 @@
 
 As of v8.0.0 a `File` scalar was added to your graphql schema by default. This could be problematic if you wanted to define your own `File` scalar.
 
-With this change it is now possible to disable including this scalar by default. To see how to do so look at the `Default Scalar` section of the `Graphql` docs [here](https://docs.redwoodjs.com/docs/graphql#default-scalars)
+With this change it is now possible to disable including this scalar by default. To see how to do so look at the `Default Scalar` section of the `Graphql` docs [here](https://docs.cedarjs.com/docs/graphql#default-scalars)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@ Love Cedar and want to get involved? You're in the right place! A perfect place 
 >
 > There are several contributing docs and references, each covering specific topics:
 >
-> 1. 🧭 [Overview and Orientation](https://redwoodjs.com/docs/contributing)
+> 1. 🧭 [Overview and Orientation](https://cedarjs.com/docs/contributing)
 > 2. 📓 **Reference: Contributing to the Framework Packages** (👈 you are here)
-> 3. 🪜 [Step-by-step Walkthrough](https://redwoodjs.com/docs/contributing-walkthrough) (including Video Recording)
+> 3. 🪜 [Step-by-step Walkthrough](https://cedarjs.com/docs/contributing-walkthrough) (including Video Recording)
 > 4. 📈 [Current Project Boards](https://github.com/orgs/redwoodjs/projects)
 > 5. 🤔 What should I work on?
 >    - ["Help Wanted" v1 Triage Board](https://redwoodjs.com/good-first-issue)
->    - [Discovery Process and Open Issues](https://redwoodjs.com/docs/contributing#what-should-i-work-on)
+>    - [Discovery Process and Open Issues](https://cedarjs.com/docs/contributing#what-should-i-work-on)
 
 ## Table of Contents
 

--- a/__fixtures__/empty-project/.env.defaults
+++ b/__fixtures__/empty-project/.env.defaults
@@ -14,6 +14,6 @@ PRISMA_HIDE_UPDATE_MESSAGE=true
 
 
 # Option to override the current environment's default api-side log level
-# See: https://redwoodjs.com/docs/logger for level options:
+# See: https://cedarjs.com/docs/logger for level options:
 # trace | info | debug | warn | error | silent
 # LOG_LEVEL=debug

--- a/__fixtures__/empty-project/README.md
+++ b/__fixtures__/empty-project/README.md
@@ -7,7 +7,7 @@
 
 ## Getting Started
 - [Tutorial](https://redwoodjs.com/tutorial/welcome-to-redwood): getting started and complete overview guide.
-- [Docs](https://redwoodjs.com/docs/introduction): using the Redwood Router, handling assets and files, list of command-line tools, and more.
+- [Docs](https://cedarjs.com/docs/introduction): using the Redwood Router, handling assets and files, list of command-line tools, and more.
 - [Redwood Community](https://community.redwoodjs.com): get help, share tips and tricks, and collaborate on everything about RedwoodJS.
 
 ### Setup

--- a/__fixtures__/empty-project/api/jest.config.js
+++ b/__fixtures__/empty-project/api/jest.config.js
@@ -1,4 +1,4 @@
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 const config = {
   rootDir: '../',

--- a/__fixtures__/empty-project/api/src/lib/auth.ts
+++ b/__fixtures__/empty-project/api/src/lib/auth.ts
@@ -5,7 +5,7 @@
  * have something to check against, simulating a logged
  * in user that is allowed to access that service.
  *
- * See https://redwoodjs.com/docs/authentication for more info.
+ * See https://cedarjs.com/docs/authentication for more info.
  */
 export const isAuthenticated = () => {
   return true

--- a/__fixtures__/empty-project/jest.config.js
+++ b/__fixtures__/empty-project/jest.config.js
@@ -1,6 +1,6 @@
 // This the Redwood root jest config
 // Each side, e.g. ./web/ and ./api/ has specific config that references this root
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 module.exports = {
   rootDir: '.',

--- a/__fixtures__/empty-project/redwood.toml
+++ b/__fixtures__/empty-project/redwood.toml
@@ -3,13 +3,13 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://cedarjs.com/docs/environment-variables#web
 [api]
   port = 8911
 [browser]

--- a/__fixtures__/empty-project/scripts/seed.ts
+++ b/__fixtures__/empty-project/scripts/seed.ts
@@ -6,7 +6,7 @@ import { db } from 'api/src/lib/db'
 // Seeds automatically run the first time you run the `yarn cedar prisma migrate dev`
 // command and every time you run the `yarn cedar prisma migrate reset` command.
 //
-// See https://redwoodjs.com/docs/database-seeds for more info
+// See https://cedarjs.com/docs/database-seeds for more info
 
 export default async () => {
   try {

--- a/__fixtures__/empty-project/web/jest.config.js
+++ b/__fixtures__/empty-project/web/jest.config.js
@@ -1,4 +1,4 @@
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 const config = {
   rootDir: '../',

--- a/__fixtures__/esm-test-project/api/src/services/contacts/contacts.test.ts
+++ b/__fixtures__/esm-test-project/api/src/services/contacts/contacts.test.ts
@@ -12,8 +12,8 @@ import type { StandardScenario } from './contacts.scenarios.js'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('contacts', () => {
   scenario('returns all contacts', async (scenario: StandardScenario) => {

--- a/__fixtures__/esm-test-project/api/src/services/posts/posts.test.ts
+++ b/__fixtures__/esm-test-project/api/src/services/posts/posts.test.ts
@@ -6,8 +6,8 @@ import type { StandardScenario } from './posts.scenarios.js'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('posts', () => {
   scenario('returns all posts', async (scenario: StandardScenario) => {

--- a/__fixtures__/esm-test-project/web/src/components/Author/Author.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/components/Author/Author.test.tsx
@@ -8,7 +8,7 @@ const author = {
 }
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('Author', () => {
   it('renders successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/components/AuthorCell/AuthorCell.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/components/AuthorCell/AuthorCell.test.tsx
@@ -6,8 +6,8 @@ import { standard } from './AuthorCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('AuthorCell', () => {
   it('renders Loading successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/components/BlogPost/BlogPost.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/components/BlogPost/BlogPost.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import BlogPost from './BlogPost'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('BlogPost', () => {
   it('renders successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/components/BlogPostCell/BlogPostCell.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/components/BlogPostCell/BlogPostCell.test.tsx
@@ -6,8 +6,8 @@ import { standard } from './BlogPostCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('BlogPostCell', () => {
   it('renders Loading successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/components/BlogPostsCell/BlogPostsCell.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/components/BlogPostsCell/BlogPostsCell.test.tsx
@@ -6,8 +6,8 @@ import { standard } from './BlogPostsCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('BlogPostsCell', () => {
   it('renders Loading successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/components/ClassWithClassField/ClassWithClassField.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/components/ClassWithClassField/ClassWithClassField.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import ClassWithClassField from './ClassWithClassField'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('ClassWithClassField', () => {
   it('renders successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/components/WaterfallBlogPostCell/WaterfallBlogPostCell.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/components/WaterfallBlogPostCell/WaterfallBlogPostCell.test.tsx
@@ -6,8 +6,8 @@ import { standard } from './WaterfallBlogPostCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('WaterfallBlogPostCell', () => {
   it('renders Loading successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/layouts/BlogLayout/BlogLayout.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/layouts/BlogLayout/BlogLayout.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import BlogLayout from './BlogLayout'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('BlogLayout', () => {
   it('renders successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/pages/AboutPage/AboutPage.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/pages/AboutPage/AboutPage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import AboutPage from './AboutPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('AboutPage', () => {
   it('renders successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/pages/BlogPostPage/BlogPostPage.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/pages/BlogPostPage/BlogPostPage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import BlogPostPage from './BlogPostPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('BlogPostPage', () => {
   it('renders successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/pages/ContactUsPage/ContactUsPage.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/pages/ContactUsPage/ContactUsPage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import ContactUsPage from './ContactUsPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('ContactUsPage', () => {
   it('renders successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/pages/DoublePage/DoublePage.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/pages/DoublePage/DoublePage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import DoublePage from './DoublePage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('DoublePage', () => {
   it('renders successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/pages/HomePage/HomePage.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/pages/HomePage/HomePage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import HomePage from './HomePage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('HomePage', () => {
   it('renders successfully', () => {

--- a/__fixtures__/esm-test-project/web/src/pages/WaterfallPage/WaterfallPage.test.tsx
+++ b/__fixtures__/esm-test-project/web/src/pages/WaterfallPage/WaterfallPage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import WaterfallPage from './WaterfallPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('WaterfallPage', () => {
   it('renders successfully', () => {

--- a/__fixtures__/rsc-caching/.env.defaults
+++ b/__fixtures__/rsc-caching/.env.defaults
@@ -13,7 +13,7 @@ DATABASE_URL=file:./dev.db
 PRISMA_HIDE_UPDATE_MESSAGE=true
 
 # Option to override the current environment's default api-side log level
-# See: https://redwoodjs.com/docs/logger for level options, defaults to "trace" otherwise.
+# See: https://cedarjs.com/docs/logger for level options, defaults to "trace" otherwise.
 # Most applications want "debug" or "info" during dev, "trace" when you have issues and "warn" in production.
 # Ordered by how verbose they are: trace | debug | info | warn | error | silent
 # LOG_LEVEL=debug

--- a/__fixtures__/rsc-caching/.vscode/launch.json
+++ b/__fixtures__/rsc-caching/.vscode/launch.json
@@ -9,7 +9,7 @@
     },
     {
       "name": "Attach API debugger",
-      "port": 18911, // you can change this port, see https://redwoodjs.com/docs/project-configuration-dev-test-build#debugger-configuration
+      "port": 18911, // you can change this port, see https://cedarjs.com/docs/project-configuration-dev-test-build#debugger-configuration
       "request": "attach",
       "skipFiles": [
         "<node_internals>/**"

--- a/__fixtures__/rsc-caching/api/jest.config.js
+++ b/__fixtures__/rsc-caching/api/jest.config.js
@@ -1,4 +1,4 @@
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 const config = {
   rootDir: '../',

--- a/__fixtures__/rsc-caching/api/src/lib/auth.ts
+++ b/__fixtures__/rsc-caching/api/src/lib/auth.ts
@@ -5,7 +5,7 @@
  * have something to check against, simulating a logged
  * in user that is allowed to access that service.
  *
- * See https://redwoodjs.com/docs/authentication for more info.
+ * See https://cedarjs.com/docs/authentication for more info.
  */
 export const isAuthenticated = () => {
   return true
@@ -26,7 +26,7 @@ export const requireAuth = ({ roles }) => {
 
 export const getCurrentUser = async () => {
   throw new Error(
-    'Auth is not set up yet. See https://redwoodjs.com/docs/authentication ' +
+    'Auth is not set up yet. See https://cedarjs.com/docs/authentication ' +
       'to get started'
   )
 }

--- a/__fixtures__/rsc-caching/jest.config.js
+++ b/__fixtures__/rsc-caching/jest.config.js
@@ -1,6 +1,6 @@
 // This the Redwood root jest config
 // Each side, e.g. ./web/ and ./api/ has specific config that references this root
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 module.exports = {
   rootDir: '.',

--- a/__fixtures__/rsc-caching/redwood.toml
+++ b/__fixtures__/rsc-caching/redwood.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
 title = "Cedar App"
 port = 8910
-apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
 includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
 ]
 [api]
 port = 8911

--- a/__fixtures__/rsc-caching/web/jest.config.js
+++ b/__fixtures__/rsc-caching/web/jest.config.js
@@ -1,4 +1,4 @@
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 const config = {
   rootDir: '../',

--- a/__fixtures__/test-project-rsa/.env.defaults
+++ b/__fixtures__/test-project-rsa/.env.defaults
@@ -13,7 +13,7 @@ DATABASE_URL=file:./dev.db
 PRISMA_HIDE_UPDATE_MESSAGE=true
 
 # Option to override the current environment's default api-side log level
-# See: https://redwoodjs.com/docs/logger for level options, defaults to "trace" otherwise.
+# See: https://cedarjs.com/docs/logger for level options, defaults to "trace" otherwise.
 # Most applications want "debug" or "info" during dev, "trace" when you have issues and "warn" in production.
 # Ordered by how verbose they are: trace | debug | info | warn | error | silent
 # LOG_LEVEL=debug

--- a/__fixtures__/test-project-rsa/.vscode/launch.json
+++ b/__fixtures__/test-project-rsa/.vscode/launch.json
@@ -9,7 +9,7 @@
     },
     {
       "name": "Attach API debugger",
-      "port": 18911, // you can change this port, see https://redwoodjs.com/docs/project-configuration-dev-test-build#debugger-configuration
+      "port": 18911, // you can change this port, see https://cedarjs.com/docs/project-configuration-dev-test-build#debugger-configuration
       "request": "attach",
       "skipFiles": [
         "<node_internals>/**"

--- a/__fixtures__/test-project-rsa/api/jest.config.js
+++ b/__fixtures__/test-project-rsa/api/jest.config.js
@@ -1,4 +1,4 @@
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 const config = {
   rootDir: '../',

--- a/__fixtures__/test-project-rsa/api/src/lib/auth.ts
+++ b/__fixtures__/test-project-rsa/api/src/lib/auth.ts
@@ -5,7 +5,7 @@
  * have something to check against, simulating a logged
  * in user that is allowed to access that service.
  *
- * See https://redwoodjs.com/docs/authentication for more info.
+ * See https://cedarjs.com/docs/authentication for more info.
  */
 export const isAuthenticated = () => {
   return true

--- a/__fixtures__/test-project-rsa/jest.config.js
+++ b/__fixtures__/test-project-rsa/jest.config.js
@@ -1,6 +1,6 @@
 // This the Redwood root jest config
 // Each side, e.g. ./web/ and ./api/ has specific config that references this root
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 module.exports = {
   rootDir: '.',

--- a/__fixtures__/test-project-rsa/redwood.toml
+++ b/__fixtures__/test-project-rsa/redwood.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = 8911

--- a/__fixtures__/test-project-rsa/scripts/seed.ts
+++ b/__fixtures__/test-project-rsa/scripts/seed.ts
@@ -6,7 +6,7 @@ import { db } from 'api/src/lib/db'
 // Seeds automatically run the first time you run the `yarn cedar prisma migrate dev`
 // command and every time you run the `yarn cedar prisma migrate reset` command.
 //
-// See https://redwoodjs.com/docs/database-seeds for more info
+// See https://cedarjs.com/docs/database-seeds for more info
 
 export default async () => {
   try {

--- a/__fixtures__/test-project-rsa/web/jest.config.js
+++ b/__fixtures__/test-project-rsa/web/jest.config.js
@@ -1,4 +1,4 @@
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 const config = {
   rootDir: '../',

--- a/__fixtures__/test-project-rsa/web/src/layouts/NavigationLayout/NavigationLayout.test.tsx
+++ b/__fixtures__/test-project-rsa/web/src/layouts/NavigationLayout/NavigationLayout.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import NavigationLayout from './NavigationLayout'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('NavigationLayout', () => {
   it('renders successfully', () => {

--- a/__fixtures__/test-project-rsc-kitchen-sink/.env.defaults
+++ b/__fixtures__/test-project-rsc-kitchen-sink/.env.defaults
@@ -13,7 +13,7 @@ DATABASE_URL=file:./dev.db
 PRISMA_HIDE_UPDATE_MESSAGE=true
 
 # Option to override the current environment's default api-side log level
-# See: https://redwoodjs.com/docs/logger for level options, defaults to "trace" otherwise.
+# See: https://cedarjs.com/docs/logger for level options, defaults to "trace" otherwise.
 # Most applications want "debug" or "info" during dev, "trace" when you have issues and "warn" in production.
 # Ordered by how verbose they are: trace | debug | info | warn | error | silent
 # LOG_LEVEL=debug

--- a/__fixtures__/test-project-rsc-kitchen-sink/.vscode/launch.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/.vscode/launch.json
@@ -9,7 +9,7 @@
     },
     {
       "name": "Attach API debugger",
-      "port": 18911, // you can change this port, see https://redwoodjs.com/docs/project-configuration-dev-test-build#debugger-configuration
+      "port": 18911, // you can change this port, see https://cedarjs.com/docs/project-configuration-dev-test-build#debugger-configuration
       "request": "attach",
       "skipFiles": [
         "<node_internals>/**"

--- a/__fixtures__/test-project-rsc-kitchen-sink/api/jest.config.js
+++ b/__fixtures__/test-project-rsc-kitchen-sink/api/jest.config.js
@@ -1,4 +1,4 @@
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 const config = {
   rootDir: '../',

--- a/__fixtures__/test-project-rsc-kitchen-sink/api/src/services/emptyUsers/emptyUsers.test.ts
+++ b/__fixtures__/test-project-rsc-kitchen-sink/api/src/services/emptyUsers/emptyUsers.test.ts
@@ -12,8 +12,8 @@ import type { StandardScenario } from './emptyUsers.scenarios'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('emptyUsers', () => {
   scenario('returns all emptyUsers', async (scenario: StandardScenario) => {

--- a/__fixtures__/test-project-rsc-kitchen-sink/jest.config.js
+++ b/__fixtures__/test-project-rsc-kitchen-sink/jest.config.js
@@ -1,6 +1,6 @@
 // This the Redwood root jest config
 // Each side, e.g. ./web/ and ./api/ has specific config that references this root
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 module.exports = {
   rootDir: '.',

--- a/__fixtures__/test-project-rsc-kitchen-sink/redwood.toml
+++ b/__fixtures__/test-project-rsc-kitchen-sink/redwood.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = 8911

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/jest.config.js
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/jest.config.js
@@ -1,4 +1,4 @@
-// More info at https://redwoodjs.com/docs/project-configuration-dev-test-build
+// More info at https://cedarjs.com/docs/project-configuration-dev-test-build
 
 const config = {
   rootDir: '../',

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/layouts/NavigationLayout/NavigationLayout.test.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/layouts/NavigationLayout/NavigationLayout.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import NavigationLayout from './NavigationLayout'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('NavigationLayout', () => {
   it('renders successfully', () => {

--- a/__fixtures__/test-project/api/src/services/contacts/contacts.test.ts
+++ b/__fixtures__/test-project/api/src/services/contacts/contacts.test.ts
@@ -12,8 +12,8 @@ import type { StandardScenario } from './contacts.scenarios.js'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('contacts', () => {
   scenario('returns all contacts', async (scenario: StandardScenario) => {

--- a/__fixtures__/test-project/api/src/services/posts/posts.test.ts
+++ b/__fixtures__/test-project/api/src/services/posts/posts.test.ts
@@ -6,8 +6,8 @@ import type { StandardScenario } from './posts.scenarios.js'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('posts', () => {
   scenario('returns all posts', async (scenario: StandardScenario) => {

--- a/__fixtures__/test-project/web/src/components/Author/Author.test.tsx
+++ b/__fixtures__/test-project/web/src/components/Author/Author.test.tsx
@@ -8,7 +8,7 @@ const author = {
 }
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('Author', () => {
   it('renders successfully', () => {

--- a/__fixtures__/test-project/web/src/components/AuthorCell/AuthorCell.test.tsx
+++ b/__fixtures__/test-project/web/src/components/AuthorCell/AuthorCell.test.tsx
@@ -6,8 +6,8 @@ import { standard } from './AuthorCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('AuthorCell', () => {
   it('renders Loading successfully', () => {

--- a/__fixtures__/test-project/web/src/components/BlogPost/BlogPost.test.tsx
+++ b/__fixtures__/test-project/web/src/components/BlogPost/BlogPost.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import BlogPost from './BlogPost'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('BlogPost', () => {
   it('renders successfully', () => {

--- a/__fixtures__/test-project/web/src/components/BlogPostCell/BlogPostCell.test.tsx
+++ b/__fixtures__/test-project/web/src/components/BlogPostCell/BlogPostCell.test.tsx
@@ -6,8 +6,8 @@ import { standard } from './BlogPostCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('BlogPostCell', () => {
   it('renders Loading successfully', () => {

--- a/__fixtures__/test-project/web/src/components/BlogPostsCell/BlogPostsCell.test.tsx
+++ b/__fixtures__/test-project/web/src/components/BlogPostsCell/BlogPostsCell.test.tsx
@@ -6,8 +6,8 @@ import { standard } from './BlogPostsCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('BlogPostsCell', () => {
   it('renders Loading successfully', () => {

--- a/__fixtures__/test-project/web/src/components/ClassWithClassField/ClassWithClassField.test.tsx
+++ b/__fixtures__/test-project/web/src/components/ClassWithClassField/ClassWithClassField.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import ClassWithClassField from './ClassWithClassField'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('ClassWithClassField', () => {
   it('renders successfully', () => {

--- a/__fixtures__/test-project/web/src/components/WaterfallBlogPostCell/WaterfallBlogPostCell.test.tsx
+++ b/__fixtures__/test-project/web/src/components/WaterfallBlogPostCell/WaterfallBlogPostCell.test.tsx
@@ -6,8 +6,8 @@ import { standard } from './WaterfallBlogPostCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('WaterfallBlogPostCell', () => {
   it('renders Loading successfully', () => {

--- a/__fixtures__/test-project/web/src/layouts/BlogLayout/BlogLayout.test.tsx
+++ b/__fixtures__/test-project/web/src/layouts/BlogLayout/BlogLayout.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import BlogLayout from './BlogLayout'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('BlogLayout', () => {
   it('renders successfully', () => {

--- a/__fixtures__/test-project/web/src/pages/AboutPage/AboutPage.test.tsx
+++ b/__fixtures__/test-project/web/src/pages/AboutPage/AboutPage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import AboutPage from './AboutPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('AboutPage', () => {
   it('renders successfully', () => {

--- a/__fixtures__/test-project/web/src/pages/BlogPostPage/BlogPostPage.test.tsx
+++ b/__fixtures__/test-project/web/src/pages/BlogPostPage/BlogPostPage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import BlogPostPage from './BlogPostPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('BlogPostPage', () => {
   it('renders successfully', () => {

--- a/__fixtures__/test-project/web/src/pages/ContactUsPage/ContactUsPage.test.tsx
+++ b/__fixtures__/test-project/web/src/pages/ContactUsPage/ContactUsPage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import ContactUsPage from './ContactUsPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('ContactUsPage', () => {
   it('renders successfully', () => {

--- a/__fixtures__/test-project/web/src/pages/DoublePage/DoublePage.test.tsx
+++ b/__fixtures__/test-project/web/src/pages/DoublePage/DoublePage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import DoublePage from './DoublePage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('DoublePage', () => {
   it('renders successfully', () => {

--- a/__fixtures__/test-project/web/src/pages/HomePage/HomePage.test.tsx
+++ b/__fixtures__/test-project/web/src/pages/HomePage/HomePage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import HomePage from './HomePage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('HomePage', () => {
   it('renders successfully', () => {

--- a/__fixtures__/test-project/web/src/pages/WaterfallPage/WaterfallPage.test.tsx
+++ b/__fixtures__/test-project/web/src/pages/WaterfallPage/WaterfallPage.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import WaterfallPage from './WaterfallPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('WaterfallPage', () => {
   it('renders successfully', () => {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # CedarJS Docs
 
-Deployment URL: https://redwoodjs.com/docs
+Deployment URL: https://cedarjs.com/docs
 
 ## Getting started
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -251,7 +251,7 @@ const config: Config = {
   //   {
   //     src: 'https://plausible.io/js/script.outbound-links.tagged-events.js',
   //     defer: true,
-  //     'data-domain': 'docs.redwoodjs.com',
+  //     'data-domain': 'cedarjs.com',
   //   },
   // ],
   stylesheets: [

--- a/packages/adapters/fastify/web/src/__fixtures__/fallback/redwood.toml
+++ b/packages/adapters/fastify/web/src/__fixtures__/fallback/redwood.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = 8911

--- a/packages/adapters/fastify/web/src/__fixtures__/main/redwood.toml
+++ b/packages/adapters/fastify/web/src/__fixtures__/main/redwood.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = 8911

--- a/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/redwood.toml
+++ b/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/redwood.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = 65500
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = 65501

--- a/packages/api-server/src/__tests__/fixtures/redwood-app-number-functions/redwood.toml
+++ b/packages/api-server/src/__tests__/fixtures/redwood-app-number-functions/redwood.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = 8911

--- a/packages/api/src/logger/README.md
+++ b/packages/api/src/logger/README.md
@@ -2,4 +2,4 @@
 
 RedwoodJS provides an opinionated logger with sensible, practical defaults that grants you visibility into the applications while you're developing and after you have deployed.
 
-For the latest documentation, see: [Logger](https://redwoodjs.com/docs/logger) on [https://redwoodjs.com](https://redwoodjs.com/).
+For the latest documentation, see: [Logger](https://cedarjs.com/docs/logger) on [https://redwoodjs.com](https://redwoodjs.com/).

--- a/packages/api/src/validations/validations.ts
+++ b/packages/api/src/validations/validations.ts
@@ -161,7 +161,7 @@ interface ValidationRecipe {
   /**
    * Requires that a field NOT be present, meaning it must be `null` or `undefined`.
    *
-   * Opposite of the [`presence`](https://redwoodjs.com/docs/services.html#presence) validator.
+   * Opposite of the [`presence`](https://cedarjs.com/docs/services.html#presence) validator.
    */
   absence?: boolean | AbsenceValidatorOptions
   /**
@@ -187,7 +187,7 @@ interface ValidationRecipe {
   /**
    * Requires that the given value not equal to any in a list of given values.
    *
-   * Opposite of the [inclusion](https://redwoodjs.com/docs/services.html#inclusion) validation.
+   * Opposite of the [inclusion](https://cedarjs.com/docs/services.html#inclusion) validation.
    */
   exclusion?: unknown[] | ExclusionValidatorOptions
   /**
@@ -197,7 +197,7 @@ interface ValidationRecipe {
   /**
    * Requires that the given value is equal to one in a list of given values.
    *
-   * Opposite of the [exclusion](https://redwoodjs.com/docs/services.html#exclusion) validation.
+   * Opposite of the [exclusion](https://cedarjs.com/docs/services.html#exclusion) validation.
    */
   inclusion?: unknown[] | InclusionValidatorOptions
   /**
@@ -211,7 +211,7 @@ interface ValidationRecipe {
   /**
    * Requires that a field be present, meaning it must not be null or undefined.
    *
-   * Opposite of the [absence](https://redwoodjs.com/docs/services.html#absence) validator.
+   * Opposite of the [absence](https://cedarjs.com/docs/services.html#absence) validator.
    */
   presence?: boolean | PresenceValidatorOptions
 

--- a/packages/auth-providers/auth0/api/README.md
+++ b/packages/auth-providers/auth0/api/README.md
@@ -12,7 +12,7 @@ look at one of the existing auth providers in
 templates in `../templates`.
 
 If you need help setting up a custom auth provider there's more info in the
-[auth docs](https://redwoodjs.com/docs/authentication).
+[auth docs](https://cedarjs.com/docs/authentication).
 
 ### Contributing to the base auth implementation
 

--- a/packages/auth-providers/auth0/setup/src/setupHandler.ts
+++ b/packages/auth-providers/auth0/setup/src/setupHandler.ts
@@ -42,7 +42,7 @@ export async function handler({ force: forceArg }: Args) {
       ']',
       '```',
       '',
-      'Also see https://redwoodjs.com/docs/auth/auth0 for a full walkthrough.',
+      'Also see https://cedarjs.com/docs/auth/auth0 for a full walkthrough.',
     ],
   })
 }

--- a/packages/auth-providers/azureActiveDirectory/api/README.md
+++ b/packages/auth-providers/azureActiveDirectory/api/README.md
@@ -12,7 +12,7 @@ look at one of the existing auth providers in
 templates in `../templates`.
 
 If you need help setting up a custom auth provider there's more info in the
-[auth docs](https://redwoodjs.com/docs/authentication).
+[auth docs](https://cedarjs.com/docs/authentication).
 
 ### Contributing to the base auth implementation
 

--- a/packages/auth-providers/azureActiveDirectory/setup/src/setupHandler.ts
+++ b/packages/auth-providers/azureActiveDirectory/setup/src/setupHandler.ts
@@ -44,7 +44,7 @@ export async function handler({ force: forceArg }: Args) {
       ']',
       '```',
       '',
-      'Also see https://redwoodjs.com/docs/auth/azure for a full walkthrough.',
+      'Also see https://cedarjs.com/docs/auth/azure for a full walkthrough.',
     ],
   })
 }

--- a/packages/auth-providers/clerk/api/README.md
+++ b/packages/auth-providers/clerk/api/README.md
@@ -12,7 +12,7 @@ look at one of the existing auth providers in
 templates in `../templates`.
 
 If you need help setting up a custom auth provider there's more info in the
-[auth docs](https://redwoodjs.com/docs/authentication).
+[auth docs](https://cedarjs.com/docs/authentication).
 
 ### Contributing to the base auth implementation
 

--- a/packages/auth-providers/clerk/setup/src/setupHandler.ts
+++ b/packages/auth-providers/clerk/setup/src/setupHandler.ts
@@ -37,7 +37,7 @@ export const handler = async ({ force: forceArg }: Args) => {
       ']',
       '```',
       '',
-      'Also see https://redwoodjs.com/docs/auth/clerk for a full walkthrough.',
+      'Also see https://cedarjs.com/docs/auth/clerk for a full walkthrough.',
     ],
   })
 }

--- a/packages/auth-providers/custom/setup/src/setupHandler.ts
+++ b/packages/auth-providers/custom/setup/src/setupHandler.ts
@@ -21,7 +21,7 @@ export async function handler({ force: forceArg }: Args) {
       'Done! But you have a little more work to do.',
       "You'll have to write the actual implementation yourself.",
       `Take a look in ${authFilename}, and for a full walkthrough`,
-      'see https://redwoodjs.com/docs/auth/custom.',
+      'see https://cedarjs.com/docs/auth/custom.',
     ],
   })
 }

--- a/packages/auth-providers/dbAuth/api/README.md
+++ b/packages/auth-providers/dbAuth/api/README.md
@@ -12,7 +12,7 @@ look at one of the existing auth providers in
 templates in `../templates`.
 
 If you need help setting up a custom auth provider there's more info in the
-[auth docs](https://redwoodjs.com/docs/authentication).
+[auth docs](https://cedarjs.com/docs/authentication).
 
 ### Contributing to the base auth implementation
 

--- a/packages/auth-providers/dbAuth/api/src/errors.ts
+++ b/packages/auth-providers/dbAuth/api/src/errors.ts
@@ -45,7 +45,7 @@ export class NoResetPasswordHandlerError extends Error {
 export class NoWebAuthnConfigError extends Error {
   constructor() {
     super(
-      'To use Webauthn you need both `webauthn` and `credentialModelAccessor` config options, see https://redwoodjs.com/docs/auth/dbAuth#webauthn',
+      'To use Webauthn you need both `webauthn` and `credentialModelAccessor` config options, see https://cedarjs.com/docs/auth/dbAuth#webauthn',
     )
     this.name = 'NoWebAuthnConfigError'
   }
@@ -54,7 +54,7 @@ export class NoWebAuthnConfigError extends Error {
 export class MissingWebAuthnConfigError extends Error {
   constructor() {
     super(
-      'You are missing one or more WebAuthn config options, see https://redwoodjs.com/docs/auth/dbAuth#webauthn',
+      'You are missing one or more WebAuthn config options, see https://cedarjs.com/docs/auth/dbAuth#webauthn',
     )
     this.name = 'MissingWebAuthnConfigError'
   }

--- a/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
@@ -112,7 +112,7 @@ async function shouldIncludeWebAuthn(webauthn: boolean | null) {
     const webAuthnResponse = await prompts({
       type: 'confirm',
       name: 'answer',
-      message: `Enable WebAuthn support (TouchID/FaceID)? See https://redwoodjs.com/docs/auth/dbAuth#webAuthn`,
+      message: `Enable WebAuthn support (TouchID/FaceID)? See https://cedarjs.com/docs/auth/dbAuth#webAuthn`,
       initial: false,
     })
 

--- a/packages/auth-providers/dbAuth/setup/src/templates/api/functions/auth.webAuthn.ts.template
+++ b/packages/auth-providers/dbAuth/setup/src/templates/api/functions/auth.webAuthn.ts.template
@@ -192,7 +192,7 @@ export const handler = async (
     resetPassword: resetPasswordOptions,
     signup: signupOptions,
 
-    // See https://redwoodjs.com/docs/auth/dbauth#webauthn for options
+    // See https://cedarjs.com/docs/auth/dbauth#webauthn for options
     webAuthn: {
       enabled: true,
       // How long to allow re-auth via WebAuthn in seconds (default is 10 years).

--- a/packages/auth-providers/firebase/api/README.md
+++ b/packages/auth-providers/firebase/api/README.md
@@ -12,7 +12,7 @@ look at one of the existing auth providers in
 templates in `../templates`.
 
 If you need help setting up a custom auth provider there's more info in the
-[auth docs](https://redwoodjs.com/docs/authentication).
+[auth docs](https://cedarjs.com/docs/authentication).
 
 ### Contributing to the base auth implementation
 

--- a/packages/auth-providers/firebase/setup/src/setupHandler.ts
+++ b/packages/auth-providers/firebase/setup/src/setupHandler.ts
@@ -41,7 +41,7 @@ export async function handler({ force: forceArg }: Args) {
       ']',
       '```',
       '',
-      'Also see https://redwoodjs.com/docs/auth/firebase for a full walkthrough.',
+      'Also see https://cedarjs.com/docs/auth/firebase for a full walkthrough.',
     ],
   })
 }

--- a/packages/auth-providers/netlify/api/README.md
+++ b/packages/auth-providers/netlify/api/README.md
@@ -12,7 +12,7 @@ look at one of the existing auth providers in
 templates in `../templates`.
 
 If you need help setting up a custom auth provider there's more info in the
-[auth docs](https://redwoodjs.com/docs/authentication).
+[auth docs](https://cedarjs.com/docs/authentication).
 
 ### Contributing to the base auth implementation
 

--- a/packages/auth-providers/netlify/setup/src/setupHandler.ts
+++ b/packages/auth-providers/netlify/setup/src/setupHandler.ts
@@ -22,7 +22,7 @@ export async function handler({ force: forceArg }: Args) {
     ],
     notes: [
       "You'll need to enable Identity on your Netlify site and configure the API endpoint locally.",
-      'See https://redwoodjs.com/docs/auth/netlify for a full walkthrough.',
+      'See https://cedarjs.com/docs/auth/netlify for a full walkthrough.',
     ],
   })
 }

--- a/packages/auth-providers/supabase/api/README.md
+++ b/packages/auth-providers/supabase/api/README.md
@@ -12,7 +12,7 @@ look at one of the existing auth providers in
 templates in `../templates`.
 
 If you need help setting up a custom auth provider there's more info in the
-[auth docs](https://redwoodjs.com/docs/authentication).
+[auth docs](https://cedarjs.com/docs/authentication).
 
 ### Contributing to the base auth implementation
 

--- a/packages/auth-providers/supabase/setup/src/setupHandler.ts
+++ b/packages/auth-providers/supabase/setup/src/setupHandler.ts
@@ -39,7 +39,7 @@ export const handler = async ({ force: forceArg }: Args) => {
       ']',
       '```',
       '',
-      'Also see https://redwoodjs.com/docs/auth/supabase for a full walkthrough.',
+      'Also see https://cedarjs.com/docs/auth/supabase for a full walkthrough.',
     ],
   })
 }

--- a/packages/auth-providers/supertokens/api/README.md
+++ b/packages/auth-providers/supertokens/api/README.md
@@ -12,7 +12,7 @@ look at one of the existing auth providers in
 templates in `../templates`.
 
 If you need help setting up a custom auth provider there's more info in the
-[auth docs](https://redwoodjs.com/docs/authentication).
+[auth docs](https://cedarjs.com/docs/authentication).
 
 ### Contributing to the base auth implementation
 

--- a/packages/auth-providers/supertokens/setup/src/setupHandler.ts
+++ b/packages/auth-providers/supertokens/setup/src/setupHandler.ts
@@ -31,7 +31,7 @@ export async function handler({ force: forceArg }: Args) {
       'but feel free to switch to something that better fits your needs. See https://supertokens.com/docs/guides.',
       '',
       "To get things working, you'll need to add quite a few env vars to your .env file.",
-      'See https://redwoodjs.com/docs/auth/supertokens for a full walkthrough.',
+      'See https://cedarjs.com/docs/auth/supertokens for a full walkthrough.',
     ],
   })
 }

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/context-wrapping/custom/code.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/context-wrapping/custom/code.js
@@ -7,7 +7,7 @@ import { logger } from 'src/lib/logger'
  * Important: When deployed, a custom serverless function is an open API endpoint and
  * is your responsibility to secure appropriately.
  *
- * @see {@link https://redwoodjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
+ * @see {@link https://cedarjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
  * in the RedwoodJS documentation for more information.
  *
  * @typedef { import('aws-lambda').APIGatewayEvent } APIGatewayEvent

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/context-wrapping/custom/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/context-wrapping/custom/output.js
@@ -7,7 +7,7 @@ import { logger } from 'src/lib/logger'
  * Important: When deployed, a custom serverless function is an open API endpoint and
  * is your responsibility to secure appropriately.
  *
- * @see {@link https://redwoodjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
+ * @see {@link https://cedarjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
  * in the RedwoodJS documentation for more information.
  *
  * @typedef { import('aws-lambda').APIGatewayEvent } APIGatewayEvent

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/app/api/src/lib/auth.ts
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/app/api/src/lib/auth.ts
@@ -5,7 +5,7 @@
  * have something to check against, simulating a logged
  * in user that is allowed to access that service.
  *
- * See https://redwoodjs.com/docs/authentication for more info.
+ * See https://cedarjs.com/docs/authentication for more info.
  */
 export const isAuthenticated = () => {
   return true

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.webAuthn.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.webAuthn.ts.template
@@ -192,7 +192,7 @@ export const handler = async (
     resetPassword: resetPasswordOptions,
     signup: signupOptions,
 
-    // See https://redwoodjs.com/docs/authentication/dbauth#webauthn for options
+    // See https://cedarjs.com/docs/authentication/dbauth#webauthn for options
     webAuthn: {
       enabled: true,
       // How long to allow re-auth via WebAuthn in seconds (default is 10 years).

--- a/packages/cli/src/commands/__tests__/info.test.js
+++ b/packages/cli/src/commands/__tests__/info.test.js
@@ -96,7 +96,7 @@ describe('yarn cedar info', () => {
       mockRedwoodToml.fileContents = `
 [web]
   title = "Hello World" # Used for the <title> tag
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
 `
 
       await handler()
@@ -108,7 +108,7 @@ describe('yarn cedar info', () => {
           '      title = "Hello World" # Used for the <title> tag',
           // This next line is a bit more tricky because it has a # to make it
           // a comment, but then also a # in the URL.
-          '      apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths',
+          '      apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths',
         ].join('\n'),
       )
     })

--- a/packages/cli/src/commands/deploy/__tests__/baremetal.test.js
+++ b/packages/cli/src/commands/deploy/__tests__/baremetal.test.js
@@ -41,7 +41,7 @@ describe('verifyServerConfig', () => {
         repo: 'git://github.com',
       }),
     ).toThrow(
-      '"host" config option not set. See https://redwoodjs.com/docs/deployment/baremetal#deploytoml',
+      '"host" config option not set. See https://cedarjs.com/docs/deployment/baremetal#deploytoml',
     )
   })
 
@@ -52,7 +52,7 @@ describe('verifyServerConfig', () => {
         repo: 'git://github.com',
       }),
     ).toThrow(
-      '"path" config option not set. See https://redwoodjs.com/docs/deployment/baremetal#deploytoml',
+      '"path" config option not set. See https://cedarjs.com/docs/deployment/baremetal#deploytoml',
     )
   })
 
@@ -63,7 +63,7 @@ describe('verifyServerConfig', () => {
         path: '/var/www/app',
       }),
     ).toThrow(
-      '"repo" config option not set. See https://redwoodjs.com/docs/deployment/baremetal#deploytoml',
+      '"repo" config option not set. See https://cedarjs.com/docs/deployment/baremetal#deploytoml',
     )
   })
 

--- a/packages/cli/src/commands/deploy/baremetal/baremetalHandler.js
+++ b/packages/cli/src/commands/deploy/baremetal/baremetalHandler.js
@@ -30,7 +30,7 @@ const pathJoin = path.posix.join
 
 export const throwMissingConfig = (name) => {
   throw new Error(
-    `"${name}" config option not set. See https://redwoodjs.com/docs/deployment/baremetal#deploytoml`,
+    `"${name}" config option not set. See https://cedarjs.com/docs/deployment/baremetal#deploytoml`,
   )
 }
 

--- a/packages/cli/src/commands/deploy/serverlessHandler.js
+++ b/packages/cli/src/commands/deploy/serverlessHandler.js
@@ -192,7 +192,7 @@ export const handler = async (yargs) => {
           'To do this run `yarn serverless` on each of the sides, and connect your account',
           '',
           'Find more information in our docs:',
-          c.underline('https://redwoodjs.com/docs/deploy#serverless'),
+          c.underline('https://cedarjs.com/docs/deploy#serverless'),
         ]
 
         console.log(

--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
@@ -148,8 +148,8 @@ import { standard } from './CustomIdFieldsCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('CustomIdFieldsCell', () => {
   it('renders Loading successfully', () => {
@@ -265,8 +265,8 @@ import { standard } from './CustomIdFieldCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('CustomIdFieldCell', () => {
   it('renders Loading successfully', () => {
@@ -382,8 +382,8 @@ import { standard } from './UserProfileCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('UserProfileCell', () => {
   it('renders Loading successfully', () => {
@@ -499,8 +499,8 @@ import { standard } from './UserProfileCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('UserProfileCell', () => {
   it('renders Loading successfully', () => {
@@ -616,8 +616,8 @@ import { standard } from './UserCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('UserCell', () => {
   it('renders Loading successfully', () => {
@@ -733,8 +733,8 @@ import { standard } from './UserProfileCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('UserProfileCell', () => {
   it('renders Loading successfully', () => {
@@ -817,8 +817,8 @@ import { standard } from './BazingaCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('BazingaCell', () => {
   it('renders Loading successfully', () => {
@@ -1024,8 +1024,8 @@ import { standard } from './UserProfileCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('UserProfileCell', () => {
   it('renders Loading successfully', () => {
@@ -1093,8 +1093,8 @@ import { standard } from './AddressCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('AddressCell', () => {
   it('renders Loading successfully', () => {
@@ -1216,8 +1216,8 @@ import { standard } from './AddressesCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('AddressesCell', () => {
   it('renders Loading successfully', () => {
@@ -1349,8 +1349,8 @@ import { standard } from './MembersCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('MembersCell', () => {
   it('renders Loading successfully', () => {

--- a/packages/cli/src/commands/generate/cell/templates/test.js.template
+++ b/packages/cli/src/commands/generate/cell/templates/test.js.template
@@ -6,8 +6,8 @@ import { standard } from './${pascalName}Cell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('${pascalName}Cell', () => {
   it('renders Loading successfully', () => {

--- a/packages/cli/src/commands/generate/component/__tests__/__snapshots__/component.test.ts.snap
+++ b/packages/cli/src/commands/generate/component/__tests__/__snapshots__/component.test.ts.snap
@@ -20,7 +20,7 @@ exports[`creates a TS component and test 2`] = `
 import TypescriptUser from './TypescriptUser'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('TypescriptUser', () => {
   it('renders successfully', () => {
@@ -73,7 +73,7 @@ exports[`creates a multi word component test 1`] = `
 import UserProfile from './UserProfile'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('UserProfile', () => {
   it('renders successfully', () => {
@@ -126,7 +126,7 @@ exports[`creates a single word component test 1`] = `
 import User from './User'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('User', () => {
   it('renders successfully', () => {

--- a/packages/cli/src/commands/generate/component/templates/test.tsx.template
+++ b/packages/cli/src/commands/generate/component/templates/test.tsx.template
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import ${pascalName} from './${pascalName}'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('${pascalName}', () => {
   it('renders successfully', () => {

--- a/packages/cli/src/commands/generate/dbAuth/dbAuth.js
+++ b/packages/cli/src/commands/generate/dbAuth/dbAuth.js
@@ -51,7 +51,7 @@ export const builder = (yargs) => {
     .epilogue(
       `Also see the ${terminalLink(
         'CedarJS dbAuth Reference',
-        'https://redwoodjs.com/docs/auth/dbauth',
+        'https://cedarjs.com/docs/auth/dbauth',
       )}`,
     )
 

--- a/packages/cli/src/commands/generate/dbAuth/dbAuthHandler.js
+++ b/packages/cli/src/commands/generate/dbAuth/dbAuthHandler.js
@@ -312,7 +312,7 @@ const tasks = ({
               name: 'answer',
               message:
                 'Enable WebAuthn support (TouchID/FaceID) on LoginPage? See ' +
-                'https://redwoodjs.com/docs/auth/dbAuth#webAuthn',
+                'https://cedarjs.com/docs/auth/dbAuth#webAuthn',
               default: false,
             },
             { enquirer: ctx.enquirer },

--- a/packages/cli/src/commands/generate/directive/__tests__/__snapshots__/directive.test.ts.snap
+++ b/packages/cli/src/commands/generate/directive/__tests__/__snapshots__/directive.test.ts.snap
@@ -30,7 +30,7 @@ const validate = ({ context, directiveArgs }) => {
 
   // You can also modify your directive to take arguments
   // and use the directiveArgs object provided to this function to get values
-  // See documentation here: https://redwoodjs.com/docs/directives
+  // See documentation here: https://cedarjs.com/docs/directives
   logger.debug(directiveArgs, 'directiveArgs in requireAdmin directive')
 
   throw new Error('Implementation missing for requireAdmin')
@@ -98,7 +98,7 @@ const transform: TransformerDirectiveFunc = ({ context, resolvedValue }) => {
 
   // You can also modify your directive to take arguments
   // and use the directiveArgs object provided to this function to get values
-  // See documentation here: https://redwoodjs.com/docs/directives
+  // See documentation here: https://cedarjs.com/docs/directives
 
   return resolvedValue.replace('foo', 'bar')
 }

--- a/packages/cli/src/commands/generate/directive/templates/transformer.directive.ts.template
+++ b/packages/cli/src/commands/generate/directive/templates/transformer.directive.ts.template
@@ -28,7 +28,7 @@ const transform: TransformerDirectiveFunc = ({ context, resolvedValue }) => {
 
   // You can also modify your directive to take arguments
   // and use the directiveArgs object provided to this function to get values
-  // See documentation here: https://redwoodjs.com/docs/directives
+  // See documentation here: https://cedarjs.com/docs/directives
 
   return resolvedValue.replace('foo', 'bar')
 }

--- a/packages/cli/src/commands/generate/directive/templates/validator.directive.ts.template
+++ b/packages/cli/src/commands/generate/directive/templates/validator.directive.ts.template
@@ -27,7 +27,7 @@ const validate: ValidatorDirectiveFunc = ({ context, directiveArgs }) => {
 
   // You can also modify your directive to take arguments
   // and use the directiveArgs object provided to this function to get values
-  // See documentation here: https://redwoodjs.com/docs/directives
+  // See documentation here: https://cedarjs.com/docs/directives
   logger.debug(directiveArgs, 'directiveArgs in ${camelName} directive')
 
 

--- a/packages/cli/src/commands/generate/function/__tests__/__snapshots__/function.test.ts.snap
+++ b/packages/cli/src/commands/generate/function/__tests__/__snapshots__/function.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Single word default files > creates a single word function file > Scenario snapshot 1`] = `
 "export const standard = defineScenario({
   // Define the "fixture" to write into your test database here
-  // See guide: https://redwoodjs.com/docs/testing#scenarios
+  // See guide: https://cedarjs.com/docs/testing#scenarios
 })
 "
 `;
@@ -14,7 +14,7 @@ exports[`Single word default files > creates a single word function file > Test 
 import { handler } from './foo'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-functions
+//    https://cedarjs.com/docs/testing#testing-functions
 
 describe('foo function', () => {
   it('Should respond with 200', async () => {
@@ -32,7 +32,7 @@ describe('foo function', () => {
   })
 
   // You can also use scenarios to test your api functions
-  // See guide here: https://redwoodjs.com/docs/testing#scenarios
+  // See guide here: https://cedarjs.com/docs/testing#scenarios
   //
   // scenario('Scenario test', async () => {
   //
@@ -51,7 +51,7 @@ exports[`Single word default files > creates a single word function file 1`] = `
  * Important: When deployed, a custom serverless function is an open API endpoint and
  * is your responsibility to secure appropriately.
  *
- * @see {@link https://redwoodjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
+ * @see {@link https://cedarjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
  * in the RedwoodJS documentation for more information.
  *
  * @typedef { import('aws-lambda').APIGatewayEvent } APIGatewayEvent
@@ -86,7 +86,7 @@ exports[`creates a .js file if --javascript=true 1`] = `
  * Important: When deployed, a custom serverless function is an open API endpoint and
  * is your responsibility to secure appropriately.
  *
- * @see {@link https://redwoodjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
+ * @see {@link https://cedarjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
  * in the RedwoodJS documentation for more information.
  *
  * @typedef { import('aws-lambda').APIGatewayEvent } APIGatewayEvent
@@ -123,7 +123,7 @@ import { logger } from 'src/lib/logger'
  * Important: When deployed, a custom serverless function is an open API endpoint and
  * is your responsibility to secure appropriately.
  *
- * @see {@link https://redwoodjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
+ * @see {@link https://cedarjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
  * in the RedwoodJS documentation for more information.
  *
  * @param { APIGatewayEvent } event - an object which contains information from the invoker.
@@ -156,7 +156,7 @@ exports[`creates a multi word function file 1`] = `
  * Important: When deployed, a custom serverless function is an open API endpoint and
  * is your responsibility to secure appropriately.
  *
- * @see {@link https://redwoodjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
+ * @see {@link https://cedarjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
  * in the RedwoodJS documentation for more information.
  *
  * @typedef { import('aws-lambda').APIGatewayEvent } APIGatewayEvent

--- a/packages/cli/src/commands/generate/function/functionHandler.js
+++ b/packages/cli/src/commands/generate/function/functionHandler.js
@@ -114,7 +114,7 @@ export const handler = async ({ name, force, ...rest }) => {
     console.info(
       `Please consult the ${terminalLink(
         'Serverless Function Considerations',
-        'https://redwoodjs.com/docs/serverless-functions#security-considerations',
+        'https://cedarjs.com/docs/serverless-functions#security-considerations',
       )} in the RedwoodJS documentation for more information.`,
     )
     console.info('')

--- a/packages/cli/src/commands/generate/function/templates/function.ts.template
+++ b/packages/cli/src/commands/generate/function/templates/function.ts.template
@@ -9,7 +9,7 @@ import { logger } from 'src/lib/logger'
  * Important: When deployed, a custom serverless function is an open API endpoint and
  * is your responsibility to secure appropriately.
  *
- * @see {@link https://redwoodjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
+ * @see {@link https://cedarjs.com/docs/serverless-functions#security-considerations|Serverless Function Considerations}
  * in the RedwoodJS documentation for more information.
  *<% if (!typescript) { %>
  * @typedef { import('aws-lambda').APIGatewayEvent } APIGatewayEvent

--- a/packages/cli/src/commands/generate/function/templates/scenarios.ts.template
+++ b/packages/cli/src/commands/generate/function/templates/scenarios.ts.template
@@ -2,7 +2,7 @@ import type { ScenarioData } from '@cedarjs/testing/api'
 
 export const standard = defineScenario({
   // Define the "fixture" to write into your test database here
-  // See guide: https://redwoodjs.com/docs/testing#scenarios
+  // See guide: https://cedarjs.com/docs/testing#scenarios
 })
 
 export type StandardScenario = ScenarioData<unknown>

--- a/packages/cli/src/commands/generate/function/templates/test.ts.template
+++ b/packages/cli/src/commands/generate/function/templates/test.ts.template
@@ -3,7 +3,7 @@ import { mockHttpEvent, mockContext } from '@cedarjs/testing/api'
 import { handler } from './${name}'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-functions
+//    https://cedarjs.com/docs/testing#testing-functions
 
 describe('${name} function', () => {
 
@@ -22,7 +22,7 @@ describe('${name} function', () => {
   })
 
 // You can also use scenarios to test your api functions
-// See guide here: https://redwoodjs.com/docs/testing#scenarios
+// See guide here: https://cedarjs.com/docs/testing#scenarios
 //
 // scenario('Scenario test', async () => {
 //

--- a/packages/cli/src/commands/generate/job/__tests__/__snapshots__/job.test.ts.snap
+++ b/packages/cli/src/commands/generate/job/__tests__/__snapshots__/job.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Single word default files > creates a single word job file > Scenario s
 
 export const standard = defineScenario({
   // Define the "fixture" to write into your test database here
-  // See guide: https://redwoodjs.com/docs/testing#scenarios
+  // See guide: https://cedarjs.com/docs/testing#scenarios
 })
 
 export type StandardScenario = ScenarioData<unknown>

--- a/packages/cli/src/commands/generate/job/templates/scenarios.ts.template
+++ b/packages/cli/src/commands/generate/job/templates/scenarios.ts.template
@@ -2,7 +2,7 @@ import type { ScenarioData } from '@cedarjs/testing/api'
 
 export const standard = defineScenario({
   // Define the "fixture" to write into your test database here
-  // See guide: https://redwoodjs.com/docs/testing#scenarios
+  // See guide: https://cedarjs.com/docs/testing#scenarios
 })
 
 export type StandardScenario = ScenarioData<unknown>

--- a/packages/cli/src/commands/generate/layout/__tests__/__snapshots__/layout.test.ts.snap
+++ b/packages/cli/src/commands/generate/layout/__tests__/__snapshots__/layout.test.ts.snap
@@ -42,7 +42,7 @@ exports[`Multi word default files > creates a multi word layout test 1`] = `
 import SinglePageLayout from './SinglePageLayout'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('SinglePageLayout', () => {
   it('renders successfully', () => {
@@ -95,7 +95,7 @@ exports[`Single Word default files > creates a single word layout test 1`] = `
 import AppLayout from './AppLayout'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('AppLayout', () => {
   it('renders successfully', () => {

--- a/packages/cli/src/commands/generate/layout/templates/test.tsx.template
+++ b/packages/cli/src/commands/generate/layout/templates/test.tsx.template
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import ${pascalName}Layout from './${pascalName}Layout'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('${pascalName}Layout', () => {
   it('renders successfully', () => {

--- a/packages/cli/src/commands/generate/model/model.js
+++ b/packages/cli/src/commands/generate/model/model.js
@@ -18,7 +18,7 @@ export const builder = (yargs) => {
     .epilogue(
       `Also see the ${terminalLink(
         'RedwoodRecord Reference',
-        'https://redwoodjs.com/docs/redwoodrecord',
+        'https://cedarjs.com/docs/redwoodrecord',
       )}`,
     )
 

--- a/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
+++ b/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
@@ -69,7 +69,7 @@ exports[`Single world files > creates a page test 1`] = `
 import HomePage from './HomePage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('HomePage', () => {
   it('renders successfully', () => {
@@ -197,7 +197,7 @@ exports[`TS Files > generates typescript pages 3`] = `
 import TsFilesPage from './TsFilesPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('TsFilesPage', () => {
   it('renders successfully', () => {
@@ -232,7 +232,7 @@ exports[`handler > file generation 2`] = `
 import HomePage from './HomePage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('HomePage', () => {
   it('renders successfully', () => {
@@ -316,7 +316,7 @@ exports[`handler > file generation with route params 2`] = `
 import PostPage from './PostPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('PostPage', () => {
   it('renders successfully', () => {
@@ -424,7 +424,7 @@ exports[`multiWorldFiles > creates a test for a component with multiple words fo
 import ContactUsPage from './ContactUsPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('ContactUsPage', () => {
   it('renders successfully', () => {
@@ -470,7 +470,7 @@ exports[`paramFiles > creates a test for page component with params 1`] = `
 import PostPage from './PostPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('PostPage', () => {
   it('renders successfully', () => {

--- a/packages/cli/src/commands/generate/page/templates/test.tsx.template
+++ b/packages/cli/src/commands/generate/page/templates/test.tsx.template
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import ${pascalName}Page from './${pascalName}Page'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('${pascalName}Page', () => {
   it('renders successfully', () => {

--- a/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdl.test.js.snap
+++ b/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdl.test.js.snap
@@ -59,8 +59,8 @@ exports[`handler > can be called with PascalCase model name 3`] = `
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('users', () => {
   scenario('returns all users', async (scenario) => {
@@ -207,8 +207,8 @@ exports[`handler > can be called with PascalCase model name 7`] = `
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('customDatums', () => {
   scenario('returns all customDatums', async (scenario) => {
@@ -353,8 +353,8 @@ exports[`handler > can be called with camelCase model name 3`] = `
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('users', () => {
   scenario('returns all users', async (scenario) => {
@@ -501,8 +501,8 @@ exports[`handler > can be called with camelCase model name 7`] = `
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('customDatums', () => {
   scenario('returns all customDatums', async (scenario) => {

--- a/packages/cli/src/commands/generate/sdl/sdlHandler.js
+++ b/packages/cli/src/commands/generate/sdl/sdlHandler.js
@@ -34,7 +34,7 @@ const missingIdConsoleMessage = () => {
   const line3 = "you'll need to update your schema definition to include"
   const line4 = 'an `@id` column. Read more here: '
   const line5 = ansis.underline.blue(
-    'https://redwoodjs.com/docs/schema-relations',
+    'https://cedarjs.com/docs/schema-relations',
   )
 
   console.error(

--- a/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.js.snap
+++ b/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.js.snap
@@ -27,8 +27,8 @@ exports[`in javascript mode > creates a multi word service test file 1`] = `
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('userProfiles', () => {
   scenario('returns all userProfiles', async (scenario) => {
@@ -52,8 +52,8 @@ exports[`in javascript mode > creates a multi word service test file with crud a
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('transactions', () => {
   scenario('returns all transactions', async (scenario) => {
@@ -112,8 +112,8 @@ exports[`in javascript mode > creates a multi word service test file with multip
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('scalarTypes', () => {
   scenario('returns all scalarTypes', async (scenario) => {
@@ -335,8 +335,8 @@ exports[`in javascript mode > creates a single word service test file 1`] = `
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('users', () => {
   scenario('returns all users', async (scenario) => {
@@ -414,8 +414,8 @@ import type { StandardScenario } from './userProfiles.scenarios.js'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('userProfiles', () => {
   scenario('returns all userProfiles', async (scenario: StandardScenario) => {
@@ -442,8 +442,8 @@ import type { StandardScenario } from './transactions.scenarios.js'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('transactions', () => {
   scenario('returns all transactions', async (scenario: StandardScenario) => {
@@ -508,8 +508,8 @@ import type { StandardScenario } from './scalarTypes.scenarios.js'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('scalarTypes', () => {
   scenario('returns all scalarTypes', async (scenario: StandardScenario) => {
@@ -761,8 +761,8 @@ import type { StandardScenario } from './users.scenarios.js'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('users', () => {
   scenario('returns all users', async (scenario: StandardScenario) => {

--- a/packages/cli/src/commands/generate/service/templates/test.ts.template
+++ b/packages/cli/src/commands/generate/service/templates/test.ts.template
@@ -39,8 +39,8 @@ import type { StandardScenario } from './${pluralCamelName}.scenarios.js'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float.
 //           Please refer to the RedwoodJS Testing Docs:
-//       https://redwoodjs.com/docs/testing#testing-services
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//       https://cedarjs.com/docs/testing#testing-services
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('${pluralCamelName}', () => {
   scenario('returns all ${pluralCamelName}', async (scenario: StandardScenario) => {

--- a/packages/cli/src/commands/prerenderHandler.js
+++ b/packages/cli/src/commands/prerenderHandler.js
@@ -398,13 +398,13 @@ export const handler = async ({ path: routerPath, dryRun, verbose }) => {
       )
       console.log(
         c.info(
-          '- Avoid using `window` in the initial render path through your React components without checks. \n  See https://redwoodjs.com/docs/prerender#prerender-utils',
+          '- Avoid using `window` in the initial render path through your React components without checks. \n  See https://cedarjs.com/docs/prerender#prerender-utils',
         ),
       )
 
       console.log(
         c.info(
-          '- Avoid prerendering Cells with authenticated queries, by conditionally rendering them.\n  See https://redwoodjs.com/docs/prerender#common-warnings--errors',
+          '- Avoid prerendering Cells with authenticated queries, by conditionally rendering them.\n  See https://cedarjs.com/docs/prerender#common-warnings--errors',
         ),
       )
     }

--- a/packages/cli/src/commands/record.js
+++ b/packages/cli/src/commands/record.js
@@ -10,7 +10,7 @@ export const builder = (yargs) =>
     .epilogue(
       `Also see the ${terminalLink(
         'RedwoodRecord Docs',
-        'https://redwoodjs.com/docs/redwoodrecord',
+        'https://cedarjs.com/docs/redwoodrecord',
       )}\n`,
     )
 

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -214,7 +214,7 @@ function directToCustomAuthCommand(provider) {
 
       const customAuthLink = terminalLink(
         'Custom Auth',
-        'https://redwoodjs.com/docs/auth/custom',
+        'https://cedarjs.com/docs/auth/custom',
       )
 
       console.log(

--- a/packages/cli/src/commands/setup/cache/cacheHandler.js
+++ b/packages/cli/src/commands/setup/cache/cacheHandler.js
@@ -60,7 +60,7 @@ export const handler = async ({ client, force }) => {
       task: (_ctx, task) => {
         task.title = `One more thing...\n
           ${c.tip('Check out the Service Cache docs for config and usage:')}
-          ${c.link('https://redwoodjs.com/docs/services#caching')}
+          ${c.link('https://cedarjs.com/docs/services#caching')}
         `
       },
     },

--- a/packages/cli/src/commands/setup/deploy/__tests__/netlify.test.js
+++ b/packages/cli/src/commands/setup/deploy/__tests__/netlify.test.js
@@ -54,8 +54,8 @@ beforeEach(() => {
     [REDWOOD_TOML_PATH]: `[web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # you can customize graphql and dbAuth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  apiUrl = "/.redwood/functions" # you can customize graphql and dbAuth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://cedarjs.com/docs/environment-variables#web
 [api]
   port = 8911
 [browser]

--- a/packages/cli/src/commands/setup/deploy/providers/baremetalHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/baremetalHandler.js
@@ -34,7 +34,7 @@ const files = [
 const notes = [
   'You are almost ready to go BAREMETAL!',
   '',
-  'See https://redwoodjs.com/docs/deploy/baremetal for the remaining',
+  'See https://cedarjs.com/docs/deploy/baremetal for the remaining',
   'config and setup required before you can perform your first deploy.',
 ]
 

--- a/packages/cli/src/commands/setup/deploy/providers/netlifyHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/netlifyHandler.js
@@ -19,7 +19,7 @@ const files = [
 
 const notes = [
   'You are ready to deploy to Netlify!',
-  'See: https://redwoodjs.com/docs/deploy/netlify',
+  'See: https://cedarjs.com/docs/deploy/netlify',
 ]
 
 export const handler = async ({ force }) => {

--- a/packages/cli/src/commands/setup/deploy/providers/serverless.js
+++ b/packages/cli/src/commands/setup/deploy/providers/serverless.js
@@ -5,7 +5,7 @@ export const description =
   '[DEPRECATED]\n' +
   'Setup Serverless Framework AWS deploy\n' +
   'For more information:\n' +
-  'https://redwoodjs.com/docs/deploy/serverless'
+  'https://cedarjs.com/docs/deploy/serverless'
 
 export const aliases = ['aws-serverless']
 export const handler = createHandler('serverless')

--- a/packages/cli/src/commands/setup/deploy/providers/serverlessHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/serverlessHandler.js
@@ -25,12 +25,12 @@ const notes = [
   c.error('DEPRECATED option not officially supported'),
   '',
   'For more information:',
-  'https://redwoodjs.com/docs/deploy/serverless',
+  'https://cedarjs.com/docs/deploy/serverless',
   '',
   '',
   c.success("You're almost ready to deploy using the Serverless framework!"),
   '',
-  '• See https://redwoodjs.com/docs/deploy#serverless-deploy for more info. If you ',
+  '• See https://cedarjs.com/docs/deploy#serverless-deploy for more info. If you ',
   '  want to give it a shot, open your `.env` file and add your AWS credentials,',
   '  then run: ',
   '',
@@ -88,7 +88,7 @@ const updateRedwoodTomlTask = () => {
 
       const newContent = content.replace(
         /apiUrl.*?\n/m,
-        'apiUrl = "${API_URL:/api}"       # Set API_URL in production to the Serverless deploy endpoint of your api service, see https://redwoodjs.com/docs/deploy/serverless-deploy\n',
+        'apiUrl = "${API_URL:/api}"       # Set API_URL in production to the Serverless deploy endpoint of your api service, see https://cedarjs.com/docs/deploy/serverless-deploy\n',
       )
       fs.writeFileSync(configPath, newContent)
     },

--- a/packages/cli/src/commands/setup/deploy/providers/vercelHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/vercelHandler.js
@@ -58,5 +58,5 @@ const vercelConfig = {
 
 const notes = [
   'You are ready to deploy to Vercel!',
-  'See: https://redwoodjs.com/docs/deploy#vercel-deploy',
+  'See: https://cedarjs.com/docs/deploy#vercel-deploy',
 ]

--- a/packages/cli/src/commands/setup/deploy/templates/baremetal.js
+++ b/packages/cli/src/commands/setup/deploy/templates/baremetal.js
@@ -26,7 +26,7 @@ export const DEPLOY = `# This file contains config for a baremetal deployment
 # * passphrase - used if your private key has a passphrase
 # * agentForward - set to \`true\` to forward the client machine's ssh credentials
 #
-# See https://redwoodjs.com/docs/deploy/baremetal for more info
+# See https://cedarjs.com/docs/deploy/baremetal for more info
 
 [[production.servers]]
 host = "server.com"

--- a/packages/cli/src/commands/setup/docker/dockerHandler.js
+++ b/packages/cli/src/commands/setup/docker/dockerHandler.js
@@ -274,7 +274,7 @@ export async function handler({ force }) {
         "Lastly, ensure you have Docker. If you don't, see https://docs.docker.com/desktop/",
         '',
         "There's a lot in the Dockerfile and there's a reason for every line.",
-        'Be sure to check out the docs: https://redwoodjs.com/docs/docker',
+        'Be sure to check out the docs: https://cedarjs.com/docs/docker',
       ].join('\n'),
     )
   } catch (e) {

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/default.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/default.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = "${API_DEV_PORT:8911}"

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/fragments.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/fragments.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = "${API_DEV_PORT:8911}"

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/fragments_no_space_equals.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/fragments_no_space_equals.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = "${API_DEV_PORT:8911}"

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_already_setup.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_already_setup.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = "${API_DEV_PORT:8911}"

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_commented_graphql.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_commented_graphql.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = "${API_DEV_PORT:8911}"

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_fragments_already_setup.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_fragments_already_setup.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = "${API_DEV_PORT:8911}"

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_no_space_equals.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_no_space_equals.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = "${API_DEV_PORT:8911}"

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__snapshots__/trustedDocuments.test.ts.snap
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__snapshots__/trustedDocuments.test.ts.snap
@@ -6,15 +6,15 @@ exports[`Trusted documents setup > Project toml configuration updates > default 
 # If you remove it and try to run \`yarn cedar dev\`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = "\${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = "\${API_DEV_PORT:8911}"
@@ -34,15 +34,15 @@ exports[`Trusted documents setup > Project toml configuration updates > default 
 # If you remove it and try to run \`yarn cedar dev\`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = "\${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = "\${API_DEV_PORT:8911}"
@@ -62,15 +62,15 @@ exports[`Trusted documents setup > Project toml configuration updates > default 
 # If you remove it and try to run \`yarn cedar dev\`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = "\${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = "\${API_DEV_PORT:8911}"
@@ -89,15 +89,15 @@ exports[`Trusted documents setup > Project toml configuration updates > toml whe
 # If you remove it and try to run \`yarn cedar dev\`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = "\${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = "\${API_DEV_PORT:8911}"

--- a/packages/cli/src/commands/setup/tsconfig/tsconfigHandler.js
+++ b/packages/cli/src/commands/setup/tsconfig/tsconfigHandler.js
@@ -50,7 +50,7 @@ export const handler = async ({ force }) => {
         task: (_ctx, task) => {
           task.title = `One more thing...\n
           ${c.tip('Quick link to the docs on configuring TypeScript')}
-          ${c.link('https://redwoodjs.com/docs/typescript')}
+          ${c.link('https://cedarjs.com/docs/typescript')}
         `
         },
       },

--- a/packages/cli/src/commands/setup/uploads/uploadsHandler.js
+++ b/packages/cli/src/commands/setup/uploads/uploadsHandler.js
@@ -95,12 +95,12 @@ export const handler = async ({ force }) => {
           if (transformResult.error) {
             if (transformResult.error === 'RW_CODEMOD_ERR_OLD_FORMAT') {
               throw new Error(
-                'It looks like your src/lib/db file is using the old format. Please update it as per the v8 upgrade guide: https://redwoodjs.com/upgrade/v8#database-file-structure-change. And run again. \n\nYou can also manually modify your api/src/lib/db to include the prisma extension: https://docs.redwoodjs.com/docs/uploads/#attaching-the-prisma-extension',
+                'It looks like your src/lib/db file is using the old format. Please update it as per the v8 upgrade guide: https://cedarjs.com/docs/upgrade-guides/v8#database-file-structure-change. And run again. \n\nYou can also manually modify your api/src/lib/db to include the prisma extension: https://cedarjs.com/docs/uploads/#attaching-the-prisma-extension',
               )
             }
 
             throw new Error(
-              'Could not add the prisma extension. \n Please modify your api/src/lib/db to include the prisma extension: https://docs.redwoodjs.com/docs/uploads/#attaching-the-prisma-extension',
+              'Could not add the prisma extension. \n Please modify your api/src/lib/db to include the prisma extension: https://cedarjs.com/docs/uploads/#attaching-the-prisma-extension',
             )
           }
         },
@@ -146,7 +146,7 @@ export const handler = async ({ force }) => {
 
 
           Check out the docs for more info:
-          ${c.link('https://docs.redwoodjs.com/docs/uploads')}
+          ${c.link('https://cedarjs.com/docs/uploads')}
 
         `
         },

--- a/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/input/web/src/components/TestCell/TestCell.test.js
+++ b/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/input/web/src/components/TestCell/TestCell.test.js
@@ -5,8 +5,8 @@ import { standard } from './TestCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('TestCell', () => {
   it('renders Loading successfully', () => {

--- a/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/input/web/src/components/TestComponent/TestComponent.test.js
+++ b/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/input/web/src/components/TestComponent/TestComponent.test.js
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import TestComponent from './TestComponent'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('TestComponent', () => {
   it('renders successfully', () => {

--- a/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/input/web/src/layouts/TestLayout/TestLayout.test.js
+++ b/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/input/web/src/layouts/TestLayout/TestLayout.test.js
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import TestLayout from './TestLayout'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('TestLayout', () => {
   it('renders successfully', () => {

--- a/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/input/web/src/pages/TestPage/TestPage.test.js
+++ b/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/input/web/src/pages/TestPage/TestPage.test.js
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import TestPage from './TestPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('TestPage', () => {
   it('renders successfully', () => {

--- a/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/output/web/src/components/TestCell/TestCell.test.jsx
+++ b/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/output/web/src/components/TestCell/TestCell.test.jsx
@@ -5,8 +5,8 @@ import { standard } from './TestCell.mock'
 // Generated boilerplate tests do not account for all circumstances
 // and can fail without adjustments, e.g. Float and DateTime types.
 //           Please refer to the RedwoodJS Testing Docs:
-//        https://redwoodjs.com/docs/testing#testing-cells
-// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
 
 describe('TestCell', () => {
   it('renders Loading successfully', () => {

--- a/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/output/web/src/components/TestComponent/TestComponent.test.jsx
+++ b/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/output/web/src/components/TestComponent/TestComponent.test.jsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import TestComponent from './TestComponent'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+//    https://cedarjs.com/docs/testing#testing-components
 
 describe('TestComponent', () => {
   it('renders successfully', () => {

--- a/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/output/web/src/layouts/TestLayout/TestLayout.test.jsx
+++ b/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/output/web/src/layouts/TestLayout/TestLayout.test.jsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import TestLayout from './TestLayout'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('TestLayout', () => {
   it('renders successfully', () => {

--- a/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/output/web/src/pages/TestPage/TestPage.test.jsx
+++ b/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/output/web/src/pages/TestPage/TestPage.test.jsx
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import TestPage from './TestPage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('TestPage', () => {
   it('renders successfully', () => {

--- a/packages/codemods/src/codemods/v6.x.x/replaceComponentSvgs/__testfixtures__/reExported/input/redwood.toml
+++ b/packages/codemods/src/codemods/v6.x.x/replaceComponentSvgs/__testfixtures__/reExported/input/redwood.toml
@@ -3,13 +3,13 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://cedarjs.com/docs/environment-variables#web
 [api]
   port = 8911
 [browser]

--- a/packages/codemods/src/codemods/v6.x.x/replaceComponentSvgs/__testfixtures__/reExported/output/redwood.toml
+++ b/packages/codemods/src/codemods/v6.x.x/replaceComponentSvgs/__testfixtures__/reExported/output/redwood.toml
@@ -3,13 +3,13 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://cedarjs.com/docs/environment-variables#web
 [api]
   port = 8911
 [browser]

--- a/packages/codemods/src/codemods/v6.x.x/replaceComponentSvgs/__testfixtures__/srcAlias/input/redwood.toml
+++ b/packages/codemods/src/codemods/v6.x.x/replaceComponentSvgs/__testfixtures__/srcAlias/input/redwood.toml
@@ -3,13 +3,13 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://cedarjs.com/docs/environment-variables#web
 [api]
   port = 8911
 [browser]

--- a/packages/forms/src/FieldError.tsx
+++ b/packages/forms/src/FieldError.tsx
@@ -40,7 +40,7 @@ const DEFAULT_MESSAGES = {
  * <FieldError name="name" className="error" />
  * ```
  *
- * @see {@link https://redwoodjs.com/docs/tutorial/chapter3/forms#fielderror}
+ * @see {@link https://cedarjs.com/docs/tutorial/chapter3/forms#fielderror}
  *
  * @privateRemarks
  *

--- a/packages/forms/src/InputComponents.tsx
+++ b/packages/forms/src/InputComponents.tsx
@@ -56,7 +56,7 @@ export interface InputFieldProps
 /**
  * Renders an `<input>` field.
  *
- * @see {@link https://redwoodjs.com/docs/forms#input-fields}
+ * @see {@link https://cedarjs.com/docs/forms#input-fields}
  */
 export const InputField = forwardRef(
   (

--- a/packages/internal/src/__tests__/__fixtures__/nestedPages/redwood.toml
+++ b/packages/internal/src/__tests__/__fixtures__/nestedPages/redwood.toml
@@ -3,13 +3,13 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "RedwoodJS.com"
   port = 8910
   apiUrl = "/.netlify/functions"
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://cedarjs.com/docs/environment-variables#web
 [api]
   port = 8911
 [browser]

--- a/packages/internal/src/__tests__/__fixtures__/nestedPages/web/src/pages/HomePage/HomePage.test.js
+++ b/packages/internal/src/__tests__/__fixtures__/nestedPages/web/src/pages/HomePage/HomePage.test.js
@@ -3,7 +3,7 @@ import { render } from '@cedarjs/testing/web'
 import HomePage from './HomePage'
 
 //   Improve this test with help from the Redwood Testing Doc:
-//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+//   https://cedarjs.com/docs/testing#testing-pages-layouts
 
 describe('HomePage', () => {
   it('renders successfully', () => {

--- a/packages/internal/src/__tests__/__fixtures__/redwood.withEnv.toml
+++ b/packages/internal/src/__tests__/__fixtures__/redwood.withEnv.toml
@@ -1,8 +1,8 @@
 [web]
   title = "App running on ${APP_ENV}"
   port = "${PORT:8910}"
-  apiUrl = "${API_URL:/.redwood/functions}" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  apiUrl = "${API_URL:/.redwood/functions}" # you can customise graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://cedarjs.com/docs/environment-variables#web
 [api]
   port = 8911
 [browser]

--- a/packages/internal/src/__tests__/graphqlSchema.test.ts
+++ b/packages/internal/src/__tests__/graphqlSchema.test.ts
@@ -87,7 +87,7 @@ test('Returns error message when schema loading fails', async () => {
         ansis.yellow(
           `  See the ${terminalLink(
             'Troubleshooting Generators',
-            'https://redwoodjs.com/docs/schema-relations#troubleshooting-generators',
+            'https://cedarjs.com/docs/schema-relations#troubleshooting-generators',
           )} section in our docs for more help.`,
         ),
       ].join('\n'),

--- a/packages/internal/src/generate/graphqlSchema.ts
+++ b/packages/internal/src/generate/graphqlSchema.ts
@@ -133,7 +133,7 @@ export const generateGraphQLSchema = async () => {
           ansis.yellow(
             `  See the ${terminalLink(
               'Troubleshooting Generators',
-              'https://redwoodjs.com/docs/schema-relations#troubleshooting-generators',
+              'https://cedarjs.com/docs/schema-relations#troubleshooting-generators',
             )} section in our docs for more help.`,
           ),
         ].join('\n')

--- a/packages/prerender/README.md
+++ b/packages/prerender/README.md
@@ -8,7 +8,7 @@
 ## Purpose and Vision
 
 Build-time prerender for pages that don't have dynamic content. See:  
-https://redwoodjs.com/docs/prerender
+https://cedarjs.com/docs/prerender
 
 ## Package Leads
 

--- a/packages/project-config/src/__tests__/fixtures/redwood.withEnv.toml
+++ b/packages/project-config/src/__tests__/fixtures/redwood.withEnv.toml
@@ -1,8 +1,8 @@
 [web]
   title = "App running on ${APP_ENV}"
   port = "${PORT:8910}"
-  apiUrl = "${API_URL:/.redwood/functions}" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  apiUrl = "${API_URL:/.redwood/functions}" # you can customise graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://cedarjs.com/docs/environment-variables#web
 [api]
   port = 8911
 [browser]

--- a/packages/record/README.md
+++ b/packages/record/README.md
@@ -6,7 +6,7 @@ RedwoodRecord is heavily inspired by [ActiveRecord](https://guides.rubyonrails.o
 
 ## Usage
 
-Usage documentation is available at https://redwoodjs.com/docs/redwoodrecord
+Usage documentation is available at https://cedarjs.com/docs/redwoodrecord
 
 ## Package Structure
 

--- a/packages/record/src/redwoodrecord/ValidationMixin.js
+++ b/packages/record/src/redwoodrecord/ValidationMixin.js
@@ -15,7 +15,7 @@ export default (Base) =>
     // Denotes validations that need to run for the given fields. Must be in the
     // form of { field: options } where `field` is the name of the field and
     // `options` are the validation options. See Service Validations docs for
-    // usage examples: https://redwoodjs.com/docs/services.html#service-validations
+    // usage examples: https://cedarjs.com/docs/services.html#service-validations
     //
     //   static validates = {
     //     emailAddress: { email: true },

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -22,7 +22,7 @@ Features include:
 - Prerendered routes
 - Sets of routes
 - Navigation and History
-- [Accessibility](https://redwoodjs.com/docs/accessibility)
+- [Accessibility](https://cedarjs.com/docs/accessibility)
 - and more...
 
 ## Contributing

--- a/packages/testing/src/api/apiFunction.ts
+++ b/packages/testing/src/api/apiFunction.ts
@@ -88,7 +88,7 @@ interface MockedSignedWebhookParams
 
 /**
  * @description Use this function to mock a signed webhook
- * @see https://redwoodjs.com/docs/webhooks#webhooks
+ * @see https://cedarjs.com/docs/webhooks#webhooks
  **/
 export const mockSignedWebhook = ({
   payload = null,

--- a/tasks/e2e/cypress/e2e/01-tutorial/codemods/Step0_1_RedwoodToml.js
+++ b/tasks/e2e/cypress/e2e/01-tutorial/codemods/Step0_1_RedwoodToml.js
@@ -4,7 +4,7 @@ export default `
 # If you remove it and try to run yarn cedar dev, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   port = 8910

--- a/tasks/e2e/cypress/e2e/01-tutorial/sharedTests.js
+++ b/tasks/e2e/cypress/e2e/01-tutorial/sharedTests.js
@@ -114,7 +114,7 @@ export const test_layouts = () =>
 
 export const test_dynamic = () =>
   it('4. Getting Dynamic', () => {
-    // https://redwoodjs.com/docs/tutorial/chapter2/getting-dynamic
+    // https://cedarjs.com/docs/tutorial/chapter2/getting-dynamic
     cy.writeFile(path.join(BASE_DIR, 'api/db/schema.prisma'), Step4_1_DbSchema)
     cy.exec(`rm ${BASE_DIR}/api/db/dev.db`, { failOnNonZeroExit: false })
     // need to also handle case where Prisma Client be out of sync
@@ -208,7 +208,7 @@ export const test_cells = () =>
 
 export const test_routing_params = () =>
   it('6. Routing Params', () => {
-    // https://redwoodjs.com/docs/tutorial/chapter2/routing-params
+    // https://cedarjs.com/docs/tutorial/chapter2/routing-params
     cy.exec(`cd ${BASE_DIR}; yarn cedar g page BlogPost --force`)
     cy.exec(`cd ${BASE_DIR}; yarn cedar g cell BlogPost --force`)
     cy.exec(`cd ${BASE_DIR}; yarn cedar g component BlogPost --force`)
@@ -273,7 +273,7 @@ export const test_routing_params = () =>
 
 export const test_forms = () =>
   it("7. Everyone's Favorite Thing to Build: Forms", () => {
-    // https://redwoodjs.com/docs/tutorial/everyone-s-favorite-thing-to-build-forms
+    // https://cedarjs.com/docs/tutorial/everyone-s-favorite-thing-to-build-forms
     cy.exec(`cd ${BASE_DIR}; yarn cedar g page contact --force`)
     cy.writeFile(
       path.join(BASE_DIR, 'web/src/layouts/BlogLayout/BlogLayout.jsx'),

--- a/tasks/e2e/cypress/e2e/01-tutorial/tutorial.cy.js
+++ b/tasks/e2e/cypress/e2e/01-tutorial/tutorial.cy.js
@@ -25,8 +25,8 @@ import {
 const BASE_DIR = Cypress.env('RW_PATH')
 
 describe('The Cedar Tutorial - Golden path edition', () => {
-  // TODO: https://redwoodjs.com/docs/tutorial/chapter3/saving-data
-  // TODO: https://redwoodjs.com/docs/tutorial/chapter4/administration
+  // TODO: https://cedarjs.com/docs/tutorial/chapter3/saving-data
+  // TODO: https://cedarjs.com/docs/tutorial/chapter4/administration
   after(() => {
     cy.exec(
       `cd ${BASE_DIR}; git add . && git commit -a --message=01-tutorial`,
@@ -51,7 +51,7 @@ describe('The Cedar Tutorial - Golden path edition', () => {
     //   Step0_2_GraphQL
     // )
 
-    // https://redwoodjs.com/docs/tutorial/chapter1/installation
+    // https://cedarjs.com/docs/tutorial/chapter1/installation
 
     waitForApiSide()
 

--- a/tasks/server-tests/fixtures/redwood-app/redwood.toml
+++ b/tasks/server-tests/fixtures/redwood-app/redwood.toml
@@ -3,15 +3,15 @@
 # If you remove it and try to run `yarn cedar dev`, you'll get an error.
 #
 # For the full list of options, see the "App Configuration: redwood.toml" doc:
-# https://redwoodjs.com/docs/app-configuration-redwood-toml
+# https://cedarjs.com/docs/app-configuration-redwood-toml
 
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
-    # See https://redwoodjs.com/docs/environment-variables#web
+    # See https://cedarjs.com/docs/environment-variables#web
   ]
 [api]
   port = 8911


### PR DESCRIPTION
Update all old rw doc links to now point to https://cedarjs.com/docs instead