### PR TITLE
fix(api): allow custom `with` validator without message attribute

### DIFF
--- a/packages/api/src/validations/__tests__/validations.test.ts
+++ b/packages/api/src/validations/__tests__/validations.test.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from '@prisma/client'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import * as ValidationErrors from '../errors.js'
+import type { UniquenessTransactionClient } from '../validations.js'
 import {
   validate,
   validateUniqueness,
@@ -32,7 +33,7 @@ describe('validate absence', () => {
   it('throws with a default message', () => {
     try {
       validate('rob@cedarjs.com', 'email', { absence: true })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Email is not absent')
     }
   })
@@ -40,7 +41,7 @@ describe('validate absence', () => {
   it('throws with a default message when input form field name is snake case', () => {
     try {
       validate('rob@cedarjs.com', 'my_email', { absence: true })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('My Email is not absent')
     }
   })
@@ -48,7 +49,7 @@ describe('validate absence', () => {
   it('throws with a default message when input form field name is camel case', () => {
     try {
       validate('rob@cedarjs.com', 'myEmail', { absence: true })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('My Email is not absent')
     }
   })
@@ -58,7 +59,7 @@ describe('validate absence', () => {
       validate('rob@cedarjs.com', {
         absence: { message: 'No email please' },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('No email please')
     }
   })
@@ -94,7 +95,7 @@ describe('validate acceptance', () => {
   it('throws with a default message', () => {
     try {
       validate(false, 'terms', { acceptance: true })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Terms must be accepted')
     }
   })
@@ -102,7 +103,7 @@ describe('validate acceptance', () => {
   it('throws with a default message', () => {
     try {
       validate(false, 'terms_of_purchase', { acceptance: true })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Terms of Purchase must be accepted')
     }
   })
@@ -110,7 +111,7 @@ describe('validate acceptance', () => {
   it('throws with a default message when input form field name is snake case', () => {
     try {
       validate(false, 'termsOfPurchase', { acceptance: true })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Terms of Purchase must be accepted')
     }
   })
@@ -118,7 +119,7 @@ describe('validate acceptance', () => {
   it('throws with a custom message when input form field name is camel case', () => {
     try {
       validate(false, { acceptance: { message: 'gotta accept' } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('gotta accept')
     }
   })
@@ -160,7 +161,7 @@ describe('validate email', () => {
   it('throws with a default message', () => {
     try {
       validate(false, 'Terms', { acceptance: true })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Terms must be accepted')
     }
   })
@@ -168,7 +169,7 @@ describe('validate email', () => {
   it('throws with a custom message', () => {
     try {
       validate(false, { acceptance: { message: 'gotta accept' } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('gotta accept')
     }
   })
@@ -227,7 +228,7 @@ describe('validate exclusion', () => {
   it('throws with a default message', () => {
     try {
       validate('foo', 'selection', { exclusion: ['foo', 'bar'] })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Selection is reserved')
     }
   })
@@ -235,7 +236,7 @@ describe('validate exclusion', () => {
   it('throws with a default message when input form field name is snake case', () => {
     try {
       validate('foo', 'selection_of_widgets', { exclusion: ['foo', 'bar'] })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Selection of Widgets is reserved')
     }
   })
@@ -243,7 +244,7 @@ describe('validate exclusion', () => {
   it('throws with a default message when input form field name is camel case', () => {
     try {
       validate('foo', 'selectionOfWidgets', { exclusion: ['foo', 'bar'] })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Selection of Widgets is reserved')
     }
   })
@@ -251,7 +252,7 @@ describe('validate exclusion', () => {
   it('throws with a default message', () => {
     try {
       validate('foo', 'selection', { exclusion: ['foo', 'bar'] })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Selection is reserved')
     }
   })
@@ -261,7 +262,7 @@ describe('validate exclusion', () => {
       validate('foo', {
         exclusion: { in: ['foo', 'bar'], message: 'Bad choice' },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Bad choice')
     }
   })
@@ -295,27 +296,31 @@ describe('validate format', () => {
 
   it('throws if no pattern given', () => {
     try {
+      // @ts-expect-error - JS scenario, wrong type
       validate('foobar', 'text', { format: { pattern: null } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('No pattern for format validation')
     }
+
     try {
       validate('foobar', 'text', { format: { pattern: undefined } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('No pattern for format validation')
     }
+
     try {
       validate('foobar', 'text', { format: { message: 'no pattern' } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('No pattern for format validation')
     }
+
     expect.assertions(3)
   })
 
   it('throws with a default message', () => {
     try {
       validate('foobar', 'text', { format: /baz/ })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Text is not formatted correctly')
     }
     expect.assertions(1)
@@ -324,7 +329,7 @@ describe('validate format', () => {
   it('throws with a default message when input form field name is snake case', () => {
     try {
       validate('foobar', 'the_text', { format: /baz/ })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('The Text is not formatted correctly')
     }
     expect.assertions(1)
@@ -333,7 +338,7 @@ describe('validate format', () => {
   it('throws with a default message when input form field name is camel case', () => {
     try {
       validate('foobar', 'theText', { format: /baz/ })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('The Text is not formatted correctly')
     }
     expect.assertions(1)
@@ -344,7 +349,7 @@ describe('validate format', () => {
       validate('foobar', {
         format: { pattern: /baz/, message: 'bad format' },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('bad format')
     }
     expect.assertions(1)
@@ -404,7 +409,7 @@ describe('validate inclusion', () => {
   it('throws with a default message', () => {
     try {
       validate('foo', 'selection', { inclusion: ['foo', 'bar'] })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Selection is not valid')
     }
   })
@@ -414,7 +419,7 @@ describe('validate inclusion', () => {
       validate('baz', {
         inclusion: { in: ['foo', 'bar'], message: 'Bad choice' },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Bad choice')
     }
   })
@@ -433,14 +438,14 @@ describe('validate length', () => {
     // default error
     try {
       validate('a', 'username', { length: { min: 2 } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Username must have at least 2 characters')
     }
 
     // custom error
     try {
       validate('a', { length: { min: 2, message: 'too short' } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('too short')
     }
 
@@ -461,7 +466,7 @@ describe('validate length', () => {
     // default error
     try {
       validate('jeff', 'Username', { length: { max: 2 } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Username must have no more than 2 characters')
     }
 
@@ -470,7 +475,7 @@ describe('validate length', () => {
       validate('jill', {
         length: { max: 2, message: 'too long, must be less than ${max}' },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('too long, must be less than 2')
     }
 
@@ -494,7 +499,7 @@ describe('validate length', () => {
     // default error
     try {
       validate('foobar', 'username', { length: { equal: 5 } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Username must have exactly 5 characters')
     }
 
@@ -503,7 +508,7 @@ describe('validate length', () => {
       validate('foobar', {
         length: { equal: 5, message: 'wrong length, must be ${equal}' },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('wrong length, must be 5')
     }
 
@@ -527,7 +532,7 @@ describe('validate length', () => {
     // default error
     try {
       validate('foobar', 'username', { length: { between: [2, 4] } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Username must be between 2 and 4 characters')
     }
 
@@ -536,7 +541,7 @@ describe('validate length', () => {
       validate('foobar', {
         length: { between: [2, 4], message: 'not enough or too many' },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('not enough or too many')
     }
 
@@ -579,7 +584,7 @@ describe('validate numericality', () => {
     // default error
     try {
       validate(1.2, 'number', { numericality: { integer: true } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Number must be an integer')
     }
   })
@@ -611,7 +616,7 @@ describe('validate numericality', () => {
     // default error
     try {
       validate(2, 'number', { numericality: { lessThan: 1 } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Number must be less than 1')
     }
     expect.assertions(8)
@@ -644,7 +649,7 @@ describe('validate numericality', () => {
     // default error
     try {
       validate(3, 'number', { numericality: { lessThanOrEqual: 2 } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Number must be less than or equal to 2')
     }
     expect.assertions(8)
@@ -680,7 +685,7 @@ describe('validate numericality', () => {
     // default error
     try {
       validate(2, 'number', { numericality: { greaterThan: 3 } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Number must be greater than 3')
     }
     expect.assertions(9)
@@ -717,7 +722,7 @@ describe('validate numericality', () => {
     // default error
     try {
       validate(2, 'number', { numericality: { greaterThanOrEqual: 3 } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Number must be greater than or equal to 3')
     }
     expect.assertions(8)
@@ -756,7 +761,7 @@ describe('validate numericality', () => {
     // default error
     try {
       validate(2, 'number', { numericality: { equal: 3 } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Number must equal 3')
     }
     expect.assertions(10)
@@ -789,7 +794,7 @@ describe('validate numericality', () => {
     // default error
     try {
       validate(3, 'number', { numericality: { otherThan: 3 } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Number must not equal 3')
     }
     expect.assertions(8)
@@ -813,7 +818,7 @@ describe('validate numericality', () => {
     // default error
     try {
       validate(3, 'number', { numericality: { even: true } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Number must be even')
     }
     expect.assertions(5)
@@ -837,7 +842,7 @@ describe('validate numericality', () => {
     // default error
     try {
       validate(2, 'number', { numericality: { odd: true } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Number must be odd')
     }
     expect.assertions(5)
@@ -864,7 +869,7 @@ describe('validate numericality', () => {
     // default error
     try {
       validate(-1, 'number', { numericality: { positive: true } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Number must be positive')
     }
     expect.assertions(6)
@@ -891,7 +896,7 @@ describe('validate numericality', () => {
     // default error
     try {
       validate(1, 'number', { numericality: { negative: true } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Number must be negative')
     }
     expect.assertions(6)
@@ -952,7 +957,7 @@ describe('validate presence', () => {
   it('throws with a default message', () => {
     try {
       validate(undefined, 'email', { presence: true })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Email must be present')
     }
   })
@@ -960,7 +965,7 @@ describe('validate presence', () => {
   it('throws with a default message when input form field name is snake case', () => {
     try {
       validate(undefined, 'primary_email', { presence: true })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Primary Email must be present')
     }
   })
@@ -968,7 +973,7 @@ describe('validate presence', () => {
   it('throws with a default message when input form field name is camel case', () => {
     try {
       validate(undefined, 'workEmail', { presence: true })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Work Email must be present')
     }
   })
@@ -976,7 +981,7 @@ describe('validate presence', () => {
   it('throws with a custom message', () => {
     try {
       validate(undefined, { presence: { message: 'Gimmie an email' } })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Gimmie an email')
     }
   })
@@ -1017,7 +1022,7 @@ describe('validate custom', () => {
           message: 'Gimmie an email',
         },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Gimmie an email')
     }
   })
@@ -1031,7 +1036,7 @@ describe('validate custom', () => {
           },
         },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Gimmie an email')
     }
   })
@@ -1046,7 +1051,7 @@ describe('validate custom', () => {
           },
         },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Gimmie an email')
     }
   })
@@ -1062,7 +1067,7 @@ describe('validate', () => {
       validate(null, {
         presence: { message: 'Email is required' },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Email is required')
     }
     expect.assertions(1)
@@ -1070,10 +1075,9 @@ describe('validate', () => {
 
   it('will not throw a bad error if custom message is not present', () => {
     try {
-      validate(null, {
-        presence: true,
-      })
-    } catch (e) {
+      // @ts-expect-error - testing a JS scenario
+      validate(null, { presence: true })
+    } catch (e: any) {
       expect(e.message).toEqual(' must be present')
     }
     expect.assertions(1)
@@ -1081,10 +1085,8 @@ describe('validate', () => {
 
   it('accepts the three argument version', () => {
     try {
-      validate(null, 'Email Address', {
-        presence: true,
-      })
-    } catch (e) {
+      validate(null, 'Email Address', { presence: true })
+    } catch (e: any) {
       expect(e.message).toEqual('Email Address must be present')
     }
     expect.assertions(1)
@@ -1092,10 +1094,8 @@ describe('validate', () => {
 
   it('accepts the three argument version when input form field name is snake case', () => {
     try {
-      validate(null, 'email_address', {
-        presence: true,
-      })
-    } catch (e) {
+      validate(null, 'email_address', { presence: true })
+    } catch (e: any) {
       expect(e.message).toEqual('Email Address must be present')
     }
     expect.assertions(1)
@@ -1106,7 +1106,7 @@ describe('validate', () => {
       validate(null, 'emailAddress', {
         presence: true,
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Email Address must be present')
     }
     expect.assertions(1)
@@ -1117,7 +1117,7 @@ describe('validate', () => {
       validate(null, 'Email Address', {
         presence: { message: 'This cannot be blank' },
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('This cannot be blank')
     }
     expect.assertions(1)
@@ -1170,7 +1170,7 @@ describe('validateWithSync', () => {
       validateWithSync(() => {
         throw new Error('Invalid value')
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e instanceof ValidationErrors.ServiceValidationError).toEqual(true)
       expect(e.message).toEqual('Invalid value')
     }
@@ -1181,7 +1181,7 @@ describe('validateWithSync', () => {
         // eslint-disable-next-line @typescript-eslint/only-throw-error
         throw 'Bad input'
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e instanceof ValidationErrors.ServiceValidationError).toEqual(true)
       expect(e.message).toEqual('Bad input')
     }
@@ -1204,7 +1204,7 @@ describe('validateWith', () => {
       await validateWith(() => {
         throw new Error('Invalid value')
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e instanceof ValidationErrors.ServiceValidationError).toEqual(true)
       expect(e.message).toEqual('Invalid value')
     }
@@ -1214,7 +1214,7 @@ describe('validateWith', () => {
         // eslint-disable-next-line @typescript-eslint/only-throw-error
         throw 'Bad input'
       })
-    } catch (e) {
+    } catch (e: any) {
       expect(e instanceof ValidationErrors.ServiceValidationError).toEqual(true)
       expect(e.message).toEqual('Bad input')
     }
@@ -1270,7 +1270,7 @@ describe('validateUniqueness', () => {
         { db: mockDb },
         () => Promise.resolve(),
       )
-    } catch (e) {
+    } catch (e: any) {
       expect(e).toBeInstanceOf(ValidationErrors.UniquenessValidationError)
     }
     expect.assertions(1)
@@ -1306,7 +1306,7 @@ describe('validateUniqueness', () => {
         { db: mockDb },
         () => Promise.resolve(),
       )
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('email must be unique')
     }
 
@@ -1318,7 +1318,7 @@ describe('validateUniqueness', () => {
         { db: mockDb },
         () => Promise.resolve(),
       )
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('name, email must be unique')
     }
     expect.assertions(2)
@@ -1340,7 +1340,7 @@ describe('validateUniqueness', () => {
         },
         () => Promise.resolve(),
       )
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Email already taken')
     }
     expect.assertions(1)
@@ -1348,12 +1348,16 @@ describe('validateUniqueness', () => {
 
   it('uses the given prisma client', async () => {
     const mockFindFirstOther = vi.fn()
+
     mockFindFirstOther.mockImplementation(() => ({
       id: 2,
       email: 'rob@cedarjs.com',
     }))
+
     const mockPrismaClient = {
-      $transaction: async (func) =>
+      $transaction: async (
+        func: (tx: UniquenessTransactionClient) => Promise<any>,
+      ) =>
         func({
           user: {
             findFirst: mockFindFirstOther,


### PR DESCRIPTION
The code comment explains it pretty well

```ts
  // `message` is optional here because the custom.with() function is expected
  // to throw an Error, and we use the message from that error if no `message`
  // is specified
```