### PR TITLE
feat(cca): Update tsconfig and jsconfig to support require(ESM)

### DIFF
--- a/__fixtures__/esm-test-project/api/tsconfig.json
+++ b/__fixtures__/esm-test-project/api/tsconfig.json
@@ -3,7 +3,7 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "skipLibCheck": false,

--- a/__fixtures__/esm-test-project/scripts/tsconfig.json
+++ b/__fixtures__/esm-test-project/scripts/tsconfig.json
@@ -3,7 +3,7 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "paths": {

--- a/__fixtures__/test-project/api/tsconfig.json
+++ b/__fixtures__/test-project/api/tsconfig.json
@@ -3,7 +3,7 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "skipLibCheck": false,

--- a/__fixtures__/test-project/scripts/tsconfig.json
+++ b/__fixtures__/test-project/scripts/tsconfig.json
@@ -3,7 +3,7 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "paths": {

--- a/packages/create-cedar-app/templates/esm-js/api/jsconfig.json
+++ b/packages/create-cedar-app/templates/esm-js/api/jsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noEmit": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "skipLibCheck": false,

--- a/packages/create-cedar-app/templates/esm-js/scripts/jsconfig.json
+++ b/packages/create-cedar-app/templates/esm-js/scripts/jsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noEmit": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "paths": {

--- a/packages/create-cedar-app/templates/esm-ts/api/tsconfig.json
+++ b/packages/create-cedar-app/templates/esm-ts/api/tsconfig.json
@@ -3,7 +3,7 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "skipLibCheck": false,

--- a/packages/create-cedar-app/templates/esm-ts/scripts/tsconfig.json
+++ b/packages/create-cedar-app/templates/esm-ts/scripts/tsconfig.json
@@ -3,7 +3,7 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "paths": {

--- a/packages/create-cedar-app/templates/js/api/jsconfig.json
+++ b/packages/create-cedar-app/templates/js/api/jsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noEmit": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "skipLibCheck": false,

--- a/packages/create-cedar-app/templates/js/scripts/jsconfig.json
+++ b/packages/create-cedar-app/templates/js/scripts/jsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noEmit": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "paths": {

--- a/packages/create-cedar-app/templates/ts/api/tsconfig.json
+++ b/packages/create-cedar-app/templates/ts/api/tsconfig.json
@@ -3,7 +3,7 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "skipLibCheck": false,

--- a/packages/create-cedar-app/templates/ts/scripts/tsconfig.json
+++ b/packages/create-cedar-app/templates/ts/scripts/tsconfig.json
@@ -3,7 +3,7 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "ES2024",
+    "target": "ES2023",
     "module": "Node20",
     "moduleResolution": "Node16",
     "paths": {


### PR DESCRIPTION
Update tsconfig and jsconfig for the api side and for scripts to align with the fact that we now require Node 24. This lets TS know that it's safe to require ES modules, allowing both scripts and the api side to use modern esm packages.

If you're upgrading to this version of Cedar we recommend you manually update your `tsconfig.json`/`jsconfig.json` files in `api/` and `scripts/`.

Docs on `"module": "node20"`
https://github.com/microsoft/TypeScript/pull/60761
https://www.typescriptlang.org/tsconfig/#node16node18node20nodenext