### PR TITLE
chore(prettier): Ignore .gitignored files in test-project

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,15 @@ packages/testing/config
 # Ignore fixture projects
 /__fixtures__
 
+# Ignore files ignored by nested .gitignore
+# prettier doesn't support this:
+# https://github.com/prettier/prettier/issues/4081
+# oxc-format does though, so we can remove this if/when we switch over
+# https://github.com/oxc-project/oxc/pull/17352
+/test-project/.redwood/
+/test-project/api/types/graphql.d.ts
+/test-project/web/types/graphql.d.ts
+
 # Ignore the certain files in /docs
 /docs/.docusaurus
 /docs/build


### PR DESCRIPTION
Workaround for https://github.com/prettier/prettier/issues/4081

If/when we switch over to oxc-format we won't need this anymore https://github.com/oxc-project/oxc/pull/17352