### PR TITLE
fix(build): Restore v4 backwards compatibility

### DIFF
--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -129,10 +129,13 @@ cedar dev:
 
 cedar build:
   prisma gen → GraphQL types → validate SDLs →
-  API + Web (unified Vite `buildApp()` with declared `client` and `api`
-      environments → web/dist/ + api/dist/, preserveModules, Babel plugin) →
-  UD (Vite SSR build → api/dist/ud/index.js, self-contained Node entry, only
-      when --ud is passed) →
+  default: legacy separate builds
+    API (`buildApi()` esbuild → api/dist/, Babel plugin) →
+    Web (`cedar-vite-build` → web/dist/) →
+  --ud: unified Vite `buildApp()` with declared `client` and `api` environments
+    (web/dist/ + api/dist/, preserveModules, Babel plugin) →
+  UD server entry (Vite SSR build → api/dist/ud/index.js, self-contained Node
+    entry, only when --ud is passed) →
   prerender marked routes
 
 *SSR/RSC: falls back to legacy separate builds; adds route hooks build, route

--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -132,10 +132,11 @@ cedar build:
   default: legacy separate builds
     API (`buildApi()` esbuild → api/dist/, Babel plugin) →
     Web (`cedar-vite-build` → web/dist/) →
-  --ud: unified Vite `buildApp()` with declared `client` and `api` environments
-    (web/dist/ + api/dist/, preserveModules, Babel plugin) →
-  UD server entry (Vite SSR build → api/dist/ud/index.js, self-contained Node
-    entry, only when --ud is passed) →
+  --ud:
+    UD server entry (Vite SSR build → api/dist/ud/index.js, self-contained Node
+      entry) →
+    unified Vite `buildApp()` with declared `client` and `api` environments
+      (web/dist/ + api/dist/, preserveModules, Babel plugin) →
   prerender marked routes
 
 *SSR/RSC: falls back to legacy separate builds; adds route hooks build, route
@@ -269,7 +270,7 @@ Routes.tsx ← 4 routes added inside <Set wrap={ScaffoldLayout} title="Posts" ..
   and `meta()` (SSR/RSC only: per-request meta tag injection)
 - Entry: `entry.client.tsx` (always). \*SSR/RSC: also `entry.server.tsx`
 - Routes in `Routes.tsx` as JSX (virtual, never rendered — Babel auto-loads pages)
-- Build: Vite (web + api); api uses `build.ssr: true` + `preserveModules: true` + Babel plugin
+- Build: default = esbuild (api) + Vite (web); `--ud` = unified Vite (web + api with `build.ssr: true` + `preserveModules: true` + Babel plugin)
 - Server: API always Fastify; opt-in srvx/WinterTC via `cedar serve api --ud` (`buildUDApiServer` emits `api/dist/ud/index.js`). Web: Fastify (SPA). \*SSR/RSC: Web uses Express
 - Package mgr: Yarn 4 (+ experimental support for npm and pnpm); Framework: Yarn 4 + Nx (build orchestration).
 - Codegen: compile-time (Vite plugins) + on-demand (cedar-gen)

--- a/packages/cli/src/commands/build/__tests__/build.test.ts
+++ b/packages/cli/src/commands/build/__tests__/build.test.ts
@@ -67,6 +67,7 @@ vi.mock('node:fs', () => {
 
 vi.mock('@cedarjs/internal/dist/build/api', () => ({
   cleanApiBuild: vi.fn(),
+  buildApi: vi.fn().mockResolvedValue({ errors: [], warnings: [] }),
 }))
 
 vi.mock('@cedarjs/vite/build', () => ({
@@ -161,7 +162,8 @@ test('the build tasks are in the correct sequence when packagesWorkspace is enab
       "Building Packages...",
       "Checking workspace packages...",
       "Verifying graphql schema...",
-      "Building App...",
+      "Building API...",
+      "Building Web...",
     ]
   `)
 })
@@ -177,7 +179,8 @@ test('the build tasks are in the correct sequence when packagesWorkspace is disa
     [
       "Generating Prisma Client...",
       "Verifying graphql schema...",
-      "Building App...",
+      "Building API...",
+      "Building Web...",
     ]
   `)
 })

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -300,11 +300,14 @@ export const handler = async ({
           await cleanApiBuild()
           const { errors, warnings } = await buildApi()
 
-          if (errors.length) {
-            console.error(errors)
-          }
           if (warnings.length) {
             console.warn(warnings)
+          }
+
+          if (errors.length) {
+            throw new Error(
+              `API build failed with ${errors.length} error(s). See output above for details.`,
+            )
           }
         },
       },
@@ -343,17 +346,14 @@ export const handler = async ({
             },
           )
 
-          // Streaming SSR does not use the index.html file.
-          if (!getConfig().experimental?.streamingSsr?.enabled) {
-            console.log('Creating 200.html...')
+          console.log('Creating 200.html...')
 
-            const indexHtmlPath = path.join(getPaths().web.dist, 'index.html')
+          const indexHtmlPath = path.join(getPaths().web.dist, 'index.html')
 
-            fs.copyFileSync(
-              indexHtmlPath,
-              path.join(getPaths().web.dist, '200.html'),
-            )
-          }
+          fs.copyFileSync(
+            indexHtmlPath,
+            path.join(getPaths().web.dist, '200.html'),
+          )
         },
       },
     // Unified build path (experimental, non-streaming-SSR, --ud)

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -14,6 +14,7 @@ import {
 } from '@cedarjs/cli-helpers/packageManager/display'
 import { runBin } from '@cedarjs/cli-helpers/packageManager/exec'
 import {
+  buildApi,
   buildApiWithVite,
   cleanApiBuild,
 } from '@cedarjs/internal/dist/build/api'
@@ -290,8 +291,74 @@ export const handler = async ({
           }
         },
       },
-    // Unified build path (default, non-streaming-SSR)
+    // Legacy separate build path (default when not --ud, non-streaming-SSR)
+    workspace.includes('api') &&
+      !ud &&
+      !getConfig().experimental?.streamingSsr?.enabled && {
+        title: 'Building API...',
+        task: async () => {
+          await cleanApiBuild()
+          const { errors, warnings } = await buildApi()
+
+          if (errors.length) {
+            console.error(errors)
+          }
+          if (warnings.length) {
+            console.warn(warnings)
+          }
+        },
+      },
+    workspace.includes('web') &&
+      !ud &&
+      !getConfig().experimental?.streamingSsr?.enabled && {
+        title: 'Building Web...',
+        task: async () => {
+          // Disable the new warning in Vite v5 about the CJS build being deprecated
+          // so that users don't have to see it when this command is called with --verbose
+          process.env.VITE_CJS_IGNORE_WARNING = 'true'
+
+          const createdRequire = createRequire(import.meta.url)
+          const buildBinPath = createdRequire.resolve(
+            '@cedarjs/vite/bins/cedar-vite-build.mjs',
+          )
+
+          // @NOTE: we're using the vite build command here, instead of the
+          // buildWeb function directly because we want the process.cwd to be
+          // the web directory, not the root of the project.
+          // This is important for postcss/tailwind to work correctly
+          // Having a separate binary lets us contain the change of cwd to that
+          // process only. If we changed cwd here, or in the buildWeb function,
+          // it could affect other things that run in parallel while building.
+          // We don't have any parallel tasks right now, but someone might add
+          // one in the future as a performance optimization.
+          await execa(
+            `node ${buildBinPath} --webDir="${cedarPaths.web.base}" --verbose=${verbose}`,
+            {
+              stdio: verbose ? 'inherit' : 'pipe',
+              shell: true,
+              // `cwd` is needed for yarn to find the cedar-vite-build binary
+              // It won't change process.cwd for anything else here, in this
+              // process
+              cwd: cedarPaths.web.base,
+            },
+          )
+
+          // Streaming SSR does not use the index.html file.
+          if (!getConfig().experimental?.streamingSsr?.enabled) {
+            console.log('Creating 200.html...')
+
+            const indexHtmlPath = path.join(getPaths().web.dist, 'index.html')
+
+            fs.copyFileSync(
+              indexHtmlPath,
+              path.join(getPaths().web.dist, '200.html'),
+            )
+          }
+        },
+      },
+    // Unified build path (experimental, non-streaming-SSR, --ud)
     (workspace.includes('api') || workspace.includes('web')) &&
+      ud &&
       !getConfig().experimental?.streamingSsr?.enabled && {
         title:
           workspace.includes('api') && workspace.includes('web')

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -107,21 +107,43 @@ export const handler = async ({
   }
 
   // Check for port conflict and exit with message if found
-  if (webPortChangeNeeded) {
-    const message = [
-      'The currently configured port for the development server is',
-      'unavailable. Suggested change to your port, which can be changed in',
-      'cedar.toml (or redwood.toml):\n',
-      ` - Web to use port ${webAvailablePort} instead`,
-      'of your currently configured',
-      `${webPreferredPort}\n`,
-      '\nCannot run the development server until your configured port is',
-      'changed or becomes available.',
-    ]
-      .filter(Boolean)
-      .join(' ')
+  if (ud) {
+    if (webPortChangeNeeded) {
+      const message = [
+        'The currently configured port for the development server is',
+        'unavailable. Suggested change to your port, which can be changed in',
+        'cedar.toml (or redwood.toml):\n',
+        ` - Web to use port ${webAvailablePort} instead`,
+        'of your currently configured',
+        `${webPreferredPort}\n`,
+        '\nCannot run the development server until your configured port is',
+        'changed or becomes available.',
+      ]
+        .filter(Boolean)
+        .join(' ')
 
-    exitWithError(undefined, { message })
+      exitWithError(undefined, { message })
+    }
+  } else {
+    if (apiPortChangeNeeded || webPortChangeNeeded) {
+      const message = [
+        'The currently configured ports for the development server are',
+        'unavailable. Suggested changes to your ports, which can be changed in',
+        'cedar.toml (or redwood.toml), are:\n',
+        apiPortChangeNeeded && ` - API to use port ${apiAvailablePort} instead`,
+        apiPortChangeNeeded && 'of your currently configured',
+        apiPortChangeNeeded && `${apiPreferredPort}\n`,
+        webPortChangeNeeded && ` - Web to use port ${webAvailablePort} instead`,
+        webPortChangeNeeded && 'of your currently configured',
+        webPortChangeNeeded && `${webPreferredPort}\n`,
+        '\nCannot run the development server until your configured ports are',
+        'changed or become available.',
+      ]
+        .filter(Boolean)
+        .join(' ')
+
+      exitWithError(undefined, { message })
+    }
   }
 
   if (workspace.includes('api')) {
@@ -131,6 +153,18 @@ export const handler = async ({
       const message = getErrorMessage(e)
       errorTelemetry(process.argv, `Error generating prisma client: ${message}`)
       console.error(c.error(message))
+    }
+
+    if (!ud && !serverFile) {
+      try {
+        await shutdownPort(apiAvailablePort)
+      } catch (e) {
+        const message = getErrorMessage(e)
+        errorTelemetry(process.argv, `Error shutting down "api": ${message}`)
+        console.error(
+          `Error whilst shutting down "api" port: ${c.error(message)}`,
+        )
+      }
     }
   }
 


### PR DESCRIPTION
Cedar v4.1.0 accidentally broke v4 compatibility. This PR tries to bring it back. So users can go from v4.0.0 to v4.2.0 without needing any code or tooling changes