### PR TITLE
chore(ci): Skip full CI for some .github/ files

### DIFF
--- a/.github/actions/detect-changes/cases/code_changes.mjs
+++ b/.github/actions/detect-changes/cases/code_changes.mjs
@@ -44,7 +44,7 @@ function isNonCodeWorkflowOrAction(filePath) {
     '.github/scripts/publish-release-candidate.ts',
 
     '.github/workflows/require-milestone.yml',
-    '.github/actions/action.yml',
+    '.github/actions/require-milestone/action.yml',
     '.github/actions/requireMilestone.mjs',
 
     '.github/workflows/require-release-label.yml',


### PR DESCRIPTION
Some files don't require a full CI run because they have no impact on how the framework code works or is tested