### PR TITLE
fix(deps): update dependency graphql-yoga to v5.13.0

### DIFF
--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -55,7 +55,7 @@
     "graphql": "16.12.0",
     "graphql-scalars": "1.25.0",
     "graphql-tag": "2.12.6",
-    "graphql-yoga": "5.12.0",
+    "graphql-yoga": "5.13.0",
     "lodash": "4.17.21",
     "uuid": "10.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3692,7 +3692,7 @@ __metadata:
     graphql: "npm:16.12.0"
     graphql-scalars: "npm:1.25.0"
     graphql-tag: "npm:2.12.6"
-    graphql-yoga: "npm:5.12.0"
+    graphql-yoga: "npm:5.13.0"
     jsonwebtoken: "npm:9.0.3"
     lodash: "npm:4.17.21"
     publint: "npm:0.3.16"
@@ -4526,7 +4526,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@envelop/core@npm:5.4.0, @envelop/core@npm:^5.0.0, @envelop/core@npm:^5.0.2":
+"@envelop/core@npm:5.4.0, @envelop/core@npm:^5.0.0, @envelop/core@npm:^5.2.1":
   version: 5.4.0
   resolution: "@envelop/core@npm:5.4.0"
   dependencies:
@@ -4582,6 +4582,16 @@ __metadata:
     "@whatwg-node/promise-helpers": "npm:^1.2.1"
     tslib: "npm:^2.5.0"
   checksum: 10c0/134df1ac481fb392aafc4522a22bcdc6ef0701f2d15d51b16207f3c9a4c7d3760adfa5f5bcc84f0c0ec7b011d84bcd40fff671eb471bed54bd928c165994b4e3
+  languageName: node
+  linkType: hard
+
+"@envelop/instruments@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@envelop/instruments@npm:1.0.0"
+  dependencies:
+    "@whatwg-node/promise-helpers": "npm:^1.2.1"
+    tslib: "npm:^2.5.0"
+  checksum: 10c0/dc3ae0df1b0e1dabb0e71f17b50f58b1f60d8dbeaab2eb23e6cc4b73a2a2fba12009d54d4d79bf93c931c3488c66895a4dfb829a82844baa5f2eff6cd029b5bb
   languageName: node
   linkType: hard
 
@@ -12517,7 +12527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@whatwg-node/fetch@npm:0.10.13, @whatwg-node/fetch@npm:^0.10.1, @whatwg-node/fetch@npm:^0.10.13, @whatwg-node/fetch@npm:^0.10.5":
+"@whatwg-node/fetch@npm:0.10.13, @whatwg-node/fetch@npm:^0.10.13, @whatwg-node/fetch@npm:^0.10.5":
   version: 0.10.13
   resolution: "@whatwg-node/fetch@npm:0.10.13"
   dependencies:
@@ -12565,7 +12575,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@whatwg-node/promise-helpers@npm:^1.0.0, @whatwg-node/promise-helpers@npm:^1.2.1, @whatwg-node/promise-helpers@npm:^1.2.2, @whatwg-node/promise-helpers@npm:^1.2.4, @whatwg-node/promise-helpers@npm:^1.3.0, @whatwg-node/promise-helpers@npm:^1.3.2":
+"@whatwg-node/promise-helpers@npm:^1.0.0, @whatwg-node/promise-helpers@npm:^1.2.1, @whatwg-node/promise-helpers@npm:^1.2.4, @whatwg-node/promise-helpers@npm:^1.3.0, @whatwg-node/promise-helpers@npm:^1.3.2":
   version: 1.3.2
   resolution: "@whatwg-node/promise-helpers@npm:1.3.2"
   dependencies:
@@ -12574,7 +12584,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@whatwg-node/server@npm:0.10.17":
+"@whatwg-node/server@npm:0.10.17, @whatwg-node/server@npm:^0.10.0":
   version: 0.10.17
   resolution: "@whatwg-node/server@npm:0.10.17"
   dependencies:
@@ -12584,18 +12594,6 @@ __metadata:
     "@whatwg-node/promise-helpers": "npm:^1.3.2"
     tslib: "npm:^2.6.3"
   checksum: 10c0/b93fffa837745213f1fb9b913654978ec0e590de751f4efb4ff114ae990383f2c10a5d27615297e5812e174145e85386661b857b96979194c8a3efbffb5dac89
-  languageName: node
-  linkType: hard
-
-"@whatwg-node/server@npm:^0.9.64":
-  version: 0.9.71
-  resolution: "@whatwg-node/server@npm:0.9.71"
-  dependencies:
-    "@whatwg-node/disposablestack": "npm:^0.0.6"
-    "@whatwg-node/fetch": "npm:^0.10.5"
-    "@whatwg-node/promise-helpers": "npm:^1.2.2"
-    tslib: "npm:^2.6.3"
-  checksum: 10c0/b5af4d596abf4baa94c84b7eb809fda975fdce649f67bcb1b208e54354a6e3582c6709b5d52122552b2b66cacfad54aa31307fa3b621411080b5f5e48aa0727f
   languageName: node
   linkType: hard
 
@@ -19403,24 +19401,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-yoga@npm:5.12.0":
-  version: 5.12.0
-  resolution: "graphql-yoga@npm:5.12.0"
+"graphql-yoga@npm:5.13.0":
+  version: 5.13.0
+  resolution: "graphql-yoga@npm:5.13.0"
   dependencies:
-    "@envelop/core": "npm:^5.0.2"
+    "@envelop/core": "npm:^5.2.1"
+    "@envelop/instruments": "npm:^1.0.0"
     "@graphql-tools/executor": "npm:^1.4.0"
     "@graphql-tools/schema": "npm:^10.0.11"
     "@graphql-tools/utils": "npm:^10.6.2"
     "@graphql-yoga/logger": "npm:^2.0.1"
     "@graphql-yoga/subscription": "npm:^5.0.3"
-    "@whatwg-node/fetch": "npm:^0.10.1"
-    "@whatwg-node/server": "npm:^0.9.64"
+    "@whatwg-node/fetch": "npm:^0.10.5"
+    "@whatwg-node/promise-helpers": "npm:^1.2.4"
+    "@whatwg-node/server": "npm:^0.10.0"
     dset: "npm:^3.1.4"
     lru-cache: "npm:^10.0.0"
     tslib: "npm:^2.8.1"
   peerDependencies:
     graphql: ^15.2.0 || ^16.0.0
-  checksum: 10c0/e6fd4e79e17428e7e28904761bcf5d0730d1197623631f2550914ba15254be89af633b8040636503302a4170d29ff3b9c75c674a02425be2131b26731d3578ab
+  checksum: 10c0/85b898c05b980b4163b6d92b3b229465175c565391e9e336118f1255206ff6410b1b514408f5da4c35f9a41db8bf579532618177b2ae75f6b7845e7607e2c3e9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/cedarjs/cedar/pull/804 originally tried to upgrade from 5.9.0 to 5.18.0, but the upgrade failed. This PR takes a smaller step, to try to narrow down what release is breaking for us.

Also tried to upgrade to 5.15.0, which failed. https://github.com/cedarjs/cedar/pull/837

Follow-up to https://github.com/cedarjs/cedar/pull/834