### PR TITLE
chore(cfw): remove legacy RWFW_PATH and RW_PATH env var fallbacks

### DIFF
--- a/packages/cli/src/cfw.js
+++ b/packages/cli/src/cfw.js
@@ -11,13 +11,7 @@ import { getConfigPath } from '@cedarjs/project-config'
 
 const config = new Configstore('@cedarjs/cli')
 
-// TODO: Remove RW related fallbacks here
-const CFW_PATH =
-  process.env.CFW_PATH ||
-  process.env.RWFW_PATH ||
-  process.env.RW_PATH ||
-  config.get('CFW_PATH') ||
-  config.get('RWFW_PATH')
+const CFW_PATH = process.env.CFW_PATH || config.get('CFW_PATH')
 
 if (!CFW_PATH) {
   console.error('Error: You must specify the path to Cedar Framework')


### PR DESCRIPTION
Closes #1611

Removes the legacy RedwoodJS env var fallbacks from `packages/cli/src/cfw.js` that were kept for backward compatibility during the RedwoodJS → CedarJS rename.

## Changes

```js
// Before
// TODO: Remove RW related fallbacks here
const CFW_PATH =
  process.env.CFW_PATH ||
  process.env.RWFW_PATH ||      // legacy RedwoodJS
  process.env.RW_PATH ||        // legacy RedwoodJS
  config.get('CFW_PATH') ||
  config.get('RWFW_PATH')       // legacy RedwoodJS configstore key

// After
const CFW_PATH = process.env.CFW_PATH || config.get('CFW_PATH')
```