### PR TITLE
fix(cli): Fix DEP0190 when building

### DIFF
--- a/packages/cli/src/commands/buildHandler.js
+++ b/packages/cli/src/commands/buildHandler.js
@@ -58,7 +58,6 @@ export const handler = async ({
 
         return execa(cmd, args, {
           stdio: verbose ? 'inherit' : 'pipe',
-          shell: true,
           cwd: cedarPaths.api.base,
         })
       },

--- a/packages/cli/src/lib/generatePrismaClient.js
+++ b/packages/cli/src/lib/generatePrismaClient.js
@@ -16,8 +16,12 @@ export const generatePrismaCommand = async () => {
   const prismaIndexPath = createdRequire.resolve('prisma/build/index.js')
 
   return {
-    cmd: `node "${prismaIndexPath}"`,
-    args: ['generate', `--config="${getPaths().api.prismaConfig}"`],
+    cmd: 'node',
+    args: [
+      prismaIndexPath,
+      'generate',
+      `--config=${getPaths().api.prismaConfig}`,
+    ],
   }
 }
 

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -554,7 +554,6 @@ export const runCommandTask = async (commands, { verbose, silent }) => {
       title,
       task: async () => {
         return execa(cmd, args, {
-          shell: true,
           cwd,
           stdio: verbose && !silent ? 'inherit' : 'pipe',
           extendEnv: true,


### PR DESCRIPTION
Running `yarn cedar build` used to print "(node:90324) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated." to the terminal. This PR fixes this by not using `shell: true`.