### PR TITLE
chore(build): Use nx run-many instead of lerna run

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:clean": "node ./tasks/clean-build.mts",
     "build:pack": "nx run-many -t build:pack",
     "build:test-project": "node ./tasks/test-project/test-project.mts",
-    "build:watch": "lerna run build:watch --parallel; tsc --build",
+    "build:watch": "nx run-many -t build:watch",
     "changesets": "tsx ./tasks/changesets/changesets.mts",
     "check": "cross-env yarn constraints && yarn dedupe --check",
     "check:package": "nx run-many -t check:package --output-style static",


### PR DESCRIPTION
The "build:watch" script was the only script still using lerna. Update it to also use nx as the other scripts that executes package-level scripts.

Also gets rid of the `tsc --build` part which was effectively dead code. The first part of the command chain launched watch scripts that never exits. They stay running to watch for changes. So the first part of the command chain never exits, making the second part never execute.