### PR TITLE
chore(deps): Remove react-refresh from `@cedarjs/core` as it's not used

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,6 @@
     "graphql-tag": "2.12.6",
     "lodash": "4.17.21",
     "nodemon": "3.1.11",
-    "react-refresh": "0.14.0",
     "rimraf": "6.1.2",
     "typescript": "5.9.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3516,7 +3516,6 @@ __metadata:
     lodash: "npm:4.17.21"
     nodemon: "npm:3.1.11"
     publint: "npm:0.3.16"
-    react-refresh: "npm:0.14.0"
     rimraf: "npm:6.1.2"
     tsx: "npm:4.21.0"
     typescript: "npm:5.9.3"
@@ -26968,13 +26967,6 @@ __metadata:
     react-native-svg:
       optional: true
   checksum: 10c0/e02896764b7ff88fb1b8eb1d8ae7201f862a459ebc97732a8a18171c3d47a51a32341906fb673d9304d0d4dc4fd90093b1ebe42f428bb148f299d2929e2399ef
-  languageName: node
-  linkType: hard
-
-"react-refresh@npm:0.14.0":
-  version: 0.14.0
-  resolution: "react-refresh@npm:0.14.0"
-  checksum: 10c0/b8ae07ad153357d77830928a7f1fc2df837aabefee907fa273ba04c7643f3b860e986f1d4b7ada9b721c8d79b8c24b5b911a314a1a2398b105f1b13d19ea2b8d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is not how we include react-refresh anymore. It's now included by `@vitejs/plugin-react` that `@cedarjs/vite` depends on.