### PR TITLE
chore(ci): Add dbAuth after users service to fix typegen

### DIFF
--- a/tasks/test-project/base-tasks.mts
+++ b/tasks/test-project/base-tasks.mts
@@ -358,11 +358,6 @@ export function apiTasksList({
       },
     },
     {
-      title: 'Add dbAuth',
-      task: async () =>
-        addDbAuth(dbAuth === 'local', getOutputPath(), linkWithLatestFwBuild),
-    },
-    {
       title: 'Add users service',
       task: async () => {
         const generateSdl = createBuilder('yarn cedar g sdl --no-crud', 'api')
@@ -397,6 +392,11 @@ export function apiTasksList({
 
         return createBuilder('yarn cedar g types')()
       },
+    },
+    {
+      title: 'Add dbAuth',
+      task: async () =>
+        addDbAuth(dbAuth === 'local', getOutputPath(), linkWithLatestFwBuild),
     },
     {
       title: 'Add describeScenario tests',


### PR DESCRIPTION
Can't add dbAuth until after we've added the "users" service. typegen will complain about missing User types if we try to do this in the wrong order