### PR TITLE
fix(eslint): Use react jsx-runtime rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,7 +88,8 @@ export default [
     },
     rules: {
       // React recommended rules
-      ...reactPlugin.configs.recommended.rules,
+      ...reactPlugin.configs.flat.recommended.rules,
+      ...reactPlugin.configs.flat['jsx-runtime'].rules,
       // React hooks recommended rules
       ...reactHooksPlugin.configs.recommended.rules,
       // Jest DOM recommended rules

--- a/packages/web/src/entry/index.jsx
+++ b/packages/web/src/entry/index.jsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { hydrateRoot, createRoot } from 'react-dom/client'
 
 import App from '~redwood-app-root'


### PR DESCRIPTION
This only changes the internal eslint config, so it would typically be a "chore" commit. But to not fail eslint checks with the new config I had to remove `import React...` from a user-exposed file. So I'm labeling this as a "fix". 

No change needed in users project as I'm not touching any eslint config they will see/use.