### PR TITLE
chore(ci): Cache prebuild entries - check if path exists

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -54,9 +54,15 @@ runs:
       shell: bash
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          echo "cache-path=$APPDATA/npm-cache/_prebuilds" >> "$GITHUB_OUTPUT"
+          PREBUILD_PATH="$APPDATA/npm-cache/_prebuilds"
         else
-          echo "cache-path=$HOME/.npm/_prebuilds" >> "$GITHUB_OUTPUT"
+          PREBUILD_PATH="$HOME/.npm/_prebuilds"
+        fi
+        echo "cache-path=$PREBUILD_PATH" >> "$GITHUB_OUTPUT"
+        if [ -d "$PREBUILD_PATH" ]; then
+          echo "cache-path-exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "cache-path-exists=false" >> "$GITHUB_OUTPUT"
         fi
 
     - name: 🔧 Get better-sqlite3 version
@@ -100,7 +106,7 @@ runs:
         key: node-modules-create-cedar-rsc-app-${{ runner.os }}-${{ hashFiles('packages/create-cedar-rsc-app/yarn.lock', 'packages/create-cedar-rsc-app/package.json') }}
 
     - name: 💾 Save prebuild-install cache
-      if: steps.cache-prebuild-install.outputs.cache-hit != 'true'
+      if: steps.cache-prebuild-install.outputs.cache-hit != 'true' && steps.prebuild-cache-path.outputs.cache-path-exists == 'true'
       uses: actions/cache/save@v5
       continue-on-error: true
       with:

--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -54,15 +54,9 @@ runs:
       shell: bash
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          PREBUILD_PATH="$APPDATA/npm-cache/_prebuilds"
+          echo "cache-path=$APPDATA/npm-cache/_prebuilds" >> "$GITHUB_OUTPUT"
         else
-          PREBUILD_PATH="$HOME/.npm/_prebuilds"
-        fi
-        echo "cache-path=$PREBUILD_PATH" >> "$GITHUB_OUTPUT"
-        if [ -d "$PREBUILD_PATH" ]; then
-          echo "cache-path-exists=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "cache-path-exists=false" >> "$GITHUB_OUTPUT"
+          echo "cache-path=$HOME/.npm/_prebuilds" >> "$GITHUB_OUTPUT"
         fi
 
     - name: 🔧 Get better-sqlite3 version
@@ -105,8 +99,13 @@ runs:
         path: packages/create-cedar-rsc-app/node_modules
         key: node-modules-create-cedar-rsc-app-${{ runner.os }}-${{ hashFiles('packages/create-cedar-rsc-app/yarn.lock', 'packages/create-cedar-rsc-app/package.json') }}
 
+    - name: 💾 Ensure prebuild-install cache path exists
+      if: steps.cache-prebuild-install.outputs.cache-hit != 'true'
+      shell: bash
+      run: mkdir -p "${{ steps.prebuild-cache-path.outputs.cache-path }}"
+
     - name: 💾 Save prebuild-install cache
-      if: steps.cache-prebuild-install.outputs.cache-hit != 'true' && steps.prebuild-cache-path.outputs.cache-path-exists == 'true'
+      if: steps.cache-prebuild-install.outputs.cache-hit != 'true'
       uses: actions/cache/save@v5
       continue-on-error: true
       with:


### PR DESCRIPTION
https://github.com/cedarjs/cedar/actions/runs/25640700281/job/75262319118#step:4:265 is showing

```
➤ YN0000: · Done with warnings in 6s 445ms
Run actions/cache/save@v5
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
Warning: Cache save failed.
Run set -o pipefail
```

This PR fixes that by making sure the dir exists first
