### PR TITLE
chore(ci): Fix set-up-rsc-project to use yarn

### DIFF
--- a/.github/actions/set-up-rsc-project/setUpRscProject.mts
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mts
@@ -64,7 +64,8 @@ async function setUpRscProject(
     'create-cedar-app@canary',
     '-y',
     '--no-git',
-    '--no-node-check',
+    '--pm',
+    'yarn',
     rscProjectPath,
   ])
   await execInProject('yarn install')


### PR DESCRIPTION
Force it to use yarn, even though we're running with npx