### PR TITLE
refactor: replace vite-node with Vite's native RunnableDevEnvironment

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,7 +88,6 @@
     "title-case": "3.0.3",
     "unionfs": "4.6.0",
     "uuid": "11.1.0",
-    "vite-node": "3.2.4",
     "yargs": "17.7.2"
   },
   "devDependencies": {

--- a/packages/cli/src/lib/exec.js
+++ b/packages/cli/src/lib/exec.js
@@ -102,6 +102,7 @@ export async function runScriptFunction({
 
   const env = server.environments.nodeRunnerEnv
   if (!env || !isRunnableDevEnvironment(env)) {
+    await server.close()
     throw new Error('Vite environment is not runnable.')
   }
 

--- a/packages/cli/src/lib/exec.js
+++ b/packages/cli/src/lib/exec.js
@@ -1,9 +1,6 @@
 import path from 'node:path'
 
-import { createServer, version as viteVersion } from 'vite'
-import { ViteNodeRunner } from 'vite-node/client'
-import { ViteNodeServer } from 'vite-node/server'
-import { installSourcemapsSupport } from 'vite-node/source-map'
+import { createServer, isRunnableDevEnvironment } from 'vite'
 
 import { getPaths, importStatementPath } from '@cedarjs/project-config'
 import {
@@ -28,9 +25,15 @@ export async function runScriptFunction({
   const server = await createServer({
     mode: 'production',
     optimizeDeps: {
-      // This is recommended in the vite-node readme
       noDiscovery: true,
       include: undefined,
+    },
+    server: {
+      hmr: false,
+      watch: null,
+    },
+    environments: {
+      nodeRunnerEnv: {},
     },
     resolve: {
       alias: [
@@ -97,49 +100,25 @@ export async function runScriptFunction({
     ],
   })
 
-  // For old Vite, this is needed to initialize the plugins.
-  if (Number(viteVersion.split('.')[0]) < 6) {
-    await server.pluginContainer.buildStart({})
+  const env = server.environments.nodeRunnerEnv
+  if (!env || !isRunnableDevEnvironment(env)) {
+    throw new Error('Vite environment is not runnable.')
   }
-
-  const node = new ViteNodeServer(server, {
-    transformMode: {
-      ssr: [/.*/],
-      web: [/\/web\//],
-    },
-    deps: {
-      fallbackCJS: true,
-    },
-  })
-
-  // fixes stacktraces in Errors
-  installSourcemapsSupport({
-    getSourceMap: (source) => node.getSourceMap(source),
-  })
-
-  const runner = new ViteNodeRunner({
-    root: server.config.root,
-    base: server.config.base,
-    fetchModule(id) {
-      return node.fetchModule(id)
-    },
-    resolveId(id, importer) {
-      return node.resolveId(id, importer)
-    },
-  })
 
   let returnValue
   let scriptError = null
 
   try {
-    const script = await runner.executeFile(scriptPath)
+    const script = await env.runner.import(scriptPath)
     returnValue = await script[functionName](args)
   } catch (error) {
     scriptError = error
   }
 
   try {
-    const { db } = await runner.executeFile(path.join(getPaths().api.lib, 'db'))
+    const { db } = await env.runner.import(
+      path.join(getPaths().api.lib, 'db'),
+    )
     db.$disconnect()
   } catch (e) {
     // silence

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -91,8 +91,7 @@
     "rollup-plugin-swc3": "0.12.1",
     "unimport": "5.7.0",
     "unplugin-auto-import": "19.3.0",
-    "vite": "7.3.2",
-    "vite-node": "3.2.4"
+    "vite": "7.3.2"
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",

--- a/packages/prerender/src/graphql/node-runner.ts
+++ b/packages/prerender/src/graphql/node-runner.ts
@@ -76,7 +76,12 @@ export class NodeRunner {
       await this.init()
     }
 
-    return this.env?.runner.import(filePath)
+    const env = this.env
+    if (!env) {
+      throw new Error('NodeRunner failed to initialize')
+    }
+
+    return env.runner.import(filePath)
   }
 
   async close() {

--- a/packages/prerender/src/graphql/node-runner.ts
+++ b/packages/prerender/src/graphql/node-runner.ts
@@ -1,8 +1,5 @@
-import { createServer, version as viteVersion, mergeConfig } from 'vite'
-import type { ViteDevServer, UserConfig } from 'vite'
-import { ViteNodeRunner } from 'vite-node/client'
-import { ViteNodeServer } from 'vite-node/server'
-import { installSourcemapsSupport } from 'vite-node/source-map'
+import { createServer, isRunnableDevEnvironment, mergeConfig } from 'vite'
+import type { ViteDevServer, RunnableDevEnvironment, UserConfig } from 'vite'
 
 import { getPaths } from '@cedarjs/project-config'
 import {
@@ -19,9 +16,15 @@ async function createViteServer(customConfig: UserConfig = {}) {
   const defaultConfig: UserConfig = {
     mode: 'production',
     optimizeDeps: {
-      // This is recommended in the vite-node readme
       noDiscovery: true,
       include: undefined,
+    },
+    server: {
+      hmr: false,
+      watch: null,
+    },
+    environments: {
+      nodeRunnerEnv: {},
     },
     resolve: {
       alias: [
@@ -45,17 +48,12 @@ async function createViteServer(customConfig: UserConfig = {}) {
 
   const server = await createServer(mergedConfig)
 
-  // For old Vite, this is needed to initialize the plugins.
-  if (Number(viteVersion.split('.')[0]) < 6) {
-    await server.pluginContainer.buildStart({})
-  }
-
   return server
 }
 
 export class NodeRunner {
   private viteServer?: ViteDevServer = undefined
-  private runner?: ViteNodeRunner = undefined
+  private env?: RunnableDevEnvironment = undefined
   private readonly customViteConfig: UserConfig
 
   constructor(customViteConfig: UserConfig = {}) {
@@ -64,39 +62,21 @@ export class NodeRunner {
 
   async init() {
     this.viteServer = await createViteServer(this.customViteConfig)
-    const nodeServer = new ViteNodeServer(this.viteServer, {
-      transformMode: {
-        ssr: [/.*/],
-        web: [/\/web\//],
-      },
-      deps: {
-        fallbackCJS: true,
-      },
-    })
 
-    // fixes stacktraces in Errors
-    installSourcemapsSupport({
-      getSourceMap: (source) => nodeServer?.getSourceMap(source),
-    })
+    const env = this.viteServer.environments.nodeRunnerEnv
+    if (!env || !isRunnableDevEnvironment(env)) {
+      throw new Error('Vite environment is not runnable.')
+    }
 
-    this.runner = new ViteNodeRunner({
-      root: this.viteServer.config.root,
-      base: this.viteServer.config.base,
-      fetchModule(id) {
-        return nodeServer.fetchModule(id)
-      },
-      resolveId(id, importer) {
-        return nodeServer.resolveId(id, importer)
-      },
-    })
+    this.env = env
   }
 
   async importFile(filePath: string) {
-    if (!this.runner) {
+    if (!this.env) {
       await this.init()
     }
 
-    return this.runner?.executeFile(filePath)
+    return this.env?.runner.import(filePath)
   }
 
   async close() {


### PR DESCRIPTION
## Summary

`vite-node` is a separate package that replicates functionality now built directly into Vite via the [Environment API](https://vite.dev/guide/api-environment) (introduced in Vite 6, and we're on Vite 7).

This replaces `ViteNodeServer` + `ViteNodeRunner` + `installSourcemapsSupport` with Vite's native `RunnableDevEnvironment`:

**Before:**
```js
const node = new ViteNodeServer(server, { ... })
installSourcemapsSupport({ getSourceMap: (source) => node.getSourceMap(source) })
const runner = new ViteNodeRunner({ root, base, fetchModule, resolveId })
const result = await runner.executeFile(filePath)
```

**After:**
```js
// In server config:
environments: { nodeRunnerEnv: {} }

// Then:
const env = server.environments.nodeRunnerEnv
if (!isRunnableDevEnvironment(env)) throw new Error(...)
const result = await env.runner.import(filePath)
```

## Files changed

- `packages/cli/src/lib/exec.js` — used by `yarn cedar exec` (script runner)
- `packages/prerender/src/graphql/node-runner.ts` — used by prerender's GraphQL node runner
- Both `package.json` files — `vite-node` dependency removed

## Inspired by

remix-run/react-router#14862

🤖 Generated with [Claude Code](https://claude.com/claude-code)