### PR TITLE
fix(cli): Don't crash on building with no packages

### DIFF
--- a/packages/cli/src/commands/build/buildHandler.js
+++ b/packages/cli/src/commands/build/buildHandler.js
@@ -74,7 +74,7 @@ export const handler = async ({
     },
     nonApiWebWorkspaces.length > 0 && {
       title: 'Building Packages...',
-      task: () => buildPackagesTask(nonApiWebWorkspaces),
+      task: (_ctx, task) => buildPackagesTask(task, nonApiWebWorkspaces),
     },
     // If using GraphQL Fragments or Trusted Documents, then we need to use
     // codegen to generate the types needed for possible types and the trusted


### PR DESCRIPTION
Gracefully handle a workspace config that includes `packages/*`, but that doesn't resolve to any actual folders on the filesystem

Without this fix users were seeing errors like these

```
❯ yarn cedar build
✔ Generating Prisma Client...
✖ [concurrently] no commands provided
◼ Verifying graphql schema...
◼ Building API...
◼ Building Web...
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
AssertionError [ERR_ASSERTION]: [concurrently] no commands provided
    at concurrently (/home/user/dev/project/node_modules/concurrently/dist/src/concurrently.js:36:22)
    at concurrently (/home/user/dev/project/node_modules/concurrently/dist/src/index.js:51:44)
    at buildPackagesTask (file:///home/user/dev/project/node_modules/@cedarjs/cli/dist/commands/build/buildPackagesTask.js:21:22)
    at async _Task.run (file:///home/user/dev/project/node_modules/listr2/dist/index.js:1979:11)

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Need help?
 - Not sure about something or need advice? Reach out on our Discord
 - Think you've found a bug? Open an issue on our GitHub
 - Here's your unique error reference to quote: '3c7eb5ef-4ab3-478a-acd3-1c581f9f5d03'
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```