### PR TITLE
chore(ci): Call `yarn cedar build` in smoke tests

### DIFF
--- a/.github/workflows/cli-smoke-tests.yml
+++ b/.github/workflows/cli-smoke-tests.yml
@@ -39,6 +39,10 @@ jobs:
         run: yarn cedar lint ./api/src --fix
         working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
 
+      - name: Run `cedar build`
+        run: yarn cedar build
+        working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
+
       - name: Run `cedar test api`
         run: yarn cedar test api --no-watch
         working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}


### PR DESCRIPTION
With the new functionality of also building workspace packages I wanted to include `yarn cedar build` in our CLI smoke tests to quickly and easily see if it breaks in any major ways

And also (and this is honestly the main reason):
When running unit (jest) tests for web and api code that is using a workspace package the workspace packages have to be built first, or the tests will fail.

I was seeing this on CI, and building first fixes that

```
FAIL web web/src/pages/ContactUsPage/ContactUsPage.test.tsx
  ● Test suite failed to run
    Cannot find module '@my-org/validators' from 'web/src/pages/ContactUsPage/ContactUsPage.tsx'
    Require stack:
      web/src/pages/ContactUsPage/ContactUsPage.tsx
      web/src/pages/ContactUsPage/ContactUsPage.test.tsx
      1 | import { useState } from 'react'
      2 |
    > 3 | import { validateEmail } from '@my-org/validators'
        | ^
      4 | import { useForm } from 'react-hook-form'
      5 |
      6 | import {
      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
      at Object.require (web/src/pages/ContactUsPage/ContactUsPage.tsx:3:1)
      at Object.require (web/src/pages/ContactUsPage/ContactUsPage.test.tsx:3:1)
PASS web web/src/layouts/BlogLayout/BlogLayout.test.tsx
```

For this specific error I could have just built the package on its own with `yarn workspace @my-org/validators build`, but for the smoke tests I wanted the more generic `yarn cedar build` command.

I love that the packages are just regular yarn workspaces though, no magic. So it works with standard yarn workspace commands.

In the future, for jest tests, I want to experiment with using a moduleNameMapper config. That might allow me to test with the source code directly, which is much nicer DX.
Something like this

```js
const config = {
  rootDir: '../',
  preset: '@cedarjs/testing/config/jest/web',
  moduleNameMapper: {
    '^@my-org/validators$': '<rootDir>/packages/validators/src/index.ts',
  },
}
```