### PR TITLE
feat(cli): Support prettier.config.mjs when calling prettify

### DIFF
--- a/packages/cli-helpers/src/lib/index.ts
+++ b/packages/cli-helpers/src/lib/index.ts
@@ -50,13 +50,16 @@ export const transformTSToJS = (filename: string, content: string) => {
 }
 
 /**
- * This returns the config present in `prettier.config.cjs` of a Redwood project.
+ * This returns the config present in `prettier.config.cjs` or
+ * `prettier.config.mjs` of a Cedar project.
  */
 export const getPrettierOptions = async () => {
   try {
-    const { default: options } = await import(
-      `file://${path.join(getPaths().base, 'prettier.config.cjs')}`
-    )
+    const cjsPath = path.join(getPaths().base, 'prettier.config.cjs')
+    const mjsPath = path.join(getPaths().base, 'prettier.config.mjs')
+    const prettierConfigPath = fs.existsSync(cjsPath) ? cjsPath : mjsPath
+
+    const { default: options } = await import(`file://${prettierConfigPath}`)
 
     if (options.tailwindConfig?.startsWith('.')) {
       // Make this work with --cwd

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -58,15 +58,15 @@ export const nameVariants = (name) => {
   }
 }
 
-export const generateTemplate = async (templateFilename, { name, ...rest }) => {
+export const generateTemplate = (templateFilename, { name, ...rest }) => {
   try {
     const templateFn = template(readFile(templateFilename).toString())
-
     const renderedTemplate = templateFn({
       name,
       ...nameVariants(name),
       ...rest,
     })
+
     return prettify(templateFilename, renderedTemplate)
   } catch (error) {
     error.message = `Error applying template at ${templateFilename} for ${name}: ${error.message}`
@@ -222,13 +222,19 @@ export const getConfig = () => {
 }
 
 /**
- * This returns the config present in `prettier.config.cjs` of a Redwood project.
+ * This returns the config present in `prettier.config.cjs` or
+ * `prettier.config.mjs` of a Cedar project.
  */
 export const getPrettierOptions = async () => {
   try {
+    const cjsPath = path.join(getPaths().base, 'prettier.config.cjs')
+    const mjsPath = path.join(getPaths().base, 'prettier.config.mjs')
+    const prettierConfigPath = fs.existsSync(cjsPath) ? cjsPath : mjsPath
+
     const { default: prettierOptions } = await import(
-      `file://${path.join(getPaths().base, 'prettier.config.cjs')}`
+      `file://${prettierConfigPath}`
     )
+
     return prettierOptions
   } catch (e) {
     // If we're in our vitest environment we want to return a consistent set of prettier options


### PR DESCRIPTION
Code formatting was silently skipped when using the generators if a project had a .mjs prettier config file. This would lead to code full of red squiggles because of formatting "errors". This PR updates the formatting code to look for both .cjs and .mjs config files.