### PR TITLE
docs(tutorial): fix chapter 1 — CLI commands, callouts, app name

### DIFF
--- a/docs/docs/tutorial/chapter1/first-page.md
+++ b/docs/docs/tutorial/chapter1/first-page.md
@@ -1,9 +1,9 @@
 # Our First Page
 
-Let's give our users something to look at besides the (awesome) Cedar welcome page (thanks [@alicelovescake](https://github.com/alicelovescake)!). We'll use the `redwood` command line tool to create a page for us:
+Let's give our users something to look at besides the (awesome) Cedar welcome page (thanks [@alicelovescake](https://github.com/alicelovescake)!). We'll use the `cedar` command line tool to create a page for us:
 
 ```bash
-yarn redwood generate page home /
+yarn cedar generate page home /
 ```
 
 The command above does four things:
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/docs/tutorial/chapter1/installation.md
+++ b/docs/docs/tutorial/chapter1/installation.md
@@ -6,25 +6,25 @@ We'll use yarn ([yarn](https://yarnpkg.com/getting-started/install) is a require
 <TabItem value="js" label="JavaScript">
 
 ```bash
-yarn create cedar-app ./redwoodblog
+yarn create cedar-app ./cedarblog
 ```
 
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
 ```bash
-yarn create cedar-app --ts ./redwoodblog
+yarn create cedar-app --ts ./cedarblog
 ```
 
 </TabItem>
 </Tabs>
 
-You'll have a new directory `redwoodblog` containing several directories and files. Change to that directory and we'll start the development server:
+You'll have a new directory `cedarblog` containing several directories and files. Change to that directory and we'll start the development server:
 
 ```bash
-cd redwoodblog
+cd cedarblog
 yarn install
-yarn redwood dev
+yarn cedar dev
 ```
 
 A browser should automatically open to [http://localhost:8910](http://localhost:8910) and you will see the Cedar welcome page:

--- a/docs/docs/tutorial/chapter1/layouts.md
+++ b/docs/docs/tutorial/chapter1/layouts.md
@@ -13,7 +13,7 @@ When you look at these two pages what do they really care about? They have some 
 Let's create a layout to hold that `<header>`:
 
 ```bash
-yarn redwood g layout blog
+yarn cedar g layout blog
 ```
 
 :::tip
@@ -242,7 +242,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -250,7 +250,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/docs/tutorial/chapter1/prerequisites.md
+++ b/docs/docs/tutorial/chapter1/prerequisites.md
@@ -9,7 +9,7 @@ Cedar is composed of several popular libraries to make full-stack web developmen
 
 **Don't panic!** You can work through this tutorial without knowing much of anything about these technologies. You may find yourself getting lost in terminology that we don't stop and take the time to explain, but that's okay: just know that the nitty-gritty details of how those technologies work is out there and there will be plenty of time to learn them. As you learn more about them you'll start to see the lines between what Cedar provides on top of the stock implementations of these projects.
 
-You could definitely learn them all at once, but it will be harder to determine where one ends and another begins, which makes it more difficult to find help once you're past the tutorial and want to dive deeper into one technology or another. Our advice? Make it through the tutorial and then start building something on your own! When you find that what you learned in the tutorial doesn't exactly apply to a feature you're trying to build, Google for where you're stuck ("prisma select only some fields") and you'll be an expert in no time. And don't forget our [Discourse](https://community.redwoodjs.com/) and [Discord](https://cedarjs.com/discord) where you can get help from the creators of the framework, as well as tons of helpful community members.
+You could definitely learn them all at once, but it will be harder to determine where one ends and another begins, which makes it more difficult to find help once you're past the tutorial and want to dive deeper into one technology or another. Our advice? Make it through the tutorial and then start building something on your own! When you find that what you learned in the tutorial doesn't exactly apply to a feature you're trying to build, Google for where you're stuck ("prisma select only some fields") and you'll be an expert in no time. And don't forget our [Discord](https://cedarjs.com/discord) where you can get help from the creators of the framework, as well as tons of helpful community members.
 
 ### Node.js and Yarn Versions
 
@@ -27,7 +27,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/docs/tutorial/chapter1/second-page.md
+++ b/docs/docs/tutorial/chapter1/second-page.md
@@ -1,14 +1,14 @@
 # A Second Page and a Link
 
-Let's create an "About" page for our blog so everyone knows about the geniuses behind this achievement. We'll create another page using `redwood`:
+Let's create an "About" page for our blog so everyone knows about the geniuses behind this achievement. We'll create another page using `cedar`:
 
 ```bash
-yarn redwood generate page about
+yarn cedar generate page about
 ```
 
-Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
+Notice that we didn't specify a route path this time. If you leave it off the `cedar generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 
@@ -94,7 +94,7 @@ Let's point out a few things here:
 
   `<Route path="/about" page={AboutPage} name="about" />`
 
-  If you don't like the name or path that `redwood generate` created for your route, feel free to change it in `Routes.{jsx,tsx}`! Named routes are awesome because if you ever change the path associated with a route (like going from `/about` to `/about-us`), you need only change it in `Routes.{jsx,tsx}` and every link using a named route function (`routes.about()`) will still point to the correct place! You can also pass a string to the `to` prop (`to="/about"`), but now if your path ever changed you would need to find and replace every instance of `/about` to `/about-us`.
+  If you don't like the name or path that `cedar generate` created for your route, feel free to change it in `Routes.{jsx,tsx}`! Named routes are awesome because if you ever change the path associated with a route (like going from `/about` to `/about-us`), you need only change it in `Routes.{jsx,tsx}` and every link using a named route function (`routes.about()`) will still point to the correct place! You can also pass a string to the `to` prop (`to="/about"`), but now if your path ever changed you would need to find and replace every instance of `/about` to `/about-us`.
 
 ### Back Home
 


### PR DESCRIPTION
## Changes

**`yarn redwood` → `yarn cedar`** across all chapter 1 pages:
- `yarn redwood generate page home /` → `yarn cedar generate page home /`
- `yarn redwood generate page about` → `yarn cedar generate page about`
- `yarn redwood g layout blog` → `yarn cedar g layout blog`
- `yarn redwood dev` → `yarn cedar dev`
- All prose references to the `redwood` CLI updated to `cedar`

**Tutorial app renamed**: `redwoodblog` → `cedarblog`

**Discourse link removed** from prerequisites (was linking to the RedwoodJS community forum), Discord link kept.

**Broken `:::info` callouts fixed**: MDX 3 requires `:::info[Title]` (bracket syntax) for titled admonitions — the old `:::info Title` (space syntax) renders as literal text. Fixed in:
- `prerequisites.md` — "Installing Node and Yarn"
- `first-page.md` — "Automatic import of pages in the Routes file"
- `second-page.md` — "Code-splitting each page"
- `layouts.md` — "The `src` alias" and "Why are things named the way they are?"