### PR TITLE
feat(cli): Update .gitignore when creating a workspace package

### DIFF
--- a/__fixtures__/esm-test-project/.gitignore
+++ b/__fixtures__/esm-test-project/.gitignore
@@ -10,6 +10,7 @@ dev.db*
 dist
 dist-babel
 node_modules
+tsconfig.tsbuildinfo
 yarn-error.log
 web/public/mockServiceWorker.js
 web/types/graphql.d.ts

--- a/__fixtures__/test-project/.gitignore
+++ b/__fixtures__/test-project/.gitignore
@@ -10,6 +10,7 @@ dev.db*
 dist
 dist-babel
 node_modules
+tsconfig.tsbuildinfo
 yarn-error.log
 web/public/mockServiceWorker.js
 web/types/graphql.d.ts

--- a/packages/create-cedar-app/templates/esm-js/gitignore.template
+++ b/packages/create-cedar-app/templates/esm-js/gitignore.template
@@ -10,6 +10,7 @@ dev.db*
 dist
 dist-babel
 node_modules
+tsconfig.tsbuildinfo
 yarn-error.log
 web/public/mockServiceWorker.js
 web/types/graphql.d.ts

--- a/packages/create-cedar-app/templates/esm-ts/gitignore.template
+++ b/packages/create-cedar-app/templates/esm-ts/gitignore.template
@@ -10,6 +10,7 @@ dev.db*
 dist
 dist-babel
 node_modules
+tsconfig.tsbuildinfo
 yarn-error.log
 web/public/mockServiceWorker.js
 web/types/graphql.d.ts

--- a/packages/create-cedar-app/templates/js/gitignore.template
+++ b/packages/create-cedar-app/templates/js/gitignore.template
@@ -10,6 +10,7 @@ dev.db*
 dist
 dist-babel
 node_modules
+tsconfig.tsbuildinfo
 yarn-error.log
 web/public/mockServiceWorker.js
 web/types/graphql.d.ts

--- a/packages/create-cedar-app/templates/ts/gitignore.template
+++ b/packages/create-cedar-app/templates/ts/gitignore.template
@@ -10,6 +10,7 @@ dev.db*
 dist
 dist-babel
 node_modules
+tsconfig.tsbuildinfo
 yarn-error.log
 web/public/mockServiceWorker.js
 web/types/graphql.d.ts


### PR DESCRIPTION
The workspace packages we generate are [composite](https://www.typescriptlang.org/docs/handbook/project-references.html#composite) packages. And for composite packages TypeScript generates `tsconfig.tsbuildinfo` files to enable faster builds. This file should not be version controlled, so we add it to project's `.gitignore` files.

Read more here https://www.typescriptlang.org/tsconfig/#tsBuildInfoFile