### PR TITLE
fix: remove unused `rimraf` dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,6 @@
     "graphql-tag": "2.12.6",
     "lodash": "4.17.23",
     "nodemon": "3.1.14",
-    "rimraf": "6.1.3",
     "typescript": "5.9.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3062,7 +3062,6 @@ __metadata:
     lodash: "npm:4.17.23"
     nodemon: "npm:3.1.14"
     publint: "npm:0.3.18"
-    rimraf: "npm:6.1.3"
     tsx: "npm:4.21.0"
     typescript: "npm:5.9.3"
   bin:


### PR DESCRIPTION
Removing a stale dependency. It's not used for anything anymore