### PR TITLE
chore(ci): Allow postcss changes in fixtures

### DIFF
--- a/.github/workflows/check-test-project-fixture-esm.yml
+++ b/.github/workflows/check-test-project-fixture-esm.yml
@@ -102,7 +102,7 @@ jobs:
             non_package_json=$(git status --porcelain | grep '^ M ' | awk '{print $2}' | grep -v 'package\.json$' || true)
             if [ -z "$non_package_json" ]; then
               # Check if the only changes are to postcss, postcss-loader, or autoprefixer versions
-              remaining=$(git diff -- '*package.json' | grep -E '^[+-]' | grep -vE '^[+-]\s*"(postcss"|postcss-loader"|autoprefixer"):' || true)
+              remaining=$(git diff -- '*package.json' | grep -E '^[+-][^+-]' | grep -vE '^[+-]\s*"(postcss"|postcss-loader"|autoprefixer"):' || true)
               if [ -z "$remaining" ]; then
                 echo 'Only allowed package version changes (postcss, postcss-loader, autoprefixer) detected. Ignoring.'
                 exit 0

--- a/.github/workflows/check-test-project-fixture-esm.yml
+++ b/.github/workflows/check-test-project-fixture-esm.yml
@@ -90,21 +90,39 @@ jobs:
       - name: Check for changed files
         if: steps.detect-changes.outputs.code == 'true' && !contains(github.event.pull_request.labels.*.name, 'fixture-ok')
         run: |
-          if [ $(git status --porcelain | wc -l) -gt 0 ]; then
-            echo 'Updating the test project fixture caused files to change'
-            echo 'Please run `yarn rebuild-test-project-fixture --esm` locally and commit any changes'
-            echo
-            echo 'Deleted files:'
-            git status --porcelain | grep '^ D ' | awk '{print "        " $2}'
-            echo
-            echo 'Modified files:'
-            git status --porcelain | grep '^ M ' | awk '{print "        " $2}'
-            echo
-            echo 'Untracked files:'
-            git status --porcelain | grep '^?? ' | awk '{print "        " $2}'
-            echo
-            echo
-            echo 'Full diff:'
-            git diff
-            exit 1;
+          if [ $(git status --porcelain | wc -l) -eq 0 ]; then
+            exit 0
           fi
+
+          # Fail fast on deleted or untracked files
+          if git status --porcelain | grep -qE '^ D |^\?\? '; then
+            : # fall through to failure output below
+          else
+            # Check if only package.json files are modified
+            non_package_json=$(git status --porcelain | grep '^ M ' | awk '{print $2}' | grep -v 'package\.json$' || true)
+            if [ -z "$non_package_json" ]; then
+              # Check if the only changes are to postcss, postcss-loader, or autoprefixer versions
+              remaining=$(git diff -- '*package.json' | grep -E '^[+-]' | grep -vE '^[+-]\s*"(postcss"|postcss-loader"|autoprefixer"):' || true)
+              if [ -z "$remaining" ]; then
+                echo 'Only allowed package version changes (postcss, postcss-loader, autoprefixer) detected. Ignoring.'
+                exit 0
+              fi
+            fi
+          fi
+
+          echo 'Updating the test project fixture caused files to change'
+          echo 'Please run `yarn rebuild-test-project-fixture --esm` locally and commit any changes'
+          echo
+          echo 'Deleted files:'
+          git status --porcelain | grep '^ D ' | awk '{print "        " $2}'
+          echo
+          echo 'Modified files:'
+          git status --porcelain | grep '^ M ' | awk '{print "        " $2}'
+          echo
+          echo 'Untracked files:'
+          git status --porcelain | grep '^?? ' | awk '{print "        " $2}'
+          echo
+          echo
+          echo 'Full diff:'
+          git diff
+          exit 1

--- a/.github/workflows/check-test-project-fixture.yml
+++ b/.github/workflows/check-test-project-fixture.yml
@@ -102,7 +102,7 @@ jobs:
             non_package_json=$(git status --porcelain | grep '^ M ' | awk '{print $2}' | grep -v 'package\.json$' || true)
             if [ -z "$non_package_json" ]; then
               # Check if the only changes are to postcss, postcss-loader, or autoprefixer versions
-              remaining=$(git diff -- '*package.json' | grep -E '^[+-]' | grep -vE '^[+-]\s*"(postcss"|postcss-loader"|autoprefixer"):' || true)
+              remaining=$(git diff -- '*package.json' | grep -E '^[+-][^+-]' | grep -vE '^[+-]\s*"(postcss"|postcss-loader"|autoprefixer"):' || true)
               if [ -z "$remaining" ]; then
                 echo 'Only allowed package version changes (postcss, postcss-loader, autoprefixer) detected. Ignoring.'
                 exit 0

--- a/.github/workflows/check-test-project-fixture.yml
+++ b/.github/workflows/check-test-project-fixture.yml
@@ -90,21 +90,39 @@ jobs:
       - name: Check for changed files
         if: steps.detect-changes.outputs.code == 'true' && !contains(github.event.pull_request.labels.*.name, 'fixture-ok')
         run: |
-          if [ $(git status --porcelain | wc -l) -gt 0 ]; then
-            echo 'Updating the test project fixture caused files to change'
-            echo 'Please run `yarn rebuild-test-project-fixture` locally and commit any changes'
-            echo
-            echo 'Deleted files:'
-            git status --porcelain | grep '^ D ' | awk '{print "        " $2}'
-            echo
-            echo 'Modified files:'
-            git status --porcelain | grep '^ M ' | awk '{print "        " $2}'
-            echo
-            echo 'Untracked files:'
-            git status --porcelain | grep '^?? ' | awk '{print "        " $2}'
-            echo
-            echo
-            echo 'Full diff:'
-            git diff
-            exit 1;
+          if [ $(git status --porcelain | wc -l) -eq 0 ]; then
+            exit 0
           fi
+
+          # Fail fast on deleted or untracked files
+          if git status --porcelain | grep -qE '^ D |^\?\? '; then
+            : # fall through to failure output below
+          else
+            # Check if only package.json files are modified
+            non_package_json=$(git status --porcelain | grep '^ M ' | awk '{print $2}' | grep -v 'package\.json$' || true)
+            if [ -z "$non_package_json" ]; then
+              # Check if the only changes are to postcss, postcss-loader, or autoprefixer versions
+              remaining=$(git diff -- '*package.json' | grep -E '^[+-]' | grep -vE '^[+-]\s*"(postcss"|postcss-loader"|autoprefixer"):' || true)
+              if [ -z "$remaining" ]; then
+                echo 'Only allowed package version changes (postcss, postcss-loader, autoprefixer) detected. Ignoring.'
+                exit 0
+              fi
+            fi
+          fi
+
+          echo 'Updating the test project fixture caused files to change'
+          echo 'Please run `yarn rebuild-test-project-fixture` locally and commit any changes'
+          echo
+          echo 'Deleted files:'
+          git status --porcelain | grep '^ D ' | awk '{print "        " $2}'
+          echo
+          echo 'Modified files:'
+          git status --porcelain | grep '^ M ' | awk '{print "        " $2}'
+          echo
+          echo 'Untracked files:'
+          git status --porcelain | grep '^?? ' | awk '{print "        " $2}'
+          echo
+          echo
+          echo 'Full diff:'
+          git diff
+          exit 1


### PR DESCRIPTION
I'm tired of changes like these blocking unrelated PRs

```
Run if [ $(git status --porcelain | wc -l) -gt 0 ]; then
Updating the test project fixture caused files to change
Please run `yarn rebuild-test-project-fixture` locally and commit any changes

Deleted files:

Modified files:
        __fixtures__/test-project/web/package.json

Untracked files:


Full diff:
diff --git a/__fixtures__/test-project/web/package.json b/__fixtures__/test-project/web/package.json
index e1a2af8..3853dce 100644
--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10.5.0",
-    "postcss": "^8.5.13",
+    "postcss": "^8.5.14",
     "postcss-loader": "^8.2.1",
     "tailwindcss": "^3.4.17"
   }
Error: Process completed with exit code 1.
```

So now I allow autoprefixer, postcss and postcss-loader version changes.