### PR TITLE
fix: add request field to CedarGraphQLContext type

### DIFF
--- a/packages/graphql-server/src/types.ts
+++ b/packages/graphql-server/src/types.ts
@@ -77,6 +77,7 @@ export interface CedarGraphQLContext {
   event: APIGatewayProxyEvent
   requestContext?: LambdaContext | undefined
   currentUser?: ThenArg<ReturnType<GetCurrentUser>> | AuthContextPayload | null
+  request?: Request
 
   [index: string]: unknown
 }


### PR DESCRIPTION
Addresses the Greptile review comment on #1621.

Adds `request?: Request` to `CedarGraphQLContext` in `packages/graphql-server/src/types.ts` so that `args.contextValue.request` is properly typed rather than falling through the `[index: string]: unknown` index signature. Without this, TypeScript's `strict` mode would reject the optional chaining on `unknown` in `useRedwoodLogger.ts`.