### PR TITLE
chore(deps): Update eslint to 9.39.2 in create-cedar-rsc-app project

### DIFF
--- a/packages/create-cedar-rsc-app/package.json
+++ b/packages/create-cedar-rsc-app/package.json
@@ -45,7 +45,7 @@
     "@types/yauzl-promise": "4.0.1",
     "concurrently": "^8.2.2",
     "esbuild": "0.27.2",
-    "eslint": "^9.7.0",
+    "eslint": "9.39.2",
     "eslint-plugin-jsdoc": "^48.7.0",
     "eslint-plugin-jsonc": "^2.16.0",
     "eslint-plugin-markdown": "^5.1.0",

--- a/packages/create-cedar-rsc-app/yarn.lock
+++ b/packages/create-cedar-rsc-app/yarn.lock
@@ -1514,7 +1514,7 @@ __metadata:
     concurrently: "npm:^8.2.2"
     enquirer: "npm:2.4.1"
     esbuild: "npm:0.27.2"
-    eslint: "npm:^9.7.0"
+    eslint: "npm:9.39.2"
     eslint-plugin-jsdoc: "npm:^48.7.0"
     eslint-plugin-jsonc: "npm:^2.16.0"
     eslint-plugin-markdown: "npm:^5.1.0"
@@ -2071,7 +2071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.7.0":
+"eslint@npm:9.39.2":
   version: 9.39.2
   resolution: "eslint@npm:9.39.2"
   dependencies:


### PR DESCRIPTION
With #832 I prematurely switched to eslint's `defineConfig`. Turns out it wasn't exported directly until eslint 9.22.0 and we only required version ^9.7.0, which for some reason caused yarn to sometimes install a version < 9.22.0