### PR TITLE
fix(api): `validateUniqueness` types and error message

### DIFF
--- a/packages/api/src/validations/validations.ts
+++ b/packages/api/src/validations/validations.ts
@@ -681,7 +681,7 @@ export async function validateUniqueness(
   model: string,
   fields: Record<string, unknown>,
   optionsOrCallback: (tx: PrismaClient) => Promise<any>,
-  callback: never,
+  callback?: never,
 ): Promise<any>
 export async function validateUniqueness(
   model: string,
@@ -732,7 +732,7 @@ export async function validateUniqueness(
     const found = await tx[model].findFirst({ where })
 
     if (found) {
-      validationError('uniqueness', fieldsToString(fields), options)
+      validationError('uniqueness', fieldsToString(rest), options)
     }
 
     return validCallback(tx)


### PR DESCRIPTION
The types for `validateUniqueness` now properly allows skipping the options object when a callback is the third argument.

Also fixed the error message to exclude the plucked `$self` and `$scope` attributes