### PR TITLE
fix(upgrade): Tweak output for package upgrades and pre-upgrade scripts

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -294,7 +294,7 @@ export const handler = async ({ dryRun, tag, verbose, dedupe, yes, force }) => {
 
   if (preUpgradeMessage) {
     console.log('')
-    console.log(`   📣 ${c.info('Pre-upgrade Message:')}`)
+    console.log(`  📣 ${c.info('Pre-upgrade Message:')}`)
     console.log('  ' + preUpgradeMessage.replace(/\n/g, '\n  '))
   }
 }
@@ -456,7 +456,7 @@ async function updatePackageVersionsFromTemplate(ctx, { dryRun, verbose }) {
 
       return {
         title: `Updating ${pkgJsonPath}`,
-        task: async () => {
+        task: async (_ctx, task) => {
           const res = await fetch(url)
           const text = await res.text()
           const templatePackageJson = JSON.parse(text)
@@ -464,12 +464,14 @@ async function updatePackageVersionsFromTemplate(ctx, { dryRun, verbose }) {
           const localPackageJsonText = fs.readFileSync(pkgJsonPath, 'utf-8')
           const localPackageJson = JSON.parse(localPackageJsonText)
 
+          const messages = []
+
           Object.entries(templatePackageJson.dependencies || {}).forEach(
             ([depName, depVersion]) => {
               // CedarJS packages are handled in another task
               if (!depName.startsWith('@cedarjs/')) {
                 if (verbose || dryRun) {
-                  console.log(
+                  messages.push(
                     ` - ${depName}: ${localPackageJson.dependencies[depName]} => ${depVersion}`,
                   )
                 }
@@ -484,7 +486,7 @@ async function updatePackageVersionsFromTemplate(ctx, { dryRun, verbose }) {
               // CedarJS packages are handled in another task
               if (!depName.startsWith('@cedarjs/')) {
                 if (verbose || dryRun) {
-                  console.log(
+                  messages.push(
                     ` - ${depName}: ${localPackageJson.devDependencies[depName]} => ${depVersion}`,
                   )
                 }
@@ -493,6 +495,10 @@ async function updatePackageVersionsFromTemplate(ctx, { dryRun, verbose }) {
               }
             },
           )
+
+          if (messages.length > 0) {
+            task.title = task.title + '\n' + messages.join('\n')
+          }
 
           if (!dryRun) {
             fs.writeFileSync(


### PR DESCRIPTION
Before:

Updated packages appears at end of output
Pre-upgrade message title icon 📣 is indented 3 spaces 

<img width="674" height="406" alt="image" src="https://github.com/user-attachments/assets/8b527b52-cc10-4b6e-8def-d9380c0981eb" />

After:

Updated packages are grouped with the correct task in the task list
Pre-upgrade message title icon is correctly indented 2 spaces

<img width="700" height="428" alt="image" src="https://github.com/user-attachments/assets/281bbfe5-632b-4182-ba73-7f25152c86f4" />
