### PR TITLE
chore(ci): Renovate minimumReleaseAge 3 days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,10 @@
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true
     },


### PR DESCRIPTION
Fixes #446 

From the issue description:

## Prevent holding broken npm packages

npm packages less than 72 hours (3 days) old can be unpublished from the npm registry, which could result in a service impact if you have already updated to it. Set `minimumReleaseAge` to 3 days for npm packages to prevent relying on a package that can be removed from the registry