### PR TITLE
fix(codemods): Run prettier on the output

### DIFF
--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/js-existing-export/output/api/db/dataMigrations/20260102000000-backfill.js
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/js-existing-export/output/api/db/dataMigrations/20260102000000-backfill.js
@@ -1,4 +1,4 @@
-import { PrismaClient } from "src/lib/db"
+import { PrismaClient } from 'src/lib/db'
 
 export default async () => {
   return new PrismaClient()

--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/js-existing-export/output/api/src/services/users/users.test.js
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/js-existing-export/output/api/src/services/users/users.test.js
@@ -1,3 +1,3 @@
-import { Prisma } from "src/lib/db"
+import { Prisma } from 'src/lib/db'
 
 export const x = Prisma

--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/api/db/dataMigrations/20260103000000-cjs.cjs
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/api/db/dataMigrations/20260103000000-cjs.cjs
@@ -1,3 +1,3 @@
-import { PrismaClient } from "src/lib/db"
+import { PrismaClient } from 'src/lib/db'
 
 module.exports = async () => new PrismaClient()

--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/api/db/dataMigrations/20260103000001-esm.mjs
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/api/db/dataMigrations/20260103000001-esm.mjs
@@ -1,3 +1,3 @@
-import { PrismaClient } from "src/lib/db"
+import { PrismaClient } from 'src/lib/db'
 
 export default async () => new PrismaClient()

--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/api/src/services/ext/types.cts
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/api/src/services/ext/types.cts
@@ -1,3 +1,3 @@
-import type { PrismaClient } from "src/lib/db"
+import type { PrismaClient } from 'src/lib/db'
 
 export type DbType = PrismaClient

--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/api/src/services/ext/types.mts
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/api/src/services/ext/types.mts
@@ -1,3 +1,3 @@
-import type { PrismaClient } from "src/lib/db"
+import type { PrismaClient } from 'src/lib/db'
 
 export type DbType = PrismaClient

--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/scripts/seed.cjs
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/scripts/seed.cjs
@@ -1,3 +1,3 @@
-import { PrismaClient } from "api/src/lib/db"
+import { PrismaClient } from 'api/src/lib/db'
 
 module.exports = new PrismaClient()

--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/scripts/seed.mjs
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/module-ext-matrix/output/scripts/seed.mjs
@@ -1,3 +1,3 @@
-import { PrismaClient } from "api/src/lib/db"
+import { PrismaClient } from 'api/src/lib/db'
 
 export default new PrismaClient()

--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/ts-core/output/api/db/dataMigrations/20260101000000-add-post-slug.ts
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/ts-core/output/api/db/dataMigrations/20260101000000-add-post-slug.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient } from "src/lib/db"
+import type { PrismaClient } from 'src/lib/db'
 
 export default async ({ db }: { db: PrismaClient }) => {
   await db.$executeRaw`SELECT 1`

--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/ts-core/output/api/src/lib/db.ts
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/ts-core/output/api/src/lib/db.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client'
 
-export * from "@prisma/client";
+export * from '@prisma/client'
 
 export const db = new PrismaClient()

--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/ts-core/output/api/src/services/posts/posts.scenarios.ts
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/ts-core/output/api/src/services/posts/posts.scenarios.ts
@@ -1,4 +1,4 @@
-import type { Prisma, Post } from "src/lib/db"
+import type { Prisma, Post } from 'src/lib/db'
 
 export const standard = defineScenario<Prisma.PostCreateArgs>({
   post: {

--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/ts-core/output/scripts/seed.ts
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/__testfixtures__/ts-core/output/scripts/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "api/src/lib/db"
+import { PrismaClient } from 'api/src/lib/db'
 
 const db = new PrismaClient()
 

--- a/packages/codemods/vite.setup.mts
+++ b/packages/codemods/vite.setup.mts
@@ -18,11 +18,6 @@ expect.extend({
       let actualOutput = fs.readFileSync(receivedPath, 'utf-8')
       let expectedOutput = fs.readFileSync(expectedPath, 'utf-8')
 
-      // Keep fixture assertions platform-independent. jscodeshift can emit
-      // CRLF on Windows while fixtures are committed with LF.
-      actualOutput = actualOutput.replace(/\r\n/g, '\n')
-      expectedOutput = expectedOutput.replace(/\r\n/g, '\n')
-
       if (removeWhitespace) {
         actualOutput = actualOutput.replace(/\s/g, '')
         expectedOutput = expectedOutput.replace(/\s/g, '')


### PR DESCRIPTION
Running prettier on the changed files after running the codemod. Without this step we'd end up with double quotes, semicolons etc in Cedar app code