### PR TITLE
chore(cli): More internal renaming to Cedar

### DIFF
--- a/packages/cli/src/commands/experimental.ts
+++ b/packages/cli/src/commands/experimental.ts
@@ -1,7 +1,7 @@
 import { terminalLink } from 'termi-link'
 import type { Argv } from 'yargs'
 
-import detectRxVersion from '../middleware/detectProjectRxVersion.js'
+import { detectCedarVersion } from '../middleware/detectProjectCedarVersion.js'
 
 // @ts-expect-error - Types not available for JS files
 import * as experimentalInngest from './experimental/setupInngest.js'
@@ -27,7 +27,7 @@ export const builder = (yargs: Argv) =>
     .command(experimentalStreamingSsr)
     .demandCommand()
     // @ts-expect-error - Yargs TS types aren't very good
-    .middleware(detectRxVersion)
+    .middleware(detectCedarVersion)
     .epilogue(
       `Also see the ${terminalLink(
         'CedarJS CLI Reference',

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,7 +1,7 @@
 import { terminalLink } from 'termi-link'
 import type { Argv } from 'yargs'
 
-import detectRxVersion from '../middleware/detectProjectRxVersion.js'
+import { detectCedarVersion } from '../middleware/detectProjectCedarVersion.js'
 
 // @ts-expect-error - Types not available for JS files
 import * as setupAuth from './setup/auth/auth.js'
@@ -68,7 +68,7 @@ export const builder = (yargs: Argv) =>
     .command(setupVite)
     .demandCommand()
     // @ts-expect-error - Yargs TS types aren't very good
-    .middleware(detectRxVersion)
+    .middleware(detectCedarVersion)
     .epilogue(
       `Also see the ${terminalLink(
         'CedarJS CLI Reference',

--- a/packages/cli/src/middleware/detectProjectCedarVersion.ts
+++ b/packages/cli/src/middleware/detectProjectCedarVersion.ts
@@ -1,9 +1,9 @@
 // @ts-expect-error - Types not available for JS files
 import { getInstalledCedarVersion } from '../lib/index.js'
 
-type RxVersionArgv = Record<string, unknown> & { rwVersion?: string }
+type CedarVersionArgv = Record<string, unknown> & { rwVersion?: string }
 
-export default async function detectRxVersion(argv: RxVersionArgv) {
+export async function detectCedarVersion(argv: CedarVersionArgv) {
   if (!argv.rwVersion) {
     return {
       rwVersion: await getInstalledCedarVersion(),


### PR DESCRIPTION
Make the code less confusing to work with by moving more and more towards naming things "Cedar" internally