### PR TITLE
fix(cli): replace unknown-as cast in prerender flatMap with proper return type

### DIFF
--- a/packages/cli/src/commands/prerenderHandler.ts
+++ b/packages/cli/src/commands/prerenderHandler.ts
@@ -274,31 +274,31 @@ export const getTasks = async (
 
     // If we're not folding the output, we'll return a list of tasks for each
     // individual case.
-    return routesToPrerender.flatMap((routeToPrerender) => {
-      // Filter out routes that don't match the supplied routePathFilter
-      if (routerPathFilter && routeToPrerender.path !== routerPathFilter) {
-        // TODO: Figure out if it's an error to return [] here
-        // TS is complaining. If it is actually correct, we can use flatMap(),
-        // or append .flat() to the end of the map call that begins above
-        // This code was originally added in
-        // https://github.com/redwoodjs/graphql/pull/10888
-        return [] as unknown as { title: string; task: () => Promise<void> }
-      }
+    type PrerenderTask = { title: string; task: () => Promise<void> }
+    return routesToPrerender.flatMap(
+      (routeToPrerender): PrerenderTask[] => {
+        // Filter out routes that don't match the supplied routePathFilter
+        if (routerPathFilter && routeToPrerender.path !== routerPathFilter) {
+          return []
+        }
 
-      const outputHtmlPath = mapRouterPathToHtml(routeToPrerender.path)
-      return {
-        title: `Prerendering ${routeToPrerender.path} -> ${outputHtmlPath}`,
-        task: async () => {
-          await prerenderRoute(
-            prerenderer,
-            queryCache,
-            routeToPrerender,
-            dryrun,
-            outputHtmlPath,
-          )
-        },
-      }
-    })
+        const outputHtmlPath = mapRouterPathToHtml(routeToPrerender.path)
+        return [
+          {
+            title: `Prerendering ${routeToPrerender.path} -> ${outputHtmlPath}`,
+            task: async () => {
+              await prerenderRoute(
+                prerenderer,
+                queryCache,
+                routeToPrerender,
+                dryrun,
+                outputHtmlPath,
+              )
+            },
+          },
+        ]
+      },
+    )
   })
 
   return listrTasks

--- a/packages/cli/src/commands/prerenderHandler.ts
+++ b/packages/cli/src/commands/prerenderHandler.ts
@@ -274,9 +274,8 @@ export const getTasks = async (
 
     // If we're not folding the output, we'll return a list of tasks for each
     // individual case.
-    type PrerenderTask = { title: string; task: () => Promise<void> }
     return routesToPrerender.flatMap(
-      (routeToPrerender): PrerenderTask[] => {
+      (routeToPrerender): { title: string; task: () => Promise<void> }[] => {
         // Filter out routes that don't match the supplied routePathFilter
         if (routerPathFilter && routeToPrerender.path !== routerPathFilter) {
           return []


### PR DESCRIPTION
Fixes #1626.

## What changed

In `packages/cli/src/commands/prerenderHandler.ts`, the `routesToPrerender.flatMap` callback used a type lie to satisfy TypeScript:

```ts
return [] as unknown as { title: string; task: () => Promise<void> }
```

Replaced with an explicit return type on the callback, so both branches return arrays that flatMap flattens normally:

```ts
type PrerenderTask = { title: string; task: () => Promise<void> }
return routesToPrerender.flatMap((routeToPrerender): PrerenderTask[] => {
  if (routerPathFilter && routeToPrerender.path !== routerPathFilter) {
    return []
  }
  ...
  return [{ title: ..., task: async () => { ... } }]
})
```

Also removed the TODO comment and the dangling link to a `redwoodjs/graphql` PR; the cast was the entire reason that comment block existed.

## Why this matters

`as unknown as` is the strongest type assertion TypeScript offers — it silences any error, including ones that would catch real bugs in the same file. Here it was hiding nothing dangerous (flatMap does the right thing with `[]`), but the pattern is easy to copy-paste into spots where it's not safe. Replacing it with an explicit callback return type closes the door without changing behavior.

## Verification

- `flatMap([] | [{...}])` flattens to `[{...}]` — same shape Listr2 received before.
- Diff is contained to one function. No call sites change; the resulting `listrTasks` array still has the same element type.