### PR TITLE
fix(cli): skip packages workspace checking during build if feature is disabled

### DIFF
--- a/packages/cli/src/commands/build/__tests__/build.test.ts
+++ b/packages/cli/src/commands/build/__tests__/build.test.ts
@@ -1,3 +1,7 @@
+const { mockGetConfig } = vi.hoisted(() => ({
+  mockGetConfig: vi.fn(),
+}))
+
 vi.mock('@cedarjs/telemetry', () => {
   return {
     errorTelemetry: () => vi.fn(),
@@ -26,12 +30,7 @@ vi.mock('@cedarjs/project-config', () => {
         },
       }
     },
-    getConfig: () => {
-      return {
-        // The build command needs nothing in this config as all
-        // the values it currently reads are optional.
-      }
-    },
+    getConfig: mockGetConfig,
     resolveFile: () => {
       // Used by packages/cli/src/lib/index.js
     },
@@ -97,7 +96,7 @@ vi.mock('./buildPackagesTask.js', () => ({
 
 import { Listr } from 'listr2'
 import type { ListrTask } from 'listr2'
-import { vi, afterEach, test, expect } from 'vitest'
+import { vi, afterEach, beforeEach, test, expect } from 'vitest'
 
 vi.mock('listr2')
 
@@ -109,14 +108,25 @@ vi.mock('execa', () => ({
   })),
 }))
 
+vi.mock('@cedarjs/prerender/detection', () => {
+  return { detectPrerenderRoutes: () => [] }
+})
+
 import { handler } from '../buildHandler.js'
+
+beforeEach(() => {
+  mockGetConfig.mockReturnValue({})
+})
 
 afterEach(() => {
   vi.clearAllMocks()
 })
 
-test('the build tasks are in the correct sequence', async () => {
+test('the build tasks are in the correct sequence when packagesWorkspace is enabled', async () => {
   vi.spyOn(console, 'log').mockImplementation(() => {})
+  mockGetConfig.mockReturnValue({
+    experimental: { packagesWorkspace: { enabled: true } },
+  })
 
   await handler({})
 
@@ -134,12 +144,28 @@ test('the build tasks are in the correct sequence', async () => {
   `)
 })
 
-vi.mock('@cedarjs/prerender/detection', () => {
-  return { detectPrerenderRoutes: () => [] }
+test('the build tasks are in the correct sequence when packagesWorkspace is disabled', async () => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+
+  await handler({})
+
+  const firstCallArg = vi.mocked(Listr).mock.calls[0][0]
+  const tasks = Array.isArray(firstCallArg) ? firstCallArg : [firstCallArg]
+  expect(tasks.map((x: ListrTask) => x.title)).toMatchInlineSnapshot(`
+    [
+      "Generating Prisma Client...",
+      "Verifying graphql schema...",
+      "Building API...",
+      "Building Web...",
+    ]
+  `)
 })
 
-test('Should run prerender for web', async () => {
+test('Should run prerender for web (packagesWorkspace enabled)', async () => {
   const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  mockGetConfig.mockReturnValue({
+    experimental: { packagesWorkspace: { enabled: true } },
+  })
 
   await handler({ workspace: ['web'], prerender: true })
   const firstCallArg = vi.mocked(Listr).mock.calls[0][0]
@@ -147,6 +173,27 @@ test('Should run prerender for web', async () => {
   expect(tasks.map((x: ListrTask) => x.title)).toMatchInlineSnapshot(`
     [
       "Checking workspace packages...",
+      "Building Web...",
+    ]
+  `)
+
+  // Run prerendering task, but expect warning,
+  // because `detectPrerenderRoutes` is empty.
+  expect(consoleSpy.mock.calls[0][0]).toBe('Starting prerendering...')
+  expect(consoleSpy.mock.calls[1][0]).toMatch(
+    /You have not marked any routes to "prerender"/,
+  )
+})
+
+test('Should run prerender for web (packagesWorkspace disabled)', async () => {
+  const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  // mockGetConfig returns {} by default (set in beforeEach), so packagesWorkspace is disabled
+
+  await handler({ workspace: ['web'], prerender: true })
+  const firstCallArg = vi.mocked(Listr).mock.calls[0][0]
+  const tasks = Array.isArray(firstCallArg) ? firstCallArg : [firstCallArg]
+  expect(tasks.map((x: ListrTask) => x.title)).toMatchInlineSnapshot(`
+    [
       "Building Web...",
     ]
   `)

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -130,6 +130,8 @@ export const handler = async ({
   const cedarConfig = getConfig()
   const useFragments = cedarConfig.graphql?.fragments
   const useTrustedDocuments = cedarConfig.graphql?.trustedDocuments
+  const usePackagesWorkspace =
+    cedarConfig.experimental?.packagesWorkspace?.enabled
 
   const prismaSchemaExists = fs.existsSync(cedarPaths.api.prismaConfig)
   const prerenderRoutes =
@@ -168,38 +170,40 @@ export const handler = async ({
         })
       },
     },
-    nonApiWebWorkspaces.length > 0 && {
-      title: 'Building Packages...',
-      task: (_ctx: unknown, task: unknown) =>
-        buildPackagesTask(task, nonApiWebWorkspaces),
-    },
-    (workspace.includes('web') || workspace.includes('api')) && {
-      title: 'Checking workspace packages...',
-      task: () => {
-        const problems = checkWorkspacePackageEntryPoints(cedarPaths)
-
-        if (problems.length === 0) {
-          return
-        }
-
-        const details = problems
-          .map(
-            ({ pkgName, entryFile, pkgDir }) =>
-              `  • ${c.error(pkgName)}: missing "${entryFile}" (in ${pkgDir})`,
-          )
-          .join('\n')
-
-        throw new Error(
-          `The following workspace package entry points are missing:\n${details}\n\n` +
-            'This usually means the package has not been built yet.\n' +
-            'Run ' +
-            c.info('yarn cedar build') +
-            ' (without specifying a workspace) to build everything,\n' +
-            'or build the package manually first, e.g. ' +
-            c.info(`yarn workspace ${problems[0].pkgName} build`),
-        )
+    nonApiWebWorkspaces.length > 0 &&
+      usePackagesWorkspace && {
+        title: 'Building Packages...',
+        task: (_ctx: unknown, task: unknown) =>
+          buildPackagesTask(task, nonApiWebWorkspaces),
       },
-    },
+    (workspace.includes('web') || workspace.includes('api')) &&
+      usePackagesWorkspace && {
+        title: 'Checking workspace packages...',
+        task: () => {
+          const problems = checkWorkspacePackageEntryPoints(cedarPaths)
+
+          if (problems.length === 0) {
+            return
+          }
+
+          const details = problems
+            .map(
+              ({ pkgName, entryFile, pkgDir }) =>
+                `  • ${c.error(pkgName)}: missing "${entryFile}" (in ${pkgDir})`,
+            )
+            .join('\n')
+
+          throw new Error(
+            `The following workspace package entry points are missing:\n${details}\n\n` +
+              'This usually means the package has not been built yet.\n' +
+              'Run ' +
+              c.info('yarn cedar build') +
+              ' (without specifying a workspace) to build everything,\n' +
+              'or build the package manually first, e.g. ' +
+              c.info(`yarn workspace ${problems[0].pkgName} build`),
+          )
+        },
+      },
     // If using GraphQL Fragments or Trusted Documents, then we need to use
     // codegen to generate the types needed for possible types and the trusted
     // document store hashes


### PR DESCRIPTION
This PR fixes the build handler to skip the Building Packages... and Checking workspace packages... tasks when the experimental.packagesWorkspace feature flag is disabled, preventing unnecessary work and potential failures for projects that don't use the feature.