### PR TITLE
chore(ci): Fix require-milestone triggers

### DIFF
--- a/.github/actions/require-milestone/requireMilestone.mjs
+++ b/.github/actions/require-milestone/requireMilestone.mjs
@@ -65,14 +65,14 @@ function getMilestoneFromConventionalCommit(title) {
  * Sets the milestone on a pull request using the GitHub API
  * @param {number} prNumber - The pull request number
  * @param {string} milestoneName - The name of the milestone to set
- * @returns {Promise<void>}
+ * @returns {Promise<boolean>} - True if the milestone was set successfully, false otherwise
  */
 async function setMilestone(prNumber, milestoneName) {
   if (!env.GITHUB_TOKEN) {
     console.error(
       'GITHUB_TOKEN is not set. Cannot automatically set milestone.',
     )
-    return
+    return false
   }
 
   const [owner, repo] = env.GITHUB_REPOSITORY.split('/')
@@ -92,7 +92,7 @@ async function setMilestone(prNumber, milestoneName) {
     console.error(
       `Failed to fetch milestones: ${milestonesResponse.status} ${milestonesResponse.statusText}`,
     )
-    return
+    return false
   }
 
   const milestones = await milestonesResponse.json()
@@ -100,7 +100,7 @@ async function setMilestone(prNumber, milestoneName) {
 
   if (!milestone) {
     console.error(`Milestone "${milestoneName}" not found in repository`)
-    return
+    return false
   }
 
   // Set the milestone on the PR
@@ -124,12 +124,13 @@ async function setMilestone(prNumber, milestoneName) {
     console.error(
       `Failed to set milestone: ${response.status} ${response.statusText}\n${errorText}`,
     )
-    return
+    return false
   }
 
   console.log(
     `Successfully set milestone "${milestoneName}" on PR #${prNumber}`,
   )
+  return true
 }
 
 async function main() {
@@ -185,7 +186,14 @@ async function main() {
         `Automatically setting milestone to "${suggestedMilestone}"...`,
     )
 
-    await setMilestone(pullRequest.number, suggestedMilestone)
+    const milestoneSet = await setMilestone(
+      pullRequest.number,
+      suggestedMilestone,
+    )
+
+    if (!milestoneSet) {
+      process.exitCode = 1
+    }
 
     return
   }

--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -9,7 +9,7 @@ on:
 # Cancel in-progress runs of this workflow.
 # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -3,6 +3,8 @@ name: 🚩 Require milestone
 on:
   pull_request:
     types: [opened, synchronize, reopened, milestoned, demilestoned, edited]
+  pull_request_target:
+    types: [opened, synchronize, reopened, milestoned, demilestoned, edited]
 
 # Cancel in-progress runs of this workflow.
 # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
@@ -17,6 +19,14 @@ jobs:
   require-milestone:
     name: 🚩 Require milestone
     runs-on: ubuntu-latest
+    # For same-repo PRs, use the pull_request event so the job runs from the
+    # PR branch (allowing workflow changes to be tested in the same PR).
+    # For fork PRs, use pull_request_target so the job runs from the base
+    # branch with a write-capable token (fork PRs get a read-only token with
+    # pull_request).
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
I was getting this in CI

```
Prepare all required actions
Run ./.github/actions/require-milestone
  with:
    github-token: ***
Run node /home/runner/work/cedar/cedar/./.github/actions/require-milestone/requireMilestone.mjs
  node /home/runner/work/cedar/cedar/./.github/actions/require-milestone/requireMilestone.mjs
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    GITHUB_TOKEN: ***
    GITHUB_EVENT_PATH: /home/runner/work/_temp/_github_workflow/event.json
    GITHUB_REPOSITORY: cedarjs/cedar
PR title "fix(live-queries): remove extra blank line before [experimental.gqlorm] in cedar.toml" matches conventional commit format. Automatically setting milestone to "next-release-patch"...
Failed to set milestone: 403 Forbidden
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/issues/issues#update-an-issue","status":"403"}
```

There are two issues with that:
1. It's not allowed to set the milestone
2. The workflow passes even though no milestone was set

Running on pull_request_target fixes issue 1. Explicit return values and then exitCode 1 fixes issue 2.