### PR TITLE
chore(ci): Skip canary for SSR test

### DIFF
--- a/.github/workflows/ssr-smoke-tests.yml
+++ b/.github/workflows/ssr-smoke-tests.yml
@@ -24,7 +24,7 @@ jobs:
         id: set-up-test-project
         uses: ./.github/actions/set-up-test-project
         with:
-          canary: true
+          canary: false
         env:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false


### PR DESCRIPTION
I don't think we actually used the canary build before because of a bug in our tooling. See #926 

Now that `canary: true` works again, I'm switching to `false` here to speed things up – upgrading to canary takes time.