### PR TITLE
docs(tutorial): fix chapter 2 — CLI names, callouts, and factual errors

### DIFF
--- a/docs/docs/tutorial/chapter2/cells.md
+++ b/docs/docs/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -124,7 +124,7 @@ We do, but you will generally want to use a _cell_ when you need data from the d
 As you'll see repeatedly going forward, Cedar has a generator for this feature! Let's call this the "Articles" cell, since "Posts" was already used by our scaffold generator, and although the names won't clash (the scaffold files were created in the `Post` directory), it will be easier to keep them straight in our heads if the names are fairly different from each other. We're going to be showing multiple things, so we'll use the plural version "Articles," rather than "Article":
 
 ```bash
-yarn rw g cell Articles
+yarn cedar g cell Articles
 ```
 
 This command will result in a new file at `/web/src/components/ArticlesCell/ArticlesCell.{jsx,tsx}` (and `test.{jsx,tsx}` `mock.{js,ts}` and `stories.{jsx,tsx}` files—more on those in [chapter 5 of the tutorial](../chapter5/storybook.md)!). This file will contain some boilerplate to get you started:
@@ -207,20 +207,20 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
 ```bash
-yarn rw g cell blog_articles
-yarn rw g cell blog-articles
-yarn rw g cell blogArticles
-yarn rw g cell BlogArticles
+yarn cedar g cell blog_articles
+yarn cedar g cell blog-articles
+yarn cedar g cell blogArticles
+yarn cedar g cell BlogArticles
 ```
 
 You will need _some_ kind of indication that you're using more than one word: either snake_case (`blog_articles`), kebab-case (`blog-articles`), camelCase (`blogArticles`) or PascalCase (`BlogArticles`).
 
-Calling `yarn redwood g cell blogarticles` (without any indication that we're using two words) will generate a file at `web/src/components/BlogarticlesCell/BlogarticlesCell.{jsx,tsx}`.
+Calling `yarn cedar g cell blogarticles` (without any indication that we're using two words) will generate a file at `web/src/components/BlogarticlesCell/BlogarticlesCell.{jsx,tsx}`.
 
 :::
 
@@ -348,14 +348,14 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 
-When you have the dev server (via `yarn rw dev`) running, the CLI watches files for changes and triggers type generation automatically, but you can trigger it manually too by running:
+When you have the dev server (via `yarn cedar dev`) running, the CLI watches files for changes and triggers type generation automatically, but you can trigger it manually too by running:
 
 ```bash
-yarn rw g types
+yarn cedar g types
 ```
 
 This looks at your Cell's `QUERY` and—as long as it's valid—tries to automatically create a TypeScript type for you to use in your code.

--- a/docs/docs/tutorial/chapter2/getting-dynamic.md
+++ b/docs/docs/tutorial/chapter2/getting-dynamic.md
@@ -55,13 +55,13 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
 `id String @id @default(cuid())`
 
-Integers make for nicer URLs like https://redwoodblog.com/posts/123 instead of https://redwoodblog.com/posts/eebb026c-b661-42fe-93bf-f1a373421a13.
+Integers make for nicer URLs like https://cedarblog.com/posts/123 instead of https://cedarblog.com/posts/eebb026c-b661-42fe-93bf-f1a373421a13.
 
 Take a look at the [official Prisma documentation](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/data-model#defining-an-id-field) for more on ID fields.
 
@@ -72,14 +72,8 @@ Take a look at the [official Prisma documentation](https://www.prisma.io/docs/re
 Now we'll want to snapshot the schema changes as a migration:
 
 ```bash
-yarn rw prisma migrate dev
+yarn cedar prisma migrate dev
 ```
-
-:::tip
-
-From now on we'll use the shorter `rw` alias instead of the full `redwood` argument.
-
-:::
 
 You'll be prompted to give this migration a name. Something that describes what it does is ideal, so how about "create post" (without the quotes, of course). This is for your own benefit—neither Cedar nor Prisma care about the migration's name, it's just a reference when looking through old migrations and trying to find when you created or modified something specific.
 
@@ -96,7 +90,7 @@ A database is a pretty abstract thing: where's the data? What's it look like? Ho
 (Ours won't have any data there yet.) To open Prisma Studio, run the command:
 
 ```bash
-yarn rw prisma studio
+yarn cedar prisma studio
 ```
 
 A new browser should open to [http://localhost:5555](http://localhost:5555) and now you can view and manipulate data in the database directly!
@@ -112,7 +106,7 @@ We haven't decided on the look and feel of our site yet, but wouldn't it be amaz
 Let's generate everything we need to perform all the CRUD (Create, Retrieve, Update, Delete) actions on posts so we can not only verify that we've got the right fields in the database, but that it will let us get some sample posts in there so we can start laying out our pages and see real content. Cedar has a _generator_ for just this occasion:
 
 ```bash
-yarn rw g scaffold post
+yarn cedar g scaffold post
 ```
 
 Let's point the browser to [http://localhost:8910/posts](http://localhost:8910/posts) and see what we have:
@@ -145,12 +139,12 @@ So, Cedar just created all the pages, components and services necessary to perfo
 
 If you head back to VSCode at some point and get a notice in one of the generated Post cells about `Cannot query "posts" on type "Query"` don't worry: we've seen this from time to time on some systems. There are two easy fixes:
 
-1. Run `yarn rw g types` in a terminal
+1. Run `yarn cedar g types` in a terminal
 2. Reload the GraphQL engine in VSCode: open the Command Palette (Cmd+Shift+P for Mac, Ctrl+Shift+P for Windows) and find "VSCode GraphQL: Manual Restart"
 
 :::
 
-Here's what happened when we ran that `yarn rw g scaffold post` command:
+Here's what happened when we ran that `yarn cedar g scaffold post` command:
 
 - Created several _pages_ in `web/src/pages/Post`:
   - `EditPostPage` for editing a post
@@ -168,14 +162,14 @@ Here's what happened when we ran that `yarn rw g scaffold post` command:
   - `Post` displays a single post
   - `PostForm` the actual form used by both the New and Edit components
   - `Posts` displays the table of all posts
-- Added an _SDL_ file to define several GraphQL queries and mutations in `api/src/graphql/posts.sdl.{jsx,ts}`
+- Added an _SDL_ file to define several GraphQL queries and mutations in `api/src/graphql/posts.sdl.{js,ts}`
 - Added a _services_ file in `api/src/services/posts/posts.{js,ts}` that makes the Prisma client calls to get data in and out of the database
 
 Pages and components/cells are nicely contained in `Post` directories to keep them organized while the layout is at the top level since there's only one of them.
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -3,7 +3,7 @@
 Now that we have our homepage listing all the posts, let's build the "detail" page—a canonical URL that displays a single post. First we'll generate the page and route:
 
 ```bash
-yarn rw g page Article
+yarn cedar g page Article
 ```
 
 Now let's link the title of the post on the homepage to the detail page (and include the `import` for `Link` and `routes`):
@@ -186,9 +186,9 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
-When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
+When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn cedar g types`.
 
 In this case, the path `/article/{id}` doesn't specify the type of `id` - so it defaults to `string` - where as our article id is actually a `number`. We'll tackle this in the next few sections - so you can ignore the red squiggle for now, and power through!
 :::
@@ -261,7 +261,7 @@ You may have noticed that when trying to view the new single-article page that y
 Ok, so the ID is in the URL. What do we need next in order to display a specific post? It sounds like we'll be doing some data retrieval from the database, which means we want a cell. Note the singular `Article` here since we're only displaying one:
 
 ```bash
-yarn rw g cell Article
+yarn cedar g cell Article
 ```
 
 And then we'll use that cell in `ArticlePage`:
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 
@@ -552,7 +552,7 @@ Thanks again, Cedar!
 Now let's display the actual post instead of just dumping the query result. We could copy the display from the articles on the homepage, but that's not very reusable! This is the perfect place for a good old fashioned component—define the display once and then reuse the component on the homepage and the article display page. Both `ArticlesCell` and `ArticleCell` will display our new component. Let's Cedar-up a component (I just invented that phrase):
 
 ```bash
-yarn rw g component Article
+yarn cedar g component Article
 ```
 
 Which creates `web/src/components/Article/Article.{jsx,tsx}` (and corresponding test and more!) as a super simple React component:


### PR DESCRIPTION
## Summary

Fixes CedarJS tutorial chapter 2 (Getting Dynamic, Cells, Routing Params) inherited from RedwoodJS:

- **CLI commands**: Replace all `yarn rw` and `yarn redwood` with `yarn cedar`
- **Remove `rw` alias tip**: CedarJS has no `rw` alias — remove the tip block in `getting-dynamic.md` that introduced it
- **Broken callouts**: Fix all titled admonitions from `:::info Title` (space syntax) to `:::info[Title]` (bracket syntax) required by MDX 3 / Docusaurus 3
- **SDL file extension**: `posts.sdl.{jsx,ts}` → `posts.sdl.{js,ts}` (SDL files are `.js`/`.ts`, not `.jsx`)
- **Example URLs**: `redwoodblog.com` → `cedarblog.com`

## Files changed

- `docs/docs/tutorial/chapter2/getting-dynamic.md`
- `docs/docs/tutorial/chapter2/cells.md`
- `docs/docs/tutorial/chapter2/routing-params.md`

## Test plan

- [ ] Verify all callouts render with titles on the live docs site
- [ ] Verify no `yarn rw` or `yarn redwood` references remain in chapter 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)