### PR TITLE
chore(ci): node24 and fix canary option

### DIFF
--- a/.github/actions/check_changesets/action.yml
+++ b/.github/actions/check_changesets/action.yml
@@ -2,7 +2,7 @@ name: Check changesets
 description: Checks if changeset was added to the PR
 
 runs:
-  using: node20
+  using: node24
   main: check_changesets.mjs
 
 inputs:

--- a/.github/actions/check_create_redwood_app/action.yml
+++ b/.github/actions/check_create_redwood_app/action.yml
@@ -1,7 +1,7 @@
 name: Check create redwood app
 description: Determines if the create redwood app JS template should be rebuilt
 runs:
-  using: node20
+  using: node24
   main: check_create_redwood_app.mjs
 inputs:
   labels:

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -10,5 +10,5 @@ outputs:
     description: If SSR-related changes have been made
 
 runs:
-  using: node20
+  using: node24
   main: detectChanges.mjs

--- a/.github/actions/set-up-rsa-project/action.yaml
+++ b/.github/actions/set-up-rsa-project/action.yaml
@@ -2,7 +2,7 @@ name: Set up RSA test project from fixture
 description: Sets up an RSA project for smoke-tests
 
 runs:
-  using: node20
+  using: node24
   main: 'setUpRsaProjectGitHub.mjs'
 
 outputs:

--- a/.github/actions/set-up-rsc-kitchen-sink-project/action.yaml
+++ b/.github/actions/set-up-rsc-kitchen-sink-project/action.yaml
@@ -2,7 +2,7 @@ name: Set up RSC kitchen sink test project from fixture
 description: Sets up an RSC project that tests all-the-things
 
 runs:
-  using: node20
+  using: node24
   main: 'setUpRscKitchenSinkProjectGitHub.mjs'
 
 outputs:

--- a/.github/actions/set-up-rsc-project/action.yaml
+++ b/.github/actions/set-up-rsc-project/action.yaml
@@ -2,7 +2,7 @@ name: Set up RSC test project
 description: Sets up an RSC project for smoke-tests
 
 runs:
-  using: node20
+  using: node24
   main: 'setUpRscProjectGitHub.mjs'
 
 outputs:

--- a/.github/actions/set-up-test-project-esm/action.yaml
+++ b/.github/actions/set-up-test-project-esm/action.yaml
@@ -2,7 +2,7 @@ name: Set up test project
 description: Sets up the test project fixture in CI for smoke tests and CLI checks
 
 runs:
-  using: node20
+  using: node24
   main: 'setUpTestProjectEsm.mjs'
 
 inputs:

--- a/.github/actions/set-up-test-project-esm/setUpTestProjectEsm.mjs
+++ b/.github/actions/set-up-test-project-esm/setUpTestProjectEsm.mjs
@@ -1,4 +1,3 @@
-/* eslint-env node */
 // @ts-check
 
 import fs from 'node:fs'
@@ -12,34 +11,22 @@ import {
   CEDAR_FRAMEWORK_PATH,
 } from '../actionsLib.mjs'
 
-const TEST_PROJECT_PATH = path.join(
-  path.dirname(process.cwd()),
-  'esm-test-project',
-)
+const parentDir = path.dirname(process.cwd())
+const TEST_PROJECT_PATH = path.join(parentDir, 'esm-test-project')
+const execInProject = createExecWithEnvInCwd(TEST_PROJECT_PATH)
 
 core.setOutput('test-project-path', TEST_PROJECT_PATH)
 
 const canary = core.getInput('canary') === 'true'
-console.log({
-  canary,
-})
+console.log({ canary })
 
 console.log()
-
-/**
- * @returns {Promise<void>}
- */
-async function main() {
-  await setUpTestProject({
-    canary: true,
-  })
-}
 
 /**
  * @param {{canary: boolean}} options
  * @returns {Promise<void>}
  */
-async function setUpTestProject({ canary }) {
+async function setUpTestProjectEsm({ canary }) {
   const TEST_PROJECT_FIXTURE_PATH = path.join(
     CEDAR_FRAMEWORK_PATH,
     '__fixtures__',
@@ -48,31 +35,25 @@ async function setUpTestProject({ canary }) {
 
   console.log(`Creating project at ${TEST_PROJECT_PATH}`)
   console.log()
+
   await fs.promises.cp(TEST_PROJECT_FIXTURE_PATH, TEST_PROJECT_PATH, {
     recursive: true,
   })
+
+  if (canary) {
+    console.log(`Upgrading project to canary`)
+
+    await execInProject('yarn cedar upgrade -t canary', {
+      input: Buffer.from('Y'),
+    })
+
+    console.log()
+  }
 
   await execInFramework('yarn project:tarsync --verbose', {
     env: { RWJS_CWD: TEST_PROJECT_PATH },
   })
 
-  if (canary) {
-    console.log(`Upgrading project to canary`)
-    await execInProject('yarn cedar upgrade -t canary', {
-      input: Buffer.from('Y'),
-    })
-    console.log()
-  }
-
-  await sharedTasks()
-}
-
-const execInProject = createExecWithEnvInCwd(TEST_PROJECT_PATH)
-
-/**
- * @returns {Promise<void>}
- */
-async function sharedTasks() {
   console.log('Generating dbAuth secret')
   const { stdout } = await execInProject('yarn cedar g secret --raw', {
     silent: true,
@@ -87,4 +68,4 @@ async function sharedTasks() {
   await execInProject('yarn cedar prisma migrate reset --force')
 }
 
-main()
+setUpTestProjectEsm({ canary })

--- a/.github/actions/set-up-test-project/action.yaml
+++ b/.github/actions/set-up-test-project/action.yaml
@@ -2,7 +2,7 @@ name: Set up test project
 description: Sets up the test project fixture in CI for smoke tests and CLI checks
 
 runs:
-  using: node20
+  using: node24
   main: 'setUpTestProject.mjs'
 
 inputs:

--- a/.github/actions/set-up-test-project/setUpTestProject.mjs
+++ b/.github/actions/set-up-test-project/setUpTestProject.mjs
@@ -1,4 +1,3 @@
-/* eslint-env node */
 // @ts-check
 
 import fs from 'node:fs'
@@ -12,23 +11,16 @@ import {
   CEDAR_FRAMEWORK_PATH,
 } from '../actionsLib.mjs'
 
-const TEST_PROJECT_PATH = path.join(path.dirname(process.cwd()), 'test-project')
+const parentDir = path.dirname(process.cwd())
+const TEST_PROJECT_PATH = path.join(parentDir, 'test-project')
+const execInProject = createExecWithEnvInCwd(TEST_PROJECT_PATH)
 
 core.setOutput('test-project-path', TEST_PROJECT_PATH)
 
 const canary = core.getInput('canary') === 'true'
-console.log({
-  canary,
-})
+console.log({ canary })
 
 console.log()
-
-/**
- * @returns {Promise<void>}
- */
-async function main() {
-  await setUpTestProject({ canary: true })
-}
 
 /**
  * @param {{ canary: boolean }} options
@@ -43,31 +35,25 @@ async function setUpTestProject({ canary }) {
 
   console.log(`Creating project at ${TEST_PROJECT_PATH}`)
   console.log()
+
   await fs.promises.cp(TEST_PROJECT_FIXTURE_PATH, TEST_PROJECT_PATH, {
     recursive: true,
   })
+
+  if (canary) {
+    console.log(`Upgrading project to canary`)
+
+    await execInProject('yarn cedar upgrade -t canary', {
+      input: Buffer.from('Y'),
+    })
+
+    console.log()
+  }
 
   await execInFramework('yarn project:tarsync --verbose', {
     env: { RWJS_CWD: TEST_PROJECT_PATH },
   })
 
-  if (canary) {
-    console.log(`Upgrading project to canary`)
-    await execInProject('yarn cedar upgrade -t canary', {
-      input: Buffer.from('Y'),
-    })
-    console.log()
-  }
-
-  await sharedTasks()
-}
-
-const execInProject = createExecWithEnvInCwd(TEST_PROJECT_PATH)
-
-/**
- * @returns {Promise<void>}
- */
-async function sharedTasks() {
   console.log('Generating dbAuth secret')
   const { stdout } = await execInProject('yarn cedar g secret --raw', {
     silent: true,
@@ -82,4 +68,4 @@ async function sharedTasks() {
   await execInProject('yarn cedar prisma migrate reset --force')
 }
 
-main()
+setUpTestProject({ canary })

--- a/.github/workflows/background-jobs-e2e.yml
+++ b/.github/workflows/background-jobs-e2e.yml
@@ -24,7 +24,7 @@ jobs:
         id: set-up-test-project
         uses: ./.github/actions/set-up-test-project
         with:
-          canary: true
+          canary: false
         env:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false

--- a/.github/workflows/fragments-smoke-tests.yml
+++ b/.github/workflows/fragments-smoke-tests.yml
@@ -24,7 +24,7 @@ jobs:
         id: set-up-test-project
         uses: ./.github/actions/set-up-test-project
         with:
-          canary: true
+          canary: false
         env:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false


### PR DESCRIPTION
- Upgrade all github actions to use node24
- Properly pass `canary` to the test project actions
- Install canary first, and then tarsync