### PR TITLE
fix(cli): Fix dry-run upgrade output saying project was upgraded

### DIFF
--- a/packages/cli/src/commands/upgrade/upgradeHandler.ts
+++ b/packages/cli/src/commands/upgrade/upgradeHandler.ts
@@ -163,10 +163,11 @@ export const handler = async ({
         title: 'One more thing..',
         task: (ctx, task) => {
           const version = ctx.versionToUpgradeTo
+          const upgradeMessage = dryRun
+            ? `🏃 Dry run complete. Your project would be upgraded to CedarJS ${version}.`
+            : `🎉 Your project has been upgraded to CedarJS ${version}!`
           const messageSections = [
-            `One more thing...\n\n   ${c.warning(
-              `🎉 Your project has been upgraded to CedarJS ${version}!`,
-            )} \n\n`,
+            `One more thing...\n\n   ${c.warning(upgradeMessage)} \n\n`,
           ]
           // Show links when switching to 'latest' or 'rc', undefined is essentially an alias of 'latest'
           if ([undefined, 'latest', 'rc'].includes(tag)) {


### PR DESCRIPTION
## Summary

When running `yarn cedarjs upgrade --dry-run`, the success message now reflects that no changes were made.

## Changes

- `packages/cli/src/commands/upgrade/upgradeHandler.ts`: Checks `dryRun` flag before constructing the message. Dry run shows "Dry run complete. Your project would be upgraded to CedarJS X." instead of "Your project has been upgraded."

## Testing

- TypeScript syntax verified
- Only modifies the message string, no behavioral change

Fixes #498

This contribution was developed with AI assistance (Claude Code).