### PR TITLE
chore(deps): Major version bump of listr2 to v8.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "jscodeshift": "17.0.0",
     "lefthook": "2.1.2",
     "lerna": "9.0.4",
-    "listr2": "7.0.2",
+    "listr2": "8.3.3",
     "make-dir-cli": "4.0.0",
     "msw": "1.3.5",
     "ncp": "2.0.0",

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -62,7 +62,7 @@
     "dotenv": "16.6.1",
     "dotenv-defaults": "5.0.2",
     "execa": "5.1.1",
-    "listr2": "7.0.2",
+    "listr2": "8.3.3",
     "lodash": "4.17.23",
     "pascalcase": "1.0.0",
     "prettier": "3.8.1",

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -31,7 +31,7 @@
     "bundle-require": "^5.1.0",
     "dotenv-defaults": "5.0.2",
     "execa": "5.1.1",
-    "listr2": "7.0.2",
+    "listr2": "8.3.3",
     "termi-link": "1.1.0",
     "yargs": "17.7.2"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -72,7 +72,7 @@
     "jscodeshift": "17.0.0",
     "jsonc-parser": "3.3.1",
     "latest-version": "9.0.0",
-    "listr2": "7.0.2",
+    "listr2": "8.3.3",
     "lodash": "4.17.23",
     "pascalcase": "1.0.0",
     "pluralize": "8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2864,7 +2864,7 @@ __metadata:
     bundle-require: "npm:^5.1.0"
     dotenv-defaults: "npm:5.0.2"
     execa: "npm:5.1.1"
-    listr2: "npm:7.0.2"
+    listr2: "npm:8.3.3"
     memfs: "npm:4.56.10"
     termi-link: "npm:1.1.0"
     tsx: "npm:4.21.0"
@@ -2895,7 +2895,7 @@ __metadata:
     dotenv: "npm:16.6.1"
     dotenv-defaults: "npm:5.0.2"
     execa: "npm:5.1.1"
-    listr2: "npm:7.0.2"
+    listr2: "npm:8.3.3"
     lodash: "npm:4.17.23"
     pascalcase: "npm:1.0.0"
     prettier: "npm:3.8.1"
@@ -2982,7 +2982,7 @@ __metadata:
     jscodeshift: "npm:17.0.0"
     jsonc-parser: "npm:3.3.1"
     latest-version: "npm:9.0.0"
-    listr2: "npm:7.0.2"
+    listr2: "npm:8.3.3"
     lodash: "npm:4.17.23"
     memfs: "npm:4.56.10"
     node-ssh: "npm:13.2.1"
@@ -12264,15 +12264,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "ansi-escapes@npm:5.0.0"
-  dependencies:
-    type-fest: "npm:^1.0.2"
-  checksum: 10c0/f705cc7fbabb981ddf51562cd950792807bccd7260cc3d9478a619dda62bff6634c87ca100f2545ac7aade9b72652c4edad8c7f0d31a0b949b5fa58f33eaf0d0
-  languageName: node
-  linkType: hard
-
 "ansi-escapes@npm:^6.0.0":
   version: 6.2.0
   resolution: "ansi-escapes@npm:6.2.0"
@@ -14104,15 +14095,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-cursor@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "cli-cursor@npm:4.0.0"
-  dependencies:
-    restore-cursor: "npm:^4.0.0"
-  checksum: 10c0/e776e8c3c6727300d0539b0d25160b2bb56aed1a63942753ba1826b012f337a6f4b7ace3548402e4f2f13b5e16bfd751be672c44b203205e7eca8be94afec42c
-  languageName: node
-  linkType: hard
-
 "cli-cursor@npm:^5.0.0":
   version: 5.0.0
   resolution: "cli-cursor@npm:5.0.0"
@@ -14182,13 +14164,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-truncate@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "cli-truncate@npm:3.1.0"
+"cli-truncate@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "cli-truncate@npm:4.0.0"
   dependencies:
     slice-ansi: "npm:^5.0.0"
-    string-width: "npm:^5.0.0"
-  checksum: 10c0/a19088878409ec0e5dc2659a5166929629d93cfba6d68afc9cde2282fd4c751af5b555bf197047e31c87c574396348d011b7aa806fec29c4139ea4f7f00b324c
+    string-width: "npm:^7.0.0"
+  checksum: 10c0/d7f0b73e3d9b88cb496e6c086df7410b541b56a43d18ade6a573c9c18bd001b1c3fba1ad578f741a4218fdc794d042385f8ac02c25e1c295a2d8b9f3cb86eb4c
   languageName: node
   linkType: hard
 
@@ -21757,17 +21739,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"listr2@npm:7.0.2":
-  version: 7.0.2
-  resolution: "listr2@npm:7.0.2"
+"listr2@npm:8.3.3":
+  version: 8.3.3
+  resolution: "listr2@npm:8.3.3"
   dependencies:
-    cli-truncate: "npm:^3.1.0"
+    cli-truncate: "npm:^4.0.0"
     colorette: "npm:^2.0.20"
     eventemitter3: "npm:^5.0.1"
-    log-update: "npm:^5.0.1"
-    rfdc: "npm:^1.3.0"
-    wrap-ansi: "npm:^8.1.0"
-  checksum: 10c0/37b6501be84ebea66dcce07c5f86c224aff0c01c9fb43f5055cc38a063030281d58198aad0aad481f174438309831ddf5f763b890e820cd7b7b4f4a5dfa229c9
+    log-update: "npm:^6.1.0"
+    rfdc: "npm:^1.4.1"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10c0/0792f8a7fd482fa516e21689e012e07081cab3653172ca606090622cfa0024c784a1eba8095a17948a0e9a4aa98a80f7c9c90f78a0dd35173d6802f9cc123a82
   languageName: node
   linkType: hard
 
@@ -22059,19 +22041,6 @@ __metadata:
     slice-ansi: "npm:^4.0.0"
     wrap-ansi: "npm:^6.2.0"
   checksum: 10c0/18b299e230432a156f2535660776406d15ba8bb7817dd3eaadd58004b363756d4ecaabcd658f9949f90b62ea7d3354423be3fdeb7a201ab951ec0e8d6139af86
-  languageName: node
-  linkType: hard
-
-"log-update@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "log-update@npm:5.0.1"
-  dependencies:
-    ansi-escapes: "npm:^5.0.0"
-    cli-cursor: "npm:^4.0.0"
-    slice-ansi: "npm:^5.0.0"
-    strip-ansi: "npm:^7.0.1"
-    wrap-ansi: "npm:^8.0.1"
-  checksum: 10c0/1050ea2027e80f32e132aace909987cb00c2719368c78b82ffca681a5b3f4020eeb5f4b4e310c47c35c6c36aff258c1d1bc51485ac44d6fdac9eb0a4275c539f
   languageName: node
   linkType: hard
 
@@ -26814,16 +26783,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"restore-cursor@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "restore-cursor@npm:4.0.0"
-  dependencies:
-    onetime: "npm:^5.1.0"
-    signal-exit: "npm:^3.0.2"
-  checksum: 10c0/6f7da8c5e422ac26aa38354870b1afac09963572cf2879443540449068cb43476e9cbccf6f8de3e0171e0d6f7f533c2bc1a0a008003c9a525bbc098e89041318
-  languageName: node
-  linkType: hard
-
 "restore-cursor@npm:^5.0.0":
   version: 5.1.0
   resolution: "restore-cursor@npm:5.1.0"
@@ -27122,7 +27081,7 @@ __metadata:
     jscodeshift: "npm:17.0.0"
     lefthook: "npm:2.1.2"
     lerna: "npm:9.0.4"
-    listr2: "npm:7.0.2"
+    listr2: "npm:8.3.3"
     make-dir-cli: "npm:4.0.0"
     msw: "npm:1.3.5"
     ncp: "npm:2.0.0"
@@ -28274,7 +28233,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^5.0.0, string-width@npm:^5.0.1, string-width@npm:^5.1.2":
+"string-width@npm:^5.0.1, string-width@npm:^5.1.2":
   version: 5.1.2
   resolution: "string-width@npm:5.1.2"
   dependencies:
@@ -29454,13 +29413,6 @@ __metadata:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: 10c0/dffbb99329da2aa840f506d376c863bd55f5636f4741ad6e65e82f5ce47e6914108f44f340a0b74009b0cb5d09d6752ae83203e53e98b1192cf80ecee5651636
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^1.0.2":
-  version: 1.4.0
-  resolution: "type-fest@npm:1.4.0"
-  checksum: 10c0/a3c0f4ee28ff6ddf800d769eafafcdeab32efa38763c1a1b8daeae681920f6e345d7920bf277245235561d8117dab765cb5f829c76b713b4c9de0998a5397141
   languageName: node
   linkType: hard
 
@@ -30698,7 +30650,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^8.0.1, wrap-ansi@npm:^8.1.0":
+"wrap-ansi@npm:^8.1.0":
   version: 8.1.0
   resolution: "wrap-ansi@npm:8.1.0"
   dependencies:


### PR DESCRIPTION
Only breaking change should be that they dropped Node 16 support
