### PR TITLE
fix(cli-helpers): Proper darwin url

### DIFF
--- a/packages/cli-helpers/src/lib/index.ts
+++ b/packages/cli-helpers/src/lib/index.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import { pathToFileURL } from 'node:url'
 import path from 'path'
 
 import * as babel from '@babel/core'
@@ -59,7 +60,9 @@ export const getPrettierOptions = async () => {
     const mjsPath = path.join(getPaths().base, 'prettier.config.mjs')
     const prettierConfigPath = fs.existsSync(cjsPath) ? cjsPath : mjsPath
 
-    const { default: options } = await import(`file://${prettierConfigPath}`)
+    const { default: options } = await import(
+      pathToFileURL(prettierConfigPath).href
+    )
 
     if (options.tailwindConfig?.startsWith('.')) {
       // Make this work with --cwd


### PR DESCRIPTION
This PR fixes this warning:

```
11:38:27 PM [vite] (ssr) warning: File URL host must be "localhost" or empty on darwin
  Plugin: vite:dynamic-import-vars
  File: /Users/tobbe/dev/cedarjs/cedar/packages/cli-helpers/src/lib/index.ts
 ✓ src/lib/__tests__/index.test.ts (1 test) 297ms
   ✓ prettify formats tsx content 297ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  23:38:27
   Duration  724ms (transform 74ms, setup 0ms, collect 154ms, tests 297ms, environment 0ms, prepare 100ms)
```