### PR TITLE
chore(gitignore): .nx/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ packages/create-cedar-app/create-cedar-app.tgz
 **/meta.json
 **/meta.*.json
 
-.nx/cache
-.nx/workspace-data
+.nx/*
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md


### PR DESCRIPTION
This is a long-shot trying to fix the CI failure here https://github.com/cedarjs/cedar/actions/runs/24747237072/job/72404815946?pr=1654 for PR #1654 

<img width="585" height="316" alt="image" src="https://github.com/user-attachments/assets/88407cf9-590c-401e-8520-354c8cc2716b" />

The `terminalOutput` files comes from NX. But I'm honestly not sure how it ends up at the repo root.
The "fix" in this PR wouldn't target the file if it's in the root of the repo. So it does seem unrelated. 
But on the other hand, the CI failure on the original PR happened twice before this "fix", and not after rebasing ontop of this PR change. So, maybe it did help anyway? 🤷 