### PR TITLE
chore(ci): Cache prebuild entries

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -59,13 +59,20 @@ runs:
           echo "cache-path=$HOME/.npm/_prebuilds" >> "$GITHUB_OUTPUT"
         fi
 
+    - name: 🔧 Get better-sqlite3 version
+      id: bs3-version
+      shell: bash
+      run: |
+        VERSION=$(grep -A 2 "^better-sqlite3@" yarn.lock | awk '/^  version:/ {print $2}')
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
     - name: ♻️ Restore prebuild-install cache
       id: cache-prebuild-install
       uses: actions/cache/restore@v5
       continue-on-error: true
       with:
         path: ${{ steps.prebuild-cache-path.outputs.cache-path }}
-        key: prebuild-cache-${{ runner.os }}
+        key: prebuild-cache-${{ runner.os }}-${{ steps.bs3-version.outputs.version }}
 
     # One of our dependencies is on GitHub instead of NPM and without authentication
     # we'll get rate limited and this step becomes flaky.
@@ -98,7 +105,7 @@ runs:
       continue-on-error: true
       with:
         path: ${{ steps.prebuild-cache-path.outputs.cache-path }}
-        key: prebuild-cache-${{ runner.os }}
+        key: prebuild-cache-${{ runner.os }}-${{ steps.bs3-version.outputs.version }}
 
     - name: 🏗️ Build
       if: inputs.build == 'true'

--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -63,7 +63,7 @@ runs:
       id: bs3-version
       shell: bash
       run: |
-        VERSION=$(grep -A 2 "^better-sqlite3@" yarn.lock | awk '/^  version:/ {print $2}')
+        VERSION=$(grep -A 1 "^\"better-sqlite3@" yarn.lock | awk '/^  version:/ {print $2}')
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
     - name: ♻️ Restore prebuild-install cache

--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -49,6 +49,24 @@ runs:
       id: set-up-yarn-cache
       uses: ./.github/actions/set-up-yarn-cache
 
+    - name: 🔧 Get prebuild-install cache path
+      id: prebuild-cache-path
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          echo "cache-path=$APPDATA/npm-cache/_prebuilds" >> "$GITHUB_OUTPUT"
+        else
+          echo "cache-path=$HOME/.npm/_prebuilds" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: ♻️ Restore prebuild-install cache
+      id: cache-prebuild-install
+      uses: actions/cache/restore@v5
+      continue-on-error: true
+      with:
+        path: ${{ steps.prebuild-cache-path.outputs.cache-path }}
+        key: prebuild-cache-${{ runner.os }}
+
     # One of our dependencies is on GitHub instead of NPM and without authentication
     # we'll get rate limited and this step becomes flaky.
     - name: 🐈 Yarn install
@@ -73,6 +91,14 @@ runs:
       with:
         path: packages/create-cedar-rsc-app/node_modules
         key: node-modules-create-cedar-rsc-app-${{ runner.os }}-${{ hashFiles('packages/create-cedar-rsc-app/yarn.lock', 'packages/create-cedar-rsc-app/package.json') }}
+
+    - name: 💾 Save prebuild-install cache
+      if: steps.cache-prebuild-install.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      continue-on-error: true
+      with:
+        path: ${{ steps.prebuild-cache-path.outputs.cache-path }}
+        key: prebuild-cache-${{ runner.os }}
 
     - name: 🏗️ Build
       if: inputs.build == 'true'


### PR DESCRIPTION
Windows CI has been flaky. Analyzing the logs it sees it often fails to download better-sqlite3 native binaries. It then falls back to manually building them, which always fails on Windows.

The download has been failing on Ubuntu too from time to time, but when it does and falls back to building it succeeds with the build, and CI for Ubuntu passes. But building is slow. Downloading prebuilt bins is faster.

Caching the bins when we do succeed in downloading them works around flaky downloads, and hopefully makes it even faster than actual downloads even if they had been fully stable