### PR TITLE
fix(cli): type-only import in realtime template

### DIFF
--- a/packages/cli/src/commands/setup/realtime/templates/realtime.ts.template
+++ b/packages/cli/src/commands/setup/realtime/templates/realtime.ts.template
@@ -1,4 +1,4 @@
-import { CedarRealtimeOptions } from '@cedarjs/realtime'
+import type { CedarRealtimeOptions } from '@cedarjs/realtime'
 
 import subscriptions from 'src/subscriptions/**/*.{js,ts}'
 


### PR DESCRIPTION
```
/Users/tobbe/dev/cedarjs/cedar/test-project/api/src/lib/realtime.ts
  1:1  error  All imports in the declaration are only used as types. Use `import type`  @typescript-eslint/consistent-type-imports

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```

This PR fixes the error above