### PR TITLE
chore(renovate): Knip is getting too noisy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -55,7 +55,7 @@
     {
       "groupName": "Noisy packages",
       "description": "Limit updates for noisy packages to twice per month",
-      "matchPackageNames": ["nx", "@clerk/clerk-react", "@clerk/types"],
+      "matchPackageNames": ["nx", "@clerk/clerk-react", "@clerk/types", "knip"],
       "schedule": ["* * 1,15 * *"]
     }
   ]


### PR DESCRIPTION
Knip seems to have at least one release per week. Lately it's been even more often than that. Cedar only uses it for create-cedar-rsc-app, which isn't used much, so not super important to stay on the latest version