### PR TITLE
fix(api): Use dynamic cache key

### DIFF
--- a/packages/api/src/cache/__tests__/cacheFindMany.test.ts
+++ b/packages/api/src/cache/__tests__/cacheFindMany.test.ts
@@ -98,4 +98,31 @@ describe('cacheFindMany', () => {
     expect(getSpy).not.toHaveBeenCalled()
     expect(setSpy).not.toHaveBeenCalled()
   })
+
+  it('builds cache key using custom id and updatedAt fields', async () => {
+    const now = new Date()
+
+    const user = {
+      uuid: 'abc-123',
+      email: 'tester@example.com',
+      modifiedAt: now,
+    }
+
+    mockFindFirst.mockImplementation(() => user)
+    mockFindMany.mockImplementation(() => [user])
+
+    const client = new InMemoryClient()
+    const { cacheFindMany } = createCache(client, {
+      fields: { id: 'uuid', updatedAt: 'modifiedAt' },
+    })
+    const spy = vi.spyOn(client, 'set')
+
+    await cacheFindMany('test', PrismaClient().user)
+
+    expect(spy).toHaveBeenCalled()
+    // Expect the cache key to include the `uuid` value (not `id`)
+    expect(client.storage[`test-${user.uuid}-${now.getTime()}`].value).toEqual(
+      JSON.stringify([user]),
+    )
+  })
 })

--- a/packages/api/src/cache/index.ts
+++ b/packages/api/src/cache/index.ts
@@ -171,7 +171,7 @@ export const createCache = (
     // create the key so just return the query
     if (latest) {
       latestCacheKey = `${cacheKey}${cacheKeySeparator}${
-        latest.id
+        latest[fields.id]
       }${cacheKeySeparator}${latest[fields.updatedAt].getTime()}`
     } else {
       logger?.debug(


### PR DESCRIPTION
Don't use hardcoded `.id` key