### PR TITLE
chore(api-server): use terminalLink for route names in lambdaLoader output

### DIFF
--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -131,6 +131,7 @@
     "pretty-bytes": "5.6.0",
     "pretty-ms": "7.0.1",
     "split2": "4.2.0",
+    "termi-link": "1.1.0",
     "yargs": "17.7.2"
   },
   "devDependencies": {

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -13,6 +13,7 @@ import type {
   FastifyRequest,
   RequestGenericInterface,
 } from 'fastify'
+import { terminalLink } from 'termi-link'
 
 import type {
   CedarHandler,
@@ -131,9 +132,8 @@ export const setLambdaFunctions = async (foundFunctions: string[]) => {
       entry: fnPath,
     })
 
-    // TODO: Use terminal link.
     console.log(
-      ansis.magenta('/' + routeName),
+      terminalLink(ansis.magenta('/' + routeName), pathToFileURL(fnPath).href),
       ansis.dim.italic(Date.now() - ts + ' ms'),
     )
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,6 +2185,7 @@ __metadata:
     pretty-bytes: "npm:5.6.0"
     pretty-ms: "npm:7.0.1"
     split2: "npm:4.2.0"
+    termi-link: "npm:1.1.0"
     tsx: "npm:4.21.0"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.4"


### PR DESCRIPTION
Closes #1638

Wraps the route name logged at dev-server startup in a `terminalLink` hyperlink pointing to the lambda source file (`file://` URL), so developers can cmd-click to open it directly in supporting terminals (iTerm2, Warp, Windows Terminal). Falls back to plain text elsewhere.

**Changes:**
- `packages/api-server/src/plugins/lambdaLoader.ts` — import `terminalLink` and wrap the route name
- `packages/api-server/package.json` — add `termi-link: 1.1.0` dependency (matches version used across the monorepo)
- `yarn.lock` — updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)