### PR TITLE
chore(esm): Add file extensions to imports

### DIFF
--- a/packages/adapters/fastify/web/src/resolveOptions.ts
+++ b/packages/adapters/fastify/web/src/resolveOptions.ts
@@ -1,6 +1,6 @@
 import { getConfig } from '@cedarjs/project-config'
 
-import type { RedwoodFastifyWebOptions } from './types'
+import type { RedwoodFastifyWebOptions } from './types.js'
 
 export function resolveOptions(options: RedwoodFastifyWebOptions) {
   const redwoodOptions = options.redwood ?? {}

--- a/packages/adapters/fastify/web/src/web.ts
+++ b/packages/adapters/fastify/web/src/web.ts
@@ -9,9 +9,9 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 
 import { getPaths } from '@cedarjs/project-config'
 
-import { coerceRootPath } from './helpers'
-import { resolveOptions } from './resolveOptions'
-import type { RedwoodFastifyWebOptions } from './types'
+import { coerceRootPath } from './helpers.js'
+import { resolveOptions } from './resolveOptions.js'
+import type { RedwoodFastifyWebOptions } from './types.js'
 
 export { coerceRootPath }
 export type { RedwoodFastifyWebOptions }

--- a/packages/auth-providers/auth0/api/src/index.ts
+++ b/packages/auth-providers/auth0/api/src/index.ts
@@ -1,1 +1,1 @@
-export { authDecoder } from './decoder'
+export { authDecoder } from './decoder.js'

--- a/packages/auth-providers/auth0/setup/src/index.ts
+++ b/packages/auth-providers/auth0/setup/src/index.ts
@@ -1,1 +1,1 @@
-export * from './setup'
+export * from './setup.js'

--- a/packages/auth-providers/auth0/setup/src/setupHandler.ts
+++ b/packages/auth-providers/auth0/setup/src/setupHandler.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import { standardAuthHandler } from '@cedarjs/cli-helpers'
 
-import type { Args } from './setup'
+import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),

--- a/packages/auth-providers/azureActiveDirectory/api/src/index.ts
+++ b/packages/auth-providers/azureActiveDirectory/api/src/index.ts
@@ -1,1 +1,1 @@
-export { authDecoder } from './decoder'
+export { authDecoder } from './decoder.js'

--- a/packages/auth-providers/azureActiveDirectory/setup/src/index.ts
+++ b/packages/auth-providers/azureActiveDirectory/setup/src/index.ts
@@ -1,1 +1,1 @@
-export * from './setup'
+export * from './setup.js'

--- a/packages/auth-providers/azureActiveDirectory/setup/src/setupHandler.ts
+++ b/packages/auth-providers/azureActiveDirectory/setup/src/setupHandler.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import { standardAuthHandler } from '@cedarjs/cli-helpers'
 
-import type { Args } from './setup'
+import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),

--- a/packages/auth-providers/clerk/api/src/index.ts
+++ b/packages/auth-providers/clerk/api/src/index.ts
@@ -1,1 +1,1 @@
-export { clerkAuthDecoder } from './decoder'
+export { clerkAuthDecoder } from './decoder.js'

--- a/packages/auth-providers/clerk/setup/src/index.ts
+++ b/packages/auth-providers/clerk/setup/src/index.ts
@@ -1,1 +1,1 @@
-export * from './setup'
+export * from './setup.js'

--- a/packages/auth-providers/clerk/setup/src/setupHandler.ts
+++ b/packages/auth-providers/clerk/setup/src/setupHandler.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import { standardAuthHandler } from '@cedarjs/cli-helpers'
 
-import type { Args } from './setup'
+import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),

--- a/packages/auth-providers/custom/setup/src/index.ts
+++ b/packages/auth-providers/custom/setup/src/index.ts
@@ -1,1 +1,1 @@
-export * from './setup'
+export * from './setup.js'

--- a/packages/auth-providers/custom/setup/src/setupHandler.ts
+++ b/packages/auth-providers/custom/setup/src/setupHandler.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import { isTypeScriptProject, standardAuthHandler } from '@cedarjs/cli-helpers'
 
-import type { Args } from './setup'
+import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),

--- a/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
+++ b/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
@@ -21,7 +21,7 @@ import {
   normalizeRequest,
 } from '@cedarjs/api'
 
-import * as DbAuthError from './errors'
+import * as DbAuthError from './errors.js'
 import {
   decryptSession,
   encryptSession,
@@ -35,7 +35,7 @@ import {
   isLegacySession,
   legacyHashPassword,
   webAuthnSession,
-} from './shared'
+} from './shared.js'
 
 interface SignupFlowOptions<TUserAttributes = Record<string, unknown>> {
   /**

--- a/packages/auth-providers/dbAuth/api/src/decoder.ts
+++ b/packages/auth-providers/dbAuth/api/src/decoder.ts
@@ -2,7 +2,7 @@ import type { APIGatewayProxyEvent } from 'aws-lambda'
 
 import type { Decoder } from '@cedarjs/api'
 
-import { dbAuthSession } from './shared'
+import { dbAuthSession } from './shared.js'
 
 export const createAuthDecoder = (cookieNameTemplate: string): Decoder => {
   return async (_token, type, req) => {

--- a/packages/auth-providers/dbAuth/api/src/index.ts
+++ b/packages/auth-providers/dbAuth/api/src/index.ts
@@ -1,4 +1,4 @@
-export * from './DbAuthHandler'
-export { PasswordValidationError } from './errors'
-export * from './shared'
-export { authDecoder, createAuthDecoder } from './decoder'
+export * from './DbAuthHandler.js'
+export { PasswordValidationError } from './errors.js'
+export * from './shared.js'
+export { authDecoder, createAuthDecoder } from './decoder.js'

--- a/packages/auth-providers/dbAuth/api/src/shared.ts
+++ b/packages/auth-providers/dbAuth/api/src/shared.ts
@@ -6,7 +6,7 @@ import type { CorsHeaders } from '@cedarjs/api'
 import { getEventHeader, isFetchApiRequest } from '@cedarjs/api'
 import { getConfig, getConfigPath } from '@cedarjs/project-config'
 
-import * as DbAuthError from './errors'
+import * as DbAuthError from './errors.js'
 
 type ScryptOptions = {
   cost?: number

--- a/packages/auth-providers/dbAuth/setup/src/index.ts
+++ b/packages/auth-providers/dbAuth/setup/src/index.ts
@@ -1,1 +1,1 @@
-export * from './setup'
+export * from './setup.js'

--- a/packages/auth-providers/dbAuth/setup/src/setupData.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupData.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { getPaths, colors, addEnvVarTask } from '@cedarjs/cli-helpers'
 import type { AuthGeneratorCtx } from '@cedarjs/cli-helpers'
 
-import { addModels, functionsPath, hasModel, libPath } from './shared'
+import { addModels, functionsPath, hasModel, libPath } from './shared.js'
 
 const secret = crypto.randomBytes(32).toString('base64')
 

--- a/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
@@ -5,20 +5,20 @@ import prompts from 'prompts'
 
 import { getGraphqlPath, standardAuthHandler } from '@cedarjs/cli-helpers'
 
-import type { Args } from './setup'
+import type { Args } from './setup.js'
 import {
   notes,
   noteGenerate,
   notesCreatedUserModel,
   extraTask,
   createUserModelTask,
-} from './setupData'
+} from './setupData.js'
 import {
   generateAuthPagesTask,
   getModelNames,
   hasAuthPages,
   hasModel,
-} from './shared'
+} from './shared.js'
 import {
   notes as webAuthnNotes,
   noteGenerate as webAuthnNoteGenerate,
@@ -26,7 +26,7 @@ import {
   webPackages as webAuthnWebPackages,
   apiPackages as webAuthnApiPackages,
   createUserModelTask as webAuthnCreateUserModelTask,
-} from './webAuthn.setupData'
+} from './webAuthn.setupData.js'
 
 export async function handler({
   webauthn,

--- a/packages/auth-providers/dbAuth/setup/src/webAuthn.setupData.ts
+++ b/packages/auth-providers/dbAuth/setup/src/webAuthn.setupData.ts
@@ -3,10 +3,10 @@ import path from 'node:path'
 import { getPaths, colors } from '@cedarjs/cli-helpers'
 import type { AuthGeneratorCtx } from '@cedarjs/cli-helpers'
 
-import { addModels, functionsPath, hasModel, libPath } from './shared'
+import { addModels, functionsPath, hasModel, libPath } from './shared.js'
 
 // copy some identical values from dbAuth provider
-export { extraTask } from './setupData'
+export { extraTask } from './setupData.js'
 
 // required packages to install on the web side
 export const webPackages = ['@simplewebauthn/browser@^10']

--- a/packages/auth-providers/firebase/api/src/index.ts
+++ b/packages/auth-providers/firebase/api/src/index.ts
@@ -1,1 +1,1 @@
-export { authDecoder } from './decoder'
+export { authDecoder } from './decoder.js'

--- a/packages/auth-providers/firebase/setup/src/index.ts
+++ b/packages/auth-providers/firebase/setup/src/index.ts
@@ -1,1 +1,1 @@
-export * from './setup'
+export * from './setup.js'

--- a/packages/auth-providers/firebase/setup/src/setupHandler.ts
+++ b/packages/auth-providers/firebase/setup/src/setupHandler.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import { standardAuthHandler } from '@cedarjs/cli-helpers'
 
-import type { Args } from './setup'
+import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),

--- a/packages/auth-providers/netlify/api/src/index.ts
+++ b/packages/auth-providers/netlify/api/src/index.ts
@@ -1,1 +1,1 @@
-export { authDecoder } from './decoder'
+export { authDecoder } from './decoder.js'

--- a/packages/auth-providers/netlify/setup/src/index.ts
+++ b/packages/auth-providers/netlify/setup/src/index.ts
@@ -1,1 +1,1 @@
-export * from './setup'
+export * from './setup.js'

--- a/packages/auth-providers/netlify/setup/src/setupHandler.ts
+++ b/packages/auth-providers/netlify/setup/src/setupHandler.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import { standardAuthHandler } from '@cedarjs/cli-helpers'
 
-import type { Args } from './setup'
+import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),

--- a/packages/auth-providers/supabase/api/src/index.ts
+++ b/packages/auth-providers/supabase/api/src/index.ts
@@ -1,1 +1,1 @@
-export { authDecoder, throwSupabaseSettingsError } from './decoder'
+export { authDecoder, throwSupabaseSettingsError } from './decoder.js'

--- a/packages/auth-providers/supabase/setup/src/index.ts
+++ b/packages/auth-providers/supabase/setup/src/index.ts
@@ -1,1 +1,1 @@
-export * from './setup'
+export * from './setup.js'

--- a/packages/auth-providers/supabase/setup/src/setupHandler.ts
+++ b/packages/auth-providers/supabase/setup/src/setupHandler.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import { standardAuthHandler } from '@cedarjs/cli-helpers'
 
-import type { Args } from './setup'
+import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),

--- a/packages/auth-providers/supertokens/api/src/index.ts
+++ b/packages/auth-providers/supertokens/api/src/index.ts
@@ -1,1 +1,1 @@
-export { authDecoder } from './decoder'
+export { authDecoder } from './decoder.js'

--- a/packages/auth-providers/supertokens/setup/src/index.ts
+++ b/packages/auth-providers/supertokens/setup/src/index.ts
@@ -1,1 +1,1 @@
-export * from './setup'
+export * from './setup.js'

--- a/packages/auth-providers/supertokens/setup/src/setupHandler.ts
+++ b/packages/auth-providers/supertokens/setup/src/setupHandler.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import { getPaths, standardAuthHandler } from '@cedarjs/cli-helpers'
 
-import type { Args } from './setup'
+import type { Args } from './setup.js'
 
 export async function handler({ force: forceArg }: Args) {
   const { version } = JSON.parse(

--- a/packages/babel-config/src/__tests__/api.test.ts
+++ b/packages/babel-config/src/__tests__/api.test.ts
@@ -3,13 +3,13 @@ import { vi } from 'vitest'
 
 import { ensurePosixPath, getPaths } from '@cedarjs/project-config'
 
-import type { PluginList } from '../api'
+import type { PluginList } from '../api.js'
 import {
   getApiSideBabelConfigPath,
   getApiSideBabelPlugins,
   getApiSideBabelPresets,
   TARGETS_NODE,
-} from '../api'
+} from '../api.js'
 
 vi.mock('node:fs', async () => ({ ...memfs, default: { ...memfs } }))
 

--- a/packages/babel-config/src/__tests__/common.test.ts
+++ b/packages/babel-config/src/__tests__/common.test.ts
@@ -1,6 +1,6 @@
 import { vol } from 'memfs'
 
-import { getCommonPlugins } from '../common'
+import { getCommonPlugins } from '../common.js'
 
 const redwoodProjectPath = '/redwood-app'
 process.env.CEDAR_CWD = redwoodProjectPath

--- a/packages/babel-config/src/__tests__/prebuildApiFile.test.ts
+++ b/packages/babel-config/src/__tests__/prebuildApiFile.test.ts
@@ -2,7 +2,7 @@ import path from 'path'
 
 import { getConfig } from '@cedarjs/project-config'
 
-import { getApiSideBabelPlugins, transformWithBabel } from '../api'
+import { getApiSideBabelPlugins, transformWithBabel } from '../api.js'
 
 const CEDAR_CWD = path.join(__dirname, '__fixtures__/redwood-app')
 process.env.CEDAR_CWD = CEDAR_CWD

--- a/packages/babel-config/src/__tests__/tsconfigParsing.test.ts
+++ b/packages/babel-config/src/__tests__/tsconfigParsing.test.ts
@@ -6,7 +6,7 @@ import { ensurePosixPath } from '@cedarjs/project-config'
 import {
   getPathsFromTypeScriptConfig,
   parseTypeScriptConfigFiles,
-} from '../common'
+} from '../common.js'
 
 vi.mock('node:fs', async () => ({ ...memfs, default: { ...memfs } }))
 

--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -7,19 +7,19 @@ import { resolvePath } from 'babel-plugin-module-resolver'
 
 import { getPaths, projectSideIsEsm } from '@cedarjs/project-config'
 
-import type { RegisterHookOptions } from './common'
+import type { RegisterHookOptions } from './common.js'
 import {
   getCommonPlugins,
   getPathsFromTypeScriptConfig,
   parseTypeScriptConfigFiles,
   registerBabel,
-} from './common'
-import pluginRedwoodContextWrapping from './plugins/babel-plugin-redwood-context-wrapping'
-import pluginRedwoodDirectoryNamedImport from './plugins/babel-plugin-redwood-directory-named-import'
-import pluginRedwoodGraphqlOptionsExtract from './plugins/babel-plugin-redwood-graphql-options-extract'
-import pluginRedwoodImportDir from './plugins/babel-plugin-redwood-import-dir'
-import pluginRedwoodJobPathInjector from './plugins/babel-plugin-redwood-job-path-injector'
-import pluginRedwoodOTelWrapping from './plugins/babel-plugin-redwood-otel-wrapping'
+} from './common.js'
+import pluginRedwoodContextWrapping from './plugins/babel-plugin-redwood-context-wrapping.js'
+import pluginRedwoodDirectoryNamedImport from './plugins/babel-plugin-redwood-directory-named-import.js'
+import pluginRedwoodGraphqlOptionsExtract from './plugins/babel-plugin-redwood-graphql-options-extract.js'
+import pluginRedwoodImportDir from './plugins/babel-plugin-redwood-import-dir.js'
+import pluginRedwoodJobPathInjector from './plugins/babel-plugin-redwood-job-path-injector.js'
+import pluginRedwoodOTelWrapping from './plugins/babel-plugin-redwood-otel-wrapping.js'
 
 export const TARGETS_NODE = '24'
 

--- a/packages/babel-config/src/common.ts
+++ b/packages/babel-config/src/common.ts
@@ -7,8 +7,8 @@ import { parseConfigFileTextToJson } from 'typescript'
 
 import { getPaths } from '@cedarjs/project-config'
 
-import { getWebSideBabelPlugins } from './web'
-import type { Flags as WebFlags } from './web'
+import { getWebSideBabelPlugins } from './web.js'
+import type { Flags as WebFlags } from './web.js'
 
 export interface RegisterHookOptions {
   /**

--- a/packages/babel-config/src/index.ts
+++ b/packages/babel-config/src/index.ts
@@ -23,7 +23,7 @@ export {
   registerApiSideBabelHook,
   /** Used by @cedarjs/internal and @cedarjs/vite */
   transformWithBabel,
-} from './api'
+} from './api.js'
 
 export {
   /**
@@ -50,9 +50,9 @@ export {
   getWebSideOverrides,
   /** Used by @cedarjs/prerender */
   registerWebSideBabelHook,
-} from './web'
+} from './web.js'
 
-export type { Flags } from './web'
+export type { Flags } from './web.js'
 
 export {
   /** Used by our eslint-config  */
@@ -74,4 +74,4 @@ export {
    * in a future version.
    */
   registerBabel,
-} from './common'
+} from './common.js'

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-context-wrapping.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-context-wrapping.test.ts
@@ -2,7 +2,7 @@ import path from 'path'
 
 import pluginTester from 'babel-plugin-tester'
 
-import redwoodOtelWrappingPlugin from '../babel-plugin-redwood-context-wrapping'
+import redwoodOtelWrappingPlugin from '../babel-plugin-redwood-context-wrapping.js'
 
 pluginTester({
   plugin: redwoodOtelWrappingPlugin,

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-directory-named-imports.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-directory-named-imports.test.ts
@@ -1,6 +1,6 @@
 import * as babel from '@babel/core'
 
-import namedDirectory from '../babel-plugin-redwood-directory-named-import'
+import namedDirectory from '../babel-plugin-redwood-directory-named-import.js'
 
 const testCases = [
   // Directory named imports

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-graphql-options-extract.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-graphql-options-extract.test.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import pluginTester from 'babel-plugin-tester'
 import { vi } from 'vitest'
 
-import redwoodGraphqlOptionsExtract from '../babel-plugin-redwood-graphql-options-extract'
+import redwoodGraphqlOptionsExtract from '../babel-plugin-redwood-graphql-options-extract.js'
 
 vi.mock('@cedarjs/project-config', () => {
   return {

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-import-dir.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-import-dir.test.ts
@@ -2,7 +2,7 @@ import path from 'path'
 
 import pluginTester from 'babel-plugin-tester'
 
-import plugin from '../babel-plugin-redwood-import-dir'
+import plugin from '../babel-plugin-redwood-import-dir.js'
 
 describe('babel plugin redwood import dir', () => {
   pluginTester({

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-mock-cell-data.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-mock-cell-data.test.ts
@@ -2,7 +2,7 @@ import path from 'path'
 
 import pluginTester from 'babel-plugin-tester'
 
-import plugin from '../babel-plugin-redwood-mock-cell-data'
+import plugin from '../babel-plugin-redwood-mock-cell-data.js'
 
 describe('babel plugin redwood mock cell data', () => {
   const __fixtures__ = path.resolve(__dirname, '../../../../../__fixtures__')

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-otel-wrapping.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-otel-wrapping.test.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import pluginTester from 'babel-plugin-tester'
 import { vi } from 'vitest'
 
-import redwoodOtelWrappingPlugin from '../babel-plugin-redwood-otel-wrapping'
+import redwoodOtelWrappingPlugin from '../babel-plugin-redwood-otel-wrapping.js'
 
 vi.mock('@cedarjs/project-config', () => {
   return {

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-remove-dev-fatal-error-page.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-remove-dev-fatal-error-page.test.ts
@@ -2,7 +2,7 @@ import path from 'path'
 
 import pluginTester from 'babel-plugin-tester'
 
-import plugin from '../babel-plugin-redwood-remove-dev-fatal-error-page'
+import plugin from '../babel-plugin-redwood-remove-dev-fatal-error-page.js'
 
 describe('babel plugin redwood remove dev fatal error page', () => {
   pluginTester({

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-routes-auto-loader.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-routes-auto-loader.test.ts
@@ -5,7 +5,7 @@ import * as babel from '@babel/core'
 
 import { getPaths } from '@cedarjs/project-config'
 
-import babelRoutesAutoLoader from '../babel-plugin-redwood-routes-auto-loader'
+import babelRoutesAutoLoader from '../babel-plugin-redwood-routes-auto-loader.js'
 
 const transform = (filename: string) => {
   const code = fs.readFileSync(filename, 'utf-8')

--- a/packages/forms/src/CheckboxField.tsx
+++ b/packages/forms/src/CheckboxField.tsx
@@ -1,9 +1,9 @@
 import type { ForwardedRef } from 'react'
 import React, { forwardRef } from 'react'
 
-import type { FieldProps } from './FieldProps'
-import { useErrorStyles } from './useErrorStyles'
-import { useRegister } from './useRegister'
+import type { FieldProps } from './FieldProps.js'
+import { useErrorStyles } from './useErrorStyles.js'
+import { useRegister } from './useRegister.js'
 
 export interface CheckboxFieldProps
   extends

--- a/packages/forms/src/FieldProps.ts
+++ b/packages/forms/src/FieldProps.ts
@@ -1,4 +1,4 @@
-import type { EmptyAsValue, RedwoodRegisterOptions } from './coercion'
+import type { EmptyAsValue, RedwoodRegisterOptions } from './coercion.js'
 
 /**
  * The main interface, just to have some sort of source of truth.

--- a/packages/forms/src/Form.tsx
+++ b/packages/forms/src/Form.tsx
@@ -4,7 +4,7 @@ import type { ForwardedRef } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import type { FieldValues, UseFormReturn, UseFormProps } from 'react-hook-form'
 
-import { ServerErrorsContext } from './ServerErrorsContext'
+import { ServerErrorsContext } from './ServerErrorsContext.js'
 
 export interface FormProps<
   TFieldValues extends FieldValues = FieldValues,

--- a/packages/forms/src/InputComponents.tsx
+++ b/packages/forms/src/InputComponents.tsx
@@ -3,9 +3,9 @@ import React, { forwardRef } from 'react'
 
 import pascalcase from 'pascalcase'
 
-import type { FieldProps } from './FieldProps'
-import { useErrorStyles } from './useErrorStyles'
-import { useRegister } from './useRegister'
+import type { FieldProps } from './FieldProps.js'
+import { useErrorStyles } from './useErrorStyles.js'
+import { useRegister } from './useRegister.js'
 
 /**
  * All the types we'll be generating named `<InputFields>` for (which is basically all of them).

--- a/packages/forms/src/Label.tsx
+++ b/packages/forms/src/Label.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-import type { FieldProps } from './FieldProps'
-import { useErrorStyles } from './useErrorStyles'
+import type { FieldProps } from './FieldProps.js'
+import { useErrorStyles } from './useErrorStyles.js'
 
 export interface LabelProps
   extends

--- a/packages/forms/src/SelectField.tsx
+++ b/packages/forms/src/SelectField.tsx
@@ -1,9 +1,9 @@
 import type { ForwardedRef } from 'react'
 import React, { forwardRef } from 'react'
 
-import type { FieldProps } from './FieldProps'
-import { useErrorStyles } from './useErrorStyles'
-import { useRegister } from './useRegister'
+import type { FieldProps } from './FieldProps.js'
+import { useErrorStyles } from './useErrorStyles.js'
+import { useRegister } from './useRegister.js'
 
 export interface SelectFieldProps
   extends

--- a/packages/forms/src/TextAreaField.tsx
+++ b/packages/forms/src/TextAreaField.tsx
@@ -1,9 +1,9 @@
 import type { ForwardedRef } from 'react'
 import React, { forwardRef } from 'react'
 
-import type { FieldProps } from './FieldProps'
-import { useErrorStyles } from './useErrorStyles'
-import { useRegister } from './useRegister'
+import type { FieldProps } from './FieldProps.js'
+import { useErrorStyles } from './useErrorStyles.js'
+import { useRegister } from './useRegister.js'
 
 export interface TextAreaFieldProps
   extends

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -48,13 +48,13 @@
 
 export * from 'react-hook-form'
 
-export { CheckboxField } from './CheckboxField'
-export type { EmptyAsValue, RedwoodRegisterOptions } from './coercion'
-export { FieldError } from './FieldError'
-export { Form } from './Form'
-export type { FormProps } from './Form'
-export { default as FormError } from './FormError'
-export type { ServerError, RWGqlError, ServerParseError } from './FormError'
+export { CheckboxField } from './CheckboxField.js'
+export type { EmptyAsValue, RedwoodRegisterOptions } from './coercion.js'
+export { FieldError } from './FieldError.js'
+export { Form } from './Form.js'
+export type { FormProps } from './Form.js'
+export { default as FormError } from './FormError.js'
+export type { ServerError, RWGqlError, ServerParseError } from './FormError.js'
 export {
   InputField,
   ButtonField,
@@ -78,12 +78,12 @@ export {
   TimeField,
   UrlField,
   WeekField,
-} from './InputComponents'
-export type { InputFieldProps } from './InputComponents'
-export { Label } from './Label'
-export { SelectField } from './SelectField'
-export { ServerErrorsContext } from './ServerErrorsContext'
-export { Submit } from './Submit'
-export { TextAreaField } from './TextAreaField'
-export { useErrorStyles } from './useErrorStyles'
-export { useRegister } from './useRegister'
+} from './InputComponents.js'
+export type { InputFieldProps } from './InputComponents.js'
+export { Label } from './Label.js'
+export { SelectField } from './SelectField.js'
+export { ServerErrorsContext } from './ServerErrorsContext.js'
+export { Submit } from './Submit.js'
+export { TextAreaField } from './TextAreaField.js'
+export { useErrorStyles } from './useErrorStyles.js'
+export { useRegister } from './useRegister.js'

--- a/packages/forms/src/useErrorStyles.ts
+++ b/packages/forms/src/useErrorStyles.ts
@@ -2,8 +2,8 @@ import React, { useContext } from 'react'
 
 import { get, useFormContext } from 'react-hook-form'
 
-import type { FieldProps } from './FieldProps'
-import { ServerErrorsContext } from './ServerErrorsContext'
+import type { FieldProps } from './FieldProps.js'
+import { ServerErrorsContext } from './ServerErrorsContext.js'
 
 export type UseErrorStylesProps = Pick<
   FieldProps,

--- a/packages/forms/src/useRegister.ts
+++ b/packages/forms/src/useRegister.ts
@@ -2,9 +2,9 @@ import type React from 'react'
 
 import { useFormContext } from 'react-hook-form'
 
-import type { EmptyAsValue } from './coercion'
-import { setCoercion } from './coercion'
-import type { FieldProps } from './FieldProps'
+import type { EmptyAsValue } from './coercion.js'
+import { setCoercion } from './coercion.js'
+import type { FieldProps } from './FieldProps.js'
 
 export type UseRegisterProps<
   Element extends HTMLTextAreaElement | HTMLSelectElement | HTMLInputElement =

--- a/packages/mailer/core/src/handler.ts
+++ b/packages/mailer/core/src/handler.ts
@@ -3,7 +3,7 @@ import type {
   MailResult,
   MailUtilities,
   MailRenderedContent,
-} from './types'
+} from './types.js'
 
 export abstract class AbstractMailHandler {
   // Send a mail

--- a/packages/mailer/core/src/index.ts
+++ b/packages/mailer/core/src/index.ts
@@ -1,5 +1,5 @@
-export * from './mailer'
-export * from './handler'
-export * from './renderer'
+export * from './mailer.js'
+export * from './handler.js'
+export * from './renderer.js'
 
-export type * from './types'
+export type * from './types.js'

--- a/packages/mailer/core/src/mailer.ts
+++ b/packages/mailer/core/src/mailer.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '@cedarjs/api/logger'
 
-import type { AbstractMailHandler } from './handler'
+import type { AbstractMailHandler } from './handler.js'
 import type {
   MailerConfig,
   MailSendWithoutRenderingOptions,
@@ -10,8 +10,8 @@ import type {
   MailerDefaults,
   MailerMode,
   MailResult,
-} from './types'
-import { constructCompleteSendOptions, extractDefaults } from './utils'
+} from './types.js'
+import { constructCompleteSendOptions, extractDefaults } from './utils.js'
 
 export class Mailer<
   THandlers extends MailHandlers,

--- a/packages/mailer/core/src/renderer.ts
+++ b/packages/mailer/core/src/renderer.ts
@@ -2,7 +2,7 @@ import type {
   MailUtilities,
   MailRenderedContent,
   MailRendererOptions,
-} from './types'
+} from './types.js'
 
 export abstract class AbstractMailRenderer {
   // Render a template

--- a/packages/mailer/core/src/types.ts
+++ b/packages/mailer/core/src/types.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '@cedarjs/api/logger'
 
-import type { AbstractMailHandler } from './handler'
-import type { AbstractMailRenderer } from './renderer'
+import type { AbstractMailHandler } from './handler.js'
+import type { AbstractMailRenderer } from './renderer.js'
 
 // TODO: Some properties we have marked as unknown or similar are actually expected to be spreadable
 //       so we should probably attempt narrow the type to ensure that remains possible

--- a/packages/mailer/core/src/utils.ts
+++ b/packages/mailer/core/src/utils.ts
@@ -1,11 +1,11 @@
-import type { Mailer } from './mailer'
+import type { Mailer } from './mailer.js'
 import type {
   MailAddress,
   MailSendOptions,
   MailSendWithoutRenderingOptions,
   MailSendOptionsComplete,
   MailerDefaults,
-} from './types'
+} from './types.js'
 
 export function convertAddress(address: MailAddress): string {
   if (typeof address === 'string') {

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,1 +1,1 @@
-export * from './telemetry'
+export * from './telemetry.js'

--- a/packages/telemetry/src/scripts/invoke.ts
+++ b/packages/telemetry/src/scripts/invoke.ts
@@ -1,4 +1,4 @@
-import { sendTelemetry } from '../sendTelemetry'
+import { sendTelemetry } from '../sendTelemetry.js'
 ;(async function () {
   await sendTelemetry()
 })()

--- a/packages/web-server/src/bin.ts
+++ b/packages/web-server/src/bin.ts
@@ -8,8 +8,8 @@ import { getPaths } from '@cedarjs/project-config'
 
 import { bin } from '../package.json'
 
-import { description, builder } from './cliConfig'
-import { handler } from './cliConfigHandler'
+import { description, builder } from './cliConfig.js'
+import { handler } from './cliConfigHandler.js'
 
 if (!process.env.REDWOOD_ENV_FILES_LOADED) {
   config({

--- a/packages/web-server/src/cliConfig.ts
+++ b/packages/web-server/src/cliConfig.ts
@@ -1,6 +1,6 @@
 import type { Argv } from 'yargs'
 
-import type { ParsedOptions } from './types'
+import type { ParsedOptions } from './types.js'
 
 export const description = 'Start a server for serving the web side'
 

--- a/packages/web-server/src/cliConfigHandler.ts
+++ b/packages/web-server/src/cliConfigHandler.ts
@@ -1,5 +1,5 @@
-import type { ParsedOptions } from './types'
-import { serveWeb } from './webServer'
+import type { ParsedOptions } from './types.js'
+import { serveWeb } from './webServer.js'
 
 export async function handler(options: ParsedOptions) {
   try {

--- a/packages/web-server/src/webServer.ts
+++ b/packages/web-server/src/webServer.ts
@@ -7,7 +7,7 @@ import Fastify from 'fastify'
 import { redwoodFastifyWeb } from '@cedarjs/fastify-web'
 import { getConfig, getPaths } from '@cedarjs/project-config'
 
-import type { ParsedOptions } from './types'
+import type { ParsedOptions } from './types.js'
 
 export async function serveWeb(options: ParsedOptions = {}) {
   const start = Date.now()


### PR DESCRIPTION
This change prepares Cedar for moving even more towards ESM packages. ESM requires extensions on relative path imports