### PR TITLE
feat(studio): Update to Cedar Studio v2

### DIFF
--- a/packages/cli/src/commands/studioHandler.js
+++ b/packages/cli/src/commands/studioHandler.js
@@ -8,7 +8,7 @@ export const handler = async (options) => {
         'The studio package is not installed, installing it for you, this ' +
           'may take a moment...',
       )
-      await installModule('@cedarjs/studio', '1')
+      await installModule('@cedarjs/studio', '2')
       console.log('Studio package installed successfully.')
 
       const installedRealtime = await installModule('@cedarjs/realtime')


### PR DESCRIPTION
Cedar Studio was updated to work with Prisma v6 and Fastify v5. It now requires Node 24 (same as Cedar), and was released as version 2.0.0

This PR makes the Studio setup command install Cedar v2