### PR TITLE
chore(ci): Only always use the cfw bin

### DIFF
--- a/.github/actions/set-up-rsc-project/setUpRscProject.mts
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mts
@@ -81,14 +81,7 @@ async function setUpRscProject(
   console.log()
 
   console.log('Syncing framework')
-  // TODO: hard code this to just be `yarn cfw proje...` as soon as cfw is part
-  // of a stable Cedar release
-  const cfwBin = fs.existsSync(
-    path.join(rscProjectPath, 'node_modules/.bin/cfw'),
-  )
-    ? 'cfw'
-    : 'rwfw'
-  await execInProject(`yarn ${cfwBin} project:tarsync --verbose`, {
+  await execInProject(`yarn cfw project:tarsync --verbose`, {
     env: {
       CFW_PATH: CEDAR_FRAMEWORK_PATH,
       RWFW_PATH: CEDAR_FRAMEWORK_PATH,

--- a/.github/actions/set-up-rsc-project/setUpRscProject.mts
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mts
@@ -84,7 +84,6 @@ async function setUpRscProject(
   await execInProject(`yarn cfw project:tarsync --verbose`, {
     env: {
       CFW_PATH: CEDAR_FRAMEWORK_PATH,
-      RWFW_PATH: CEDAR_FRAMEWORK_PATH,
     },
   })
   console.log()


### PR DESCRIPTION
Fixing a TODO now that `cfw` has been working well for a while