### PR TITLE
fix(cli): Tweak pre-upgrade message header in upgrade command

### DIFF
--- a/packages/cli/src/commands/upgrade/preUpgradeScripts.ts
+++ b/packages/cli/src/commands/upgrade/preUpgradeScripts.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 
 import execa from 'execa'
 import type { ExecaError } from 'execa'
+import type { ListrRendererFactory, ListrTaskWrapper } from 'listr2'
 import semver from 'semver'
 
 function isExecaError(e: unknown): e is ExecaError {
@@ -15,7 +16,7 @@ function isExecaError(e: unknown): e is ExecaError {
 
 export async function runPreUpgradeScripts(
   ctx: Record<string, unknown>,
-  task: { output: unknown },
+  task: ListrTaskWrapper<unknown, ListrRendererFactory, ListrRendererFactory>,
   { verbose, force }: { verbose?: boolean; force?: boolean },
 ) {
   if (!ctx.versionToUpgradeTo) {

--- a/packages/cli/src/commands/upgrade/upgradeHandler.ts
+++ b/packages/cli/src/commands/upgrade/upgradeHandler.ts
@@ -234,7 +234,7 @@ export const handler = async ({
 
   if (preUpgradeMessage) {
     console.log('')
-    console.log(`  📣 ${c.info('Pre-upgrade Message:')}`)
+    console.log(`  📣 ${c.info('Pre-upgrade Script Messages:')}`)
     console.log('  ' + preUpgradeMessage.replace(/\n/g, '\n  '))
   }
 }


### PR DESCRIPTION
I found it a little confusing that a "pre" message was printed "post" installation.
Updating the title to make it more clear that the message comes from the pre-upgrade scripts