### PR TITLE
fix(codemods): Add Prisma v7 prep codemod to list of commands

### DIFF
--- a/packages/codemods/src/codemods.ts
+++ b/packages/codemods/src/codemods.ts
@@ -22,11 +22,13 @@ import * as v6DevFatalErrorPage from './codemods/redwood/v6.x.x/updateDevFatalEr
 import * as v6ThemeConfig from './codemods/redwood/v6.x.x/updateThemeConfig/updateThemeConfig.yargs.js'
 import * as v7Gql from './codemods/redwood/v7.x.x/updateGraphQLConfig/updateGraphqlConfig.yargs.js'
 import * as v2MoveGeneratorTemplates from './codemods/v2.3.x/moveGeneratorTemplates/moveGeneratorTemplates.yargs.js'
+import * as v2PrismaV7Prep from './codemods/v2.7.x/prismaV7Prep/prismaV7Prep.yargs.js'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 yargs
   .scriptName('')
   .command(v2MoveGeneratorTemplates)
+  .command(v2PrismaV7Prep)
   .command('redwood', 'List or run Redwood codemods', (yargs) => {
     return yargs
       .command(v2TsconfigForRouteHooks)


### PR DESCRIPTION
The new codemod for prepping for the Prisma v7 upgrade should be listed when just running `npx -y @cedarjs/codemods@latest`