### PR TITLE
chore(estlint): Remove Cedar app rule from FW rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -96,7 +96,6 @@ export default [
 
       curly: 'error',
       'unused-imports/no-unused-imports': 'error',
-      '@cedarjs/process-env-computed': 'error',
       'no-console': 'off',
       'no-extra-semi': 'off',
       'prefer-object-spread': 'warn',


### PR DESCRIPTION
The `@cedarjs/process-env-computed` is really only relevant for Cedar apps. Not for the framework itself. So it shouldn't be in the fw eslint config