### PR TITLE
fix(cli): Remove mention of yarn 1 from error help

### DIFF
--- a/packages/cli/src/commands/upgrade/upgradeHandler.ts
+++ b/packages/cli/src/commands/upgrade/upgradeHandler.ts
@@ -595,8 +595,10 @@ const dedupeDeps = async (
     // ExecaError is an instance of Error
     const message = e instanceof Error ? e.message : String(e)
     console.log(c.error(message))
+
     throw new Error(
-      'Could not finish de-duplication. For yarn 1.x, please run `npx yarn-deduplicate`, or for yarn >= 3 run `yarn dedupe` before continuing',
+      'Could not finish de-duplication. Please run `yarn dedupe` before ' +
+        'continuing',
     )
   }
 


### PR DESCRIPTION
Remove mention of yarn 1 as we don't support anything older than yarn 4 anymore