### PR TITLE
chore(prettier): Add comment to explain prettier trailingComma value

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -6,6 +6,12 @@
  * @type {import("prettier").Config}
  */
 const config = {
+  // The default changed from 'es5' to 'all' in Prettier v3. It'd be better
+  // if this framework config matched the config we use for projects. And
+  // ideally they'd both stay as close as possible to the defaults. But for
+  // now it's too disruptive to change the config for projects, and I don't
+  // want to change *away* from defaults here. So I'm leaving it as 'all'.
+  trailingComma: 'all',
   bracketSpacing: true,
   tabWidth: 2,
   semi: false,


### PR DESCRIPTION
The problem with the different configs between framework and projects here shows up in `__fixtures__/test-project/packages/validators/src/index.ts`

<img width="457" height="142" alt="Screenshot 2026-01-24 at 23 29 30" src="https://github.com/user-attachments/assets/f12c0954-9848-45d8-939e-5237975595ea" />
