### PR TITLE
fix(api-server): use pathToFileURL instead of file:// string interpolation

### DIFF
--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
-import path from 'path'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 // See https://github.com/webdiscus/ansis#troubleshooting
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -140,7 +141,7 @@ export async function createServer(options: CreateServerOptions = {}) {
     // This comes from a babel plugin that's applied to
     // api/dist/functions/graphql.{ts,js} in user projects
     const { __rw_graphqlOptions } = await import(
-      `file://${graphqlFunctionPath}`
+      pathToFileURL(graphqlFunctionPath).href
     )
 
     await server.register(redwoodFastifyGraphQLServer, {

--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from 'node:url'
+
 import fastifyMultiPart from '@fastify/multipart'
 import fastifyUrlData from '@fastify/url-data'
 import fg from 'fast-glob'
@@ -47,7 +49,7 @@ export async function redwoodFastifyGraphQLServer(
         cwd: getPaths().api.base,
         absolute: true,
       })
-      const filePath = `file://${graphqlFunctionPath}`
+      const filePath = pathToFileURL(graphqlFunctionPath).href
 
       // This comes from a babel plugin that's applied to
       // api/dist/functions/graphql.{ts,js} in user projects

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -1,4 +1,5 @@
-import path from 'path'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 // See https://github.com/webdiscus/ansis#troubleshooting
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -31,7 +32,7 @@ export const setLambdaFunctions = async (foundFunctions: string[]) => {
     const ts = Date.now()
     const routeName = path.basename(fnPath).replace('.js', '')
 
-    const fnImport = await import(`file://${fnPath}`)
+    const fnImport = await import(pathToFileURL(fnPath).href)
     const handler: Handler = (() => {
       if ('handler' in fnImport) {
         // ESModule export of handler - when using


### PR DESCRIPTION
Fixes the following warning when running unit tests

```
❯ yarn workspace @cedarjs/api-server test

 RUN  v3.2.4 /Users/tobbe/dev/cedarjs/cedar/packages/api-server

11:25:19 AM [vite] (ssr) warning: File URL host must be "localhost" or empty on darwin
  Plugin: vite:dynamic-import-vars
  File: /Users/tobbe/dev/cedarjs/cedar/packages/api-server/src/plugins/lambdaLoader.ts
 ```