### PR TITLE
fix(cli): Improve realtime setup command [DEP0040]

### DIFF
--- a/packages/cli/src/commands/setup/realtime/realtimeHandler.js
+++ b/packages/cli/src/commands/setup/realtime/realtimeHandler.js
@@ -6,7 +6,6 @@ import { Listr } from 'listr2'
 import prompts from 'prompts'
 
 import { addApiPackages } from '@cedarjs/cli-helpers'
-import { generate as generateTypes } from '@cedarjs/internal/dist/generate/generate'
 import { projectIsEsm } from '@cedarjs/project-config'
 import { errorTelemetry } from '@cedarjs/telemetry'
 
@@ -412,7 +411,11 @@ export async function handler(args) {
       {
         title: `Generating types...`,
         task: async () => {
-          await generateTypes()
+          const { generate } =
+            await import('@cedarjs/internal/dist/generate/generate')
+
+          await generate()
+
           console.log(
             'Note: You may need to manually restart GraphQL in VSCode to see ' +
               'the new types take effect.\n\n',


### PR DESCRIPTION
Dynamic import to *delay* the DEP0040 warning.

## Before

```
❯ yarn cedar setup realtime
? Do you want to generate examples? › No / Yes(node:92208) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
✖ Do you want to generate examples? … No / Yes
✖ Adding required api packages...
```

## After

```
❯ yarn cedar setup realtime -f
✔ Do you want to generate examples? … No / Yes
✔ Adding required api packages...
✔ Adding the realtime api lib...
✔ Enabling realtime support in the GraphQL handler...
✔ Generating types...
✔ Cleaning up...

(node:97523) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Note: You may need to manually restart GraphQL in VSCode to see the new types take effect.
```