### PR TITLE
chore(deps): update dependency @sentry/* to v10 and @envelop/sentry t…

### DIFF
--- a/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
+++ b/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
@@ -28,8 +28,8 @@ export const handler = async ({ force }: Args) => {
   const notes: string[] = []
 
   const tasks = new Listr([
-    addApiPackages(['@envelop/sentry@5', '@sentry/node@7']),
-    addWebPackages(['@sentry/react@7', '@sentry/browser@7']),
+    addApiPackages(['@envelop/sentry@^15', '@sentry/node@^10']),
+    addWebPackages(['@sentry/react@^10', '@sentry/browser@^10']),
     addEnvVarTask(
       'SENTRY_DSN',
       '',

--- a/packages/cli/src/commands/setup/monitoring/sentry/templates/sentryApi.ts.template
+++ b/packages/cli/src/commands/setup/monitoring/sentry/templates/sentryApi.ts.template
@@ -1,13 +1,11 @@
 import * as Sentry from '@sentry/node'
 
-import { db as client } from 'src/lib/db'
-
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV,
   integrations: [
-    new Sentry.Integrations.Prisma({ client }),
-    new Sentry.Integrations.Http({ tracing: true }),
+    Sentry.prismaIntegration(),
+    Sentry.httpIntegration(),
   ],
   tracesSampleRate: 1.0,
 })

--- a/packages/cli/src/commands/setup/monitoring/sentry/templates/sentryWeb.ts.template
+++ b/packages/cli/src/commands/setup/monitoring/sentry/templates/sentryWeb.ts.template
@@ -24,7 +24,7 @@ if (typeof process === 'undefined' || !process.env?.SENTRY_DSN) {
 Sentry.init({
   dsn,
   environment,
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [ Sentry.browserTracingIntegration() ],
   tracesSampleRate: 1.0,
 })
 


### PR DESCRIPTION
I started having some bugs with the current Prisma version ([issue on sentry-javascript repo](https://github.com/getsentry/sentry-javascript/issues/12462))

```
TypeError: request.headers.split is not a function
    at setHeadersOnRequest (…/node_modules/@sentry/node/cjs/integrations/undici/index.js:247:39)
    at _onRequestCreate (…/node_modules/@sentry/node/cjs/integrations/undici/index.js:151:9)
    …
```

I upgraded beyond v7, and it went fluently, in dev and production. Let me know if there's something more to do before merging !