### PR TITLE
fix(cli-helpers): Add missing listr2 related deps

### DIFF
--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -62,6 +62,7 @@
     "ansis": "4.2.0",
     "dotenv": "16.6.1",
     "dotenv-defaults": "5.0.2",
+    "enquirer": "2.4.1",
     "execa": "5.1.1",
     "listr2": "10.2.1",
     "lodash": "4.17.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2895,6 +2895,7 @@ __metadata:
     ansis: "npm:4.2.0"
     dotenv: "npm:16.6.1"
     dotenv-defaults: "npm:5.0.2"
+    enquirer: "npm:2.4.1"
     execa: "npm:5.1.1"
     listr2: "npm:10.2.1"
     lodash: "npm:4.17.23"


### PR DESCRIPTION
cli-helpers depends on @listr2/prompt-adapter-enquirer directly, but didn't include it in its list of deps, and that adapter depends on enquirer which also wasn't listed
