### PR TITLE
fix(cli): Update generator paths message in upgrade script

### DIFF
--- a/upgrade-scripts/3.x.ts
+++ b/upgrade-scripts/3.x.ts
@@ -8,7 +8,8 @@ const webGeneratorTemplatesPath = path.join(getPaths().web.base, 'generators')
 
 if (fs.existsSync(webGeneratorTemplatesPath)) {
   console.log(
-    'Deprecated generator templates detected at ' + webGeneratorTemplatesPath,
+    'Deprecated generator templates path detected at ' +
+      webGeneratorTemplatesPath,
   )
   console.log(
     'Please see https://github.com/cedarjs/cedar/pull/813 for more ' +
@@ -18,7 +19,8 @@ if (fs.existsSync(webGeneratorTemplatesPath)) {
 
 if (fs.existsSync(apiGeneratorTemplatesPath)) {
   console.log(
-    'Deprecated generator templates detected at ' + apiGeneratorTemplatesPath,
+    'Deprecated generator templates path detected at ' +
+      apiGeneratorTemplatesPath,
   )
   console.log(
     'Please see https://github.com/cedarjs/cedar/pull/813 for more ' +

--- a/upgrade-scripts/canary.ts
+++ b/upgrade-scripts/canary.ts
@@ -21,7 +21,8 @@ const webGeneratorTemplatesPath = path.join(getPaths().web.base, 'generators')
 
 if (fs.existsSync(webGeneratorTemplatesPath)) {
   console.log(
-    'Deprecated generator templates detected at ' + webGeneratorTemplatesPath,
+    'Deprecated generator templates path detected at ' +
+      webGeneratorTemplatesPath,
   )
   console.log(
     'Please see https://github.com/cedarjs/cedar/pull/813 for more ' +
@@ -31,7 +32,8 @@ if (fs.existsSync(webGeneratorTemplatesPath)) {
 
 if (fs.existsSync(apiGeneratorTemplatesPath)) {
   console.log(
-    'Deprecated generator templates detected at ' + apiGeneratorTemplatesPath,
+    'Deprecated generator templates path detected at ' +
+      apiGeneratorTemplatesPath,
   )
   console.log(
     'Please see https://github.com/cedarjs/cedar/pull/813 for more ' +


### PR DESCRIPTION
Make it clear that it's not the templates themselves that are deprecated – it's just the path they're located at