### PR TITLE
chore(test-project): More unification of tasks and tui-tasks

### DIFF
--- a/tasks/test-project/base-tasks.mts
+++ b/tasks/test-project/base-tasks.mts
@@ -68,7 +68,7 @@ export function createBuilder(cmd: string, dir = '') {
   }
 }
 
-export function getPagesTasks() {
+function getPagesTasks() {
   // Passing 'web' here to test executing 'yarn cedar' in the /web directory
   // to make sure it works as expected. We do the same for the /api directory
   // further down in this file.
@@ -196,6 +196,38 @@ export function getPagesTasks() {
       },
     },
   ]
+}
+
+export function webTasksList() {
+  const taskList = [
+    {
+      title: 'Creating pages',
+      task: async () => getPagesTasks(),
+      isNested: true,
+    },
+    {
+      title: 'Creating layout',
+      task: () => createLayout(),
+    },
+    {
+      title: 'Creating components',
+      task: () => createComponents(),
+    },
+    {
+      title: 'Creating cells',
+      task: () => createCells(),
+    },
+    {
+      title: 'Updating cell mocks',
+      task: () => updateCellMocks(),
+    },
+    {
+      title: 'Changing routes',
+      task: () => applyCodemod('routes.js', fullPath('web/src/Routes')),
+    },
+  ]
+
+  return taskList
 }
 
 export async function createLayout() {

--- a/tasks/test-project/rebuild-test-project-fixture.mts
+++ b/tasks/test-project/rebuild-test-project-fixture.mts
@@ -569,6 +569,7 @@ async function runCommand() {
         getExecaOptions(OUTPUT_PROJECT_PATH),
       )
 
+      // Verify that we're not including test files in the build output
       const distFiles = fs.readdirSync(
         path.join(OUTPUT_PROJECT_PATH, 'packages', 'validators', 'dist'),
       )

--- a/tasks/test-project/tui-tasks.mts
+++ b/tasks/test-project/tui-tasks.mts
@@ -5,16 +5,12 @@ import type { Options as ExecaOptions } from 'execa'
 
 import {
   createBuilder,
-  createCells,
-  createComponents,
-  createLayout,
   fullPath,
   getOutputPath,
-  getPagesTasks,
   setOutputPath,
-  updateCellMocks,
   addModel,
   addDbAuth,
+  webTasksList,
 } from './base-tasks.mts'
 import { getPrerenderTasks } from './prerender-tasks.mts'
 import type { TuiTaskList } from './typing.mts'
@@ -35,30 +31,7 @@ export async function webTasks(outputPath: string) {
   const execaOptions = getExecaOptions(outputPath)
 
   const tuiTaskList: TuiTaskList = [
-    {
-      title: 'Creating pages',
-      task: async () => getPagesTasks(),
-    },
-    {
-      title: 'Creating layout',
-      task: () => createLayout(),
-    },
-    {
-      title: 'Creating components',
-      task: () => createComponents(),
-    },
-    {
-      title: 'Creating cells',
-      task: () => createCells(),
-    },
-    {
-      title: 'Updating cell mocks',
-      task: () => updateCellMocks(),
-    },
-    {
-      title: 'Changing routes',
-      task: () => applyCodemod('routes.js', fullPath('web/src/Routes')),
-    },
+    ...webTasksList(),
     {
       title: 'Adding Tailwind',
       task: async () => {
@@ -165,7 +138,8 @@ export async function apiTasks(
       },
     },
     {
-      // This task renames the migration folders so that we don't have to deal with duplicates/conflicts when committing to the repo
+      // This task renames the migration folders so that we don't have to deal
+      // with duplicates/conflicts when committing to the repo
       title: 'Adjust dates within migration folder names',
       task: () => {
         const migrationsFolderPath = path.join(
@@ -174,7 +148,8 @@ export async function apiTasks(
           'db',
           'migrations',
         )
-        // Migration folders are folders which start with 14 digits because they have a yyyymmddhhmmss
+        // Migration folders are folders which start with 14 digits because they
+        // have a yyyymmddhhmmss
         const migrationFolders = fs
           .readdirSync(migrationsFolderPath)
           .filter((name) => {
@@ -201,6 +176,10 @@ export async function apiTasks(
           datetime.setDate(datetime.getDate() + 1)
         })
       },
+    },
+    {
+      title: 'Add dbAuth',
+      task: async () => addDbAuth(outputPath, linkWithLatestFwBuild),
     },
     {
       title: 'Add users service',
@@ -237,10 +216,6 @@ export async function apiTasks(
 
         return createBuilder('yarn cedar g types')()
       },
-    },
-    {
-      title: 'Add dbAuth',
-      task: async () => addDbAuth(outputPath, linkWithLatestFwBuild),
     },
     {
       title: 'Add describeScenario tests',


### PR DESCRIPTION
I need to add some more codemods for testing workspace packages. And I don't want to have to worry about implementation drift between tasks/test-project and tasks/rebuild-test-project-fixture, so I'm extracting common code to be reused between both scripts