### PR TITLE
fix(cli): Update workspace package templates

### DIFF
--- a/packages/cli/src/commands/generate/package/__tests__/__snapshots__/package.test.ts.snap
+++ b/packages/cli/src/commands/generate/package/__tests__/__snapshots__/package.test.ts.snap
@@ -14,7 +14,7 @@ into your code:
 \`\`\`
 
 \`\`\`javascript
-import { formValidators } from '@my-camel-case-app/form-validators';
+import { formValidators } from '@my-camel-case-app/form-validators'
 \`\`\`
 "
 `;
@@ -51,7 +51,7 @@ into your code:
 \`\`\`
 
 \`\`\`javascript
-import { formValidators } from '@my-camel-case-app/form-validators';
+import { formValidators } from '@my-camel-case-app/form-validators'
 \`\`\`
 "
 `;
@@ -88,6 +88,13 @@ exports[`packageHandler > files > multi-word package names > uses the provided s
   "private": true,
   "type": "module",
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch"
@@ -114,7 +121,7 @@ into your code:
 \`\`\`
 
 \`\`\`javascript
-import { formValidatorsPkg } from '@my-org/form-validators-pkg';
+import { formValidatorsPkg } from '@my-org/form-validators-pkg'
 \`\`\`
 "
 `;
@@ -144,7 +151,7 @@ into your code:
 \`\`\`
 
 \`\`\`javascript
-import { foo } from '@my-cedar-app/foo';
+import { foo } from '@my-cedar-app/foo'
 \`\`\`
 "
 `;
@@ -174,6 +181,13 @@ exports[`packageHandler > files > single word package name > infers package scop
   "private": true,
   "type": "module",
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch"
@@ -202,6 +216,7 @@ exports[`packageHandler > files > single word package name > infers package scop
     "declarationMap": true,
   },
   "include": ["src"],
+  "exclude": ["**/*.test.ts"],
 }
 "
 `;

--- a/packages/cli/src/commands/generate/package/templates/README.md.template
+++ b/packages/cli/src/commands/generate/package/templates/README.md.template
@@ -11,5 +11,5 @@ into your code:
 ```
 
 ```javascript
-import { ${camelName} } from '${packageName}';
+import { ${camelName} } from '${packageName}'
 ```

--- a/packages/cli/src/commands/generate/package/templates/package.json.template
+++ b/packages/cli/src/commands/generate/package/templates/package.json.template
@@ -4,6 +4,13 @@
   "private": true,
   "type": "module",
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch"

--- a/packages/cli/src/commands/generate/package/templates/tsconfig.json.template
+++ b/packages/cli/src/commands/generate/package/templates/tsconfig.json.template
@@ -13,4 +13,5 @@
     "declarationMap": true,
   },
   "include": ["src"],
+  "exclude": ["**/*.test.ts"],
 }


### PR DESCRIPTION
- Use ESM exports in `package.json`
- Remove eol semicolon in README code snippet
- Exclude test files from TypeScript compilation

For the future I probably want a separate tsconfig for building, so that I can keep including test files for IDE integration