### PR TITLE
chore(cjs): Update package.json files to be explicit about the type

### DIFF
--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/auth-providers/dbAuth/setup"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/babel-config"
   },
   "license": "MIT",
+  "type": "commonjs",
   "exports": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/eslint-plugin"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/mailer/handlers/in-memory/package.json
+++ b/packages/mailer/handlers/in-memory/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/mailer/handlers/in-memory"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/mailer/handlers/nodemailer/package.json
+++ b/packages/mailer/handlers/nodemailer/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/mailer/handlers/nodemailer"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/mailer/handlers/resend/package.json
+++ b/packages/mailer/handlers/resend/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/mailer/handlers/resend"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/mailer/handlers/studio/package.json
+++ b/packages/mailer/handlers/studio/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/mailer/handlers/studio"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/tui"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -8,6 +8,7 @@
     "directory": "packages/web-server"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/cliConfig.js",
   "types": "./dist/cliConfig.d.ts",
   "bin": {

--- a/packages/web/apollo/package.json
+++ b/packages/web/apollo/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "commonjs",
   "main": "./index.js",
   "types": "../dist/apollo/index.d.ts"
 }

--- a/packages/web/toast/package.json
+++ b/packages/web/toast/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "commonjs",
   "main": "./index.js",
   "types": "../dist/toast/index.d.ts"
 }

--- a/tasks/server-tests/fixtures/redwood-app/api/package.json
+++ b/tasks/server-tests/fixtures/redwood-app/api/package.json
@@ -2,6 +2,7 @@
   "name": "api",
   "version": "0.0.0",
   "private": true,
+  "type": "commonjs",
   "dependencies": {
     "@cedarjs/api": "0.0.5",
     "@cedarjs/auth-dbauth-api": "0.0.5",

--- a/tasks/server-tests/fixtures/redwood-app/package.json
+++ b/tasks/server-tests/fixtures/redwood-app/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "type": "commonjs",
   "workspaces": [
     "api",
     "web"

--- a/tasks/server-tests/fixtures/redwood-app/web/package.json
+++ b/tasks/server-tests/fixtures/redwood-app/web/package.json
@@ -2,6 +2,7 @@
   "name": "web",
   "version": "0.0.0",
   "private": true,
+  "type": "commonjs",
   "browserslist": {
     "development": [
       "last 1 version"


### PR DESCRIPTION
Being more explicit about the type makes it easier to find all packages we still need to convert to ESM