### PR TITLE
fix(upgrade-script): Fix prisma-v7-prep canary codemod command

### DIFF
--- a/upgrade-scripts/canary.ts
+++ b/upgrade-scripts/canary.ts
@@ -77,5 +77,5 @@ if (!hasPrismaV7PrepExport) {
   console.log(
     'Please run the following command after the upgrade has completed:',
   )
-  console.log('  yarn dlx @cedarjs/codemods prisma-v7-prep')
+  console.log('  yarn dlx @cedarjs/codemods@canary prisma-v7-prep')
 }


### PR DESCRIPTION
Have to specify `@canary`, otherwise it'll get `@latest`, which is v2.6.0 when I'm writing this