### PR TITLE
fix(cli): side -> workspace for `cedar build`

### DIFF
--- a/packages/cli/src/commands/__tests__/build.test.js
+++ b/packages/cli/src/commands/__tests__/build.test.js
@@ -79,7 +79,7 @@ vi.mock('@cedarjs/prerender/detection', () => {
 test('Should run prerender for web', async () => {
   const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-  await handler({ side: ['web'], prerender: true })
+  await handler({ workspace: ['web'], prerender: true })
   expect(Listr.mock.calls[0][0].map((x) => x.title)).toMatchInlineSnapshot(`
     [
       "Building Web...",

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -2,14 +2,14 @@ import { terminalLink } from 'termi-link'
 
 import c from '../lib/colors.js'
 import { exitWithError } from '../lib/exit.js'
-import { sides } from '../lib/project.js'
+import { workspaces } from '../lib/project.js'
 import { checkNodeVersion } from '../middleware/checkNodeVersion.js'
 
-export const command = 'build [side..]'
+export const command = 'build [workspace..]'
 export const description = 'Build for production'
 
 export const builder = (yargs) => {
-  const choices = sides()
+  const choices = workspaces()
 
   yargs
     .positional('workspace', {

--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -1,7 +1,7 @@
 import { terminalLink } from 'termi-link'
 
 import c from '../lib/colors.js'
-import { sides } from '../lib/project.js'
+import { workspaces } from '../lib/project.js'
 
 export const command = 'test [filter..]'
 export const description = 'Run Jest tests. Defaults to watch mode'
@@ -9,7 +9,7 @@ export const builder = (yargs) => {
   yargs
     .strict(false) // so that we can forward arguments to jest
     .positional('filter', {
-      default: sides(),
+      default: workspaces(),
       description:
         'Which side(s) to test, and/or a regular expression to match against your test files to filter by',
       type: 'array',

--- a/packages/cli/src/commands/testEsm.js
+++ b/packages/cli/src/commands/testEsm.js
@@ -1,7 +1,7 @@
 import { terminalLink } from 'termi-link'
 
 import c from '../lib/colors.js'
-import { sides } from '../lib/project.js'
+import { workspaces } from '../lib/project.js'
 
 export const command = 'test [filter..]'
 export const description = 'Run Vitest tests. Defaults to watch mode'
@@ -15,7 +15,7 @@ export const builder = (yargs) => {
   yargs
     .strict(false) // so that we can forward arguments to vitest
     .positional('filter', {
-      default: sides(),
+      default: workspaces(),
       description:
         'Which side(s) to test, and/or a regular expression to match against ' +
         'your test files to filter by',

--- a/packages/cli/src/commands/testHandler.js
+++ b/packages/cli/src/commands/testHandler.js
@@ -99,13 +99,13 @@ export const handler = async ({
 
   // Only the side params
   const sides = filterParams.filter((filterString) =>
-    project.sides().includes(filterString),
+    project.workspaces().includes(filterString),
   )
 
   // All the other params, apart from sides
   const jestFilterArgs = [
     ...filterParams.filter(
-      (filterString) => !project.sides().includes(filterString),
+      (filterString) => !project.workspaces().includes(filterString),
     ),
   ]
 
@@ -125,7 +125,7 @@ export const handler = async ({
 
   // if no sides declared with yargs, default to all sides
   if (!sides.length) {
-    project.sides().forEach((side) => sides.push(side))
+    project.workspaces().forEach((side) => sides.push(side))
   }
 
   if (sides.length > 0) {

--- a/packages/cli/src/commands/testHandlerEsm.js
+++ b/packages/cli/src/commands/testHandlerEsm.js
@@ -45,13 +45,13 @@ export const handler = async ({
 
   // Only the side params
   const sides = filterParams.filter((filterString) =>
-    project.sides().includes(filterString),
+    project.workspaces().includes(filterString),
   )
 
   // All the other params, apart from sides
   const vitestFilterArgs = [
     ...filterParams.filter(
-      (filterString) => !project.sides().includes(filterString),
+      (filterString) => !project.workspaces().includes(filterString),
     ),
   ]
 
@@ -68,7 +68,7 @@ export const handler = async ({
 
   // if no sides declared with yargs, default to all sides
   if (!sides.length) {
-    project.sides().forEach((side) => sides.push(side))
+    project.workspaces().forEach((side) => sides.push(side))
   }
 
   sides.forEach((side) => vitestArgs.push('--project', side))

--- a/packages/cli/src/commands/type-check.js
+++ b/packages/cli/src/commands/type-check.js
@@ -1,6 +1,6 @@
 import { terminalLink } from 'termi-link'
 
-import { sides } from '../lib/project.js'
+import { workspaces } from '../lib/project.js'
 
 export const command = 'type-check [sides..]'
 export const aliases = ['tsc', 'tc']
@@ -9,7 +9,7 @@ export const builder = (yargs) => {
   yargs
     .strict(false) // so that we can forward arguments to tsc
     .positional('sides', {
-      default: sides(),
+      default: workspaces(),
       description: 'Which side(s) to run a typecheck on',
       type: 'array',
     })

--- a/packages/cli/src/lib/project.js
+++ b/packages/cli/src/lib/project.js
@@ -11,17 +11,20 @@ export const isTypeScriptProject = () => {
   )
 }
 
-export const sides = () => {
+export const workspaces = () => {
   const paths = getPaths()
 
-  let sides = []
+  let workspaces = []
+
   if (fs.existsSync(path.join(paths.web.base, 'package.json'))) {
-    sides = [...sides, 'web']
+    workspaces = [...workspaces, 'web']
   }
+
   if (fs.existsSync(path.join(paths.api.base, 'package.json'))) {
-    sides = [...sides, 'api']
+    workspaces = [...workspaces, 'api']
   }
-  return sides
+
+  return workspaces
 }
 
 export const serverFileExists = () => {

--- a/packages/cli/src/lib/test.js
+++ b/packages/cli/src/lib/test.js
@@ -92,7 +92,7 @@ vi.mock('@cedarjs/cli-helpers', async (importOriginal) => {
 
 vi.mock('./project', () => ({
   isTypeScriptProject: () => false,
-  sides: () => ['web', 'api'],
+  workspaces: () => ['web', 'api'],
 }))
 
 globalThis.__prettierPath = path.resolve(


### PR DESCRIPTION
This is mostly a chore kind of commit preparing for adding support for building workspace packages.
I did some refactoring to make the code easier to read. I also renamed "side" to "workspace" since that's what they really are. And that's why this is a "fix" and not just a "chore" because the help output now says "workspace" instead of "side" making this a user facing change as well.