### PR TITLE
feat(cli): Better upgrade and exit output

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -1,4 +1,4 @@
-import path from 'path'
+import path from 'node:path'
 
 import { ListrEnquirerPromptAdapter } from '@listr2/prompt-adapter-enquirer'
 import execa from 'execa'
@@ -22,7 +22,8 @@ export const builder = (yargs) => {
   yargs
     .example(
       'cedar upgrade -t 0.20.1-canary.5',
-      'Specify a version. URL for Version History:\nhttps://www.npmjs.com/package/@cedarjs/core',
+      'Specify a version. URL for Version History:\n' +
+        'https://www.npmjs.com/package/@cedarjs/core',
     )
     .option('dry-run', {
       alias: 'd',
@@ -111,7 +112,7 @@ export const handler = async ({ dryRun, tag, verbose, dedupe, yes }) => {
     [
       {
         title: 'Confirm upgrade',
-        task: async (ctx, task) => {
+        task: async (_ctx, task) => {
           if (yes) {
             task.skip('Skipping confirmation prompt because of --yes flag.')
             return
@@ -213,6 +214,7 @@ export const handler = async ({ dryRun, tag, verbose, dedupe, yes }) => {
                 `   ❖ ${discordLink}\n`,
             )
           }
+
           // @MARK
           // This should be temporary and eventually superseded by a more generic notification system
           if (tag) {
@@ -246,6 +248,7 @@ export const handler = async ({ dryRun, tag, verbose, dedupe, yes }) => {
 
   await tasks.run()
 }
+
 async function yarnInstall({ verbose }) {
   try {
     await execa('yarn install', {
@@ -298,34 +301,46 @@ async function setLatestVersionToContext(ctx, tag) {
 }
 
 /**
- * Iterates over CedarJS dependencies in package.json files and updates the version.
+ * Iterates over CedarJS dependencies in package.json files and updates the
+ * version.
  */
-function updatePackageJsonVersion(pkgPath, version, { dryRun, verbose }) {
+function updatePackageJsonVersion(pkgPath, version, task, { dryRun, verbose }) {
   const pkg = JSON.parse(
     fs.readFileSync(path.join(pkgPath, 'package.json'), 'utf-8'),
   )
+
+  const messages = []
 
   if (pkg.dependencies) {
     for (const depName of Object.keys(pkg.dependencies).filter(
       (x) => x.startsWith('@cedarjs/') && x !== '@cedarjs/studio',
     )) {
       if (verbose || dryRun) {
-        console.log(` - ${depName}: ${pkg.dependencies[depName]} => ${version}`)
+        messages.push(
+          ` - ${depName}: ${pkg.dependencies[depName]} => ${version}`,
+        )
       }
+
       pkg.dependencies[depName] = `${version}`
     }
   }
+
   if (pkg.devDependencies) {
     for (const depName of Object.keys(pkg.devDependencies).filter(
       (x) => x.startsWith('@cedarjs/') && x !== '@cedarjs/studio',
     )) {
       if (verbose || dryRun) {
-        console.log(
+        messages.push(
           ` - ${depName}: ${pkg.devDependencies[depName]} => ${version}`,
         )
       }
+
       pkg.devDependencies[depName] = `${version}`
     }
+  }
+
+  if (messages.length > 0) {
+    task.title = task.title + '\n' + messages.join('\n')
   }
 
   if (!dryRun) {
@@ -352,8 +367,13 @@ function updateCedarJSDepsForAllSides(ctx, options) {
       const pkgJsonPath = path.join(basePath, 'package.json')
       return {
         title: `Updating ${pkgJsonPath}`,
-        task: () =>
-          updatePackageJsonVersion(basePath, ctx.versionToUpgradeTo, options),
+        task: (_ctx, task) =>
+          updatePackageJsonVersion(
+            basePath,
+            ctx.versionToUpgradeTo,
+            task,
+            options,
+          ),
         skip: () => !fs.existsSync(pkgJsonPath),
       }
     }),
@@ -519,7 +539,7 @@ async function refreshPrismaClient(task, { verbose }) {
   }
 }
 
-const dedupeDeps = async (task, { verbose }) => {
+const dedupeDeps = async (_task, { verbose }) => {
   try {
     await execa('yarn dedupe', {
       shell: true,

--- a/packages/cli/src/lib/exit.js
+++ b/packages/cli/src/lib/exit.js
@@ -7,16 +7,12 @@ import {
   recordTelemetryError,
 } from '@cedarjs/cli-helpers'
 
+const discordLink = terminalLink('Discord', 'https://cedarjs.com/discord')
+const githubLink = terminalLink('GitHub', 'https://github.com/cedarjs/cedar')
 const DEFAULT_ERROR_EPILOGUE = [
   'Need help?',
-  ` - Not sure about something or need advice? Reach out on our ${terminalLink(
-    'Forum',
-    'https://community.redwoodjs.com/',
-  )}`,
-  ` - Think you've found a bug? Open an issue on our ${terminalLink(
-    'GitHub',
-    'https://github.com/cedarjs/cedar',
-  )}`,
+  ` - Not sure about something or need advice? Reach out on our ${discordLink}`,
+  ` - Think you've found a bug? Open an issue on our ${githubLink}`,
 ].join('\n')
 
 export function exitWithError(
@@ -36,7 +32,9 @@ export function exitWithError(
   // the error in telemetry if needed and if the user chooses to share it
   const errorReferenceCode = uuidv4()
 
-  const line = ansis.red('-'.repeat(process.stderr.columns))
+  // Scrollbars sometimes cause wrapping issues, so we shorten the line length
+  // to prevent wrapping issues
+  const line = ansis.red('-'.repeat(process.stderr.columns - 4))
 
   // Generate and print a nice message to the user
   const content = !includeEpilogue


### PR DESCRIPTION
This PR improves cli command output for the upgrade command specifically and the error display for all cli commands in general.

The upgrade command has update information displayed inline instead of at the end of the command output.

Error output has been updated to link to the Cedar Discord instead of the RW forums. And error delimiter lines have been shortened to prevent wrapping when the output is long enough to cause scrollbars to render.

## Before

dry-run

<img width="514" height="425" alt="image" src="https://github.com/user-attachments/assets/59827c13-9d2a-419d-9420-bf4e7be17f93" />

error

<img width="962" height="466" alt="image" src="https://github.com/user-attachments/assets/bfdfbfeb-b02f-4fa1-9c37-34ef2ce696d1" />

## After

dry-run

<img width="624" height="407" alt="image" src="https://github.com/user-attachments/assets/9158a7ce-e848-4f26-a968-6d940ae7f22b" />

error

<img width="964" height="519" alt="image" src="https://github.com/user-attachments/assets/daa07c53-49be-4c14-82f1-df0b78ab2bbf" />
