### PR TITLE
chore(dev): Upgrade devcontainer to Node24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "CedarJS",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:3-24-bullseye",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },


### PR DESCRIPTION
The devcontainer needs to use Node 24 or it won't work with newer versions of Cedar