### PR TITLE
feat(gqlorm): guard schema generation behind experimental.gqlorm.enabled

### DIFF
--- a/__fixtures__/test-project-live/cedar.toml
+++ b/__fixtures__/test-project-live/cedar.toml
@@ -23,5 +23,8 @@
 [notifications]
   versionUpdates = ["latest"]
 
+[experimental.gqlorm]
+  enabled = true
+
 [experimental.packagesWorkspace]
   enabled = true

--- a/local-testing-project-live/cedar.toml
+++ b/local-testing-project-live/cedar.toml
@@ -25,3 +25,6 @@
 
 [experimental.packagesWorkspace]
   enabled = true
+
+[experimental.gqlorm]
+  enabled = true

--- a/packages/cli/src/commands/build/__tests__/build.test.ts
+++ b/packages/cli/src/commands/build/__tests__/build.test.ts
@@ -74,6 +74,10 @@ vi.mock('@cedarjs/internal/dist/generate/generate', () => ({
   generate: vi.fn(),
 }))
 
+vi.mock('@cedarjs/internal/dist/generate/gqlormSchema', () => ({
+  generateGqlormArtifacts: vi.fn().mockResolvedValue({ errors: [] }),
+}))
+
 vi.mock('@cedarjs/internal/dist/validateSchema', () => ({
   loadAndValidateSdls: vi.fn(),
 }))
@@ -153,7 +157,6 @@ test('the build tasks are in the correct sequence when packagesWorkspace is enab
       "Generating Prisma Client...",
       "Building Packages...",
       "Checking workspace packages...",
-      "Generating gqlorm schema...",
       "Verifying graphql schema...",
       "Building API...",
       "Building Web...",
@@ -171,7 +174,6 @@ test('the build tasks are in the correct sequence when packagesWorkspace is disa
   expect(tasks.map((x: ListrTask) => x.title)).toMatchInlineSnapshot(`
     [
       "Generating Prisma Client...",
-      "Generating gqlorm schema...",
       "Verifying graphql schema...",
       "Building API...",
       "Building Web...",
@@ -191,7 +193,6 @@ test('Should run prerender for web (packagesWorkspace enabled)', async () => {
   expect(tasks.map((x: ListrTask) => x.title)).toMatchInlineSnapshot(`
     [
       "Checking workspace packages...",
-      "Generating gqlorm schema...",
       "Building Web...",
     ]
   `)
@@ -213,7 +214,6 @@ test('Should run prerender for web (packagesWorkspace disabled)', async () => {
   const tasks = Array.isArray(firstCallArg) ? firstCallArg : [firstCallArg]
   expect(tasks.map((x: ListrTask) => x.title)).toMatchInlineSnapshot(`
     [
-      "Generating gqlorm schema...",
       "Building Web...",
     ]
   `)
@@ -224,4 +224,22 @@ test('Should run prerender for web (packagesWorkspace disabled)', async () => {
   expect(consoleSpy.mock.calls[1][0]).toMatch(
     /You have not marked any routes to "prerender"/,
   )
+})
+
+test('Generating gqlorm schema task is included when experimental.gqlorm.enabled is true', async () => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  mockGetConfig.mockReturnValue({
+    experimental: { gqlorm: { enabled: true } },
+  })
+
+  await handler({ workspace: ['web'] })
+
+  const firstCallArg = vi.mocked(Listr).mock.calls[0][0]
+  const tasks = Array.isArray(firstCallArg) ? firstCallArg : [firstCallArg]
+  expect(tasks.map((x: ListrTask) => x.title)).toMatchInlineSnapshot(`
+    [
+      "Generating gqlorm schema...",
+      "Building Web...",
+    ]
+  `)
 })

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -217,7 +217,7 @@ export const handler = async ({
       title: gqlFeaturesTaskTitle,
       task: generate,
     },
-    workspace.includes('web') && getConfig().experimental.gqlorm.enabled && {
+    workspace.includes('web') && cedarConfig.experimental.gqlorm.enabled && {
       title: 'Generating gqlorm schema...',
       task: async () => {
         const { errors } = await generateGqlormArtifacts()

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -217,7 +217,7 @@ export const handler = async ({
       title: gqlFeaturesTaskTitle,
       task: generate,
     },
-    workspace.includes('web') && {
+    workspace.includes('web') && getConfig().experimental.gqlorm.enabled && {
       title: 'Generating gqlorm schema...',
       task: async () => {
         const { errors } = await generateGqlormArtifacts()

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -217,17 +217,18 @@ export const handler = async ({
       title: gqlFeaturesTaskTitle,
       task: generate,
     },
-    workspace.includes('web') && cedarConfig.experimental.gqlorm.enabled && {
-      title: 'Generating gqlorm schema...',
-      task: async () => {
-        const { errors } = await generateGqlormArtifacts()
-        if (errors.length > 0) {
-          for (const { message } of errors) {
-            console.warn(`Warning: ${message}`)
+    workspace.includes('web') &&
+      cedarConfig.experimental?.gqlorm?.enabled && {
+        title: 'Generating gqlorm schema...',
+        task: async () => {
+          const { errors } = await generateGqlormArtifacts()
+          if (errors.length > 0) {
+            for (const { message } of errors) {
+              console.warn(`Warning: ${message}`)
+            }
           }
-        }
+        },
       },
-    },
     workspace.includes('api') && {
       title: 'Verifying graphql schema...',
       task: loadAndValidateSdls,

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -162,7 +162,11 @@ export const handler = async ({
   // static `import schema from '../../.cedar/gqlorm-schema.json'` in App.tsx
   // almost immediately (~200ms), but rw-gen-watch doesn't write the file until
   // chokidar's 'ready' event + full DMMF parse (~3-8s later).
-  if (generate && workspace.includes('web') && getConfig().experimental.gqlorm.enabled) {
+  if (
+    generate &&
+    workspace.includes('web') &&
+    getConfig().experimental?.gqlorm?.enabled
+  ) {
     try {
       await generateGqlormArtifacts()
     } catch (e) {

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -162,7 +162,7 @@ export const handler = async ({
   // static `import schema from '../../.cedar/gqlorm-schema.json'` in App.tsx
   // almost immediately (~200ms), but rw-gen-watch doesn't write the file until
   // chokidar's 'ready' event + full DMMF parse (~3-8s later).
-  if (generate && workspace.includes('web')) {
+  if (generate && workspace.includes('web') && getConfig().experimental.gqlorm.enabled) {
     try {
       await generateGqlormArtifacts()
     } catch (e) {

--- a/packages/internal/src/generate/generate.ts
+++ b/packages/internal/src/generate/generate.ts
@@ -22,7 +22,9 @@ export const generate = async () => {
     await generatePossibleTypes()
 
   const { files: gqlormFiles, errors: gqlormErrors } =
-    await generateGqlormArtifacts()
+    config.experimental.gqlorm.enabled
+      ? await generateGqlormArtifacts()
+      : { files: [], errors: [] }
 
   if (config.graphql.trustedDocuments) {
     const preset = await generateClientPreset()

--- a/packages/internal/src/generate/generate.ts
+++ b/packages/internal/src/generate/generate.ts
@@ -21,10 +21,10 @@ export const generate = async () => {
   const { possibleTypesFiles, errors: generatePossibleTypesErrors } =
     await generatePossibleTypes()
 
-  const { files: gqlormFiles, errors: gqlormErrors } =
-    config.experimental.gqlorm.enabled
-      ? await generateGqlormArtifacts()
-      : { files: [], errors: [] }
+  const { files: gqlormFiles, errors: gqlormErrors } = config.experimental
+    ?.gqlorm?.enabled
+    ? await generateGqlormArtifacts()
+    : { files: [], errors: [] }
 
   if (config.graphql.trustedDocuments) {
     const preset = await generateClientPreset()


### PR DESCRIPTION
## Summary

Wraps all `generateGqlormArtifacts()` calls behind a `config.experimental.gqlorm.enabled` check so the schema is only generated when the feature is explicitly opted into via `cedar.toml`:

```toml
[experimental.gqlorm]
  enabled = true
```

Three places updated:

- **`packages/internal/src/generate/generate.ts`** — the `generate()` function called by `rw-gen` / `rw-gen-watch`
- **`packages/cli/src/commands/dev/devHandler.ts`** — the eager pre-Vite generation
- **`packages/cli/src/commands/build/buildHandler.ts`** — the Listr build task

## Test plan

- [ ] With `experimental.gqlorm.enabled = false` (or absent): `yarn cedar build`, `yarn cedar dev`, and `yarn cedar generate` should not generate `.cedar/gqlorm-schema.json`
- [ ] With `experimental.gqlorm.enabled = true`: all three should generate the schema as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)