### PR TITLE
chore(ci): Use Node 24 for running Cypress

### DIFF
--- a/.github/workflows/tutorial-e2e.yml
+++ b/.github/workflows/tutorial-e2e.yml
@@ -41,7 +41,6 @@ jobs:
         working-directory: ./tasks/e2e
         run: |
           echo "Waiting for dev server..."
-          echo "Waiting for dev server..."
           attempt=0
           until curl --silent --fail http://[::1]:8910; do
             attempt=$((attempt + 1))
@@ -51,6 +50,7 @@ jobs:
             fi
             sleep 2
           done
+          echo "Dev server is up"
           npx cypress run \
             --browser chrome \
             --spec 'cypress/e2e/01-tutorial/*.cy.js'


### PR DESCRIPTION
Dropping cypress' github action we get rid of a dependendency, and we're in control of the execution environment. Mostly the useful thing it gave us was a "waitOn" utility, which I just replaced by a very small shell script

<img width="321" height="450" alt="image" src="https://github.com/user-attachments/assets/bad8a352-986d-4ce6-b728-4148af1501ea" />
