### PR TITLE
fix(cli): Don't show stale upgrade info

### DIFF
--- a/packages/cli/src/lib/__tests__/updateCheck.test.ts
+++ b/packages/cli/src/lib/__tests__/updateCheck.test.ts
@@ -1,7 +1,18 @@
 global.__dirname = __dirname
 
+const { spawnBackgroundProcessMock } = vi.hoisted(() => {
+  return {
+    spawnBackgroundProcessMock: vi.fn(),
+  }
+})
+
 vi.mock('node:fs')
 vi.mock('latest-version')
+vi.mock('../background.js', () => {
+  return {
+    spawnBackgroundProcess: spawnBackgroundProcessMock,
+  }
+})
 
 vi.mock('@cedarjs/project-config', async (importOriginal) => {
   const originalProjectConfig = await importOriginal<typeof ProjectConfig>()
@@ -305,5 +316,51 @@ describe('Update is available with rc tag (1.0.0-rc.1 -> 1.0.1-rc.58)', () => {
   it('Respects the lock', async () => {
     setLock(updateCheck.CHECK_LOCK_IDENTIFIER)
     expect(updateCheck.shouldCheck()).toBe(false)
+  })
+})
+
+describe('Update middleware', () => {
+  beforeAll(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(TESTING_CURRENT_DATETIME))
+  })
+
+  afterAll(() => {
+    vi.useRealTimers()
+  })
+
+  beforeEach(() => {
+    // Prevent the appearance of stale locks
+    // @ts-expect-error - This is assignable in tests
+    fs.statSync = vi.fn(() => {
+      return {
+        birthtimeMs: Date.now(),
+      }
+    })
+
+    vol.fromJSON({
+      '.redwood/updateCheck/data.json': JSON.stringify({
+        localVersion: '2.4.1',
+        remoteVersions: {
+          latest: '2.5.0',
+        },
+        checkedAt: updateCheck.DEFAULT_DATETIME_MS,
+        shownAt: updateCheck.DEFAULT_DATETIME_MS,
+      }),
+    })
+  })
+
+  afterEach(() => {
+    vol.reset()
+    vi.clearAllMocks()
+  })
+
+  it('does not show stale update info when a fresh check is due', () => {
+    const processOnSpy = vi.spyOn(process, 'on')
+
+    updateCheck.updateCheckMiddleware({ _: ['info'] })
+
+    expect(spawnBackgroundProcessMock).toHaveBeenCalledTimes(1)
+    expect(processOnSpy).not.toHaveBeenCalledWith('exit', expect.any(Function))
   })
 })

--- a/packages/cli/src/lib/updateCheck.ts
+++ b/packages/cli/src/lib/updateCheck.ts
@@ -128,7 +128,7 @@ export function isEnabled() {
 
 /**
  * Determines if an update check is due based on if enough time has elapsed since the last check
- * @return {boolean} `true` if an update check is overdue
+ * @return `true` if an update check is overdue
  * @see {@link CHECK_PERIOD} for the time between notifications
  */
 export function shouldCheck() {
@@ -144,7 +144,7 @@ export function shouldCheck() {
 
 /**
  * Determines if the user should see an update notification based on if a new version is available and enough time has elapsed since the last notification
- * @return {boolean} `true` if the user should see an update notification
+ * @return `true` if the user should see an update notification
  * @see {@link SHOW_PERIOD} for the time between notifications
  */
 export function shouldShow() {
@@ -173,7 +173,7 @@ export function showUpdateMessage() {
 
 /**
  * Returns a nicely formatted string containing an update notification
- * @return {string} A specifically formatted update notification message
+ * @return A specifically formatted update notification message
  */
 function getUpdateMessage() {
   const data = readUpdateDataFile()
@@ -300,19 +300,19 @@ export function updateCheckMiddleware(argv: { _: (string | number)[] }) {
     return
   }
 
-  if (shouldShow()) {
-    setLock(SHOW_LOCK_IDENTIFIER)
-    process.on('exit', () => {
-      showUpdateMessage()
-      unsetLock(SHOW_LOCK_IDENTIFIER)
-    })
-  }
-
+  // Always prefer refreshing cached version data first. This avoids showing a
+  // notification based on stale local/remote versions in the same run.
   if (shouldCheck()) {
     setLock(CHECK_LOCK_IDENTIFIER)
     spawnBackgroundProcess('updateCheck', 'yarn', [
       'node',
       path.join(import.meta.dirname, 'updateCheckExecute.js'),
     ])
+  } else if (shouldShow()) {
+    setLock(SHOW_LOCK_IDENTIFIER)
+    process.on('exit', () => {
+      showUpdateMessage()
+      unsetLock(SHOW_LOCK_IDENTIFIER)
+    })
   }
 }


### PR DESCRIPTION
If a check for a new version is due to run, don't display the upgrade message

Fixes #192 