### PR TITLE
chore(release): Fix canary release script

### DIFF
--- a/.github/scripts/publish_canary.sh
+++ b/.github/scripts/publish_canary.sh
@@ -119,13 +119,11 @@ echo "Publishing $TAG from $GITHUB_REF_NAME using npm token ${NPM_AUTH_TOKEN:0:5
 
 # ── Calculate version ──────────────────────────────────────────────────────────
 
-LATEST_TAG=$(git describe --abbrev=0 --tags)
+LATEST_TAG=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
 echo "Latest tag: $LATEST_TAG"
 
-COMMIT_COUNT=$(git rev-list --count "${LATEST_TAG}..HEAD")
-echo "Commits since tag: $COMMIT_COUNT"
-
-CURRENT_VERSION="${LATEST_TAG#v}"
+CURRENT_VERSION="${LATEST_TAG##*/}"
+CURRENT_VERSION="${CURRENT_VERSION#v}"
 echo "Current version: $CURRENT_VERSION"
 
 MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)

--- a/.github/scripts/publish_canary.sh
+++ b/.github/scripts/publish_canary.sh
@@ -120,11 +120,20 @@ echo "Publishing $TAG from $GITHUB_REF_NAME using npm token ${NPM_AUTH_TOKEN:0:5
 # ── Calculate version ──────────────────────────────────────────────────────────
 
 LATEST_TAG=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+
+if [[ -z "$LATEST_TAG" ]]; then
+  echo "Error: No version tags (vX.Y.Z) found in the repository"
+  exit 1
+fi
+
 echo "Latest tag: $LATEST_TAG"
 
 CURRENT_VERSION="${LATEST_TAG##*/}"
 CURRENT_VERSION="${CURRENT_VERSION#v}"
 echo "Current version: $CURRENT_VERSION"
+
+COMMIT_COUNT=$(git rev-list --count "${LATEST_TAG}..HEAD")
+echo "Commits since tag: $COMMIT_COUNT"
 
 MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
 MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)


### PR DESCRIPTION
Was getting this error when trying to release canary versions:

```
Run ./.github/scripts/publish_canary.sh
npm user: tobbe
NPM token for 'cedarjs' org scope is valid and not expired
Publishing canary from main using npm token npm_Z
Latest tag: create-redmix-rsc-app/v0.0.3
Commits since tag: 1776
Current version: create-redmix-rsc-app/v0.0.3
./.github/scripts/publish_canary.sh: line 136: create: unbound variable
Error: Process completed with exit code 1. 
```