### PR TITLE
fix(codemods): prisma v7 prep reorder tip

### DIFF
--- a/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/prismaV7Prep.yargs.ts
+++ b/packages/codemods/src/codemods/v2.7.x/prismaV7Prep/prismaV7Prep.yargs.ts
@@ -72,8 +72,9 @@ export const handler = async () => {
     await task('One more thing...', async ({ setOutput }) => {
       setOutput(
         '\n\n' +
-          "Some imports might be in the wrong order. If that's the case,\n" +
-          'you can run `yarn cedar lint --fix` to reorder them.',
+          'Some imports (most likely in your scenario files) might now be\n' +
+          "in the wrong order. If that's the case, you can run\n" +
+          '`yarn cedar lint --fix` to reorder them.',
       )
     })
   })


### PR DESCRIPTION
Make tip about fixing imports order read a little bit better