### PR TITLE
feat(cli): API proxy path defaults to .api/functions

### DIFF
--- a/__fixtures__/empty-project/README.md
+++ b/__fixtures__/empty-project/README.md
@@ -24,4 +24,6 @@ yarn install
 yarn cedar dev
 ```
 
-Your browser should open automatically to `http://localhost:8910` to see the web app. Lambda functions run on `http://localhost:8911` and are also proxied to `http://localhost:8910/.cedar/functions/*`.
+Your browser should open automatically to `http://localhost:8910` to see the web
+app. Lambda functions run on `http://localhost:8911` and are also proxied to
+`http://localhost:8910/.api/functions/*`.

--- a/__fixtures__/empty-project/redwood.toml
+++ b/__fixtures__/empty-project/redwood.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # you can customise graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://cedarjs.com/docs/environment-variables#web
 [api]
   port = 8911

--- a/__fixtures__/rsc-caching/redwood.toml
+++ b/__fixtures__/rsc-caching/redwood.toml
@@ -8,7 +8,7 @@
 [web]
 title = "Cedar App"
 port = 8910
-apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
 includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/__fixtures__/test-project-esm/cedar.toml
+++ b/__fixtures__/test-project-esm/cedar.toml
@@ -11,7 +11,7 @@
 [web]
   title = "Cedar App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions"
+  apiUrl = "/.api/functions"
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/__fixtures__/test-project-live/cedar.toml
+++ b/__fixtures__/test-project-live/cedar.toml
@@ -11,7 +11,7 @@
 [web]
   title = "Cedar App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions"
+  apiUrl = "/.api/functions"
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/__fixtures__/test-project-rsa/redwood.toml
+++ b/__fixtures__/test-project-rsa/redwood.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/__fixtures__/test-project-rsc-kitchen-sink/redwood.toml
+++ b/__fixtures__/test-project-rsc-kitchen-sink/redwood.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/__fixtures__/test-project/cedar.toml
+++ b/__fixtures__/test-project/cedar.toml
@@ -11,7 +11,7 @@
 [web]
   title = "Cedar App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions"
+  apiUrl = "/.api/functions"
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/docs/docs/app-configuration-cedar-toml.md
+++ b/docs/docs/app-configuration-cedar-toml.md
@@ -43,7 +43,7 @@ For certain options, instead of having to configure build tools directly, there'
 
 ### Customizing the GraphQL Endpoint
 
-By default, Cedar derives the GraphQL endpoint from `apiUrl` such that it's `${apiUrl}/graphql`, (with the default `apiUrl`, `./redwood/functions/graphql`).
+By default, Cedar derives the GraphQL endpoint from `apiUrl` such that it's `${apiUrl}/graphql`, (with the default `apiUrl`, `./api/functions/graphql`).
 But sometimes you want to host your api side somewhere else.
 There's two ways you can do this:
 

--- a/docs/docs/app-configuration-cedar-toml.md
+++ b/docs/docs/app-configuration-cedar-toml.md
@@ -12,7 +12,7 @@ default, `cedar.toml` lists the following configuration options:
 [web]
   title = "Cedar App"
   port = 8910
-  apiUrl = "/.redwood/functions"
+  apiUrl = "/.api/functions"
   includeEnvironmentVariables = []
 [api]
   port = 8911
@@ -33,7 +33,7 @@ For certain options, instead of having to configure build tools directly, there'
 | :---------------------------- | :-------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------- |
 | `title`                       | Title of your Cedar app                                                                                         | `'Cedar App'`                                                   |
 | `port`                        | Port for the web server to listen at                                                                            | `8910`                                                          |
-| `apiUrl`                      | URL to your api server. This can be a relative URL in which case it acts like a proxy, or a fully-qualified URL | `'/.redwood/functions'`                                         |
+| `apiUrl`                      | URL to your api server. This can be a relative URL in which case it acts like a proxy, or a fully-qualified URL | `'/.api/functions'`                                             |
 | `includeEnvironmentVariables` | Environment variables made available to the web side during dev and build                                       | `[]`                                                            |
 | `host`                        | Hostname for the web server to listen at                                                                        | Defaults to `'0.0.0.0'` in production and `'::'` in development |
 | `apiGraphQLUrl`               | URL to your GraphQL function                                                                                    | `'${apiUrl}/graphql'`                                           |
@@ -60,7 +60,7 @@ Now the GraphQL endpoint is at `https://api.coolcedarapp.com/graphql`.
 
 ```diff title="cedar.toml"
  [web]
-   apiUrl = "/.redwood/functions"
+   apiUrl = "/.api/functions"
 +  apiGraphQLUrl = "https://api.coolcedarapp.com/graphql"
 ```
 
@@ -72,7 +72,7 @@ your `cedar.toml`:
 
 ```diff title="cedar.toml"
  [web]
-   apiUrl = "/.redwood/functions"
+   apiUrl = "/.api/functions"
 +  apiDbAuthUrl = "https://api.coolcedarapp.com/auth"
 ```
 
@@ -167,7 +167,7 @@ Let's look at an example:
   // highlight-start
   title = "App running on ${APP_TITLE}"
   port = "${PORT:8910}"
-  apiUrl = "${API_URL:/.redwood/functions}"
+  apiUrl = "${API_URL:/.api/functions}"
   // highlight-end
   includeEnvironmentVariables = []
 ```
@@ -176,7 +176,7 @@ This `${<envVar>:[fallback]}` syntax does the following:
 
 - sets `title` by interpolating the env var `APP_TITLE`
 - sets `port` to the env var `PORT`, falling back to `8910`
-- sets `apiUrl` to the env var `API_URL`, falling back to `/.redwood/functions` (the default)
+- sets `apiUrl` to the env var `API_URL`, falling back to `/.api/functions` (the default)
 
 That's pretty much all there is to it.
 Just remember two things:

--- a/docs/docs/auth/supertokens.md
+++ b/docs/docs/auth/supertokens.md
@@ -31,7 +31,7 @@ The environment variables have to be added either to your project's `.env` file 
 
 ```bash
 SUPERTOKENS_APP_NAME="Redwoodjs App" # this will be used in the email template for password reset or email verification emails.
-SUPERTOKENS_JWKS_URL=http://localhost:8910/.redwood/functions/auth/jwt/jwks.json
+SUPERTOKENS_JWKS_URL=http://localhost:8910/.api/functions/auth/jwt/jwks.json
 SUPERTOKENS_CONNECTION_URI=https://try.supertokens.io # set to the correct connection uri
 ```
 
@@ -41,7 +41,7 @@ Assuming that your web side is hosted on `https://myapp.com`:
 
 ```bash
 SUPERTOKENS_WEBSITE_DOMAIN=https://myapp.com
-SUPERTOKENS_JWKS_URL=https://myapp.com/.redwood/functions/auth/jwt/jwks.json
+SUPERTOKENS_JWKS_URL=https://myapp.com/.api/functions/auth/jwt/jwks.json
 ```
 
 ## Managed Supertokens service setup

--- a/docs/docs/deploy/baremetal.md
+++ b/docs/docs/deploy/baremetal.md
@@ -359,9 +359,9 @@ wget http://localhost:8910
 If you don't see the content of your `web/src/index.html` file then something isn't working. You'll need to fix those issues before you can deploy. Verify the api side is responding:
 
 ```bash
-curl http://localhost:8910/.redwood/functions/graphql?query={redwood{version}}
+curl http://localhost:8910/.api/functions/graphql?query={redwood{version}}
 # or
-wget http://localhost:8910/.redwood/functions/graphql?query={redwood{version}}
+wget http://localhost:8910/.api/functions/graphql?query={redwood{version}}
 ```
 
 You should see something like:
@@ -653,7 +653,7 @@ This should get your site available on port 80 (for HTTP), but you really want i
 
 [nginx](https://www.nginx.com/) is a very robust, dedicated web server that can do a better job of serving our static web-side files than Cedar's own built-in web server (Fastify) which isn't really configured in Cedar for a high traffic, production website.
 
-If nginx will be serving our web side, what about api-side? Cedar's internal API server will be running, but on the default port of 8911. But browsers are going to want to connect on port 80 (HTTP) or 443 (HTTPS). nginx takes care of this as well: it will [proxy](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/) (forward) any requests to a path of your choosing (like the default of `/.redwood/functions`) to port 8911 behind the scenes, then return the response to the browser.
+If nginx will be serving our web side, what about api-side? Cedar's internal API server will be running, but on the default port of 8911. But browsers are going to want to connect on port 80 (HTTP) or 443 (HTTPS). nginx takes care of this as well: it will [proxy](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/) (forward) any requests to a path of your choosing (like the default of `/.api/functions`) to port 8911 behind the scenes, then return the response to the browser.
 
 This doc isn't going to go through installing and getting nginx running, there are plenty of resources for that available. What we will show is a successful nginx configuration file used by several Cedar apps currently in production.
 
@@ -688,8 +688,8 @@ server {
     add_header Cache-Control public;
   }
 
-  location ~ /.redwood/functions(.*) {
-    rewrite ^/.redwood/functions(.*) $1 break;
+  location ~ /.api/functions(.*) {
+    rewrite ^/.api/functions(.*) $1 break;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_pass http://redwood_server;
   }
@@ -741,7 +741,7 @@ This is the bare minimum to get your site served over HTTP, insecurely. After ve
 
 #### Custom API Path
 
-If you don't love the path of `/.redwood/functions` for your API calls, this is easy to change. You'll need to tell Cedar to use a different path in development, and then let nginx know about that same path so that it resolves the same in production.
+If you don't love the path of `/.api/functions` for your API calls, this is easy to change. You'll need to tell Cedar to use a different path in development, and then let nginx know about that same path so that it resolves the same in production.
 
 For example, to simplify the path to just `/api` you'll need to make a change to `cedar.toml` and your new nginx config file:
 

--- a/docs/docs/how-to/custom-function.md
+++ b/docs/docs/how-to/custom-function.md
@@ -24,7 +24,7 @@ That creates a stub you can test out right away. Make sure your dev server is ru
 
 ### Interlude: `apiUrl`
 
-The `.redwood/functions` bit in the link you pointed your browser to is what's called the `apiUrl`. You can configure it in your `cedar.toml`:
+The `.api/functions` bit in the link you pointed your browser to is what's called the `apiUrl`. You can configure it in your `cedar.toml`:
 
 ```toml {5}
 # cedar.toml

--- a/docs/docs/how-to/custom-function.md
+++ b/docs/docs/how-to/custom-function.md
@@ -18,7 +18,7 @@ Step one is to actually create the custom Function. Naturally, we have a generat
 yarn rw generate function serverTime
 ```
 
-That creates a stub you can test out right away. Make sure your dev server is running (`yarn rw dev`), then point your browser to `http://localhost:8910/.redwood/functions/serverTime`.
+That creates a stub you can test out right away. Make sure your dev server is running (`yarn rw dev`), then point your browser to `http://localhost:8910/.api/functions/serverTime`.
 
 ![serverTime Function output](https://user-images.githubusercontent.com/32992335/107839683-609c2300-6d62-11eb-93d7-ff9c1bfb0ff2.png)
 
@@ -31,7 +31,7 @@ The `.redwood/functions` bit in the link you pointed your browser to is what's c
 
 [web]
   port = 8910
-  apiUrl = "/.redwood/functions"
+  apiUrl = "/.api/functions"
 ```
 
 After you setup a deploy (via `yarn rw setup deploy <provider>`), it'll change to something more appropriate, like `.netlify/functions` in Netlify's case.
@@ -60,7 +60,7 @@ from the web side would give you an error like:
 Access to fetch at 'http://localhost:8911/serverTime' from origin 'http://localhost:8910' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
 ```
 
-We could set the headers for `serverTime` to allow requests from any origin... but maybe a better idea would be to never request `8911` from `8910` in the first place. Hence the `apiUrl`! We're making a request to `8910/.redwood/functions/serverTime`&mdash;still the same domain&mdash;but [Vite](https://github.com/cedarjs/cedar/blob/main/packages/vite/src/index.ts#L119) proxies them to `localhost:8911/serverTime` for us. Since we can access the `apiUrl` on the frontend via [environment variables](../environment-variables#accessing-api-urls), we can now change the above fetch to work in development as well as in production:
+We could set the headers for `serverTime` to allow requests from any origin... but maybe a better idea would be to never request `8911` from `8910` in the first place. Hence the `apiUrl`! We're making a request to `8910/.api/functions/serverTime`&mdash;still the same domain&mdash;but [Vite](https://github.com/cedarjs/cedar/blob/main/packages/vite/src/index.ts#L119) proxies them to `localhost:8911/serverTime` for us. Since we can access the `apiUrl` on the frontend via [environment variables](../environment-variables#accessing-api-urls), we can now change the above fetch to work in development as well as in production:
 
 ```javascript
 const serverTime = await fetch(globalThis.RWJS_API_URL + '/serverTime')

--- a/docs/docs/how-to/oauth.md
+++ b/docs/docs/how-to/oauth.md
@@ -53,7 +53,7 @@ Click [**New OAuth App**](https://github.com/settings/applications/new) and fill
 
 ![New OAuth app settings](https://user-images.githubusercontent.com/300/245298106-b35a6abe-6e8c-4ab1-8ab5-7b7e1dcc0a39.png)
 
-The important part is the **Authorization callback URL** which is where GitHub will redirect you back once authenticated (step 4 of the login flow above). This callback URL assumes you're using the default function location of `/.redwood/functions`. If you've changed that in your app be sure to change it here as well.
+The important part is the **Authorization callback URL** which is where GitHub will redirect you back once authenticated (step 4 of the login flow above). This callback URL assumes you're using the default function location of `/.api/functions`. If you've changed that in your app be sure to change it here as well.
 
 Click **Register application** and then on the screen that follows, click the **Generate a new client secret** button:
 
@@ -88,7 +88,7 @@ GITHUB_OAUTH_CLIENT_ID=41a08ae238b5aee4121d
 GITHUB_OAUTH_CLIENT_SECRET=92e8662e9c562aca8356d45562911542d89450e1
 GITHUB_OAUTH_SCOPES="read:user user:email"
 # highlight-next-line
-GITHUB_OAUTH_REDIRECT_URI="http://localhost:8910/.redwood/functions/oauth/callback"
+GITHUB_OAUTH_REDIRECT_URI="http://localhost:8910/.api/functions/oauth/callback"
 ```
 
 ## The Login Button
@@ -120,7 +120,7 @@ We're using several of our new ENV vars here, and need to tell Cedar to make the
 [web]
   title = "Cedar App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions"
+  apiUrl = "/.api/functions"
   # highlight-next-line
   includeEnvironmentVariables = ["GITHUB_OAUTH_CLIENT_ID", "GITHUB_OAUTH_REDIRECT_URI", "GITHUB_OAUTH_SCOPES"]
 [api]

--- a/docs/docs/how-to/self-hosting-redwood.md
+++ b/docs/docs/how-to/self-hosting-redwood.md
@@ -41,7 +41,7 @@ mv ecosystem.config.js pm2.config.js
 Last but not least, change the API endpoint in `cedar.toml`:
 
 ```diff
-- apiUrl = "/.redwood/functions"
+- apiUrl = "/.api/functions"
 + apiUrl = "/api"
 ```
 

--- a/docs/docs/seo-head.md
+++ b/docs/docs/seo-head.md
@@ -15,7 +15,7 @@ You certainly want to change the title of your Cedar app from the default of "Ce
 - title = "Cedar App"
 + title = "My Cool App"
   port = 8910
-  apiUrl = "/.redwood/functions"
+  apiUrl = "/.api/functions"
 ```
 
 This title (the app title) is used by default for all your pages if you don't define another one.

--- a/docs/docs/serverless-functions.md
+++ b/docs/docs/serverless-functions.md
@@ -91,7 +91,7 @@ When you run `yarn rw dev` - it'll watch for changes and make your functions ava
 - `localhost:8911/{functionName}` and
 - `localhost:8910/.api/functions/{functionName}` (used by the web side).
 
-Note that the `.redwood/functions` path is determined by your setting in your [cedar.toml](app-configuration-cedar-toml.md#web) - and is used both in development and in the deployed Cedar app
+Note that the `.api/functions` path is determined by your setting in your [cedar.toml](app-configuration-cedar-toml.md#web) - and is used both in development and in the deployed Cedar app
 
 ## Testing
 

--- a/docs/docs/serverless-functions.md
+++ b/docs/docs/serverless-functions.md
@@ -89,7 +89,7 @@ api/src
 When you run `yarn rw dev` - it'll watch for changes and make your functions available at:
 
 - `localhost:8911/{functionName}` and
-- `localhost:8910/.redwood/functions/{functionName}` (used by the web side).
+- `localhost:8910/.api/functions/{functionName}` (used by the web side).
 
 Note that the `.redwood/functions` path is determined by your setting in your [cedar.toml](app-configuration-cedar-toml.md#web) - and is used both in development and in the deployed Cedar app
 

--- a/docs/docs/upgrade-guides/v8.md
+++ b/docs/docs/upgrade-guides/v8.md
@@ -343,3 +343,16 @@ You'll want to ensure you have generated a new Prisma client once you've upgrade
 ### Node v18 to v20 upgrade
 
 If you happen to be migrating from node version v18 to v20 as part of this upgrade you should take care to deal with any changes that itself required. For example, deploying baremental and using pm2. In that case, there are additional pm2 specific actions you must take when upgrading your system from v18 to v20. It won't be possible for us to document all things like that here. We can of course try to offer help in debugging issues that arise on our [community forums](https://community.redwoodjs.com/).
+
+## API Proxy Path (Optional)
+
+New Cedar apps now default to `apiUrl = "/.api/functions"` instead of `apiUrl = "/.redwood/functions"`. Existing apps are **not** migrated automatically.
+
+To opt in, change your `cedar.toml` (or `redwood.toml`):
+
+```toml
+[web]
+  apiUrl = "/.api/functions"
+```
+
+If you have serverless functions deployed behind a specific path (e.g., Netlify's `/.netlify/functions`), keep your current `apiUrl`.

--- a/docs/docs/upgrade-guides/v8.md
+++ b/docs/docs/upgrade-guides/v8.md
@@ -343,16 +343,3 @@ You'll want to ensure you have generated a new Prisma client once you've upgrade
 ### Node v18 to v20 upgrade
 
 If you happen to be migrating from node version v18 to v20 as part of this upgrade you should take care to deal with any changes that itself required. For example, deploying baremental and using pm2. In that case, there are additional pm2 specific actions you must take when upgrading your system from v18 to v20. It won't be possible for us to document all things like that here. We can of course try to offer help in debugging issues that arise on our [community forums](https://community.redwoodjs.com/).
-
-## API Proxy Path (Optional)
-
-New Cedar apps now default to `apiUrl = "/.api/functions"` instead of `apiUrl = "/.redwood/functions"`. Existing apps are **not** migrated automatically.
-
-To opt in, change your `cedar.toml` (or `redwood.toml`):
-
-```toml
-[web]
-  apiUrl = "/.api/functions"
-```
-
-If you have serverless functions deployed behind a specific path (e.g., Netlify's `/.netlify/functions`), keep your current `apiUrl`.

--- a/docs/docs/uploads.md
+++ b/docs/docs/uploads.md
@@ -615,18 +615,18 @@ The object being returned will look like:
 ```ts
 {
   id: 125,
-  avatar: '/.redwood/functions/signedUrl?s=s1gnatur3&expiry=1725190749613&path=path.png'
+  avatar: '/.api/functions/signedUrl?s=s1gnatur3&expiry=1725190749613&path=path.png'
 }
 ```
 
 This will generate a URL that will expire in 2 days (from the point of query). Let's breakdown the URL:
 
-| URL Component                   |                                                      |
-| ------------------------------- | ---------------------------------------------------- |
-| `/.redwood/functions/signedUrl` | Point to the API server, and the endpoint configured |
-| `s=s1gnatur3`                   | The signature that we'll validate                    |
-| `expiry=1725190749613`          | Time stamp for when it expires                       |
-| `path=path.png`                 | The key to look up the file on your storage          |
+| URL Component               |                                                      |
+| --------------------------- | ---------------------------------------------------- |
+| `/.api/functions/signedUrl` | Point to the API server, and the endpoint configured |
+| `s=s1gnatur3`               | The signature that we'll validate                    |
+| `expiry=1725190749613`      | Time stamp for when it expires                       |
+| `path=path.png`             | The key to look up the file on your storage          |
 
 <details>
 <summary>How the signedUrl function validates</summary>
@@ -788,7 +788,7 @@ main()
 
 Based on the above, you'll be able to access your files at:
 
-`http://localhost:8910/.redwood/functions/public_uploads/01J6AF89Y89WTWZF12DRC72Q2A.jpeg`
+`http://localhost:8910/.api/functions/public_uploads/01J6AF89Y89WTWZF12DRC72Q2A.jpeg`
 
 OR directly
 

--- a/docs/implementation-plans/default-api-proxy-path-dot-api-plan.md
+++ b/docs/implementation-plans/default-api-proxy-path-dot-api-plan.md
@@ -1,0 +1,389 @@
+# Plan: Default API Proxy Path to `.api/functions`
+
+## Summary
+
+Switch Cedar's default frontend-to-backend proxy path from `/.redwood/functions`
+to `/.api/functions`, removing the framework name from the URL. Deployment
+provider setup commands will read the user's configured `apiUrl` instead of
+hardcoding a path.
+
+This change is **opt-in for existing apps**. Only newly created apps get
+`/.api/functions` as the default. Existing apps keep whatever `apiUrl` they
+already have.
+
+## Goals
+
+- New Cedar apps default to `apiUrl = "/.api/functions"` in their `cedar.toml`
+- Existing apps are untouched — no automatic migration
+- Deployment setup commands (`setup deploy <provider>`) read `apiUrl` from the
+  user's config instead of hardcoding `/.redwood/functions`
+- The framework respects whatever `apiUrl` the user configures
+- Upgrade docs explain how existing apps can opt in to `/.api/functions`
+
+## Non-Goals
+
+- Changing the generated data directory (`.redwood/` vs `.cedar/`) — already
+  handled separately
+- Removing support for `/.redwood/functions` — it continues to work
+- Forcing existing apps to migrate
+- Changing how `apiGraphQLUrl` works
+
+## Current State
+
+### Default Config
+
+`packages/project-config/src/config.ts` hardcodes the fallback:
+
+```ts
+export const DEFAULT_CONFIG: Config = {
+  web: {
+    // ...
+    apiUrl: '/.redwood/functions',
+    // ...
+  },
+}
+```
+
+### Templates
+
+All four `create-cedar-app` templates set:
+
+```toml
+[web]
+  apiUrl = "/.redwood/functions"
+```
+
+### Deployment Provider Hardcoding
+
+**Render handler** (`packages/cli/src/commands/setup/deploy/providers/renderHandler.js`):
+
+```js
+updateApiURLTask('/.redwood/functions'),
+```
+
+**Flightcontrol handler** (`packages/cli/src/commands/setup/deploy/providers/flightcontrolHandler.js`):
+
+```js
+REDWOOD_API_URL=/.redwood/functions
+```
+
+**Render template** (`packages/cli/src/commands/setup/deploy/templates/render.js`):
+
+```js
+source: /.redwood/functions/*
+```
+
+**Netlify** and **Vercel** already use their own paths (`/.netlify/functions`,
+`/api`) and are unaffected.
+
+### Where the Path Flows
+
+| Location                                              | Uses                                       |
+| ----------------------------------------------------- | ------------------------------------------ |
+| `packages/project-config/src/config.ts`               | Hardcoded default                          |
+| `packages/vite/src/lib/getMergedConfig.ts`            | `cedarConfig.web.apiUrl`                   |
+| `packages/vite/src/runFeServer.ts`                    | `rwConfig.web.apiUrl`                      |
+| `packages/vite/src/rsc/rscStudioHandlers.ts`          | Hardcoded `/.redwood/functions/rsc-flight` |
+| `packages/adapters/fastify/web/src/resolveOptions.ts` | `getConfig().web.apiUrl`                   |
+| `packages/project-config/src/envVarDefinitions.ts`    | `rwConfig.web.apiUrl`                      |
+
+## Guiding Principles
+
+### 1. Existing Apps Are Frozen
+
+No automatic migration. The framework must not rewrite a user's `cedar.toml` or
+`redwood.toml` on upgrade. Opt-in is a deliberate user action.
+
+### 2. Providers Respect User Config
+
+Deployment setup commands must read the existing `apiUrl` value and use it.
+Hardcoding a path in a provider setup command is a bug, not a convenience.
+
+### 3. The Default Is for New Apps Only
+
+`create-cedar-app` templates ship with the new default. The framework fallback
+(`DEFAULT_CONFIG`) also returns the new default so that apps without an explicit
+`apiUrl` get `/.api/functions`.
+
+### 4. One Source of Truth
+
+The user's `cedar.toml` / `redwood.toml` is the single source of truth for the
+proxy path. Framework code, deployment templates, and documentation all derive
+from that value.
+
+## Implementation
+
+### Phase 1: Change the Default
+
+**Effort: S (Small)**
+
+#### 1.1 Update `DEFAULT_CONFIG`
+
+`packages/project-config/src/config.ts`:
+
+```ts
+export const DEFAULT_CONFIG: Config = {
+  web: {
+    // ...
+    apiUrl: '/.api/functions',
+    // ...
+  },
+}
+```
+
+#### 1.2 Update all `create-cedar-app` templates
+
+Change `apiUrl` in the `[web]` section of every template's `cedar.toml`:
+
+- `packages/create-cedar-app/templates/ts/cedar.toml`
+- `packages/create-cedar-app/templates/js/cedar.toml`
+- `packages/create-cedar-app/templates/esm-ts/cedar.toml`
+- `packages/create-cedar-app/templates/esm-js/cedar.toml`
+
+```toml
+[web]
+  apiUrl = "/.api/functions"
+```
+
+#### 1.3 Update template tests
+
+`packages/create-cedar-app/tests/templates.test.ts` asserts on generated TOML
+content. Update expectations.
+
+#### Exit Criteria
+
+- `yarn create-cedar-app` produces apps with `apiUrl = "/.api/functions"`
+- Apps without an explicit `apiUrl` in TOML get `/.api/functions` as the
+  fallback
+
+---
+
+### Phase 2: Make Deployment Providers Config-Driven
+
+**Effort: S (Small)**
+
+Replace hardcoded `/.redwood/functions` in deployment setup commands with
+config-derived values.
+
+The key insight: deployment setup should **not** force-update the user's
+`apiUrl` in TOML. The provider's routing rules should match whatever the user
+already has configured.
+
+#### 2.1 Add a helper to read the user's `apiUrl`
+
+If one does not already exist near `updateApiURLTask`, add:
+
+```js
+import { getConfig } from '@cedarjs/project-config'
+
+export function getUserApiUrl() {
+  return getConfig().web.apiUrl
+}
+```
+
+#### 2.2 Update Render handler and template
+
+**Remove** `updateApiURLTask` from the task list in
+`packages/cli/src/commands/setup/deploy/providers/renderHandler.js`.
+The user's TOML is the source of truth and should not be mutated.
+
+Update the Render template in
+`packages/cli/src/commands/setup/deploy/templates/render.js`:
+
+```js
+import { getUserApiUrl } from '../helpers/index.js'
+
+// ...
+source: `${getUserApiUrl()}/*`,
+```
+
+#### 2.3 Update Flightcontrol handler and `.env.defaults` writer
+
+**Remove** `updateApiURLTask` from the task list in
+`packages/cli/src/commands/setup/deploy/providers/flightcontrolHandler.js`.
+The TOML already uses `${REDWOOD_API_URL}`, which is fine.
+
+Update `addToDotEnvDefaultTask` to use the user's `apiUrl` instead of
+hardcoding `/.redwood/functions`:
+
+```js
+const addToDotEnvDefaultTask = () => {
+  const apiUrl = getUserApiUrl()
+  return {
+    // ...
+    task: async (_ctx) => {
+      const env = path.resolve(getPaths().base, '.env.defaults')
+      const line = `\n\nREDWOOD_API_URL=${apiUrl}\n`
+      fs.appendFileSync(env, line)
+    },
+  }
+}
+```
+
+#### 2.4 Audit all other provider templates
+
+Search for any remaining `/.redwood/functions` hardcoding in:
+
+- `packages/cli/src/commands/setup/deploy/**/*`
+- `packages/cli/src/commands/setup/deploy/templates/**/*`
+
+#### Exit Criteria
+
+- `yarn cedar setup deploy render` generates a `render.yaml` whose `source`
+  matches the user's `apiUrl` without touching `cedar.toml`
+- `yarn cedar setup deploy flightcontrol` writes the user's `apiUrl` to
+  `.env.defaults` without touching `cedar.toml`
+- No deployment setup command hardcodes `/.redwood/functions`
+
+---
+
+### Phase 3: Framework Code Audit
+
+**Effort: S (Small)**
+
+#### 3.1 Fix hardcoded references in source code
+
+`packages/vite/src/rsc/rscStudioHandlers.ts` hardcodes:
+
+```ts
+path: '/.redwood/functions/rsc-flight',
+```
+
+This should derive from `getConfig().web.apiUrl`:
+
+```ts
+const apiUrl = getConfig().web.apiUrl.replace(/\/$/, '')
+path: `${apiUrl}/rsc-flight`,
+```
+
+#### 3.2 Audit comments and error messages
+
+Search for `.redwood/functions` in framework source (not tests/docs) and update
+comments, error messages, and help text that mention the old path.
+
+#### 3.3 Keep test fixtures on old path (or parameterize)
+
+Test fixtures that explicitly test `/.redwood/functions` behavior should
+continue to work. Either:
+
+- Leave the fixture config as `/.redwood/functions` to verify backward compat, or
+- Parameterize the test so it runs with both `/.redwood/functions` and
+  `/.api/functions`
+
+#### Exit Criteria
+
+- No framework source code hardcodes `/.redwood/functions` except for backward-
+  compatibility tests
+- `rsc-flight` path is derived from config
+
+---
+
+### Phase 4: Rebuild Test Project Fixture
+
+**Effort: XS (Extra Small)**
+
+After Phases 1–3 land, run `yarn rebuild-test-project-fixture` so the fixture
+apps have `apiUrl = "/.api/functions"`.
+
+This ensures CI, e2e tests, and the fixture snapshot match the new default.
+
+#### Exit Criteria
+
+- `__fixtures__/test-project` has `apiUrl = "/.api/functions"`
+- `__fixtures__/test-project-esm` has `apiUrl = "/.api/functions"`
+- `__fixtures__/test-project-live` has `apiUrl = "/.api/functions"`
+
+---
+
+### Phase 5: Documentation and Upgrade Guide
+
+**Effort: S (Small)**
+
+#### 5.1 Upgrade guide
+
+Add a section to `docs/docs/upgrade-guides/*.md`:
+
+````md
+## API Proxy Path (Optional)
+
+New Cedar apps now default to `apiUrl = "/.api/functions"` instead of
+`apiUrl = "/.redwood/functions"`. Existing apps are **not** migrated
+automatically.
+
+To opt in, change your `cedar.toml` (or `redwood.toml`):
+
+```toml
+[web]
+  apiUrl = "/.api/functions"
+```
+````
+
+If you have serverless functions deployed behind a specific path
+(e.g., Netlify's `/.netlify/functions`), keep your current `apiUrl`.
+
+````
+
+#### 5.2 Deployment provider docs
+
+Update deployment setup docs to note that Cedar reads `apiUrl` from the user's
+config. No manual template editing should be required.
+
+#### 5.3 Changelog
+
+Document the change for the next release.
+
+#### Exit Criteria
+
+- Upgrade guide explains the opt-in nature of the change
+- Deployment docs mention config-driven `apiUrl`
+
+---
+
+## Migration Path for Existing Apps
+
+No automatic migration. Existing apps keep their current `apiUrl` forever unless
+the developer manually changes it.
+
+### Manual Opt-In Steps
+
+1. Open `cedar.toml` (or `redwood.toml`)
+2. Change `apiUrl` from `"/.redwood/functions"` to `"/.api/functions"`
+3. If using serverless functions, update the function path in the provider
+dashboard (e.g., Netlify, Vercel) to match
+4. Re-deploy
+
+### Codemod (Optional)
+
+If demand is high, a simple codemod can be provided later:
+
+```ts
+// codemod: change-api-url-to-dot-api
+// Replaces apiUrl = "/.redwood/functions" with apiUrl = "/.api/functions"
+````
+
+This is low priority because the change is one line in TOML.
+
+## Risks
+
+- **Deployment provider templates break** if the provider expects a specific path
+  and the user configures something unexpected. Mitigation: providers that need
+  a specific path (Netlify, Vercel) already use their own paths; Cedar should
+  not override them.
+- **Existing tutorials/docs reference `/.redwood/functions`** and confuse new
+  users who see `/.api/functions` in their app. Mitigation: update docs promptly.
+- **Third-party integrations** (e.g., custom middleware, external API clients)
+  may hardcode `/.redwood/functions`. Those are outside Cedar's control.
+- **Flightcontrol/Render users** who previously ran setup deploy and now rerun
+  it may get a different path. Mitigation: setup deploy should be idempotent
+  and use current config.
+
+## Acceptance Criteria
+
+- [ ] `DEFAULT_CONFIG.apiUrl` is `/.api/functions`
+- [ ] All `create-cedar-app` templates ship with `apiUrl = "/.api/functions"`
+- [ ] No deployment setup command hardcodes `/.redwood/functions`
+- [ ] `rscStudioHandlers.ts` derives the flight endpoint from config
+- [ ] Test project fixtures are rebuilt with `/.api/functions`
+- [ ] Upgrade docs explain opt-in migration
+- [ ] `yarn test` and `yarn test:types` pass
+- [ ] `yarn rebuild-test-project-fixture` passes

--- a/packages/adapters/fastify/web/src/resolveOptions.ts
+++ b/packages/adapters/fastify/web/src/resolveOptions.ts
@@ -40,7 +40,7 @@ export function resolveOptions(options: RedwoodFastifyWebOptions) {
   // }
   // ```
   //
-  // This is pretty unlikely because we default `apiUrl` to '/.redwood/functions'
+  // This is pretty unlikely because we default `apiUrl` to '/.api/functions'
   if (!redwoodOptions.apiUrl && redwoodOptions.apiProxyTarget) {
     throw new Error(
       `If you provide \`apiProxyTarget\`, \`apiUrl\` has to be a relative URL. \`apiUrl\` is '${redwoodOptions.apiUrl}'`,

--- a/packages/adapters/fastify/web/src/types.ts
+++ b/packages/adapters/fastify/web/src/types.ts
@@ -2,9 +2,9 @@ export interface RedwoodFastifyWebOptions {
   redwood?: {
     /**
      * Specify the URL to your API server.
-     * This can be a relative URL on the current domain (`/.redwood/functions`),
+     * This can be a relative URL on the current domain (`/.api/functions`),
      * in which case the `apiProxyTarget` option must be set,
-     * or a fully-qualified URL (`https://api.redwood.horse`).
+     * or a fully-qualified URL (`https://api.example.com`).
      *
      * Note: This should not include the path to the GraphQL Server.
      **/

--- a/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
+++ b/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
@@ -1480,7 +1480,7 @@ export class DbAuthHandler<
 
   // figure out which auth method we're trying to call
   async _getAuthMethod() {
-    // try getting it from the query string, /.redwood/functions/auth?method=[methodName]
+    // try getting it from the query string, /<apiUrl>/auth?method=[methodName]
     let methodName = this.normalizedRequest.query?.method as AuthMethodNames
 
     if (

--- a/packages/cli-helpers/src/lib/__tests__/__snapshots__/project.test.ts.snap
+++ b/packages/cli-helpers/src/lib/__tests__/__snapshots__/project.test.ts.snap
@@ -54,7 +54,7 @@ exports[`updateTomlConfig > updateTomlConfig configures a new CLI plugin > adds 
 "[web]
 title = "Redwood App"
 port = 8910
-apiUrl = "/.redwood/functions"
+apiUrl = "/.api/functions"
 includeEnvironmentVariables = []
 
 [api]
@@ -74,7 +74,7 @@ exports[`updateTomlConfig > updateTomlConfig configures a new CLI plugin > adds 
 "[web]
 title = "Redwood App"
 port = 8910
-apiUrl = "/.redwood/functions"
+apiUrl = "/.api/functions"
 includeEnvironmentVariables = []
 
 [api]
@@ -97,7 +97,7 @@ exports[`updateTomlConfig > updateTomlConfig configures a new CLI plugin > adds 
 "[web]
 title = "Redwood App"
 port = 8910
-apiUrl = "/.redwood/functions"
+apiUrl = "/.api/functions"
 includeEnvironmentVariables = []
 
 [api]
@@ -117,7 +117,7 @@ exports[`updateTomlConfig > updateTomlConfig configures a new CLI plugin > adds 
 "[web]
 title = "Redwood App"
 port = 8910
-apiUrl = "/.redwood/functions"
+apiUrl = "/.api/functions"
 includeEnvironmentVariables = []
 
 [api]
@@ -137,7 +137,7 @@ exports[`updateTomlConfig > updateTomlConfig configures a new CLI plugin > does 
 "[web]
 title = "Redwood App"
 port = 8910
-apiUrl = "/.redwood/functions"
+apiUrl = "/.api/functions"
 includeEnvironmentVariables = []
 
 [api]

--- a/packages/cli-helpers/src/lib/__tests__/project.test.ts
+++ b/packages/cli-helpers/src/lib/__tests__/project.test.ts
@@ -17,7 +17,7 @@ const defaultRedwoodToml: Record<string, any> = {
   web: {
     title: 'Redwood App',
     port: 8910,
-    apiUrl: '/.redwood/functions',
+    apiUrl: '/.api/functions',
     includeEnvironmentVariables: [],
   },
   api: {

--- a/packages/cli/src/commands/__tests__/info.test.ts
+++ b/packages/cli/src/commands/__tests__/info.test.ts
@@ -99,7 +99,7 @@ describe('yarn cedar info', () => {
       mockCedarToml.fileContents = `
 [web]
   title = "Hello World" # Used for the <title> tag
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
 `
 
       await handler()
@@ -111,7 +111,7 @@ describe('yarn cedar info', () => {
           '      title = "Hello World" # Used for the <title> tag',
           // This next line is a bit more tricky because it has a # to make it
           // a comment, but then also a # in the URL.
-          '      apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths',
+          '      apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths',
         ].join('\n'),
       )
     })

--- a/packages/cli/src/commands/experimental/templates/opentelemetry.ts.template
+++ b/packages/cli/src/commands/experimental/templates/opentelemetry.ts.template
@@ -24,11 +24,12 @@ const resource = Resource.default().merge(
 )
 
 const studioPort = getConfig().studio.basePort
+const apiUrl = getConfig().web.apiUrl.replace(/\/$/, '')
 const exporter = new OTLPTraceExporter({
   // Update this URL to point to where your OTLP compatible collector is listening
   // The redwood development studio (`yarn cedar exp studio`) can collect your
   // telemetry at `http://127.0.0.1:<PORT>/v1/traces` (default PORT is 4318)
-  url: `http://127.0.0.1:${studioPort}/.redwood/functions/otel-trace`,
+  url: `http://127.0.0.1:${studioPort}${apiUrl}/otel-trace`,
   concurrencyLimit: 64,
 })
 

--- a/packages/cli/src/commands/setup/deploy/__tests__/netlify.test.js
+++ b/packages/cli/src/commands/setup/deploy/__tests__/netlify.test.js
@@ -69,7 +69,7 @@ beforeEach(() => {
     [mockConfigPath]: `[web]
   title = "Cedar App"
   port = 8910
-  apiUrl = "/.redwood/functions" # you can customize graphql and dbAuth urls individually too: see https://cedarjs.com/docs/app-configuration-cedar-toml#api-paths
+  apiUrl = "/.api/functions" # you can customize graphql and dbAuth urls individually too: see https://cedarjs.com/docs/app-configuration-cedar-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/cli/src/commands/setup/deploy/helpers/index.js
+++ b/packages/cli/src/commands/setup/deploy/helpers/index.js
@@ -4,7 +4,7 @@ import path from 'node:path'
 import execa from 'execa'
 import { Listr } from 'listr2'
 
-import { getConfigPath } from '@cedarjs/project-config'
+import { getConfigPath, getConfig } from '@cedarjs/project-config'
 
 import { getPaths, writeFilesTask } from '../../../../lib/index.js'
 
@@ -29,6 +29,10 @@ export const updateApiURLTask = (apiUrl) => {
       fs.writeFileSync(configTomlPath, newToml)
     },
   }
+}
+
+export function getUserApiUrl() {
+  return getConfig().web.apiUrl
 }
 
 /**

--- a/packages/cli/src/commands/setup/deploy/providers/flightcontrolHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/flightcontrolHandler.js
@@ -11,7 +11,7 @@ import { getPaths, getPrismaSchemas } from '@cedarjs/project-config'
 import { errorTelemetry } from '@cedarjs/telemetry'
 
 import { writeFilesTask, printSetupNotes } from '../../../../lib/index.js'
-import { getUserApiUrl } from '../helpers/index.js'
+import { getUserApiUrl, updateApiURLTask } from '../helpers/index.js'
 import {
   flightcontrolConfig,
   databaseEnvVariables,
@@ -55,7 +55,7 @@ const getFlightcontrolJson = async (database) => {
             ...flightcontrolConfig.environments[0],
             services: [
               ...flightcontrolConfig.environments[0].services.map((service) => {
-                if (service.id === 'redwood-api') {
+                if (service.id === 'cedar-api') {
                   return {
                     ...service,
                     envVariables: {
@@ -106,7 +106,7 @@ const updateGraphQLFunction = () => {
     Couldn't find graphql handler in api/src/functions/graphql.js.
     You'll have to add the following cors config manually:
 
-      cors: { origin: process.env.REDWOOD_WEB_URL, credentials: true}
+      cors: { origin: process.env.CEDAR_WEB_URL, credentials: true}
     `)
         return
       }
@@ -123,7 +123,7 @@ const updateGraphQLFunction = () => {
     Couldn't find graphql handler in api/src/functions/graphql.js.
     You'll have to add the following cors config manually:
 
-      cors: { origin: process.env.REDWOOD_WEB_URL, credentials: true}
+      cors: { origin: process.env.CEDAR_WEB_URL, credentials: true}
     `)
         return
       }
@@ -131,7 +131,7 @@ const updateGraphQLFunction = () => {
       graphqlContent.splice(
         graphqlHanderIndex + 1,
         0,
-        '  cors: { origin: process.env.REDWOOD_WEB_URL, credentials: true },',
+        '  cors: { origin: process.env.CEDAR_WEB_URL, credentials: true },',
       )
 
       fs.writeFileSync(graphqlFunctionsPath, graphqlContent.join(EOL))
@@ -179,14 +179,14 @@ const updateDbAuth = () => {
     Couldn't find DbAuthHandler in api/src/functions/auth.js.
     You'll have to add the following cors config manually:
 
-      cors: { origin: process.env.REDWOOD_WEB_URL, credentials: true}
+      cors: { origin: process.env.CEDAR_WEB_URL, credentials: true}
     `)
         return
       }
       authContent.splice(
         dbHandlerIndex + 1,
         0,
-        '  cors: { origin: process.env.REDWOOD_WEB_URL, credentials: true },',
+        '  cors: { origin: process.env.CEDAR_WEB_URL, credentials: true },',
       )
 
       fs.writeFileSync(authFnPath, authContent.join(EOL))
@@ -264,14 +264,14 @@ const addToDotEnvDefaultTask = () => {
 
         You'll have to add the following env var manually:
 
-        REDWOOD_API_URL=${getUserApiUrl()}
+        CEDAR_API_URL=${getUserApiUrl()}
         `
       }
     },
     task: async (_ctx) => {
       const env = path.resolve(getPaths().base, '.env.defaults')
       const apiUrl = getUserApiUrl()
-      const line = `\n\nREDWOOD_API_URL=${apiUrl}\n`
+      const line = `\n\nCEDAR_API_URL=${apiUrl}\n`
 
       fs.appendFileSync(env, line)
     },
@@ -306,6 +306,7 @@ export const handler = async ({ force, database }) => {
       updateGraphQLFunction(),
       updateDbAuth(),
       updateApp(),
+      updateApiURLTask('${CEDAR_API_URL}'),
       addToDotEnvDefaultTask(),
       printSetupNotes(notes),
     ],

--- a/packages/cli/src/commands/setup/deploy/providers/flightcontrolHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/flightcontrolHandler.js
@@ -11,7 +11,7 @@ import { getPaths, getPrismaSchemas } from '@cedarjs/project-config'
 import { errorTelemetry } from '@cedarjs/telemetry'
 
 import { writeFilesTask, printSetupNotes } from '../../../../lib/index.js'
-import { updateApiURLTask } from '../helpers/index.js'
+import { getUserApiUrl } from '../helpers/index.js'
 import {
   flightcontrolConfig,
   databaseEnvVariables,
@@ -264,13 +264,14 @@ const addToDotEnvDefaultTask = () => {
 
         You'll have to add the following env var manually:
 
-        REDWOOD_API_URL=/.redwood/functions
+        REDWOOD_API_URL=${getUserApiUrl()}
         `
       }
     },
     task: async (_ctx) => {
       const env = path.resolve(getPaths().base, '.env.defaults')
-      const line = '\n\nREDWOOD_API_URL=/.redwood/functions\n'
+      const apiUrl = getUserApiUrl()
+      const line = `\n\nREDWOOD_API_URL=${apiUrl}\n`
 
       fs.appendFileSync(env, line)
     },
@@ -305,7 +306,6 @@ export const handler = async ({ force, database }) => {
       updateGraphQLFunction(),
       updateDbAuth(),
       updateApp(),
-      updateApiURLTask('${REDWOOD_API_URL}'),
       addToDotEnvDefaultTask(),
       printSetupNotes(notes),
     ],

--- a/packages/cli/src/commands/setup/deploy/providers/renderHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/renderHandler.js
@@ -8,7 +8,7 @@ import { getPaths, getPrismaSchemas } from '@cedarjs/project-config'
 import { errorTelemetry } from '@cedarjs/telemetry'
 
 import { writeFilesTask, printSetupNotes } from '../../../../lib/index.js'
-import { addFilesTask, updateApiURLTask } from '../helpers/index.js'
+import { addFilesTask } from '../helpers/index.js'
 import {
   POSTGRES_YAML,
   RENDER_HEALTH_CHECK,
@@ -91,7 +91,6 @@ export const handler = async ({ force, database }) => {
           return writeFilesTask(files, { overwriteExisting: force })
         },
       },
-      updateApiURLTask('/.redwood/functions'),
       // Add health check api function
       addFilesTask({
         files: additionalFiles,

--- a/packages/cli/src/commands/setup/deploy/templates/flightcontrol.js
+++ b/packages/cli/src/commands/setup/deploy/templates/flightcontrol.js
@@ -10,8 +10,8 @@ export const flightcontrolConfig = {
       },
       services: [
         {
-          id: 'redwood-api',
-          name: 'Redwood API',
+          id: 'cedar-api',
+          name: 'Cedar API',
           type: 'web',
           buildType: 'nixpacks',
           cpu: 0.5,
@@ -24,14 +24,14 @@ export const flightcontrolConfig = {
             type: 'ec2',
           },
           envVariables: {
-            REDWOOD_WEB_URL: {
-              fromService: { id: 'redwood-web', value: 'origin' },
+            CEDAR_WEB_URL: {
+              fromService: { id: 'cedar-web', value: 'origin' },
             },
           },
         },
         {
-          id: 'redwood-web',
-          name: 'Redwood Web',
+          id: 'cedar-web',
+          name: 'Cedar Web',
           type: 'static',
           buildType: 'nixpacks',
           singlePageApp: true,
@@ -41,8 +41,8 @@ export const flightcontrolConfig = {
             type: 'ec2',
           },
           envVariables: {
-            REDWOOD_API_URL: {
-              fromService: { id: 'redwood-api', value: 'origin' },
+            CEDAR_API_URL: {
+              fromService: { id: 'cedar-api', value: 'origin' },
             },
           },
         },

--- a/packages/cli/src/commands/setup/deploy/templates/render.js
+++ b/packages/cli/src/commands/setup/deploy/templates/render.js
@@ -6,7 +6,7 @@ import { getUserApiUrl } from '../helpers/index.js'
 export const PROJECT_NAME = path.basename(getPaths().base)
 
 export const RENDER_YAML = (database) => {
-  const apiUrl = getUserApiUrl()
+  const apiUrl = getUserApiUrl().replace(/\/$/, '')
   return `# Quick links to the docs:
 # - Redwood on Render: https://render.com/docs/deploy-redwood
 # - Render's Blueprint spec: https://render.com/docs/yaml-spec

--- a/packages/cli/src/commands/setup/deploy/templates/render.js
+++ b/packages/cli/src/commands/setup/deploy/templates/render.js
@@ -1,10 +1,12 @@
 import path from 'path'
 
 import { getPaths } from '../../../../lib/index.js'
+import { getUserApiUrl } from '../helpers/index.js'
 
 export const PROJECT_NAME = path.basename(getPaths().base)
 
 export const RENDER_YAML = (database) => {
+  const apiUrl = getUserApiUrl()
   return `# Quick links to the docs:
 # - Redwood on Render: https://render.com/docs/deploy-redwood
 # - Render's Blueprint spec: https://render.com/docs/yaml-spec
@@ -22,7 +24,7 @@ services:
 
   routes:
   - type: rewrite
-    source: /.redwood/functions/*
+    source: ${apiUrl}/*
     # Replace \`destination\` here after your first deploy:
     #
     # \`\`\`

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/default.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/default.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/fragments.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/fragments.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/fragments_no_space_equals.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/fragments_no_space_equals.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_already_setup.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_already_setup.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_commented_graphql.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_commented_graphql.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_fragments_already_setup.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_fragments_already_setup.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_no_space_equals.toml
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__fixtures__/toml/trusted_docs_no_space_equals.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__snapshots__/trustedDocuments.test.ts.snap
+++ b/packages/cli/src/commands/setup/graphql/features/trustedDocuments/__tests__/__snapshots__/trustedDocuments.test.ts.snap
@@ -11,7 +11,7 @@ exports[`Trusted documents setup > Project toml configuration updates > default 
 [web]
   title = "Redwood App"
   port = "\${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web
@@ -39,7 +39,7 @@ exports[`Trusted documents setup > Project toml configuration updates > default 
 [web]
   title = "Redwood App"
   port = "\${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web
@@ -67,7 +67,7 @@ exports[`Trusted documents setup > Project toml configuration updates > default 
 [web]
   title = "Redwood App"
   port = "\${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web
@@ -94,7 +94,7 @@ exports[`Trusted documents setup > Project toml configuration updates > toml whe
 [web]
   title = "Redwood App"
   port = "\${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/create-cedar-app/templates/esm-js/cedar.toml
+++ b/packages/create-cedar-app/templates/esm-js/cedar.toml
@@ -11,7 +11,7 @@
 [web]
   title = "Cedar App"
   port = 8910
-  apiUrl = "/.redwood/functions"
+  apiUrl = "/.api/functions"
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/create-cedar-app/templates/esm-ts/cedar.toml
+++ b/packages/create-cedar-app/templates/esm-ts/cedar.toml
@@ -11,7 +11,7 @@
 [web]
   title = "Cedar App"
   port = 8910
-  apiUrl = "/.redwood/functions"
+  apiUrl = "/.api/functions"
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/create-cedar-app/templates/js/cedar.toml
+++ b/packages/create-cedar-app/templates/js/cedar.toml
@@ -11,7 +11,7 @@
 [web]
   title = "Cedar App"
   port = 8910
-  apiUrl = "/.redwood/functions"
+  apiUrl = "/.api/functions"
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/create-cedar-app/templates/ts/cedar.toml
+++ b/packages/create-cedar-app/templates/ts/cedar.toml
@@ -11,7 +11,7 @@
 [web]
   title = "Cedar App"
   port = 8910
-  apiUrl = "/.redwood/functions"
+  apiUrl = "/.api/functions"
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/packages/project-config/src/__tests__/config.test.ts
+++ b/packages/project-config/src/__tests__/config.test.ts
@@ -129,7 +129,7 @@ describe('getConfig', () => {
         },
         "web": {
           "a11y": true,
-          "apiUrl": "/.redwood/functions",
+          "apiUrl": "/.api/functions",
           "fastRefresh": true,
           "includeEnvironmentVariables": [],
           "path": "./web",
@@ -259,7 +259,7 @@ describe('getConfig', () => {
           [web]
             title = "App running on \${APP_ENV}"
             port = "\${PORT:8910}"
-            apiUrl = "\${API_URL:/.redwood/functions}" # you can customise graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+            apiUrl = "\${API_URL:/.api/functions}" # you can customise graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-cedar-toml#api-paths
             includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://cedarjs.com/docs/environment-variables#web
           [api]
             port = "\${API_PORT:8911}"

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -145,7 +145,7 @@ export const DEFAULT_CONFIG: Config = {
     path: './web',
     target: TargetEnum.BROWSER,
     includeEnvironmentVariables: [],
-    apiUrl: '/.redwood/functions',
+    apiUrl: '/.api/functions',
     fastRefresh: true,
     a11y: true,
     sourceMap: false,

--- a/packages/vite/src/lib/getMergedConfig.ts
+++ b/packages/vite/src/lib/getMergedConfig.ts
@@ -86,7 +86,7 @@ export function getMergedConfig(cedarConfig: Config, cedarPaths: Paths) {
             target: `http://${apiHost}:${apiPort}`,
             changeOrigin: false,
             rewrite: (path) => {
-              // Remove the `.redwood/functions` part, but leave the `/graphql`
+              // Remove the `apiUrl` part, but leave the `/graphql`
               return path.replace(cedarConfig.web.apiUrl, '')
             },
           },

--- a/packages/vite/src/rsc/rscStudioHandlers.ts
+++ b/packages/vite/src/rsc/rscStudioHandlers.ts
@@ -71,10 +71,11 @@ const postFlightToStudio = (payload: string, metadata: Record<string, any>) => {
 
   // Options to configure the HTTP POST request
   // TODO (RSC): Get these from the toml and Studio config
+  const apiUrl = getConfig().web.apiUrl.replace(/\/$/, '')
   const options = {
     hostname: 'localhost',
     port: getStudioPort(),
-    path: '/.redwood/functions/rsc-flight',
+    path: `${apiUrl}/rsc-flight`,
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/tasks/e2e/cypress/e2e/01-tutorial/codemods/Step0_1_RedwoodToml.js
+++ b/tasks/e2e/cypress/e2e/01-tutorial/codemods/Step0_1_RedwoodToml.js
@@ -8,7 +8,7 @@ export default `
 
 [web]
   port = 8910
-  apiProxyPath = "/.redwood/functions"
+  apiProxyPath = "/.api/functions"
 [api]
   port = 8911
 [browser]

--- a/tasks/e2e/cypress/e2e/01-tutorial/sharedTests.js
+++ b/tasks/e2e/cypress/e2e/01-tutorial/sharedTests.js
@@ -44,7 +44,7 @@ export function waitForApiSide() {
       cy
         .request({
           method: 'POST',
-          url: 'http://localhost:8910/.redwood/functions/graphql',
+          url: 'http://localhost:8910/.api/functions/graphql',
           headers: {
             'content-type': 'application/json',
           },

--- a/tasks/server-tests/fixtures/redwood-app/redwood.toml
+++ b/tasks/server-tests/fixtures/redwood-app/redwood.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/.api/functions" # You can customize graphql and dbauth urls individually too: see https://cedarjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://cedarjs.com/docs/environment-variables#web

--- a/tasks/smoke-tests/prerender/tests/prerender.spec.ts
+++ b/tasks/smoke-tests/prerender/tests/prerender.spec.ts
@@ -48,7 +48,7 @@ test('Check that rehydration works for page not wrapped in Set', async ({
   // Wait for page to have been rehydrated before getting page content.
   // We know the page has been rehydrated when it sends an auth request
   await page.waitForResponse((response) =>
-    response.url().includes('/.redwood/functions/auth'),
+    response.url().includes('/.api/functions/auth'),
   )
 
   await page.locator('h1').first().waitFor()
@@ -89,7 +89,7 @@ test('Check that rehydration works for page with Cell in Set', async ({
   // before getting page content.
   // We know cells have started fetching data when we see graphql requests
   await page.waitForResponse((response) =>
-    response.url().includes('/.redwood/functions/graphql'),
+    response.url().includes('/.api/functions/graphql'),
   )
 
   await page.locator('h2').first().waitFor()
@@ -137,7 +137,7 @@ test('Check that rehydration works for page with code split chunks', async ({
   // Wait for page to have been rehydrated before getting page content.
   // We know the page has been rehydrated when it sends an auth request
   await page.waitForResponse((response) =>
-    response.url().includes('/.redwood/functions/auth'),
+    response.url().includes('/.api/functions/auth'),
   )
 
   await expect(page.getByLabel('Name')).toBeVisible()


### PR DESCRIPTION
Switch from `.redwood/functions` to `.api/functions` as the default api proxy path

Only switches the default for new apps. No impact on existing apps