### PR TITLE
fix(tui): Don't draw boxen around warnings or errors

### DIFF
--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "ansis": "4.2.0",
-    "boxen": "5.1.2",
     "enquirer": "2.4.1",
     "stdout-update": "1.6.8"
   },

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -337,21 +337,12 @@ export class RedwoodTUI {
   }
 
   /**
-   * Writes a fenced text block to the TUI output stream
+   * Writes a string to the TUI output stream
    *
-   * @param title The string to write out
+   * @param text The string to write out
    */
-  drawFencedText(color: AnsiColors, title: string, message: string) {
-    const width = Math.min(80, (this.outStream.columns || 80) - 2)
-
-    const headerText = `────  ${title}  `
-    const header =
-      headerText + '─'.repeat(Math.max(0, width - headerText.length))
-    const line = '─'.repeat(width)
-
-    this.outStream.write(
-      ansis[color](`\n${header}\n${line}\n\n  ${message}\n\n${line}`),
-    )
+  drawText(text: string) {
+    this.outStream.write(`${text}\n`)
   }
 
   // TODO: Consider a custom prompting implementation for full control of look/feel/functionality etc...
@@ -374,6 +365,24 @@ export class RedwoodTUI {
       this.startReactive()
     }
     return result
+  }
+
+  /**
+   * Writes a fenced text block to the TUI output stream
+   *
+   * @param title The string to write out
+   */
+  drawFencedText(color: AnsiColors, title: string, message: string) {
+    const width = Math.min(80, (this.outStream.columns || 80) - 2)
+
+    const headerText = `────  ${title}  `
+    const header =
+      headerText + '─'.repeat(Math.max(0, width - headerText.length))
+    const line = '─'.repeat(width)
+
+    this.outStream.write(
+      ansis[color](`\n${header}\n${line}\n\n  ${message}\n\n${line}`),
+    )
   }
 
   /**

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -376,13 +376,12 @@ export class RedwoodTUI {
     const width = Math.min(80, (this.outStream.columns || 80) - 2)
 
     const headerText = `────  ${title}  `
-    const header =
-      headerText + '─'.repeat(Math.max(0, width - headerText.length))
-    const line = '─'.repeat(width)
-
-    this.outStream.write(
-      ansis[color](`\n${header}\n${line}\n\n  ${message}\n\n${line}`),
+    const header = ansis[color](
+      headerText + '─'.repeat(Math.max(0, width - headerText.length)),
     )
+    const line = ansis[color]('─'.repeat(width))
+
+    this.outStream.write(`\n${header}\n${line}\n\n  ${message}\n\n${line}\n`)
   }
 
   /**

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -1,6 +1,7 @@
 import stream from 'stream'
 
 import ansis from 'ansis'
+import type { AnsiColors } from 'ansis'
 import { prompt as enquirerPrompt } from 'enquirer'
 import { UpdateManager } from 'stdout-update'
 
@@ -336,12 +337,21 @@ export class RedwoodTUI {
   }
 
   /**
-   * Writes a string to the TUI output stream
+   * Writes a fenced text block to the TUI output stream
    *
-   * @param text The string to write out
+   * @param title The string to write out
    */
-  drawText(text: string) {
-    this.outStream.write(`${text}\n`)
+  drawFencedText(color: AnsiColors, title: string, message: string) {
+    const width = Math.min(80, (this.outStream.columns || 80) - 2)
+
+    const headerText = `────  ${title}  `
+    const header =
+      headerText + '─'.repeat(Math.max(0, width - headerText.length))
+    const line = '─'.repeat(width)
+
+    this.outStream.write(
+      ansis[color](`\n${header}\n${line}\n\n  ${message}\n\n${line}`),
+    )
   }
 
   // TODO: Consider a custom prompting implementation for full control of look/feel/functionality etc...
@@ -373,14 +383,9 @@ export class RedwoodTUI {
    * @param message Error message
    */
   displayError(title: string, message: string) {
-    const width = Math.min(80, (this.outStream.columns || 80) - 2)
+    const headerText = `⚠ Error: ${title}`
 
-    const headerText = `────  ⚠ Error: ${title}  `
-    const header =
-      headerText + '─'.repeat(Math.max(0, width - headerText.length))
-    const line = '─'.repeat(width)
-
-    this.drawText(ansis.red(`\n${header}\n${line}\n\n  ${message}\n\n${line}`))
+    this.drawFencedText('red', headerText, message)
   }
 
   /**
@@ -390,15 +395,8 @@ export class RedwoodTUI {
    * @param message Warning message
    */
   displayWarning(title: string, message: string) {
-    const width = Math.min(80, (this.outStream.columns || 80) - 2)
+    const headerText = `⚠ Warning: ${title}`
 
-    const headerText = `────  ⚠ Warning: ${title}  `
-    const header =
-      headerText + '─'.repeat(Math.max(0, width - headerText.length))
-    const line = '─'.repeat(width)
-
-    this.drawText(
-      ansis.yellow(`\n${header}\n${line}\n\n  ${message}\n\n${line}`),
-    )
+    this.drawFencedText('yellow', headerText, message)
   }
 }

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -1,7 +1,6 @@
 import stream from 'stream'
 
 import ansis from 'ansis'
-import boxen from 'boxen'
 import { prompt as enquirerPrompt } from 'enquirer'
 import { UpdateManager } from 'stdout-update'
 
@@ -35,7 +34,6 @@ export class ReactiveTUIContent {
     enabled: boolean
     characters: string[]
   }
-  private boxen: boxen.Options
   private frameInterval: number
 
   // TODO: Implement a progress bar
@@ -50,7 +48,6 @@ export class ReactiveTUIContent {
       enabled?: boolean
       characters?: string[]
     }
-    boxen?: boxen.Options
     outStream?: stream.Readable
     frameInterval?: number
   }) {
@@ -77,7 +74,6 @@ export class ReactiveTUIContent {
     }
 
     this.spinner = { ...defaultSpinner, ...options.spinner }
-    this.boxen = { ...options.boxen }
 
     // Validate frameInterval if provided
     if (options.frameInterval !== undefined) {
@@ -105,7 +101,6 @@ export class ReactiveTUIContent {
       enabled?: boolean
       characters?: string[]
     }
-    boxen?: boxen.Options
     outStream?: stream.Readable
     frameInterval?: number
   }) {
@@ -130,9 +125,6 @@ export class ReactiveTUIContent {
         )
       }
       this.spinner = { ...this.spinner, ...options.spinner }
-    }
-    if (options.boxen) {
-      this.boxen = { ...this.boxen, ...options.boxen }
     }
     if (options.outStream) {
       this.setOutStream(options.outStream)
@@ -375,36 +367,32 @@ export class RedwoodTUI {
   }
 
   /**
-   * Display an error message in a box
+   * Display an error message with a red header and footer
    *
-   * @param title Error box title
+   * @param title Error title
    * @param message Error message
    */
   displayError(title: string, message: string) {
-    this.drawText(
-      boxen(message, {
-        padding: 1,
-        borderColor: 'red',
-        title: `⚠ Error: ${title}`,
-        titleAlignment: 'left',
-      }),
-    )
+    const width = Math.min(80, (this.outStream.columns || 80) - 2)
+    const headerText = `────  ⚠ Error: ${title}  `
+    const header = ansis.red(headerText + '─'.repeat(width - headerText.length))
+    const line = ansis.red('─'.repeat(width))
+    this.drawText(`\n${header}\n${line}\n\n  ${message}\n\n${line}`)
   }
 
   /**
-   * Display a warning message in a box
+   * Display a warning message with a yellow header and footer
    *
-   * @param title Error box title
-   * @param message Error message
+   * @param title Warning title
+   * @param message Warning message
    */
   displayWarning(title: string, message: string) {
-    this.drawText(
-      boxen(message, {
-        padding: 1,
-        borderColor: 'yellow',
-        title: `⚠ Warning: ${title}`,
-        titleAlignment: 'left',
-      }),
+    const width = Math.min(80, (this.outStream.columns || 80) - 2)
+    const headerText = `────  ⚠ Warning: ${title}  `
+    const header = ansis.yellow(
+      headerText + '─'.repeat(width - headerText.length),
     )
+    const line = ansis.yellow('─'.repeat(width))
+    this.drawText(`\n${header}\n${line}\n\n  ${message}\n\n${line}`)
   }
 }

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -374,10 +374,13 @@ export class RedwoodTUI {
    */
   displayError(title: string, message: string) {
     const width = Math.min(80, (this.outStream.columns || 80) - 2)
+
     const headerText = `────  ⚠ Error: ${title}  `
-    const header = ansis.red(headerText + '─'.repeat(width - headerText.length))
-    const line = ansis.red('─'.repeat(width))
-    this.drawText(`\n${header}\n${line}\n\n  ${message}\n\n${line}`)
+    const header =
+      headerText + '─'.repeat(Math.max(0, width - headerText.length))
+    const line = '─'.repeat(width)
+
+    this.drawText(ansis.red(`\n${header}\n${line}\n\n  ${message}\n\n${line}`))
   }
 
   /**
@@ -388,11 +391,14 @@ export class RedwoodTUI {
    */
   displayWarning(title: string, message: string) {
     const width = Math.min(80, (this.outStream.columns || 80) - 2)
+
     const headerText = `────  ⚠ Warning: ${title}  `
-    const header = ansis.yellow(
-      headerText + '─'.repeat(width - headerText.length),
+    const header =
+      headerText + '─'.repeat(Math.max(0, width - headerText.length))
+    const line = '─'.repeat(width)
+
+    this.drawText(
+      ansis.yellow(`\n${header}\n${line}\n\n  ${message}\n\n${line}`),
     )
-    const line = ansis.yellow('─'.repeat(width))
-    this.drawText(`\n${header}\n${line}\n\n  ${message}\n\n${line}`)
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3709,7 +3709,6 @@ __metadata:
   dependencies:
     "@cedarjs/framework-tools": "workspace:*"
     ansis: "npm:4.2.0"
-    boxen: "npm:5.1.2"
     enquirer: "npm:2.4.1"
     stdout-update: "npm:1.6.8"
     tsx: "npm:4.21.0"


### PR DESCRIPTION
The vertical lines in the boxes messes too much with the terminal output when it's resized. A simple header and footer is more resilient to this.