### PR TITLE
chore(ci): Print canary upgrade message after PR publishing

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -64,7 +64,7 @@ jobs:
             VERSION="${{ steps.get-version.outputs.value }}"
             # Strip build metadata/commit hash suffix that starts with '+'
             VERSION="${VERSION%%+*}"
-            gh pr comment $PR_NUMBER --body "The changes in this PR are now available in $VERSION"
+            gh pr comment $PR_NUMBER --body "The changes in this PR are now available on npm.\n\nTry them out by running `yarn cedar upgrade -t $VERSION`"
           else
             echo "No PR found for commit ${{ github.sha }}"
           fi


### PR DESCRIPTION
Give a copy/paste friendly message for trying the canary release with the changes in the recently merged and published PR