### PR TITLE
fix(cca): Set proper versions for canary releases

### DIFF
--- a/.github/scripts/publish_canary.sh
+++ b/.github/scripts/publish_canary.sh
@@ -160,27 +160,16 @@ if [ ! -s canary_version ]; then
   exit 1
 fi
 
-# Update create-cedar-app templates to use canary packages
+# Update create-cedar-app templates and overlays to use canary packages
 
-sed "s/\"@cedarjs\/\(.*\)\": \".*\"/\"@cedarjs\/\1\": \"$(cat canary_version)\"/" \
-  packages/create-cedar-app/templates/js/package.json > tmpfile \
-  && mv tmpfile packages/create-cedar-app/templates/js/package.json
-sed "s/\"@cedarjs\/\(.*\)\": \".*\"/\"@cedarjs\/\1\": \"$(cat canary_version)\"/" \
-  packages/create-cedar-app/templates/js/api/package.json > tmpfile \
-  && mv tmpfile packages/create-cedar-app/templates/js/api/package.json
-sed "s/\"@cedarjs\/\(.*\)\": \".*\"/\"@cedarjs\/\1\": \"$(cat canary_version)\"/" \
-  packages/create-cedar-app/templates/js/web/package.json > tmpfile \
-  && mv tmpfile packages/create-cedar-app/templates/js/web/package.json
-
-sed "s/\"@cedarjs\/\(.*\)\": \".*\"/\"@cedarjs\/\1\": \"$(cat canary_version)\"/" \
-  packages/create-cedar-app/templates/ts/package.json > tmpfile \
-  && mv tmpfile packages/create-cedar-app/templates/ts/package.json
-sed "s/\"@cedarjs\/\(.*\)\": \".*\"/\"@cedarjs\/\1\": \"$(cat canary_version)\"/" \
-  packages/create-cedar-app/templates/ts/api/package.json > tmpfile \
-  && mv tmpfile packages/create-cedar-app/templates/ts/api/package.json
-sed "s/\"@cedarjs\/\(.*\)\": \".*\"/\"@cedarjs\/\1\": \"$(cat canary_version)\"/" \
-  packages/create-cedar-app/templates/ts/web/package.json > tmpfile \
-  && mv tmpfile packages/create-cedar-app/templates/ts/web/package.json
+canary_ver=$(cat canary_version)
+find packages/create-cedar-app/templates packages/create-cedar-app/database-overlays \
+  -name "package.json" \
+  | while IFS= read -r pkg_json; do
+    sed "s/\"@cedarjs\/\(.*\)\": \".*\"/\"@cedarjs\/\1\": \"$canary_ver\"/" \
+      "$pkg_json" > tmpfile \
+      && mv tmpfile "$pkg_json"
+  done
 
 # Update all packages to replace any "workspace:*" with this canary version
 

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -64,7 +64,11 @@ jobs:
             VERSION="${{ steps.get-version.outputs.value }}"
             # Strip build metadata/commit hash suffix that starts with '+'
             VERSION="${VERSION%%+*}"
-            gh pr comment $PR_NUMBER --body "$(printf "The changes in this PR are now available on npm.\n\nTry them out by running \`yarn cedar upgrade -t %s\`" "$VERSION")"
+            COMMENT_BODY=$(printf "%s\n\n%s\n\n%s" \
+              "The changes in this PR are now available on npm." \
+              "Try them out by running \`yarn cedar upgrade -t $VERSION\`" \
+              "Or try it in a new app with \`yarn dlx create-cedar-app@$VERSION\`")
+            gh pr comment $PR_NUMBER --body "$COMMENT_BODY"
           else
             echo "No PR found for commit ${{ github.sha }}"
           fi


### PR DESCRIPTION
Fix the publish script for canary releases after adding the create-cedar-app template overlays