### PR TITLE
chore(ci): Cache node_modules

### DIFF
--- a/.github/actions/set-up-yarn-cache/action.yml
+++ b/.github/actions/set-up-yarn-cache/action.yml
@@ -30,3 +30,19 @@ runs:
         key: yarn-install-state-${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock', '.yarnrc.yml') }}-${{ github.run_id }}
         restore-keys: |
           yarn-install-state-${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock', '.yarnrc.yml') }}-
+
+    - name: ♻️ Cache node_modules
+      uses: actions/cache@v5
+      with:
+        path: node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock', '.yarnrc.yml') }}
+        restore-keys: |
+          node-modules-${{ runner.os }}-
+
+    - name: ♻️ Cache create-cedar-rsc-app node_modules
+      uses: actions/cache@v5
+      with:
+        path: packages/create-cedar-rsc-app/node_modules
+        key: node-modules-create-cedar-rsc-app-${{ runner.os }}-${{ hashFiles('packages/create-cedar-rsc-app/yarn.lock', 'packages/create-cedar-rsc-app/package.json') }}
+        restore-keys: |
+          node-modules-create-cedar-rsc-app-${{ runner.os }}-


### PR DESCRIPTION
From AI's reasoning
> **Key design choice:** These two new caches intentionally do **not** include `${{ github.run_id }}` in the primary key (unlike the Yarn global cache and install state entries). That's correct here — you want an exact cache hit when lock files are unchanged, so the link/build step is skipped on the next run. The existing caches use `run_id` because they benefit from always being refreshed; `node_modules` only needs updating when dependencies actually change.