### PR TITLE
chore(github): Don't mark "good first issue" or "help wanted" issues as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,3 +17,4 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           days-before-stale: 30
           days-before-close: 5
+          exempt-issue-labels: 'good first issue, help wanted'


### PR DESCRIPTION
The syntax to use for labels with spaces in their names is a bit unclear. 
Trying it like this for now, if it doesn't seem to work I'll try URL-encoding the label names (%20 instead of spaces).

See https://github.com/actions/stale/issues/98