### PR TITLE
fix(gqlorm): Use Prisma's datasource url as pg connection string

### DIFF
--- a/__fixtures__/test-project-live/api/src/lib/liveQueriesListener.ts
+++ b/__fixtures__/test-project-live/api/src/lib/liveQueriesListener.ts
@@ -81,11 +81,18 @@ async function onNotification(payload: string | undefined) {
 async function connect() {
   connectionGeneration = connectionGeneration + 1
   const generation = connectionGeneration
-
   const prismaConfigPath = getPaths().api.prismaConfig
-
   const prismaConfig = await loadPrismaConfig(prismaConfigPath)
   const prismaDatasourceUrl = prismaConfig.datasource?.url
+
+  if (!prismaDatasourceUrl) {
+    const config = JSON.stringify(prismaConfig, null, 2)
+
+    throw new Error(
+      'Could not determine Postgres connection URL from Prisma config ' +
+        `datasource. Using parsed Prisma config: ${config}`
+    )
+  }
 
   try {
     if (reconnectTimeout) {

--- a/__fixtures__/test-project-live/api/src/lib/liveQueriesListener.ts
+++ b/__fixtures__/test-project-live/api/src/lib/liveQueriesListener.ts
@@ -1,5 +1,6 @@
 import { Client } from 'pg'
 
+import { getPaths, loadPrismaConfig } from '@cedarjs/project-config'
 import { liveQueryStore } from '@cedarjs/realtime'
 import { pluralize } from '@cedarjs/utils/cedarPluralize'
 
@@ -81,6 +82,11 @@ async function connect() {
   connectionGeneration = connectionGeneration + 1
   const generation = connectionGeneration
 
+  const prismaConfigPath = getPaths().api.prismaConfig
+
+  const prismaConfig = await loadPrismaConfig(prismaConfigPath)
+  const prismaDatasourceUrl = prismaConfig.datasource?.url
+
   try {
     if (reconnectTimeout) {
       clearTimeout(reconnectTimeout)
@@ -94,9 +100,7 @@ async function connect() {
       await previousClient.end().catch(() => {})
     }
 
-    const nextClient = new Client({
-      connectionString: process.env.DATABASE_URL,
-    })
+    const nextClient = new Client({ connectionString: prismaDatasourceUrl })
 
     nextClient.on('notification', async (msg) => {
       await onNotification(msg.payload)

--- a/packages/cli/src/commands/setup/live-queries/templates/liveQueriesListener.ts.template
+++ b/packages/cli/src/commands/setup/live-queries/templates/liveQueriesListener.ts.template
@@ -81,11 +81,18 @@ async function onNotification(payload: string | undefined) {
 async function connect() {
   connectionGeneration = connectionGeneration + 1
   const generation = connectionGeneration
-
   const prismaConfigPath = getPaths().api.prismaConfig
-
   const prismaConfig = await loadPrismaConfig(prismaConfigPath)
   const prismaDatasourceUrl = prismaConfig.datasource?.url
+
+  if (!prismaDatasourceUrl) {
+    const config = JSON.stringify(prismaConfig, null, 2)
+
+    throw new Error(
+      'Could not determine Postgres connection URL from Prisma config ' +
+        `datasource. Using parsed Prisma config: ${config}`
+    )
+  }
 
   try {
     if (reconnectTimeout) {

--- a/packages/cli/src/commands/setup/live-queries/templates/liveQueriesListener.ts.template
+++ b/packages/cli/src/commands/setup/live-queries/templates/liveQueriesListener.ts.template
@@ -1,5 +1,6 @@
 import { Client } from 'pg'
 
+import { getPaths, loadPrismaConfig } from '@cedarjs/project-config'
 import { liveQueryStore } from '@cedarjs/realtime'
 import { pluralize } from '@cedarjs/utils/cedarPluralize'
 
@@ -81,6 +82,11 @@ async function connect() {
   connectionGeneration = connectionGeneration + 1
   const generation = connectionGeneration
 
+  const prismaConfigPath = getPaths().api.prismaConfig
+
+  const prismaConfig = await loadPrismaConfig(prismaConfigPath)
+  const prismaDatasourceUrl = prismaConfig.datasource?.url
+
   try {
     if (reconnectTimeout) {
       clearTimeout(reconnectTimeout)
@@ -94,9 +100,7 @@ async function connect() {
       await previousClient.end().catch(() => {})
     }
 
-    const nextClient = new Client({
-      connectionString: process.env.DATABASE_URL,
-    })
+    const nextClient = new Client({ connectionString: prismaDatasourceUrl })
 
     nextClient.on('notification', async (msg) => {
       await onNotification(msg.payload)


### PR DESCRIPTION
LISTEN connections shouldn't use pooled connections. They need a direct connection, just like Prisma's migrations. And the connection string to use for direct connections come from Prisma's config file, so now, instead of assuming `DATABASE_URL` is the connection string to use, we reuse what's already configured for Prisma. This also makes all of this more suitable for integrating in the framework itself later (instead of having it live in the user's code)