### PR TITLE
chore(cli): Direct import of handler in tests for speedup

### DIFF
--- a/packages/cli/src/commands/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/__tests__/dev.test.ts
@@ -79,7 +79,7 @@ import type * as ProjectConfig from '@cedarjs/project-config'
 import { generatePrismaClient } from '../../lib/generatePrismaClient.js'
 // @ts-expect-error - Types not available for JS files
 import { getPaths } from '../../lib/index.js'
-import { handler } from '../dev.js'
+import { handler } from '../devHandler.js'
 
 function defaultPaths() {
   return {

--- a/packages/cli/src/commands/__tests__/prisma.test.js
+++ b/packages/cli/src/commands/__tests__/prisma.test.js
@@ -31,7 +31,7 @@ import fs from 'node:fs'
 import execa from 'execa'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 
-import { handler } from '../prisma.js'
+import { handler } from '../prismaHandler.js'
 
 beforeEach(() => {
   vi.spyOn(console, 'info').mockImplementation(() => {})

--- a/packages/cli/src/commands/__tests__/test.test.js
+++ b/packages/cli/src/commands/__tests__/test.test.js
@@ -13,7 +13,7 @@ import fs from 'node:fs'
 import execa from 'execa'
 import { vi, afterEach, test, expect, beforeEach } from 'vitest'
 
-import { handler } from '../test.js'
+import { handler } from '../testHandler.js'
 
 vi.mock('@cedarjs/structure', () => {
   return {

--- a/packages/cli/src/commands/__tests__/testEsm.test.js
+++ b/packages/cli/src/commands/__tests__/testEsm.test.js
@@ -11,7 +11,7 @@ vi.mock('execa', () => ({
 import execa from 'execa'
 import { vi, afterEach, test, expect } from 'vitest'
 
-import { handler } from '../testEsm.js'
+import { handler } from '../testHandlerEsm.js'
 
 vi.mock('@cedarjs/structure', () => {
   return {

--- a/packages/cli/src/commands/__tests__/type-check.test.js
+++ b/packages/cli/src/commands/__tests__/type-check.test.js
@@ -50,7 +50,7 @@ import execa from 'execa'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 
 import { runCommandTask } from '../../lib/index.js'
-import { handler } from '../type-check.js'
+import { handler } from '../type-checkHandler.js'
 
 beforeEach(() => {
   vi.spyOn(console, 'info').mockImplementation(() => {})

--- a/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
+++ b/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
@@ -32,7 +32,7 @@ import {
 
 import { Listr2Mock } from '../../../../__tests__/Listr2Mock.js'
 // @ts-expect-error - no types
-import { handler } from '../libraries/tailwindcss.js'
+import { handler } from '../libraries/tailwindcssHandler.js'
 
 // Set up RWJS_CWD
 let original_RWJS_CWD: string | undefined


### PR DESCRIPTION
When I was working on #915 I noticed that the tests were really slow. The first test to run took around 2 seconds, while the next test only took a few ms. 

The reason was that `build.test.js` did `import { handler } from '../build.js'`, and the `handler()` function in `build.js` does a dynamic import of `./buildHandler.js`. 
Directly importing buildHandler in the test, and thus bypassing the dynamic import, cut the initial test execution time from ~2s to ~7ms