### PR TITLE
feat(api): expose protocol and host on lambda fastify requests

### DIFF
--- a/packages/api-server/src/__tests__/requestHandlers/awsLambdaFastify.test.ts
+++ b/packages/api-server/src/__tests__/requestHandlers/awsLambdaFastify.test.ts
@@ -2,7 +2,10 @@ import type { Handler } from 'aws-lambda'
 import type { FastifyRequest, FastifyReply } from 'fastify'
 import { vi, describe, beforeEach, test, expect, afterEach } from 'vitest'
 
-import { requestHandler } from '../../requestHandlers/awsLambdaFastify.js'
+import {
+  lambdaEventForFastifyRequest,
+  requestHandler,
+} from '../../requestHandlers/awsLambdaFastify.js'
 
 describe('Tests AWS Lambda to Fastify request transformation and handling', () => {
   beforeEach(() => {
@@ -170,5 +173,39 @@ describe('Tests AWS Lambda to Fastify request transformation and handling', () =
       'content-type',
       'application/json; text/html',
     )
+  })
+})
+
+describe('lambdaEventForFastifyRequest', () => {
+  const baseRequest = {
+    method: 'GET',
+    headers: {},
+    url: '/',
+    urlData: () => ({ path: '/' }),
+    ip: '127.0.0.1',
+    id: 'req-1',
+    hostname: 'localhost',
+    rawBody: '',
+  } as unknown as FastifyRequest
+
+  test('sets x-forwarded-proto from request.protocol when header is absent', () => {
+    const req = {
+      ...baseRequest,
+      protocol: 'https',
+    } as unknown as FastifyRequest
+
+    const event = lambdaEventForFastifyRequest(req)
+    expect(event.headers?.['x-forwarded-proto']).toBe('https')
+  })
+
+  test('preserves x-forwarded-proto from upstream headers over request.protocol', () => {
+    const req = {
+      ...baseRequest,
+      headers: { 'x-forwarded-proto': 'https' },
+      protocol: 'http',
+    } as unknown as FastifyRequest
+
+    const event = lambdaEventForFastifyRequest(req)
+    expect(event.headers?.['x-forwarded-proto']).toBe('https')
   })
 })

--- a/packages/api-server/src/requestHandlers/awsLambdaFastify.ts
+++ b/packages/api-server/src/requestHandlers/awsLambdaFastify.ts
@@ -33,6 +33,8 @@ export const lambdaEventForFastifyRequest = (
       identity: {
         sourceIp: request.ip,
       },
+      domainName: request.hostname,
+      protocol: request.protocol,
     },
     ...parseBody(request.rawBody || ''), // adds `body` and `isBase64Encoded`
   } as APIGatewayProxyEvent

--- a/packages/api-server/src/requestHandlers/awsLambdaFastify.ts
+++ b/packages/api-server/src/requestHandlers/awsLambdaFastify.ts
@@ -3,6 +3,7 @@ import type {
   APIGatewayProxyEvent,
   Handler,
   APIGatewayProxyEventQueryStringParameters,
+  APIGatewayProxyEventHeaders,
 } from 'aws-lambda'
 import type { FastifyRequest, FastifyReply } from 'fastify'
 import { parse } from 'picoquery'
@@ -25,7 +26,10 @@ export const lambdaEventForFastifyRequest = (
 
   return {
     httpMethod: request.method,
-    headers: request.headers,
+    headers: {
+      'x-forwarded-proto': request.protocol,
+      ...request.headers,
+    } as unknown as APIGatewayProxyEventHeaders,
     path: request.urlData('path'),
     queryStringParameters: qsParams,
     requestContext: {
@@ -34,7 +38,6 @@ export const lambdaEventForFastifyRequest = (
         sourceIp: request.ip,
       },
       domainName: request.hostname,
-      protocol: request.protocol,
     },
     ...parseBody(request.rawBody || ''), // adds `body` and `isBase64Encoded`
   } as APIGatewayProxyEvent


### PR DESCRIPTION
We have a use case where we need to re-construct a url in our lambda handler based on the event.

In a typical lambda handler, these properties are expected to be there, but cedar appears to not be mapping all required properties from the fastify request. We just need these ones, but worth considering if we should be trying to map more. This is the expected type from aws lambda:

```ts
export interface APIGatewayProxyEventBase<TAuthorizerContext> {
    body: string | null;
    headers: APIGatewayProxyEventHeaders;
    multiValueHeaders: APIGatewayProxyEventMultiValueHeaders;
    httpMethod: string;
    isBase64Encoded: boolean;
    path: string;
    pathParameters: APIGatewayProxyEventPathParameters | null;
    queryStringParameters: APIGatewayProxyEventQueryStringParameters | null;
    multiValueQueryStringParameters: APIGatewayProxyEventMultiValueQueryStringParameters | null;
    stageVariables: APIGatewayProxyEventStageVariables | null;
    requestContext: APIGatewayEventRequestContextWithAuthorizer<TAuthorizerContext>;
    resource: string;
}

export interface APIGatewayEventRequestContextWithAuthorizer<TAuthorizerContext> {
    accountId: string;
    apiId: string;
    authorizer: TAuthorizerContext;
    connectedAt?: number | undefined;
    connectionId?: string | undefined;
    domainName?: string | undefined;
    domainPrefix?: string | undefined;
    eventType?: string | undefined;
    extendedRequestId?: string | undefined;
    protocol: string;
    httpMethod: string;
    identity: APIGatewayEventIdentity;
    messageDirection?: string | undefined;
    messageId?: string | null | undefined;
    path: string;
    stage: string;
    requestId: string;
    requestTime?: string | undefined;
    requestTimeEpoch: number;
    resourceId: string;
    resourcePath: string;
    routeKey?: string | undefined;
}
```