### PR TITLE
fix(cca): Add missing dev dep to Cedar apps

### DIFF
--- a/__fixtures__/esm-test-project/package.json
+++ b/__fixtures__/esm-test-project/package.json
@@ -8,6 +8,7 @@
   ],
   "devDependencies": {
     "@cedarjs/core": "3.0.0-canary.13206",
+    "@cedarjs/eslint-config": "3.0.0-canary.13206",
     "@cedarjs/project-config": "3.0.0-canary.13206",
     "@cedarjs/testing": "3.0.0-canary.13206",
     "vitest": "3.2.4",

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -7,6 +7,7 @@
   ],
   "devDependencies": {
     "@cedarjs/core": "3.0.0-canary.13206",
+    "@cedarjs/eslint-config": "3.0.0-canary.13206",
     "@cedarjs/project-config": "3.0.0-canary.13206",
     "@cedarjs/testing": "3.0.0-canary.13206",
     "prettier-plugin-tailwindcss": "^0.5.12"

--- a/packages/create-cedar-app/templates/esm-js/package.json
+++ b/packages/create-cedar-app/templates/esm-js/package.json
@@ -7,6 +7,7 @@
   ],
   "devDependencies": {
     "@cedarjs/core": "3.0.0-canary.13206",
+    "@cedarjs/eslint-config": "3.0.0-canary.13206",
     "@cedarjs/project-config": "3.0.0-canary.13206",
     "@cedarjs/testing": "3.0.0-canary.13206",
     "vitest": "3.2.4"

--- a/packages/create-cedar-app/templates/esm-ts/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/package.json
@@ -7,6 +7,7 @@
   ],
   "devDependencies": {
     "@cedarjs/core": "3.0.0-canary.13206",
+    "@cedarjs/eslint-config": "3.0.0-canary.13206",
     "@cedarjs/project-config": "3.0.0-canary.13206",
     "@cedarjs/testing": "3.0.0-canary.13206",
     "vitest": "3.2.4"

--- a/packages/create-cedar-app/templates/js/package.json
+++ b/packages/create-cedar-app/templates/js/package.json
@@ -6,6 +6,7 @@
   ],
   "devDependencies": {
     "@cedarjs/core": "3.0.0-canary.13206",
+    "@cedarjs/eslint-config": "3.0.0-canary.13206",
     "@cedarjs/project-config": "3.0.0-canary.13206",
     "@cedarjs/testing": "3.0.0-canary.13206"
   },

--- a/packages/create-cedar-app/templates/ts/package.json
+++ b/packages/create-cedar-app/templates/ts/package.json
@@ -6,6 +6,7 @@
   ],
   "devDependencies": {
     "@cedarjs/core": "3.0.0-canary.13206",
+    "@cedarjs/eslint-config": "3.0.0-canary.13206",
     "@cedarjs/project-config": "3.0.0-canary.13206",
     "@cedarjs/testing": "3.0.0-canary.13206"
   },


### PR DESCRIPTION
The root eslint config file uses `@cedarjs/eslint-config`, so it should list it as a dev dependency

For existing Cedar apps: It's recommended that you manually add this dependency yourself