### PR TITLE
chore(prettier): Re-enable prettier-plugin-sh

### DIFF
--- a/docs/implementation-plans/pglite-database-support-plan.md
+++ b/docs/implementation-plans/pglite-database-support-plan.md
@@ -108,8 +108,8 @@ include this. Instead, the generated app relies on Cedar's standard Prisma
 workflow:
 
 ```bash
-yarn cedar prisma migrate dev    # Create and apply migrations
-yarn cedar prisma db push        # Push schema changes without migration files
+yarn cedar prisma migrate dev # Create and apply migrations
+yarn cedar prisma db push     # Push schema changes without migration files
 ```
 
 Because PGlite's socket server looks like a real PostgreSQL server, Prisma's

--- a/packages/cli/src/commands/setup/docker/templates/Dockerfile
+++ b/packages/cli/src/commands/setup/docker/templates/Dockerfile
@@ -99,7 +99,7 @@ ENV NODE_ENV=production
 # This is important if you intend to configure GraphQL to use Realtime.
 #
 # CMD [ "./api/dist/server.js" ]
-CMD [ "node_modules/.bin/cedarjs-server", "api" ]
+CMD ["node_modules/.bin/cedarjs-server", "api"]
 
 # web serve
 # ---------

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -18,9 +18,7 @@ const config = {
   singleQuote: true,
   plugins: [
     'prettier-plugin-curly',
-    // See here for why this is commented out
-    // https://github.com/cedarjs/cedar/issues/964
-    // 'prettier-plugin-sh',
+    'prettier-plugin-sh',
     'prettier-plugin-packagejson',
   ],
   overrides: [


### PR DESCRIPTION
Closes #964

I disabled the plugin because it would randomly cause a panic and crash prettier. An update was recently released that should fix that issue, so I'm enabling the plugin again