### PR TITLE
fix(deps): update dependency vite to v5.4.21 [security]

### DIFF
--- a/__fixtures__/esm-test-project/package.json
+++ b/__fixtures__/esm-test-project/package.json
@@ -22,6 +22,6 @@
   "packageManager": "yarn@4.9.4",
   "resolutions": {
     "react-is": "19.2.3",
-    "vite": "5.4.19"
+    "vite": "5.4.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "resolutions": {
     "prettier-plugin-packagejson/sort-package-json": "3.6.0",
-    "vite": "5.4.19",
+    "vite": "5.4.21",
     "vscode-languageserver": "6.1.1",
     "vscode-languageserver-protocol": "3.17.5",
     "vscode-languageserver-textdocument": "1.0.12",

--- a/packages/create-cedar-app/templates/esm-js/package.json
+++ b/packages/create-cedar-app/templates/esm-js/package.json
@@ -17,6 +17,6 @@
   "packageManager": "yarn@4.12.0",
   "resolutions": {
     "react-is": "19.2.3",
-    "vite": "5.4.19"
+    "vite": "5.4.21"
   }
 }

--- a/packages/create-cedar-app/templates/esm-ts/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/package.json
@@ -17,6 +17,6 @@
   "packageManager": "yarn@4.12.0",
   "resolutions": {
     "react-is": "19.2.3",
-    "vite": "5.4.19"
+    "vite": "5.4.21"
   }
 }

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -55,7 +55,7 @@
     "ts-toolbelt": "9.6.0",
     "tsx": "4.21.0",
     "typescript": "5.9.3",
-    "vite": "5.4.19",
+    "vite": "5.4.21",
     "vitest": "3.2.4"
   },
   "publishConfig": {

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -91,7 +91,7 @@
     "rollup-plugin-swc3": "0.12.1",
     "unimport": "5.6.0",
     "unplugin-auto-import": "19.3.0",
-    "vite": "5.4.19",
+    "vite": "5.4.21",
     "vite-node": "3.2.4"
   },
   "devDependencies": {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -69,7 +69,7 @@
     "@types/node": "24.10.4",
     "tsx": "4.21.0",
     "typescript": "5.9.3",
-    "vite": "5.4.19",
+    "vite": "5.4.21",
     "vitest": "3.2.4"
   },
   "peerDependencies": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -90,7 +90,7 @@
     "react": "19.2.3",
     "react-server-dom-webpack": "19.2.3",
     "rimraf": "6.1.2",
-    "vite": "5.4.19",
+    "vite": "5.4.21",
     "vite-plugin-cjs-interop": "2.3.0",
     "vite-plugin-node-polyfills": "0.24.0",
     "ws": "8.18.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3874,7 +3874,7 @@ __metadata:
     ts-toolbelt: "npm:9.6.0"
     tsx: "npm:4.21.0"
     typescript: "npm:5.9.3"
-    vite: "npm:5.4.19"
+    vite: "npm:5.4.21"
     vitest: "npm:3.2.4"
   languageName: unknown
   linkType: soft
@@ -3915,7 +3915,7 @@ __metadata:
     typescript: "npm:5.9.3"
     unimport: "npm:5.6.0"
     unplugin-auto-import: "npm:19.3.0"
-    vite: "npm:5.4.19"
+    vite: "npm:5.4.21"
     vite-node: "npm:3.2.4"
     vitest: "npm:3.2.4"
   peerDependencies:
@@ -4225,7 +4225,7 @@ __metadata:
     rollup: "npm:4.54.0"
     tsx: "npm:4.21.0"
     typescript: "npm:5.9.3"
-    vite: "npm:5.4.19"
+    vite: "npm:5.4.21"
     vite-plugin-cjs-interop: "npm:2.3.0"
     vite-plugin-node-polyfills: "npm:0.24.0"
     vitest: "npm:3.2.4"
@@ -28595,7 +28595,7 @@ __metadata:
     tsx: "npm:4.21.0"
     typescript: "npm:5.9.3"
     unplugin-auto-import: "npm:19.3.0"
-    vite: "npm:5.4.19"
+    vite: "npm:5.4.21"
     vite-plugin-node-polyfills: "npm:0.24.0"
     vitest: "npm:3.2.4"
   peerDependencies:
@@ -30646,9 +30646,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:5.4.19":
-  version: 5.4.19
-  resolution: "vite@npm:5.4.19"
+"vite@npm:5.4.21":
+  version: 5.4.21
+  resolution: "vite@npm:5.4.21"
   dependencies:
     esbuild: "npm:^0.21.3"
     fsevents: "npm:~2.3.3"
@@ -30685,7 +30685,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/c97601234dba482cea5290f2a2ea0fcd65e1fab3df06718ea48adc8ceb14bc3129508216c4989329c618f6a0470b42f439677a207aef62b0c76f445091c2d89e
+  checksum: 10c0/468336a1409f728b464160cbf02672e72271fb688d0e605e776b74a89d27e1029509eef3a3a6c755928d8011e474dbf234824d054d07960be5f23cd176bc72de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This update fixes a Dependabot Alert

For Cedar App developers:
If you have an explicit resolution of the Vite version in your package.json(s) you have to update it to point to v5.4.21

## Summary

Files denied by [server.fs.deny](https://vitejs.dev/config/server-options.html#server-fs-deny) were sent if the URL ended with `\` when the dev server is running on Windows.

## Impact

Only apps that match the following conditions are affected:

- explicitly exposes the Vite dev server to the network (using --host or [server.host config option](https://vitejs.dev/config/server-options.html#server-host))
- running the dev server on Windows

## Details

`server.fs.deny` can contain patterns matching against files (by default it includes `.env`, `.env.*`, `*.{crt,pem}` as such patterns). These patterns were able to bypass by using a back slash(`\`). The root cause is that `fs.readFile('/foo.png/')` loads `/foo.png`.

## PoC

```sh
npm create vite@latest
cd vite-project/
cat "secret" > .env
npm install
npm run dev
curl --request-target /.env\ http://localhost:5173
```