### PR TITLE
chore(tarsync): Copy instead of move tarballs

### DIFF
--- a/tasks/framework-tools/tarsync/lib.mts
+++ b/tasks/framework-tools/tarsync/lib.mts
@@ -102,19 +102,17 @@ export async function buildTarballs() {
   await $`yarn nx run-many -t build:pack --exclude create-cedar-app`
 }
 
-export async function moveTarballs(projectPath: string) {
+export async function copyTarballs(projectPath: string) {
   const tarballDest = path.join(projectPath, TARBALL_DEST_DIRNAME)
   await fs.promises.mkdir(tarballDest, { recursive: true })
 
   const tarballs = await glob(['./packages/**/*.tgz'])
 
   await Promise.all(
-    tarballs.map((tarball) =>
-      fs.promises.rename(
-        tarball,
-        path.join(tarballDest, path.basename(tarball)),
-      ),
-    ),
+    tarballs.map(async (tarball) => {
+      const dest = path.join(tarballDest, path.basename(tarball))
+      await fs.promises.copyFile(tarball, dest)
+    }),
   )
 }
 

--- a/tasks/framework-tools/tarsync/output.mts
+++ b/tasks/framework-tools/tarsync/output.mts
@@ -122,7 +122,7 @@ export class OutputManager {
     )
     lines.push(
       this.getPrefix(Stage.MOVE) +
-        ' Moving tarballs' +
+        ' Copying tarballs' +
         this.getSuffix(Stage.MOVE),
     )
     lines.push(

--- a/tasks/framework-tools/tarsync/tarsync.mts
+++ b/tasks/framework-tools/tarsync/tarsync.mts
@@ -4,7 +4,7 @@ import type { Options } from './lib.mjs'
 import {
   buildTarballs,
   FRAMEWORK_PATH,
-  moveTarballs,
+  copyTarballs,
   updateResolutions,
   yarnInstall,
 } from './lib.mjs'
@@ -34,7 +34,7 @@ export async function tarsync(
 
   outputManager.switchStage(Stage.MOVE)
   try {
-    await moveTarballs(projectPath)
+    await copyTarballs(projectPath)
   } catch (error) {
     outputManager.stop(error)
     return


### PR DESCRIPTION
Two problems with moving the tarballs:

1. When rebuilding/repacking the tarballs, if the code hasn't changed in the package or up the dependency chain NX's cache will say it doesn't need to be rebuilt/repackaged. So the build:pack step will succeed (from cache), but the package won't be there (because we moved it elsewhere). So when we later go to move it into a new test-project there's nothing to move and the test-project will have a broken resolution in its package.json file
2. The framework's test project (not the fixture) uses "file:" references to point to package tarballs inside the package directories. Removing them from there breaks that reference.