### PR TITLE
docs(tutorial): replace stale version callout with Discord tip

### DIFF
--- a/docs/docs/tutorial/foreword.md
+++ b/docs/docs/tutorial/foreword.md
@@ -28,11 +28,14 @@ or maybe even like this!
 
 :::
 
-It's usually something that goes into more detail about a specific point, refers you to further reading, or calls out something important you should know. Here comes one now:
+It's usually something that goes into more detail about a specific point, refers
+you to further reading, or calls out something important you should know. Here
+comes one now:
 
 :::tip
 
-If you get stuck at any point during the tutorial, the [CedarJS community on Discord](https://discord.gg/cedarjs) is a great place to ask for help!
+If you get stuck at any point during the tutorial, the [CedarJS community on
+Discord](https://discord.gg/cedarjs) is a great place to ask for help!
 
 :::
 

--- a/docs/docs/tutorial/foreword.md
+++ b/docs/docs/tutorial/foreword.md
@@ -28,6 +28,12 @@ or maybe even like this!
 
 :::
 
-It's usually something that goes into more detail about a specific point, refers you to further reading, or calls out something important you should know.
+It's usually something that goes into more detail about a specific point, refers you to further reading, or calls out something important you should know. Here comes one now:
+
+:::tip
+
+If you get stuck at any point during the tutorial, the [CedarJS community on Discord](https://discord.gg/cedarjs) is a great place to ask for help!
+
+:::
 
 Let's get started!

--- a/docs/docs/tutorial/foreword.md
+++ b/docs/docs/tutorial/foreword.md
@@ -28,12 +28,6 @@ or maybe even like this!
 
 :::
 
-It's usually something that goes into more detail about a specific point, refers you to further reading, or calls out something important you should know. Here comes one now:
-
-:::info
-
-This tutorial assumes you are using version 0.1.0 or greater of CedarJS.
-
-:::
+It's usually something that goes into more detail about a specific point, refers you to further reading, or calls out something important you should know.
 
 Let's get started!

--- a/docs/docs/tutorial/foreword.md
+++ b/docs/docs/tutorial/foreword.md
@@ -10,7 +10,7 @@ If you went through an earlier version of this tutorial you may remember it bein
 
 You'll find some callouts throughout the text to draw your attention:
 
-:::tip
+:::info
 
 They might look like this...
 


### PR DESCRIPTION
The callout saying _"This tutorial assumes you are using version 0.1.0 or greater of CedarJS"_ was outdated — CedarJS is now on 3.x.

Rather than just removing it, this replaces it with a tip pointing readers to the CedarJS Discord if they get stuck — which is genuinely useful in a tutorial context and still demonstrates the callout concept.