### PR TITLE
fix(esm): Update lodash imports to work with ESM

### DIFF
--- a/packages/cli/src/commands/dev/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/dev.test.ts
@@ -69,7 +69,7 @@ vi.mock('../../../lib/index.js', () => ({
 }))
 
 import concurrently from 'concurrently'
-import { find } from 'lodash'
+import find from 'lodash/find.js'
 import { vi, describe, afterEach, it, expect } from 'vitest'
 
 import { getConfig, getConfigPath } from '@cedarjs/project-config'

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -9,7 +9,8 @@ import { paramCase } from 'change-case'
 import decamelize from 'decamelize'
 import execa from 'execa'
 import { Listr } from 'listr2'
-import lodash from 'lodash'
+import memoize from 'lodash/memoize.js'
+import template from 'lodash/template.js'
 import pascalcase from 'pascalcase'
 import { format } from 'prettier'
 
@@ -25,8 +26,6 @@ import c from './colors.js'
 import { addFileToRollback } from './rollback.js'
 
 export { findUp }
-
-const { memoize, template } = lodash
 
 /**
  * Returns variants of the passed `name` for usage in templates. If the given

--- a/packages/cli/src/lib/merge/strategy.js
+++ b/packages/cli/src/lib/merge/strategy.js
@@ -1,5 +1,5 @@
 import * as t from '@babel/types'
-import _ from 'lodash'
+import uniqWith from 'lodash/uniqWith.js'
 
 import { nodeIs, sieve } from './algorithms.js'
 
@@ -86,7 +86,7 @@ const interleaveStrategy = {
       lhs.local?.name == rhs.local?.name
 
     const uniqueSpecifiersOfType = (type) =>
-      _.uniqWith(
+      uniqWith(
         [...baseSpecs, ...extSpecs].filter(nodeIs(type)),
         importSpecifierEquality,
       )
@@ -151,11 +151,11 @@ export function concat(base, ext) {
 const concatUniqueStrategy = {
   ArrayExpression(base, ext, eq) {
     eq ||= defaultEquality(base.elements, ext.elements)
-    base.elements = _.uniqWith([...base.elements, ...ext.elements], eq)
+    base.elements = uniqWith([...base.elements, ...ext.elements], eq)
   },
   ObjectExpression(base, ext, eq) {
     eq ||= defaultEquality(base.properties, ext.properties)
-    base.properties = _.uniqWith([...base.properties, ...ext.properties], eq)
+    base.properties = uniqWith([...base.properties, ...ext.properties], eq)
   },
 }
 export function concatUnique(baseOrEq, ext) {

--- a/packages/graphql-server/src/makeMergedSchema.ts
+++ b/packages/graphql-server/src/makeMergedSchema.ts
@@ -16,8 +16,8 @@ import type {
   GraphQLUnionType,
   GraphQLObjectType,
 } from 'graphql'
-import lodash from 'lodash'
-const { merge, omitBy } = lodash
+import merge from 'lodash/merge.js'
+import omitBy from 'lodash/omitBy.js'
 
 import type { RedwoodDirective } from './plugins/useRedwoodDirective.js'
 import * as rootGqlSchema from './rootSchema.js'

--- a/packages/structure/src/model/RWEnvHelper.ts
+++ b/packages/structure/src/model/RWEnvHelper.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import { join } from 'node:path'
 
 import * as dotenv from 'dotenv-defaults'
-import { pickBy } from 'lodash'
+import pickBy from 'lodash/pickBy.js'
 import type * as tsm from 'ts-morph'
 
 import { getSchemaPath } from '@cedarjs/project-config'

--- a/packages/structure/src/x/diagnostics.ts
+++ b/packages/structure/src/x/diagnostics.ts
@@ -1,5 +1,7 @@
 import lc from 'line-column'
-import { groupBy, mapValues, uniqBy } from 'lodash'
+import groupBy from 'lodash/groupBy.js'
+import mapValues from 'lodash/mapValues.js'
+import uniqBy from 'lodash/uniqBy.js'
 import * as tsm from 'ts-morph'
 
 import type { Location } from './Location'

--- a/packages/structure/src/x/ts-morph.ts
+++ b/packages/structure/src/x/ts-morph.ts
@@ -1,6 +1,6 @@
 import * as crypto from 'crypto'
 
-import { memoize } from 'lodash'
+import memoize from 'lodash/memoize.js'
 import { LRUCache } from 'lru-cache'
 import * as tsm from 'ts-morph'
 

--- a/upgrade-scripts/README.md
+++ b/upgrade-scripts/README.md
@@ -55,6 +55,6 @@ To specify a specific version, use a comment directive at the top of the file:
 ```typescript
 // @dependency: lodash@4.17.21
 // @dependency: @cedarjs/project-config@3.0.0
-import _ from 'lodash'
+import memoize from 'lodash/memoize.js'
 import { getConfig } from '@cedarjs/project-config'
 ```


### PR DESCRIPTION
Follow-up on #939 and following the guidelines here https://lodash.com/per-method-packages they ask you to do `const throttle = require('lodash/throttle')`. The ESM version of that is `import throttle from `lodash/throttle.js`. So that's what I'm doing everywhere.