### PR TITLE
fix(live-queries): remove extra blank line before [experimental.gqlorm] in cedar.toml

### DIFF
--- a/packages/cli/src/commands/experimental/live-queries/liveQueriesHandler.ts
+++ b/packages/cli/src/commands/experimental/live-queries/liveQueriesHandler.ts
@@ -308,7 +308,7 @@ export async function handler({ force, verbose }: HandlerArgs) {
             writeFile(
               configTomlPath,
               configContent.concat(
-                '\n\n[experimental.gqlorm]\n  enabled = true\n',
+                '\n[experimental.gqlorm]\n  enabled = true\n',
               ),
               {
                 overwriteExisting: true,


### PR DESCRIPTION
## Summary

- When running `yarn cedar experimental live-queries`, the setup command appended `[experimental.gqlorm]` with two leading newlines (`\n\n`), causing an extra blank line in `cedar.toml`
- All other experimental setup handlers use a single `\n` prefix — this one was inconsistent
- Fix: change `'\n\n[experimental.gqlorm]\n  enabled = true\n'` → `'\n[experimental.gqlorm]\n  enabled = true\n'`

## Test plan

- [ ] Run `yarn cedar experimental live-queries` on a fresh project and verify `cedar.toml` has no extra blank line before `[experimental.gqlorm]`
- [ ] Run `yarn rebuild-test-project-fixture --live` and confirm the fixture diff no longer shows the extra blank line

🤖 Generated with [Claude Code](https://claude.com/claude-code)