### PR TITLE
chore(ci): Revert adding Renovate postUpgradeTasks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,14 +12,6 @@
     "**/*/__fixtures__/**"
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],
-  "postUpgradeTasks": {
-    "commands": [
-      "yarn rebuild-test-project-fixture",
-      "yarn rebuild-test-project-fixture-esm"
-    ],
-    "fileFilters": ["__fixtures__/**"],
-    "executionMode": "branch"
-  },
   "prConcurrentLimit": 8,
   "rebaseWhen": "conflicted",
   "packageRules": [


### PR DESCRIPTION
This feature is only available if you self-host renovate
https://github.com/renovatebot/renovate/discussions/16555

This reverts https://github.com/cedarjs/cedar/pull/1647