### PR TITLE
fix(cli-helpers): Add missing listr2 related deps

### DIFF
--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -57,6 +57,7 @@
     "@babel/core": "^7.26.10",
     "@cedarjs/project-config": "workspace:*",
     "@cedarjs/telemetry": "workspace:*",
+    "@listr2/prompt-adapter-enquirer": "4.2.1",
     "@opentelemetry/api": "1.9.0",
     "ansis": "4.2.0",
     "dotenv": "16.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,6 +2884,7 @@ __metadata:
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
     "@cedarjs/telemetry": "workspace:*"
+    "@listr2/prompt-adapter-enquirer": "npm:4.2.1"
     "@opentelemetry/api": "npm:1.9.0"
     "@types/dotenv-defaults": "npm:^5.0.0"
     "@types/lodash": "npm:4.17.24"


### PR DESCRIPTION
This is replaced by https://github.com/cedarjs/cedar/pull/1324