### PR TITLE
chore(ci): Fix concurrency key for require-milestone

### DIFF
--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -9,7 +9,7 @@ on:
 # Cancel in-progress runs of this workflow.
 # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
PR #1602 didn't quite work the way we wanted. Now the require-milestone job never runs. I think it's cancling itself...

For example, on PR 1606 I get this:

Canceling since a higher priority waiting request for 🚩 Require milestone-1606 exists
Canceling since a higher priority waiting request for 🚩 Require milestone-1606 exists

The problem is that this "higher priority waiting request" is skipped.

---

AI analysis

**The problem:** Both `pull_request` and `pull_request_target` events fire simultaneously whenever a PR is opened/updated. They shared the same concurrency group, so they'd race:

1. Run A starts (e.g. `pull_request_target`)
2. Run B queues as "waiting" (e.g. `pull_request`)
3. Run A is cancelled — *"higher priority waiting request exists"*
4. Run B starts, but its `if` condition is `false` (wrong event for this PR type) → **skipped**
5. Nothing ran. The second "Canceling" message comes from the same thing happening again on the next event.

**The fix:** By adding `${{ github.event_name }}` to the concurrency group key, the two event types now have separate groups:
- `🚩 Require milestone-pull_request-1606`
- `🚩 Require milestone-pull_request_target-1606`

They no longer cancel each other. Each event type only cancels its own previous run (the intended behavior), and whichever event's `if` condition is `true` for that PR will run uninterrupted.