### PR TITLE
fix(docs): Fix comment text color on highlighted lines

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -170,6 +170,10 @@ blockquote {
   padding: 0 var(--ifm-pre-padding);
 }
 
+.theme-code-block-highlighted-line .comment {
+  color: #99d !important;
+}
+
 [data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: hsl(0deg 0% 0% / 30%);
 }


### PR DESCRIPTION
### Before

<img width="726" height="194" alt="image" src="https://github.com/user-attachments/assets/971d6462-3b8a-457a-ab97-1d9ae088545c" />


### After

<img width="729" height="194" alt="image" src="https://github.com/user-attachments/assets/dfca3561-e686-4909-80b1-69e5e68127fd" />
