### PR TITLE
chore(rebuild-test-project-fixture): Fix crash in error reporting

### DIFF
--- a/tasks/test-project/rebuild-test-project-fixture.mts
+++ b/tasks/test-project/rebuild-test-project-fixture.mts
@@ -172,11 +172,9 @@ async function tuiTask({ step, title, content, task, parent }: TuiTaskDef) {
       )
     } else {
       const message = isTuiError(e) ? e.message : ''
+      const errorTitle = title?.toLowerCase().replace('...', '') || '<no title>'
 
-      tui.displayError(
-        'Failed ' + title.toLowerCase().replace('...', ''),
-        message || '',
-      )
+      tui.displayError('Failed ' + errorTitle, message || '')
     }
 
     const exitCode = isTuiError(e) ? e.exitCode : 1


### PR DESCRIPTION
I had a crash where `title` was undefined, so I'm adding a fallback to display "<no title>" in that case