### PR TITLE
chore(yarn): Fix build after yarn 4.14.1 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,32 @@
     "yargs": "17.7.2",
     "zx": "8.8.5"
   },
+  "dependenciesMeta": {
+    "@prisma/engines": {
+      "built": true
+    },
+    "@swc/core": {
+      "built": true
+    },
+    "better-sqlite3": {
+      "built": true
+    },
+    "cypress": {
+      "built": true
+    },
+    "esbuild": {
+      "built": true
+    },
+    "lefthook": {
+      "built": true
+    },
+    "msw": {
+      "built": true
+    },
+    "prisma": {
+      "built": true
+    }
+  },
   "packageManager": "yarn@4.14.1",
   "npmClient": "yarn"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26966,6 +26966,23 @@ __metadata:
     vitest: "npm:3.2.4"
     yargs: "npm:17.7.2"
     zx: "npm:8.8.5"
+  dependenciesMeta:
+    "@prisma/engines":
+      built: true
+    "@swc/core":
+      built: true
+    better-sqlite3:
+      built: true
+    cypress:
+      built: true
+    esbuild:
+      built: true
+    lefthook:
+      built: true
+    msw:
+      built: true
+    prisma:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#1673 disables build scripts for packages by default. I added overrides for packages we need to build for Cedar apps, but didn't realize I needed to add them for the framework itself too. This PR addresses that oversight.