### PR TITLE
chore(tsconfig): Modernize and clean up settings

### DIFF
--- a/__fixtures__/example-todo-main/web/src/graphql/fragment-masking.ts
+++ b/__fixtures__/example-todo-main/web/src/graphql/fragment-masking.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
-import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
-import { FragmentDefinitionNode } from 'graphql';
-import { Incremental } from './graphql';
+import type { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
+import type { FragmentDefinitionNode } from 'graphql';
+import type { Incremental } from './graphql';
 
 
 export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>> = TDocumentType extends DocumentTypeDecoration<

--- a/__fixtures__/example-todo-main/web/src/graphql/gql.ts
+++ b/__fixtures__/example-todo-main/web/src/graphql/gql.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import * as types from "./graphql";
-import { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
 
 /**
  * Map of all GraphQL operations in the project.

--- a/__fixtures__/example-todo-main/web/src/graphql/graphql.ts
+++ b/__fixtures__/example-todo-main/web/src/graphql/graphql.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = T | null | undefined;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/packages/adapters/fastify/web/package.json
+++ b/packages/adapters/fastify/web/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/adapters/fastify/web"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/web.js",
   "types": "./dist/web.d.ts",
   "files": [

--- a/packages/adapters/fastify/web/tsconfig.json
+++ b/packages/adapters/fastify/web/tsconfig.json
@@ -1,9 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../project-config" }]
 }

--- a/packages/api-server/tsconfig.cjs.json
+++ b/packages/api-server/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/api/tsconfig.cjs.json
+++ b/packages/api/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/auth-providers/auth0/api/tsconfig.json
+++ b/packages/auth-providers/auth0/api/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../api" }]
 }

--- a/packages/auth-providers/auth0/setup/tsconfig.json
+++ b/packages/auth-providers/auth0/setup/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../cli-helpers" }]
 }

--- a/packages/auth-providers/auth0/web/tsconfig.cjs.json
+++ b/packages/auth-providers/auth0/web/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/auth-providers/azureActiveDirectory/api/tsconfig.json
+++ b/packages/auth-providers/azureActiveDirectory/api/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../api" }]
 }

--- a/packages/auth-providers/azureActiveDirectory/setup/tsconfig.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../cli-helpers" }]
 }

--- a/packages/auth-providers/azureActiveDirectory/web/tsconfig.build.json
+++ b/packages/auth-providers/azureActiveDirectory/web/tsconfig.build.json
@@ -1,15 +1,9 @@
 {
-  "extends": "../../../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "strict": true,
     "rootDir": "src",
-    "outDir": "dist",
     "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
   },
   "include": ["src"],
-  "references": [
-    {
-      "path": "./../../../auth/tsconfig.build.json"
-    }
-  ]
+  "references": [{ "path": "./../../../auth/tsconfig.build.json" }]
 }

--- a/packages/auth-providers/azureActiveDirectory/web/tsconfig.cjs.json
+++ b/packages/auth-providers/azureActiveDirectory/web/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/auth-providers/azureActiveDirectory/web/tsconfig.json
+++ b/packages/auth-providers/azureActiveDirectory/web/tsconfig.json
@@ -1,9 +1,7 @@
 {
-  "extends": "../../../../tsconfig.base.json",
+  "extends": "../../../../tsconfig.cjs-base.json",
   "compilerOptions": {
-    "strict": true,
-    "module": "Node16",
-    "moduleResolution": "node16"
+    "rootDir": "."
   },
   "include": ["."],
   "references": [

--- a/packages/auth-providers/clerk/api/tsconfig.json
+++ b/packages/auth-providers/clerk/api/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../api" }]
 }

--- a/packages/auth-providers/clerk/setup/tsconfig.json
+++ b/packages/auth-providers/clerk/setup/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../cli-helpers" }]
 }

--- a/packages/auth-providers/clerk/web/tsconfig.cjs.json
+++ b/packages/auth-providers/clerk/web/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/auth-providers/custom/setup/tsconfig.json
+++ b/packages/auth-providers/custom/setup/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../cli-helpers" }]
 }

--- a/packages/auth-providers/dbAuth/api/tsconfig.json
+++ b/packages/auth-providers/dbAuth/api/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [
     { "path": "../../../auth/tsconfig.build.json" },

--- a/packages/auth-providers/dbAuth/middleware/tsconfig.cjs.json
+++ b/packages/auth-providers/dbAuth/middleware/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/auth-providers/dbAuth/setup/tsconfig.json
+++ b/packages/auth-providers/dbAuth/setup/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../cli-helpers" }]
 }

--- a/packages/auth-providers/dbAuth/web/tsconfig.cjs.json
+++ b/packages/auth-providers/dbAuth/web/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/auth-providers/firebase/api/tsconfig.json
+++ b/packages/auth-providers/firebase/api/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../api" }]
 }

--- a/packages/auth-providers/firebase/setup/tsconfig.json
+++ b/packages/auth-providers/firebase/setup/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../cli-helpers" }]
 }

--- a/packages/auth-providers/firebase/web/tsconfig.cjs.json
+++ b/packages/auth-providers/firebase/web/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/auth-providers/netlify/api/tsconfig.json
+++ b/packages/auth-providers/netlify/api/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../api" }]
 }

--- a/packages/auth-providers/netlify/setup/tsconfig.json
+++ b/packages/auth-providers/netlify/setup/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../cli-helpers" }]
 }

--- a/packages/auth-providers/netlify/web/tsconfig.cjs.json
+++ b/packages/auth-providers/netlify/web/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/auth-providers/supabase/api/tsconfig.json
+++ b/packages/auth-providers/supabase/api/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../api" }]
 }

--- a/packages/auth-providers/supabase/middleware/tsconfig.cjs.json
+++ b/packages/auth-providers/supabase/middleware/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/auth-providers/supabase/setup/tsconfig.json
+++ b/packages/auth-providers/supabase/setup/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../cli-helpers" }]
 }

--- a/packages/auth-providers/supabase/web/tsconfig.cjs.json
+++ b/packages/auth-providers/supabase/web/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/auth-providers/supertokens/api/tsconfig.json
+++ b/packages/auth-providers/supertokens/api/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../api" }]
 }

--- a/packages/auth-providers/supertokens/setup/tsconfig.json
+++ b/packages/auth-providers/supertokens/setup/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../../../cli-helpers" }]
 }

--- a/packages/auth-providers/supertokens/web/tsconfig.cjs.json
+++ b/packages/auth-providers/supertokens/web/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/auth/tsconfig.cjs.json
+++ b/packages/auth/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/babel-config/tsconfig.json
+++ b/packages/babel-config/tsconfig.json
@@ -1,8 +1,6 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.cjs-base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist",
     "types": ["node", "jest"]
   },
   "include": ["ambient.d.ts", "src"],

--- a/packages/cli-helpers/tsconfig.build.json
+++ b/packages/cli-helpers/tsconfig.build.json
@@ -1,15 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "NodeNext",
-    "module": "NodeNext",
-    "rootDir": "src",
-    "outDir": "dist"
+    "rootDir": "src"
   },
-  "include": ["src"],
-  "references": [
-    { "path": "../framework-tools" },
-    { "path": "../telemetry" },
-    { "path": "../project-config" }
-  ]
+  "include": ["src"]
 }

--- a/packages/cli-helpers/tsconfig.cjs.json
+++ b/packages/cli-helpers/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/cli-helpers/tsconfig.json
+++ b/packages/cli-helpers/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "moduleResolution": "NodeNext",
-    "module": "NodeNext",
-    "outDir": "dist"
+    "rootDir": "."
   },
   "include": ["."],
   "references": [

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/cli-packages/dataMigrate"
   },
   "license": "MIT",
+  "type": "commonjs",
   "exports": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {

--- a/packages/cli-packages/dataMigrate/src/commands/upHandlerEsm.ts
+++ b/packages/cli-packages/dataMigrate/src/commands/upHandlerEsm.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+// @ts-expect-error - bundle-require has a missing types export for the "."
+// specifier in its package.json
 import { bundleRequire } from 'bundle-require'
 import { Listr } from 'listr2'
 

--- a/packages/cli-packages/dataMigrate/tsconfig.json
+++ b/packages/cli-packages/dataMigrate/tsconfig.json
@@ -1,9 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [
     { "path": "../../babel-config" },

--- a/packages/cli-packages/storybook-vite/package.json
+++ b/packages/cli-packages/storybook-vite/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/cli-packages/storybook-vite"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/cli-packages/storybook-vite/tsconfig.json
+++ b/packages/cli-packages/storybook-vite/tsconfig.json
@@ -1,9 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [
     { "path": "../../cli-helpers" },

--- a/packages/cli/src/commands/prerenderHandler.ts
+++ b/packages/cli/src/commands/prerenderHandler.ts
@@ -221,11 +221,9 @@ export const getTasks = async (
     prerenderRoutes.map((route) => expandRouteParameters(route)),
   )
 
-  const prerenderer = (
-    projectIsEsm()
-      ? await import('@cedarjs/prerender')
-      : await import('@cedarjs/prerender/cjs')
-  ) as typeof Prerender
+  const prerenderer = projectIsEsm()
+    ? await import('@cedarjs/prerender')
+    : await import('@cedarjs/prerender/cjs')
 
   const listrTasks = expandedRouteParameters.flatMap((routesToPrerender) => {
     const queryCache: Record<string, QueryInfo> = {}

--- a/packages/context/tsconfig.cjs.json
+++ b/packages/context/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/cookie-jar/tsconfig.json
+++ b/packages/cookie-jar/tsconfig.json
@@ -1,12 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "moduleResolution": "NodeNext",
-    "module": "NodeNext",
-    "baseUrl": ".",
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../framework-tools" }]
 }

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,11 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "moduleResolution": "NodeNext",
-    "module": "NodeNext",
-    "strict": true,
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../tsconfig.cjs-base.json",
   "include": ["src"]
 }

--- a/packages/forms/tsconfig.build.json
+++ b/packages/forms/tsconfig.build.json
@@ -1,11 +1,8 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16",
     "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/__mocks__", "**/__tests__"]
 }

--- a/packages/forms/tsconfig.json
+++ b/packages/forms/tsconfig.json
@@ -1,9 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "node16"
-  },
+  "extends": "../../tsconfig.cjs-base.json",
   "include": ["."],
   "exclude": ["dist", "node_modules", "**/__mocks__", "**/__tests__/fixtures"]
 }

--- a/packages/gqlorm/tsconfig.cjs.json
+++ b/packages/gqlorm/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/graphql-server/tsconfig.cjs.json
+++ b/packages/graphql-server/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/internal/tsconfig.cjs.json
+++ b/packages/internal/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/jobs/tsconfig.build.json
+++ b/packages/jobs/tsconfig.build.json
@@ -1,13 +1,11 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "moduleResolution": "node16",
-    "module": "Node16",
     "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
   },
   "include": ["src"],
+  "exclude": ["**/__tests__"],
   "references": [
     { "path": "../cli-helpers/tsconfig.build.json" },
     { "path": "../project-config" }

--- a/packages/jobs/tsconfig.json
+++ b/packages/jobs/tsconfig.json
@@ -1,10 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.cjs-base.json",
   "compilerOptions": {
-    "moduleResolution": "node16",
-    "module": "Node16",
-    "emitDeclarationOnly": false,
-    "noEmit": true
+    "rootDir": "."
   },
   "include": ["."],
   "exclude": ["dist", "node_modules", "**/__mocks__", "**/__tests__/fixtures"],

--- a/packages/mailer/core/package.json
+++ b/packages/mailer/core/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/mailer/core"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/mailer/core/tsconfig.json
+++ b/packages/mailer/core/tsconfig.json
@@ -1,10 +1,4 @@
 {
-  "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "node16"
-  },
+  "extends": "../../../tsconfig.cjs-base.json",
   "include": ["src"]
 }

--- a/packages/mailer/handlers/in-memory/tsconfig.json
+++ b/packages/mailer/handlers/in-memory/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
-  "references": [
-    {
-      "path": "../../core"
-    }
-  ]
+  "references": [{ "path": "../../core" }]
 }

--- a/packages/mailer/handlers/nodemailer/tsconfig.json
+++ b/packages/mailer/handlers/nodemailer/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
-  "references": [
-    {
-      "path": "../../core"
-    }
-  ]
+  "references": [{ "path": "../../core" }]
 }

--- a/packages/mailer/handlers/resend/tsconfig.json
+++ b/packages/mailer/handlers/resend/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
-  "references": [
-    {
-      "path": "../../core"
-    }
-  ]
+  "references": [{ "path": "../../core" }]
 }

--- a/packages/mailer/handlers/studio/tsconfig.json
+++ b/packages/mailer/handlers/studio/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
-  "references": [
-    {
-      "path": "../../core"
-    }
-  ]
+  "references": [{ "path": "../../core" }]
 }

--- a/packages/mailer/renderers/mjml-react/package.json
+++ b/packages/mailer/renderers/mjml-react/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/mailer/renderers/mjml-react"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/mailer/renderers/mjml-react/tsconfig.json
+++ b/packages/mailer/renderers/mjml-react/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
-  "references": [
-    {
-      "path": "../../core"
-    }
-  ]
+  "references": [{ "path": "../../core" }]
 }

--- a/packages/mailer/renderers/react-email/package.json
+++ b/packages/mailer/renderers/react-email/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/mailer/renderers/react-email"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/mailer/renderers/react-email/tsconfig.json
+++ b/packages/mailer/renderers/react-email/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../../../tsconfig.cjs-base.json",
   "include": ["src"],
-  "references": [
-    {
-      "path": "../../core"
-    }
-  ]
+  "references": [{ "path": "../../core" }]
 }

--- a/packages/ogimage-gen/tsconfig.json
+++ b/packages/ogimage-gen/tsconfig.json
@@ -1,9 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [
     { "path": "../project-config" },

--- a/packages/prerender/src/graphql/__tests__/__fixtures__/node-runner/cedar-app/web/src/graphql/gql.ts
+++ b/packages/prerender/src/graphql/__tests__/__fixtures__/node-runner/cedar-app/web/src/graphql/gql.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import * as types from "./graphql.js";
-import { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
 
 /**
  * Map of all GraphQL operations in the project.

--- a/packages/prerender/src/graphql/__tests__/__fixtures__/node-runner/cedar-app/web/src/graphql/graphql.ts
+++ b/packages/prerender/src/graphql/__tests__/__fixtures__/node-runner/cedar-app/web/src/graphql/graphql.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/packages/prerender/tsconfig.cjs.json
+++ b/packages/prerender/tsconfig.cjs.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   },
   "exclude": [
     "**/__tests__",

--- a/packages/prerender/tsconfig.json
+++ b/packages/prerender/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
   "include": ["."],
   "exclude": ["dist", "node_modules", "**/__fixtures__"],
   "references": [

--- a/packages/prerender/tsconfig.json
+++ b/packages/prerender/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "isolatedModules": true,
-    "outDir": "dist"
-  },
   "include": ["."],
   "exclude": ["dist", "node_modules", "**/__fixtures__"],
   "references": [

--- a/packages/project-config/tsconfig.cjs.json
+++ b/packages/project-config/tsconfig.cjs.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "dist/cjs",
     "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/project-config/tsconfig.json
+++ b/packages/project-config/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "moduleResolution": "NodeNext",
-    "module": "NodeNext",
-    "rootDir": "src",
-    "outDir": "dist"
-  },
   "include": ["src"]
 }

--- a/packages/router/tsconfig.cjs.json
+++ b/packages/router/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/packages/server-store/tsconfig.json
+++ b/packages/server-store/tsconfig.json
@@ -1,12 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "moduleResolution": "NodeNext",
-    "module": "NodeNext",
-    "baseUrl": ".",
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [
     { "path": "../auth/tsconfig.build.json" },

--- a/packages/storage/tsconfig.types-cjs.json
+++ b/packages/storage/tsconfig.types-cjs.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.types-cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.types-cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   },
   "exclude": [
     "dist",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/telemetry"
   },
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,9 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../tsconfig.cjs-base.json",
   "include": ["src"],
   "references": [{ "path": "../project-config" }, { "path": "../structure" }]
 }

--- a/packages/testing/tsconfig.cjs.json
+++ b/packages/testing/tsconfig.cjs.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   },
   "exclude": [
     "dist",

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -1,8 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../tsconfig.cjs-base.json",
   "include": ["src"]
 }

--- a/packages/web-server/tsconfig.json
+++ b/packages/web-server/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.cjs-base.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  },
   "include": ["src", "ambient.d.ts"],
   "references": [
     { "path": "../adapters/fastify/web" },

--- a/packages/web-server/tsconfig.json
+++ b/packages/web-server/tsconfig.json
@@ -1,9 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
+  "extends": "../../tsconfig.cjs-base.json",
   "include": ["src", "ambient.d.ts"],
   "references": [
     { "path": "../adapters/fastify/web" },

--- a/packages/web/tsconfig.cjs.json
+++ b/packages/web/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
+    "verbatimModuleSyntax": false
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,22 +1,40 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "target": "esnext",
-    "moduleResolution": "node",
-    "module": "esnext",
+    "target": "es2024",
+    "lib": [
+      "es2024",
+      "DOM",
+      "DOM.Iterable",
+      "ESNext.Array",
+      "ESNext.Collection",
+      "ESNext.Error",
+      "ESNext.Iterator",
+      "ESNext.Promise"
+    ],
+    "module": "node20",
+    "moduleResolution": "node16",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+
+    "verbatimModuleSyntax": true,
+    // "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true,
+
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "sourceMap": true,
     "composite": true,
-    "strict": true,
-    "esModuleInterop": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "jsx": "preserve",
-    "skipLibCheck": true,
-    "resolveJsonModule": true
+
+    "rootDir": "${configDir}/src",
+    "outDir": "${configDir}/dist"
   },
   "exclude": [
     "dist",

--- a/tsconfig.cjs-base.json
+++ b/tsconfig.cjs-base.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "verbatimModuleSyntax": false
+  }
+}


### PR DESCRIPTION
Use recommended Node24 tsconfig settings from https://www.npmjs.com/package/@tsconfig/node24, except I prefer explicit targets instead of "*next". 

Also cleans up tsconfig files to reduce duplication and redundant settings