### PR TITLE
fix(ud): Build order and function fallback

### DIFF
--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -133,10 +133,10 @@ cedar build:
     API (`buildApi()` esbuild → api/dist/, Babel plugin) →
     Web (`cedar-vite-build` → web/dist/) →
   --ud:
-    UD server entry (Vite SSR build → api/dist/ud/index.js, self-contained Node
-      entry) →
     unified Vite `buildApp()` with declared `client` and `api` environments
       (web/dist/ + api/dist/, preserveModules, Babel plugin) →
+    UD server entry (Vite SSR build → api/dist/ud/index.js, self-contained Node
+      entry) →
   prerender marked routes
 
 *SSR/RSC: falls back to legacy separate builds; adds route hooks build, route

--- a/packages/cli/src/commands/build/__tests__/build.test.ts
+++ b/packages/cli/src/commands/build/__tests__/build.test.ts
@@ -241,8 +241,8 @@ test('UD server entry task is included when --ud is passed', async () => {
     [
       "Generating Prisma Client...",
       "Verifying graphql schema...",
-      "Bundling API server entry (Universal Deploy)...",
       "Building App...",
+      "Bundling API server entry (Universal Deploy)...",
     ]
   `)
 })

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -241,13 +241,6 @@ export const handler = async ({
       title: 'Verifying graphql schema...',
       task: loadAndValidateSdls,
     },
-    ud &&
-      workspace.includes('api') && {
-        title: 'Bundling API server entry (Universal Deploy)...',
-        task: async () => {
-          await buildUDApiServer({ verbose })
-        },
-      },
     // When streaming SSR is enabled, fall back to the legacy separate build
     // paths because streaming SSR has its own complex build orchestration.
     // Phase 7 (SSR/RSC rebuild) will address unifying this path.
@@ -397,6 +390,13 @@ export const handler = async ({
               path.join(getPaths().web.dist, '200.html'),
             )
           }
+        },
+      },
+    ud &&
+      workspace.includes('api') && {
+        title: 'Bundling API server entry (Universal Deploy)...',
+        task: async () => {
+          await buildUDApiServer({ verbose })
         },
       },
   ].filter((t): t is ListrTask => Boolean(t))

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -8,7 +8,7 @@ import { normalizePath } from 'vite'
 import type { ModuleNode, ViteDevServer } from 'vite'
 
 import { buildCedarContext, wrapLegacyHandler } from '@cedarjs/api/runtime'
-import type { LegacyHandler } from '@cedarjs/api/runtime'
+import type { CedarHandler, LegacyHandler } from '@cedarjs/api/runtime'
 import {
   getApiSideBabelPlugins,
   transformWithBabel,
@@ -20,7 +20,7 @@ import { getConfig, getPaths, projectSideIsEsm } from '@cedarjs/project-config'
 
 import { getWorkspacePackageAliases } from './lib/workspacePackageAliases.js'
 
-const LAMBDA_FUNCTIONS: Record<string, Handler> = {}
+const LAMBDA_FUNCTIONS: Record<string, CedarHandler> = {}
 
 interface YogaInstance {
   handle(request: Request, context: Record<string, unknown>): Promise<Response>
@@ -87,25 +87,45 @@ async function internalLoadApiFunctions(viteServer: ViteDevServer) {
     try {
       const mod = await viteServer.ssrLoadModule(pathToFileURL(fnPath).href)
 
-      const handler: Handler | undefined = (() => {
+      const cedarHandler: CedarHandler | undefined = (() => {
+        // Prefer the new Fetch-native handleRequest shape.
+        if ('handleRequest' in mod) {
+          return mod.handleRequest as CedarHandler
+        }
+
+        if ('default' in mod && mod.default && 'handleRequest' in mod.default) {
+          return mod.default.handleRequest as CedarHandler
+        }
+
+        // Fall back to the legacy Lambda-shaped handler and wrap it.
+        let legacyHandler: Handler | undefined
+
         if ('handler' in mod) {
-          return mod.handler as Handler
+          legacyHandler = mod.handler as Handler
+        } else if (
+          'default' in mod &&
+          mod.default &&
+          'handler' in mod.default
+        ) {
+          legacyHandler = mod.default.handler as Handler
         }
-        if ('default' in mod && mod.default && 'handler' in mod.default) {
-          return mod.default.handler as Handler
+
+        if (legacyHandler) {
+          return wrapLegacyHandler(legacyHandler as LegacyHandler)
         }
+
         return undefined
       })()
 
-      if (handler) {
-        LAMBDA_FUNCTIONS[routeName] = handler
+      if (cedarHandler) {
+        LAMBDA_FUNCTIONS[routeName] = cedarHandler
         console.log(
           ansis.magenta('/' + routeName),
           ansis.dim.italic(Date.now() - ts + ' ms'),
         )
       } else {
         console.warn(
-          `[apiDevMiddleware] No handler export found in function: ${fnPath}`,
+          `[apiDevMiddleware] No handler or handleRequest export found in function: ${fnPath}`,
         )
       }
 
@@ -370,9 +390,9 @@ export function createApiFetchHandler() {
         params: { routeName },
       })
 
-      // Wrap the legacy Lambda handler into a fetch-native CedarHandler
-      const cedarHandler = wrapLegacyHandler(handler as LegacyHandler)
-      return await cedarHandler(request, ctx)
+      // LAMBDA_FUNCTIONS stores CedarHandlers directly (either native
+      // handleRequest or already-wrapped legacy handlers).
+      return await handler(request, ctx)
     } catch (err) {
       console.error(
         `[apiDevMiddleware] Error handling function "${routeName}":`,

--- a/packages/vite/src/ud-handlers/__tests__/__fixtures__/legacy-function-module.js
+++ b/packages/vite/src/ud-handlers/__tests__/__fixtures__/legacy-function-module.js
@@ -1,0 +1,8 @@
+const handler = async (_event, _context) => {
+  return {
+    statusCode: 200,
+    body: 'hello from legacy handler',
+  }
+}
+
+module.exports = { handler }

--- a/packages/vite/src/ud-handlers/__tests__/function.test.ts
+++ b/packages/vite/src/ud-handlers/__tests__/function.test.ts
@@ -9,7 +9,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 vi.mock('@cedarjs/api-server/udFetchable', () => ({
   createCedarFetchable: vi.fn((handler) => ({
-    fetch: (request: Request) => handler(request, { mock: 'context' }),
+    fetch: (request: Request) =>
+      handler(request, {
+        params: {},
+        query: new URLSearchParams(),
+        cookies: new Map(),
+      }),
   })),
 }))
 
@@ -22,12 +27,21 @@ describe('createFunctionHandler', () => {
     expect(await response.text()).toBe('hello from function')
   })
 
+  it('falls back to a legacy handler export wrapped with wrapLegacyHandler', async () => {
+    const fixturePath = path.join(
+      __dirname,
+      '__fixtures__/legacy-function-module.js',
+    )
+    const handler = createFunctionHandler({ distPath: fixturePath })
+    const request = new Request('http://localhost/api/test')
+    const response = await handler.fetch(request)
+    expect(await response.text()).toBe('hello from legacy handler')
+  })
+
   it('throws if no handler is found', async () => {
     const fixturePath = path.join(__dirname, '__fixtures__/empty-module.js')
     const handler = createFunctionHandler({ distPath: fixturePath })
     const request = new Request('http://localhost/api/test')
-    await expect(handler.fetch(request)).rejects.toThrow(
-      'Fetch-native handler not found',
-    )
+    await expect(handler.fetch(request)).rejects.toThrow('Handler not found')
   })
 })

--- a/packages/vite/src/ud-handlers/function.ts
+++ b/packages/vite/src/ud-handlers/function.ts
@@ -1,6 +1,7 @@
 import { pathToFileURL } from 'node:url'
 
-import type { CedarHandler } from '@cedarjs/api/runtime'
+import { wrapLegacyHandler } from '@cedarjs/api/runtime'
+import type { CedarHandler, LegacyHandler } from '@cedarjs/api/runtime'
 import { createCedarFetchable } from '@cedarjs/api-server/udFetchable'
 
 export interface FunctionHandlerOptions {
@@ -10,17 +11,25 @@ export interface FunctionHandlerOptions {
 export function createFunctionHandler(options: FunctionHandlerOptions) {
   const handleRequest: CedarHandler = async (request, ctx) => {
     const mod = await import(pathToFileURL(options.distPath).href)
-    const handler = mod.handleRequest || mod.default?.handleRequest
 
-    if (!handler) {
-      throw new Error(
-        `Fetch-native handler not found in ${options.distPath}. Expected ` +
-          '`export async function handleRequest(request, ctx)` or ' +
-          '`export default { handleRequest }`.',
-      )
+    // Prefer the new Fetch-native handleRequest shape.
+    const nativeHandler = mod.handleRequest || mod.default?.handleRequest
+    if (nativeHandler) {
+      return nativeHandler(request, ctx)
     }
 
-    return handler(request, ctx)
+    // Fall back to the legacy Lambda-shaped handler and wrap it.
+    const legacyHandler = mod.handler || mod.default?.handler
+    if (legacyHandler) {
+      return wrapLegacyHandler(legacyHandler as LegacyHandler)(request, ctx)
+    }
+
+    throw new Error(
+      `Handler not found in ${options.distPath}. Expected ` +
+        '`export async function handleRequest(request, ctx)`, ' +
+        '`export default { handleRequest }`, ' +
+        'or a legacy Lambda-shaped `handler`.',
+    )
   }
 
   return createCedarFetchable(handleRequest)


### PR DESCRIPTION
Fix build order so that the ud output isn't overwritten

Support both `handleRequest` and `handler`, where the latter is wrapped by `wrapLegacyHandler()`