### PR TITLE
fix(realtime): Add better realtime support to prerender

### DIFF
--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -4,7 +4,6 @@ import fastifyMultiPart from '@fastify/multipart'
 import fastifyUrlData from '@fastify/url-data'
 import fg from 'fast-glob'
 import type { FastifyInstance, FastifyRequest, HTTPMethods } from 'fastify'
-import type { Plugin as YogaPlugin } from 'graphql-yoga'
 
 import { buildCedarContext } from '@cedarjs/api/runtime'
 import type { GlobalContext } from '@cedarjs/context'
@@ -68,31 +67,12 @@ export async function redwoodFastifyGraphQLServer(
 
     const graphqlOptions = redwoodOptions.graphql
 
-    // Here we can add any plugins that we want to use with GraphQL Yoga Server
-    // that we do not want to add the the GraphQLHandler in the graphql-server
-    // graphql function.
-    //
-    // These would be plugins that need a server instance such as Cedar Realtime
-    if (graphqlOptions?.realtime) {
-      const { useCedarRealtime } = await import('@cedarjs/realtime')
-
-      const originalExtraPlugins = graphqlOptions.extraPlugins ?? []
-      originalExtraPlugins.push(
-        // This type cast is needed because useCedarRealtime returns an
-        // EnvelopPlugin and here we need a YogaPlugin. I can't change the
-        // return type of `useCedarRealtime` yet, because it'd be a breaking
-        // change.
-        useCedarRealtime(graphqlOptions.realtime) as YogaPlugin,
-      )
-      graphqlOptions.extraPlugins = originalExtraPlugins
-
-      // uses for SSE single connection mode with the `/graphql/stream` endpoint
-      if (graphqlOptions.realtime.subscriptions) {
-        method.push('PUT')
-      }
+    // Used for SSE single connection mode with the `/graphql/stream` endpoint
+    if (graphqlOptions?.realtime?.subscriptions) {
+      method.push('PUT')
     }
 
-    const { yoga } = createGraphQLYoga(graphqlOptions)
+    const { yoga } = await createGraphQLYoga(graphqlOptions)
 
     const graphqlEndpoint = trimSlashes(yoga.graphqlEndpoint)
 

--- a/packages/graphql-server/src/__tests__/createGraphQLYoga.test.ts
+++ b/packages/graphql-server/src/__tests__/createGraphQLYoga.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { vi, describe, expect, it } from 'vitest'
 
 import { createLogger } from '@cedarjs/api/logger'
 
 import { createGraphQLYoga } from '../createGraphQLYoga.js'
+
+vi.mock('@cedarjs/realtime', () => ({
+  useCedarRealtime: vi.fn(() => ({ name: 'useCedarRealtime' })),
+}))
 
 describe('createGraphQLYoga smoke-test', () => {
   it('Should only require required parameters', async () => {
@@ -12,6 +16,21 @@ describe('createGraphQLYoga smoke-test', () => {
       services: {},
     })
 
+    expect(logger).toBeTruthy()
+    expect(yoga).toBeTruthy()
+  })
+
+  it('should load the cedar realtime plugin when realtime options are given', async () => {
+    const { useCedarRealtime } = await import('@cedarjs/realtime')
+
+    const { logger, yoga } = await createGraphQLYoga({
+      loggerConfig: { logger: createLogger({}) },
+      sdls: {},
+      services: {},
+      realtime: { subscriptions: {} as any },
+    })
+
+    expect(useCedarRealtime).toHaveBeenCalledWith({ subscriptions: {} })
     expect(logger).toBeTruthy()
     expect(yoga).toBeTruthy()
   })

--- a/packages/graphql-server/src/__tests__/createGraphQLYoga.test.ts
+++ b/packages/graphql-server/src/__tests__/createGraphQLYoga.test.ts
@@ -5,8 +5,8 @@ import { createLogger } from '@cedarjs/api/logger'
 import { createGraphQLYoga } from '../createGraphQLYoga.js'
 
 describe('createGraphQLYoga smoke-test', () => {
-  it('Should only require required parameters', () => {
-    const { logger, yoga } = createGraphQLYoga({
+  it('Should only require required parameters', async () => {
+    const { logger, yoga } = await createGraphQLYoga({
       loggerConfig: { logger: createLogger({}) },
       sdls: {},
       services: {},

--- a/packages/graphql-server/src/createGraphQLYoga.ts
+++ b/packages/graphql-server/src/createGraphQLYoga.ts
@@ -1,10 +1,10 @@
 import { useDisableIntrospection } from '@envelop/disable-introspection'
 import { useFilterAllowedOperations } from '@envelop/filter-operation-type'
 import type { FastifyReply, FastifyRequest } from 'fastify'
-import type { GraphQLSchema } from 'graphql'
 import { OperationTypeNode } from 'graphql'
-import type { Plugin } from 'graphql-yoga'
+import type { GraphQLSchema } from 'graphql'
 import { useReadinessCheck, createYoga } from 'graphql-yoga'
+import type { Plugin } from 'graphql-yoga'
 
 import { mapRwCorsOptionsToYoga } from './cors.js'
 import { makeDirectivesForPlugin } from './directives/makeDirectives.js'
@@ -30,7 +30,7 @@ import { makeSubscriptions } from './subscriptions/makeSubscriptions.js'
 import type { RedwoodSubscription } from './subscriptions/makeSubscriptions.js'
 import type { GraphQLYogaOptions, CedarGraphQLContext } from './types.js'
 
-export const createGraphQLYoga = ({
+export const createGraphQLYoga = async ({
   healthCheckId = 'yoga',
   loggerConfig,
   context,
@@ -105,6 +105,14 @@ export const createGraphQLYoga = ({
     // Important: Plugins are executed in order of their usage, and inject functionality serially,
     // so the order here matters
     const plugins: Plugin<any>[] = []
+
+    if (realtime) {
+      // Add Cedar Realtime plugin for live queries and subscriptions support
+      // This registers the @live directive on the schema and handles live query
+      // execution
+      const { useCedarRealtime } = await import('@cedarjs/realtime')
+      plugins.push(useCedarRealtime(realtime))
+    }
 
     const { disableIntrospection } = configureGraphQLIntrospection({
       allowIntrospection,

--- a/packages/graphql-server/src/functions/__tests__/graphqlHandler.test.ts
+++ b/packages/graphql-server/src/functions/__tests__/graphqlHandler.test.ts
@@ -1,0 +1,66 @@
+import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
+import { vi, describe, expect, it } from 'vitest'
+
+import { createLogger } from '@cedarjs/api/logger'
+
+import * as yogaFactoryModule from '../../createGraphQLYoga.js'
+import { createGraphQLHandler } from '../../functions/graphql.js'
+
+interface MockLambdaParams {
+  headers?: { [key: string]: string }
+  body?: string | null
+  httpMethod: string
+  [key: string]: any
+}
+
+const mockLambdaEvent = ({
+  headers,
+  body = null,
+  httpMethod,
+  ...others
+}: MockLambdaParams): APIGatewayProxyEvent => {
+  return {
+    headers: headers || {},
+    body,
+    httpMethod,
+    multiValueQueryStringParameters: null,
+    isBase64Encoded: false,
+    multiValueHeaders: {},
+    path: '/graphql',
+    pathParameters: null,
+    stageVariables: null,
+    queryStringParameters: null,
+    requestContext: null as any,
+    resource: null as any,
+    ...others,
+  }
+}
+
+describe('createGraphQLHandler caching', () => {
+  it('only initializes yoga once across multiple invocations', async () => {
+    const createGraphQLYoga = vi.spyOn(yogaFactoryModule, 'createGraphQLYoga')
+
+    const handler = createGraphQLHandler({
+      loggerConfig: { logger: createLogger({}), options: {} },
+      sdls: {},
+      directives: {},
+      services: {},
+      onException: () => {},
+    })
+
+    const mockedEvent = mockLambdaEvent({
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      path: '/graphql',
+      httpMethod: 'GET',
+    })
+
+    // Even when calling the handler twice createGraphQLYoga() should only be
+    // called once
+    await handler(mockedEvent, {} as Context)
+    await handler(mockedEvent, {} as Context)
+
+    expect(createGraphQLYoga).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -85,10 +85,13 @@ export const createGraphQLHandler = ({
   defaultError = 'Something went wrong.',
   graphiQLEndpoint = '/graphql',
   schemaOptions,
+  realtime,
   openTelemetryOptions,
   trustedDocuments,
 }: GraphQLHandlerOptions) => {
-  const { yoga, logger } = createGraphQLYoga({
+  // Eager initialization of GraphQL Yoga
+  // Starts immediately (non-blocking because createGraphQLYoga is async)
+  const yogaAndLoggerPromise = createGraphQLYoga({
     healthCheckId,
     loggerConfig,
     context,
@@ -108,6 +111,7 @@ export const createGraphQLHandler = ({
     defaultError,
     graphiQLEndpoint,
     schemaOptions,
+    realtime,
     openTelemetryOptions,
     trustedDocuments,
   })
@@ -118,6 +122,8 @@ export const createGraphQLHandler = ({
   ): Promise<APIGatewayProxyResult> => {
     // In the future, this could be part of a specific handler for AWS lambdas
     requestContext.callbackWaitsForEmptyEventLoop = false
+
+    const { yoga, logger } = await yogaAndLoggerPromise
 
     let lambdaResponse: APIGatewayProxyResult
     try {

--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -89,8 +89,9 @@ export const createGraphQLHandler = ({
   openTelemetryOptions,
   trustedDocuments,
 }: GraphQLHandlerOptions) => {
-  // Eager initialization of GraphQL Yoga
-  // Starts immediately (non-blocking because createGraphQLYoga is async)
+  // Eager initialization of GraphQL Yoga. It starts immediately when the
+  // handler is first created and is awaited on each request. Initialization is
+  // shared across all Lambda invocations within the same process lifecycle.
   const yogaAndLoggerPromise = createGraphQLYoga({
     healthCheckId,
     loggerConfig,

--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -60,6 +60,7 @@ export async function rscBuildAnalyze() {
         'better-sqlite3',
         '@cedarjs/auth-dbauth-api',
         '@cedarjs/cookie-jar',
+        '@cedarjs/realtime',
         '@cedarjs/server-store',
         '@simplewebauthn/server',
         'graphql-scalars',
@@ -89,6 +90,7 @@ export async function rscBuildAnalyze() {
       ssr: true,
       rollupOptions: {
         onwarn: onWarn,
+        external: ['@cedarjs/realtime'],
         input: getEntries(),
       },
     },

--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -64,6 +64,7 @@ export async function rscBuildForServer(
         'better-sqlite3',
         '@cedarjs/auth-dbauth-api',
         '@cedarjs/cookie-jar',
+        '@cedarjs/realtime',
         '@cedarjs/server-store',
         '@simplewebauthn/server',
         'graphql-scalars',
@@ -109,6 +110,7 @@ export async function rscBuildForServer(
       manifest: 'server-build-manifest.json',
       rollupOptions: {
         onwarn: onWarn,
+        external: ['@cedarjs/realtime'],
         input: {
           ...entryFiles,
           ...clientEntryFiles,

--- a/packages/vite/src/rsc/rscBuildForSsr.ts
+++ b/packages/vite/src/rsc/rscBuildForSsr.ts
@@ -55,6 +55,7 @@ export async function rscBuildForSsr({
         'better-sqlite3',
         '@cedarjs/auth-dbauth-api',
         '@cedarjs/cookie-jar',
+        '@cedarjs/realtime',
         '@cedarjs/server-store',
         '@simplewebauthn/server',
         'graphql-scalars',
@@ -83,6 +84,7 @@ export async function rscBuildForSsr({
       emptyOutDir: true, // Needed because `outDir` is not inside `root`
       rollupOptions: {
         onwarn: onWarn,
+        external: ['@cedarjs/realtime'],
         input: {
           // @MARK: temporary hack to find the entry client so we can get the
           // index.css bundle but we don't actually want this on an rsc page!


### PR DESCRIPTION
Add better (but not full) realtime support to prerender and any other codepath that don't load a full Fastify server. And by "not full", I mean that you for example can't use `@live` queries (yet). They still error, but they do get further