### PR TITLE
fix(gql): RedwoodGraphQLContext -> CedarGraphQLContext

### DIFF
--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -32,7 +32,7 @@ export async function redwoodFastifyGraphQLServer(
   // This is to allow multi-part form data to be parsed - otherwise you get errors
   fastify.register(fastifyMultiPart)
 
-  const method = ['GET', 'POST', 'OPTIONS'] as HTTPMethods[]
+  const method: HTTPMethods[] = ['GET', 'POST', 'OPTIONS']
 
   fastify.addHook('onRequest', (_req, _reply, done) => {
     getAsyncStoreInstance().run(new Map<string, GlobalContext>(), done)
@@ -97,7 +97,6 @@ export async function redwoodFastifyGraphQLServer(
             req,
             reply,
             event: lambdaEventForFastifyRequest(req),
-            requestContext: {},
           }),
       })
     }

--- a/packages/graphql-server/src/createGraphQLYoga.ts
+++ b/packages/graphql-server/src/createGraphQLYoga.ts
@@ -28,7 +28,7 @@ import type {
 } from './plugins/useRedwoodDirective.js'
 import { makeSubscriptions } from './subscriptions/makeSubscriptions.js'
 import type { RedwoodSubscription } from './subscriptions/makeSubscriptions.js'
-import type { GraphQLYogaOptions } from './types.js'
+import type { GraphQLYogaOptions, CedarGraphQLContext } from './types.js'
 
 export const createGraphQLYoga = ({
   healthCheckId = 'yoga',
@@ -188,10 +188,12 @@ export const createGraphQLYoga = ({
     // so can process any data added to results and extensions
     plugins.push(useRedwoodLogger(loggerConfig))
 
-    const yoga = createYoga<{
-      req: FastifyRequest
-      reply: FastifyReply
-    }>({
+    const yoga = createYoga<
+      {
+        req: FastifyRequest
+        reply: FastifyReply
+      } & CedarGraphQLContext
+    >({
       id: healthCheckId,
       landingPage: isDevEnv,
       schema,

--- a/packages/graphql-server/src/plugins/__tests__/useRedwoodAuthContext.test.ts
+++ b/packages/graphql-server/src/plugins/__tests__/useRedwoodAuthContext.test.ts
@@ -61,7 +61,7 @@ describe('useRedwoodAuthContext', () => {
       testSchema,
     )
 
-    await testkit.execute(testQuery, {}, { requestContext: {} })
+    await testkit.execute(testQuery, {}, {})
 
     expectContextContains({
       currentUser: MOCK_USER,
@@ -92,7 +92,7 @@ describe('useRedwoodAuthContext', () => {
     )
 
     await expect(async () => {
-      await testkit.execute(testQuery, {}, { requestContext: {} })
+      await testkit.execute(testQuery, {}, {})
     }).rejects.toEqual(
       new Error('Exception in getCurrentUser: Could not fetch user from db.'),
     )

--- a/packages/graphql-server/src/plugins/useRedwoodAuthContext.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodAuthContext.ts
@@ -3,7 +3,7 @@ import type { Plugin } from 'graphql-yoga'
 import type { AuthContextPayload, Decoder } from '@cedarjs/api'
 import { getAuthenticationContext } from '@cedarjs/api'
 
-import type { RedwoodGraphQLContext, GraphQLHandlerOptions } from '../types.js'
+import type { CedarGraphQLContext, GraphQLHandlerOptions } from '../types.js'
 
 /**
  * Envelop plugin for injecting the current user into the GraphQL Context,
@@ -12,18 +12,16 @@ import type { RedwoodGraphQLContext, GraphQLHandlerOptions } from '../types.js'
 export const useRedwoodAuthContext = (
   getCurrentUser: GraphQLHandlerOptions['getCurrentUser'],
   authDecoder?: Decoder | Decoder[],
-): Plugin<RedwoodGraphQLContext> => {
+): Plugin<CedarGraphQLContext> => {
   return {
     async onContextBuilding({ context, extendContext }) {
-      const { requestContext } = context
-
       let authContext: AuthContextPayload | undefined = undefined
 
       try {
         authContext = await getAuthenticationContext({
           authDecoder,
           event: context.event,
-          context: requestContext,
+          context: context.requestContext,
         })
       } catch (error: any) {
         throw new Error(

--- a/packages/graphql-server/src/plugins/useRedwoodError.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodError.ts
@@ -7,7 +7,7 @@ import {
 import { RedwoodError } from '@cedarjs/api'
 import type { Logger } from '@cedarjs/api/logger'
 
-import type { RedwoodGraphQLContext } from '../types.js'
+import type { CedarGraphQLContext } from '../types.js'
 
 /**
  * Converts RedwoodErrors to GraphQLErrors
@@ -26,7 +26,7 @@ import type { RedwoodGraphQLContext } from '../types.js'
  */
 export const useRedwoodError = (
   logger: Logger,
-): Plugin<RedwoodGraphQLContext> => {
+): Plugin<CedarGraphQLContext> => {
   return {
     async onExecute() {
       return {

--- a/packages/graphql-server/src/plugins/useRedwoodGlobalContextSetter.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodGlobalContextSetter.ts
@@ -2,7 +2,7 @@ import type { Plugin } from 'graphql-yoga'
 
 import { setContext } from '@cedarjs/context'
 
-import type { RedwoodGraphQLContext } from '../types.js'
+import type { CedarGraphQLContext } from '../types.js'
 
 /**
  * This Envelop plugin waits until the GraphQL context is done building and sets
@@ -10,7 +10,7 @@ import type { RedwoodGraphQLContext } from '../types.js'
  * `import { context } from '@cedarjs/context'`
  */
 export const useRedwoodGlobalContextSetter =
-  (): Plugin<RedwoodGraphQLContext> => ({
+  (): Plugin<CedarGraphQLContext> => ({
     onContextBuilding() {
       return ({ context }) => {
         setContext(context)

--- a/packages/graphql-server/src/plugins/useRedwoodLogger.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodLogger.ts
@@ -11,7 +11,7 @@ import { v4 as uuidv4 } from 'uuid'
 import type { Logger, LevelWithSilent } from '@cedarjs/api/logger'
 
 import { AuthenticationError, ForbiddenError } from '../errors.js'
-import type { RedwoodGraphQLContext } from '../types.js'
+import type { CedarGraphQLContext } from '../types.js'
 
 /**
  * Options for request and response information to include in the log statements
@@ -194,7 +194,7 @@ const logResult =
  */
 export const useRedwoodLogger = (
   loggerConfig: LoggerConfig,
-): Plugin<RedwoodGraphQLContext> => {
+): Plugin<CedarGraphQLContext> => {
   const logger = loggerConfig.logger
   const level = loggerConfig.options?.level || logger.level || 'warn'
 

--- a/packages/graphql-server/src/plugins/useRedwoodPopulateContext.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodPopulateContext.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'graphql-yoga'
 
-import type { RedwoodGraphQLContext, GraphQLHandlerOptions } from '../types.js'
+import type { CedarGraphQLContext, GraphQLHandlerOptions } from '../types.js'
 
 /**
  * This Envelop plugin enriches the context on a per-request basis
@@ -9,7 +9,7 @@ import type { RedwoodGraphQLContext, GraphQLHandlerOptions } from '../types.js'
  */
 export const useRedwoodPopulateContext = (
   populateContextBuilder: NonNullable<GraphQLHandlerOptions['context']>,
-): Plugin<RedwoodGraphQLContext> => {
+): Plugin<CedarGraphQLContext> => {
   return {
     async onContextBuilding({ context, extendContext }) {
       const populateContext =

--- a/packages/graphql-server/src/plugins/useRedwoodTrustedDocuments.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodTrustedDocuments.ts
@@ -2,7 +2,7 @@ import { usePersistedOperations } from '@graphql-yoga/plugin-persisted-operation
 import type { UsePersistedOperationsOptions } from '@graphql-yoga/plugin-persisted-operations'
 import type { Plugin } from 'graphql-yoga'
 
-import type { RedwoodGraphQLContext } from '../types.js'
+import type { CedarGraphQLContext } from '../types.js'
 
 export type RedwoodTrustedDocumentOptions = Omit<
   UsePersistedOperationsOptions,
@@ -92,7 +92,7 @@ const allowCedarStudioResyncMailMutations = async (request: Request) => {
 
 export const useRedwoodTrustedDocuments = (
   options: RedwoodTrustedDocumentOptions,
-): Plugin<RedwoodGraphQLContext> => {
+): Plugin<CedarGraphQLContext> => {
   return usePersistedOperations({
     ...options,
     customErrors: {

--- a/packages/graphql-server/src/types.ts
+++ b/packages/graphql-server/src/types.ts
@@ -70,10 +70,24 @@ export type ArmorConfig = {
   logErrors?: boolean
 } & GraphQLArmorConfig
 
-/** This is an interface so you can extend it inside your application when needed */
+/**
+ * This is an interface so you can extend it inside your application when needed
+ */
+export interface CedarGraphQLContext {
+  event: APIGatewayProxyEvent
+  requestContext?: LambdaContext | undefined
+  currentUser?: ThenArg<ReturnType<GetCurrentUser>> | AuthContextPayload | null
+
+  [index: string]: unknown
+}
+
+/**
+ * This is an interface so you can extend it inside your application when needed
+ * @deprecated Please use CedarGraphQLContext
+ */
 export interface RedwoodGraphQLContext {
   event: APIGatewayProxyEvent
-  requestContext: LambdaContext
+  requestContext: LambdaContext | undefined
   currentUser?: ThenArg<ReturnType<GetCurrentUser>> | AuthContextPayload | null
 
   [index: string]: unknown

--- a/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
+++ b/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Generate gql typedefs api 1`] = `
 import { MergePrismaWithSdlTypes, MakeRelationsOptional } from '@cedarjs/api'
 import { PrismaModelOne as PrismaPrismaModelOne, PrismaModelTwo as PrismaPrismaModelTwo, Post as PrismaPost, Todo as PrismaTodo } from '@prisma/client'
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
-import { RedwoodGraphQLContext } from '@cedarjs/graphql-server/dist/types';
+import { CedarGraphQLContext } from '@cedarjs/graphql-server/dist/types';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -202,11 +202,11 @@ export type requireAuthDirectiveArgs = {
   roles?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
-export type requireAuthDirectiveResolver<Result, Parent, ContextType = RedwoodGraphQLContext, Args = requireAuthDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type requireAuthDirectiveResolver<Result, Parent, ContextType = CedarGraphQLContext, Args = requireAuthDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type skipAuthDirectiveArgs = { };
 
-export type skipAuthDirectiveResolver<Result, Parent, ContextType = RedwoodGraphQLContext, Args = skipAuthDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type skipAuthDirectiveResolver<Result, Parent, ContextType = CedarGraphQLContext, Args = skipAuthDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export interface BigIntScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['BigInt'], any> {
   name: 'BigInt';
@@ -236,19 +236,19 @@ export interface JSONObjectScalarConfig extends GraphQLScalarTypeConfig<Resolver
   name: 'JSONObject';
 }
 
-export type MutationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+export type MutationResolvers<ContextType = CedarGraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   createTodo: Resolver<Maybe<ResolversTypes['Todo']>, ParentType, ContextType, RequireFields<MutationcreateTodoArgs, 'body'>>;
   renameTodo: Resolver<Maybe<ResolversTypes['Todo']>, ParentType, ContextType, RequireFields<MutationrenameTodoArgs, 'body' | 'id'>>;
   updateTodoStatus: Resolver<Maybe<ResolversTypes['Todo']>, ParentType, ContextType, RequireFields<MutationupdateTodoStatusArgs, 'id' | 'status'>>;
 };
 
-export type MutationRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+export type MutationRelationResolvers<ContextType = CedarGraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   createTodo?: RequiredResolverFn<Maybe<ResolversTypes['Todo']>, ParentType, ContextType, RequireFields<MutationcreateTodoArgs, 'body'>>;
   renameTodo?: RequiredResolverFn<Maybe<ResolversTypes['Todo']>, ParentType, ContextType, RequireFields<MutationrenameTodoArgs, 'body' | 'id'>>;
   updateTodoStatus?: RequiredResolverFn<Maybe<ResolversTypes['Todo']>, ParentType, ContextType, RequireFields<MutationupdateTodoStatusArgs, 'id' | 'status'>>;
 };
 
-export type QueryResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+export type QueryResolvers<ContextType = CedarGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   cedarjs: OptArgsResolverFn<Maybe<ResolversTypes['Redwood']>, ParentType, ContextType>;
   currentUser: OptArgsResolverFn<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   redwood: OptArgsResolverFn<Maybe<ResolversTypes['Redwood']>, ParentType, ContextType>;
@@ -256,7 +256,7 @@ export type QueryResolvers<ContextType = RedwoodGraphQLContext, ParentType exten
   todosCount: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
 };
 
-export type QueryRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+export type QueryRelationResolvers<ContextType = CedarGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   cedarjs?: RequiredResolverFn<Maybe<ResolversTypes['Redwood']>, ParentType, ContextType>;
   currentUser?: RequiredResolverFn<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   redwood?: RequiredResolverFn<Maybe<ResolversTypes['Redwood']>, ParentType, ContextType>;
@@ -264,14 +264,14 @@ export type QueryRelationResolvers<ContextType = RedwoodGraphQLContext, ParentTy
   todosCount?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
 };
 
-export type RedwoodResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Redwood'] = ResolversParentTypes['Redwood']> = {
+export type RedwoodResolvers<ContextType = CedarGraphQLContext, ParentType extends ResolversParentTypes['Redwood'] = ResolversParentTypes['Redwood']> = {
   currentUser: OptArgsResolverFn<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   prismaVersion: OptArgsResolverFn<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   version: OptArgsResolverFn<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type RedwoodRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Redwood'] = ResolversParentTypes['Redwood']> = {
+export type RedwoodRelationResolvers<ContextType = CedarGraphQLContext, ParentType extends ResolversParentTypes['Redwood'] = ResolversParentTypes['Redwood']> = {
   currentUser?: RequiredResolverFn<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   prismaVersion?: RequiredResolverFn<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   version?: RequiredResolverFn<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -282,21 +282,21 @@ export interface TimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes
   name: 'Time';
 }
 
-export type TodoResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Todo'] = ResolversParentTypes['Todo']> = {
+export type TodoResolvers<ContextType = CedarGraphQLContext, ParentType extends ResolversParentTypes['Todo'] = ResolversParentTypes['Todo']> = {
   body: OptArgsResolverFn<ResolversTypes['String'], ParentType, ContextType>;
   id: OptArgsResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   status: OptArgsResolverFn<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type TodoRelationResolvers<ContextType = RedwoodGraphQLContext, ParentType extends ResolversParentTypes['Todo'] = ResolversParentTypes['Todo']> = {
+export type TodoRelationResolvers<ContextType = CedarGraphQLContext, ParentType extends ResolversParentTypes['Todo'] = ResolversParentTypes['Todo']> = {
   body?: RequiredResolverFn<ResolversTypes['String'], ParentType, ContextType>;
   id?: RequiredResolverFn<ResolversTypes['Int'], ParentType, ContextType>;
   status?: RequiredResolverFn<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type Resolvers<ContextType = RedwoodGraphQLContext> = {
+export type Resolvers<ContextType = CedarGraphQLContext> = {
   BigInt: GraphQLScalarType;
   Byte: GraphQLScalarType;
   Date: GraphQLScalarType;
@@ -311,7 +311,7 @@ export type Resolvers<ContextType = RedwoodGraphQLContext> = {
   Todo: TodoResolvers<ContextType>;
 };
 
-export type DirectiveResolvers<ContextType = RedwoodGraphQLContext> = {
+export type DirectiveResolvers<ContextType = CedarGraphQLContext> = {
   requireAuth: requireAuthDirectiveResolver<any, any, ContextType>;
   skipAuth: skipAuthDirectiveResolver<any, any, ContextType>;
 };

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -323,7 +323,7 @@ async function getPluginConfig(side: CodegenSide) {
       // Look at type or source https://shrtm.nu/2BA0 for possible config, not well documented
       resolvers: true,
     },
-    contextType: `@cedarjs/graphql-server/dist/types#RedwoodGraphQLContext`,
+    contextType: `@cedarjs/graphql-server/dist/types#CedarGraphQLContext`,
   }
 
   return pluginConfig


### PR DESCRIPTION
This PR deprecates the `RedwoodGraphQLContext` type in favor of `CedarGraphQLContext` which has `requestContext` as optional.

The PR also fixes an internal type error in `packages/api-server/src/plugins/graphql.ts` related to `requestContext` 