### PR TITLE
chore(internal): Fix cedar.toml path tests

### DIFF
--- a/packages/internal/src/__tests__/configPath.test.ts
+++ b/packages/internal/src/__tests__/configPath.test.ts
@@ -28,7 +28,7 @@ describe('getConfigPath', () => {
 
     it('finds the correct config path when at base directory', () => {
       process.env.RWJS_CWD = FIXTURE_BASEDIR
-      expect(getConfigPath()).toBe(path.join(FIXTURE_BASEDIR, 'redwood.toml'))
+      expect(getConfigPath()).toBe(path.join(FIXTURE_BASEDIR, 'cedar.toml'))
     })
 
     it('finds the correct config path when inside a project directory', () => {
@@ -39,7 +39,7 @@ describe('getConfigPath', () => {
         'pages',
         'AboutPage',
       )
-      expect(getConfigPath()).toBe(path.join(FIXTURE_BASEDIR, 'redwood.toml'))
+      expect(getConfigPath()).toBe(path.join(FIXTURE_BASEDIR, 'cedar.toml'))
     })
   })
 
@@ -65,7 +65,7 @@ describe('getConfigPath', () => {
     it('finds the correct config path when at base directory', () => {
       const spy = vi.spyOn(process, 'cwd')
       spy.mockReturnValue(FIXTURE_BASEDIR)
-      expect(getConfigPath()).toBe(path.join(FIXTURE_BASEDIR, 'redwood.toml'))
+      expect(getConfigPath()).toBe(path.join(FIXTURE_BASEDIR, 'cedar.toml'))
     })
 
     it('finds the correct config path when inside a project directory', () => {
@@ -73,7 +73,7 @@ describe('getConfigPath', () => {
       spy.mockReturnValue(
         path.join(FIXTURE_BASEDIR, 'web', 'src', 'pages', 'AboutPage'),
       )
-      expect(getConfigPath()).toBe(path.join(FIXTURE_BASEDIR, 'redwood.toml'))
+      expect(getConfigPath()).toBe(path.join(FIXTURE_BASEDIR, 'cedar.toml'))
     })
   })
 })


### PR DESCRIPTION
I updated the test project to have a cedar.toml file instead of a redwood.toml file, but forgot to update these tests