### PR TITLE
fix(deps): update dependency graphql-yoga to v5.13.2

### DIFF
--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -55,7 +55,7 @@
     "graphql": "16.12.0",
     "graphql-scalars": "1.25.0",
     "graphql-tag": "2.12.6",
-    "graphql-yoga": "5.13.0",
+    "graphql-yoga": "5.13.2",
     "lodash": "4.17.21",
     "uuid": "10.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3693,7 +3693,7 @@ __metadata:
     graphql: "npm:16.12.0"
     graphql-scalars: "npm:1.25.0"
     graphql-tag: "npm:2.12.6"
-    graphql-yoga: "npm:5.13.0"
+    graphql-yoga: "npm:5.13.2"
     jsonwebtoken: "npm:9.0.3"
     lodash: "npm:4.17.21"
     publint: "npm:0.3.16"
@@ -4527,7 +4527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@envelop/core@npm:5.4.0, @envelop/core@npm:^5.0.0, @envelop/core@npm:^5.2.1":
+"@envelop/core@npm:5.4.0, @envelop/core@npm:^5.0.0, @envelop/core@npm:^5.2.3":
   version: 5.4.0
   resolution: "@envelop/core@npm:5.4.0"
   dependencies:
@@ -4583,16 +4583,6 @@ __metadata:
     "@whatwg-node/promise-helpers": "npm:^1.2.1"
     tslib: "npm:^2.5.0"
   checksum: 10c0/134df1ac481fb392aafc4522a22bcdc6ef0701f2d15d51b16207f3c9a4c7d3760adfa5f5bcc84f0c0ec7b011d84bcd40fff671eb471bed54bd928c165994b4e3
-  languageName: node
-  linkType: hard
-
-"@envelop/instruments@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@envelop/instruments@npm:1.0.0"
-  dependencies:
-    "@whatwg-node/promise-helpers": "npm:^1.2.1"
-    tslib: "npm:^2.5.0"
-  checksum: 10c0/dc3ae0df1b0e1dabb0e71f17b50f58b1f60d8dbeaab2eb23e6cc4b73a2a2fba12009d54d4d79bf93c931c3488c66895a4dfb829a82844baa5f2eff6cd029b5bb
   languageName: node
   linkType: hard
 
@@ -12569,7 +12559,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@whatwg-node/server@npm:0.10.17, @whatwg-node/server@npm:^0.10.0":
+"@whatwg-node/server@npm:0.10.17, @whatwg-node/server@npm:^0.10.1":
   version: 0.10.17
   resolution: "@whatwg-node/server@npm:0.10.17"
   dependencies:
@@ -19386,12 +19376,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-yoga@npm:5.13.0":
-  version: 5.13.0
-  resolution: "graphql-yoga@npm:5.13.0"
+"graphql-yoga@npm:5.13.2":
+  version: 5.13.2
+  resolution: "graphql-yoga@npm:5.13.2"
   dependencies:
-    "@envelop/core": "npm:^5.2.1"
-    "@envelop/instruments": "npm:^1.0.0"
+    "@envelop/core": "npm:^5.2.3"
+    "@envelop/instrumentation": "npm:^1.0.0"
     "@graphql-tools/executor": "npm:^1.4.0"
     "@graphql-tools/schema": "npm:^10.0.11"
     "@graphql-tools/utils": "npm:^10.6.2"
@@ -19399,13 +19389,13 @@ __metadata:
     "@graphql-yoga/subscription": "npm:^5.0.3"
     "@whatwg-node/fetch": "npm:^0.10.5"
     "@whatwg-node/promise-helpers": "npm:^1.2.4"
-    "@whatwg-node/server": "npm:^0.10.0"
+    "@whatwg-node/server": "npm:^0.10.1"
     dset: "npm:^3.1.4"
     lru-cache: "npm:^10.0.0"
     tslib: "npm:^2.8.1"
   peerDependencies:
     graphql: ^15.2.0 || ^16.0.0
-  checksum: 10c0/85b898c05b980b4163b6d92b3b229465175c565391e9e336118f1255206ff6410b1b514408f5da4c35f9a41db8bf579532618177b2ae75f6b7845e7607e2c3e9
+  checksum: 10c0/c89823f36e661fb5b45e0ba038e85f3feece658bf29a947a550454491f442270684160490756656d11380202a25d26818c9fe48b9d09b4e73cc16a838196d376
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/cedarjs/cedar/pull/804 originally tried to upgrade from 5.9.0 to 5.18.0, but the upgrade failed. This PR takes a smaller step, to try to narrow down what release is breaking for us.

Also tried to upgrade to 5.15.0, which failed. https://github.com/cedarjs/cedar/pull/837

Follow-up to #842 

This is the last version where I don't hit the errors below

```
× useRedwoodError > when masking errors > with Service Validation errors > Service 25ms
  → expected 'Something went wrong.' to contain 'Emailmissingatexample.com must be for…'
× useRedwoodError > when masking errors > with Custom Redwood Error > shows the custom error message 10ms
  → expected 'Something went wrong.' to deeply equal 'Check outside instead'
```