### PR TITLE
fix(codegen): guard gqlorm generation behind experimental.gqlorm.enabled flag

### DIFF
--- a/packages/internal/src/generate/gqlormSchema.ts
+++ b/packages/internal/src/generate/gqlormSchema.ts
@@ -923,6 +923,23 @@ export async function generateGqlormArtifacts(): Promise<{
   files: string[]
   errors: { message: string; error: unknown }[]
 }> {
+  if (!getConfig().experimental?.gqlorm?.enabled) {
+    // Clean up any stale files left over from when gqlorm was previously
+    // enabled, so that disabling the flag removes all generated artifacts.
+    const generatedBase = getPaths().generated.base
+    const staleFiles = [
+      path.join(generatedBase, 'gqlorm', 'backend.ts'),
+      path.join(generatedBase, 'gqlorm-schema.json'),
+      path.join(generatedBase, 'types', 'includes', 'web-gqlorm-models.d.ts'),
+    ]
+    for (const staleFile of staleFiles) {
+      if (fs.existsSync(staleFile)) {
+        fs.unlinkSync(staleFile)
+      }
+    }
+    return { files: [], errors: [] }
+  }
+
   const files: string[] = []
   const errors: { message: string; error: unknown }[] = []
 
@@ -968,68 +985,61 @@ export async function generateGqlormArtifacts(): Promise<{
     const backendOutputDir = path.join(generatedBase, 'gqlorm')
     const backendOutputPath = path.join(backendOutputDir, 'backend.ts')
 
-    if (getConfig().experimental?.gqlorm?.enabled) {
-      const graphqlDir = paths.api.graphql
-      const existingTypes = getExistingSdlTypeNames(graphqlDir)
-      const allModels = buildBackendModelInfo(dmmf)
+    const graphqlDir = paths.api.graphql
+    const existingTypes = getExistingSdlTypeNames(graphqlDir)
+    const allModels = buildBackendModelInfo(dmmf)
 
-      const gqlormConfig = getConfig().experimental.gqlorm
-      const membershipModel: string =
-        gqlormConfig.membershipModel ?? 'Membership'
-      const membershipModelCamel =
-        membershipModel.charAt(0).toLowerCase() + membershipModel.slice(1)
-      const membershipUserField: string =
-        gqlormConfig.membershipUserField ?? 'userId'
-      const membershipOrganizationField: string =
-        gqlormConfig.membershipOrganizationField ?? 'organizationId'
+    const gqlormConfig = getConfig().experimental.gqlorm
+    const membershipModel: string = gqlormConfig.membershipModel ?? 'Membership'
+    const membershipModelCamel =
+      membershipModel.charAt(0).toLowerCase() + membershipModel.slice(1)
+    const membershipUserField: string =
+      gqlormConfig.membershipUserField ?? 'userId'
+    const membershipOrganizationField: string =
+      gqlormConfig.membershipOrganizationField ?? 'organizationId'
 
-      // Check if membership model exists in the DMMF (not just gqlorm-visible models)
-      const membershipModelExists = dmmf.datamodel.models.some(
-        (m) => m.name === membershipModel,
+    // Check if membership model exists in the DMMF (not just gqlorm-visible models)
+    const membershipModelExists = dmmf.datamodel.models.some(
+      (m) => m.name === membershipModel,
+    )
+
+    const backendConfig: GqlormBackendConfig = {
+      membershipModel,
+      membershipModelCamel,
+      membershipUserField,
+      membershipOrganizationField,
+      membershipModelExists,
+    }
+
+    // Filter out models whose type name already exists in user-authored SDLs
+    const gqlormModels = allModels.filter(
+      (m) => !existingTypes.has(m.modelName),
+    )
+
+    // Warn when org scoping can't be applied because the membership model is missing
+    const anyModelHasOrgField = gqlormModels.some((m) =>
+      m.fields.some((f) => f.name === membershipOrganizationField),
+    )
+    if (anyModelHasOrgField && !membershipModelExists) {
+      console.warn(
+        `[gqlorm] One or more models have a \`${membershipOrganizationField}\` field, ` +
+          `but the membership model "${membershipModel}" was not found in the schema. ` +
+          `Organization-based access scoping will not be applied for these models. ` +
+          `Add a \`${membershipModel}\` model to your schema.prisma or configure ` +
+          `\`experimental.gqlorm.membershipModel\` in cedar.toml.`,
       )
+    }
 
-      const backendConfig: GqlormBackendConfig = {
-        membershipModel,
-        membershipModelCamel,
-        membershipUserField,
-        membershipOrganizationField,
-        membershipModelExists,
-      }
-
-      // Filter out models whose type name already exists in user-authored SDLs
-      const gqlormModels = allModels.filter(
-        (m) => !existingTypes.has(m.modelName),
+    if (gqlormModels.length > 0) {
+      const backendContent = generateGqlormBackendContent(
+        gqlormModels,
+        backendConfig,
       )
-
-      // Warn when org scoping can't be applied because the membership model is missing
-      const anyModelHasOrgField = gqlormModels.some((m) =>
-        m.fields.some((f) => f.name === membershipOrganizationField),
-      )
-      if (anyModelHasOrgField && !membershipModelExists) {
-        console.warn(
-          `[gqlorm] One or more models have a \`${membershipOrganizationField}\` field, ` +
-            `but the membership model "${membershipModel}" was not found in the schema. ` +
-            `Organization-based access scoping will not be applied for these models. ` +
-            `Add a \`${membershipModel}\` model to your schema.prisma or configure ` +
-            `\`experimental.gqlorm.membershipModel\` in cedar.toml.`,
-        )
-      }
-
-      if (gqlormModels.length > 0) {
-        const backendContent = generateGqlormBackendContent(
-          gqlormModels,
-          backendConfig,
-        )
-        fs.mkdirSync(backendOutputDir, { recursive: true })
-        fs.writeFileSync(backendOutputPath, backendContent)
-        files.push(backendOutputPath)
-      } else {
-        // No models to generate — clean up stale file if it exists
-        if (fs.existsSync(backendOutputPath)) {
-          fs.unlinkSync(backendOutputPath)
-        }
-      }
+      fs.mkdirSync(backendOutputDir, { recursive: true })
+      fs.writeFileSync(backendOutputPath, backendContent)
+      files.push(backendOutputPath)
     } else {
+      // No models to generate — clean up stale file if it exists
       if (fs.existsSync(backendOutputPath)) {
         fs.unlinkSync(backendOutputPath)
       }


### PR DESCRIPTION
## Problem

`[gqlorm]` log messages were appearing during `yarn dev` and code generation in every Cedar app, even those that haven't enabled gqlorm:

```
[gqlorm] User.hashedPassword was automatically hidden because its name appears sensitive.
[gqlorm] User.salt was automatically hidden because its name appears sensitive.
```

`generateGqlormArtifacts()` was called unconditionally. The `experimental.gqlorm.enabled` config check only gated writing `backend.ts` — the schema-building step (which emits the warnings) always ran regardless.

## Fix

Guard gqlorm artifact generation at every call site and inside the function itself:

- **`generate.ts`** — only calls `generateGqlormArtifacts()` when `experimental.gqlorm.enabled` is set
- **`watch.ts`** — same guard on the Prisma schema file watcher path
- **`gqlormSchema.ts`** — early return at the top of `generateGqlormArtifacts()` as belt-and-suspenders; also cleans up any stale `backend.ts` if the flag is turned off after having been enabled

Apps without `experimental.gqlorm.enabled = true` in `cedar.toml` will no longer see any gqlorm output.

Closes #1675