### PR TITLE
chore(renovate): Update test-project fixture packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,10 +8,8 @@
   "ignorePaths": [
     "**/node_modules/**",
     "**/__tests__/**",
-    "**/test/**",
     "**/tests/**",
-    "*/__fixtures__/**",
-    "/**/__fixtures__/**"
+    "**/*/__fixtures__/**"
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 8,


### PR DESCRIPTION
We have renovate setup on this repo, and it's great. There's one issue with it though. Whenever it bumps the version of one of the packages used by `/__fixtures__/test-project/api/package.json` or `/__fixtures__/test-project/web/package.json` that upgrade PR itself goes through just fine, but every other PR after is now blocked because `/.github/workflows/check-test-project-fixture.yml` will fail. The reason for failing is that renovate only updates the create-cedar-app template package.jsons, not the fixture ones. And so – that github workflow detects the drift and fails.

The reason was that we were using `"extends": ["config:recommended"]`, and that included a glob ignore on every `__fixtures__` directory in the entire repo. 
This PR sets a more targeted `"ignorePaths"` rule to let renovate also update the test project fixtures