### PR TITLE
chore(esm): Disable renovate for cross-env

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,6 +32,7 @@
       "matchPackageNames": [
         "boxen",
         "camelcase",
+        "cross-env",
         "execa",
         "humanize-string",
         "pascalcase",


### PR DESCRIPTION
cross-env is esm now, and we can't use that (even with require(esm) support) because we run into dual module hazzard issues if we try to use it.