### PR TITLE
chore(internal): Regenerate clientPreset test fixtures

### DIFF
--- a/__fixtures__/example-todo-main/web/src/graphql/fragment-masking.ts
+++ b/__fixtures__/example-todo-main/web/src/graphql/fragment-masking.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
-import type { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
-import type { FragmentDefinitionNode } from 'graphql';
-import type { Incremental } from './graphql';
+import { ResultOf, DocumentTypeDecoration, TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { FragmentDefinitionNode } from 'graphql';
+import { Incremental } from './graphql';
 
 
 export type FragmentType<TDocumentType extends DocumentTypeDecoration<any, any>> = TDocumentType extends DocumentTypeDecoration<

--- a/__fixtures__/example-todo-main/web/src/graphql/gql.ts
+++ b/__fixtures__/example-todo-main/web/src/graphql/gql.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import * as types from "./graphql";
-import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+import { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
 
 /**
  * Map of all GraphQL operations in the project.

--- a/__fixtures__/example-todo-main/web/src/graphql/graphql.ts
+++ b/__fixtures__/example-todo-main/web/src/graphql/graphql.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = T | null | undefined;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/packages/internal/src/__tests__/clientPreset.test.ts
+++ b/packages/internal/src/__tests__/clientPreset.test.ts
@@ -23,12 +23,12 @@ vi.mock('@cedarjs/project-config', async (importOriginal) => {
   }
 })
 
-beforeEach(() => {
-  const FIXTURE_PATH = path.resolve(
-    __dirname,
-    '../../../../__fixtures__/example-todo-main',
-  )
+const FIXTURE_PATH = path.resolve(
+  __dirname,
+  '../../../../__fixtures__/example-todo-main',
+)
 
+beforeEach(() => {
   process.env.CEDAR_CWD = FIXTURE_PATH
 })
 

--- a/packages/internal/src/generate/clientPreset.ts
+++ b/packages/internal/src/generate/clientPreset.ts
@@ -17,7 +17,6 @@ export const shouldGenerateTrustedDocuments = (): boolean => {
 }
 
 export const generateClientPreset = async () => {
-  let generatedFiles = []
   let clientPresetFiles = [] as string[]
 
   const errors: { message: string; error: unknown }[] = []
@@ -47,7 +46,7 @@ export const generateClientPreset = async () => {
   }
 
   try {
-    generatedFiles = await generate(config, true)
+    const generatedFiles = await generate(config, true)
 
     clientPresetFiles = generatedFiles.map((f: GeneratedFile) => f.filename)
 


### PR DESCRIPTION
graphql codegen doesn't generate the `type` specifier. 