### PR TITLE
chore(prettier): Disable prettier-plugin-sh because of upstream bug

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -12,7 +12,9 @@ const config = {
   singleQuote: true,
   plugins: [
     'prettier-plugin-curly',
-    'prettier-plugin-sh',
+    // See here for why this is commented out
+    // https://github.com/cedarjs/cedar/issues/964
+    // 'prettier-plugin-sh',
     'prettier-plugin-packagejson',
   ],
   overrides: [


### PR DESCRIPTION
See https://github.com/cedarjs/cedar/issues/964 and specifically https://github.com/reteps/dockerfmt/issues/25

prettier-format-sh (https://github.com/un-ts/prettier/tree/master/packages/sh) says 
> This plugin adds support for various file formats through [mvdan-sh](https://github.com/mvdan/sh) via [sh-syntax](https://github.com/un-ts/sh-syntax) and [dockerfmt](https://github.com/reteps/dockerfmt).

That's how I made the connection from prettier-plugin-sh to dockerfmt and the issue linked above at the top