### PR TITLE
fix(studio): Regenerate the Prisma client after installing the Studio package

### DIFF
--- a/packages/cli/src/commands/studioHandler.js
+++ b/packages/cli/src/commands/studioHandler.js
@@ -1,3 +1,6 @@
+import execa from 'execa'
+
+import { getPaths } from '../lib/index.js'
 import { isModuleInstalled, installModule } from '../lib/packages.js'
 
 export const handler = async (options) => {
@@ -24,6 +27,11 @@ export const handler = async (options) => {
           "Added @cedarjs/api-server to your project, as it's used by Studio",
         )
       }
+
+      await execa.command(`yarn cedar prisma generate`, {
+        stdio: 'inherit',
+        cwd: getPaths().base,
+      })
     }
 
     // Import studio and start it


### PR DESCRIPTION
I got this error when trying to run `yarn cedar dev` right after running `yarn cedar studio` for the first time.

```
api | /Users/tobbe/dev/aerafarms/victory/node_modules/@prisma/client/src/runtime/core/engines/library/LibraryEngine.ts:141
api |       trace: engine.trace.bind(engine),
api |                           ^
api |
api | TypeError: Cannot read properties of undefined (reading 'bind')
api |     at Qr.wrapEngine (/Users/tobbe/dev/aerafarms/victory/node_modules/@prisma/client/src/runtime/core/engines/library/LibraryEngine.ts:141:27)
api |     at Qr.loadEngine (/Users/tobbe/dev/aerafarms/victory/node_modules/@prisma/client/src/runtime/core/engines/library/LibraryEngine.ts:311:26)
api |     at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
api |     at async Qr.instantiateLibrary (/Users/tobbe/dev/aerafarms/victory/node_modules/@prisma/client/src/runtime/core/engines/library/LibraryEngine.ts:243:5)
api |
api | Node.js v24.12.0
web | Error: connect ECONNREFUSED :::8911
web |     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
web |   errno: -61,
web |   code: 'ECONNREFUSED',
web |   syscall: 'connect',
web |   address: '::',
web |   port: 8911
web | }
web | 6:17:48 PM [vite] http proxy error: /graphql/health
web | Error: connect ECONNREFUSED :::8911
web |     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
web | Error: connect ECONNREFUSED :::8911
web |     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
web |   errno: -61,
web |   code: 'ECONNREFUSED',
web |   syscall: 'connect',
web |   address: '::',
web |   port: 8911
web | }
```

In an attempt to fix the error I regenerated the Prisma client, and after that running the dev server worked. So I'm adding `yarn cedar prisma generate` as an automated step in the initial Studio setup.