### PR TITLE
chore(ci): fix create-cedar-rsc-app yarn install on Windows

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -83,7 +83,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         yarn install --inline-builds
-        cd packages/create-cedar-rsc-app
+        cd "$GITHUB_WORKSPACE/packages/create-cedar-rsc-app"
         yarn install --inline-builds
 
     - name: 💾 Save node_modules cache

--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -81,7 +81,10 @@ runs:
       working-directory: ${{ inputs.yarn-install-directory }}
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: yarn install --inline-builds && yarn --cwd packages/create-cedar-rsc-app install --inline-builds
+      run: |
+        yarn install --inline-builds
+        cd packages/create-cedar-rsc-app
+        yarn install --inline-builds
 
     - name: 💾 Save node_modules cache
       if: inputs.set-up-yarn-cache == 'true' && steps.set-up-yarn-cache.outputs.node-modules-cache-hit != 'true'


### PR DESCRIPTION
## Problem

`yarn --cwd packages/create-cedar-rsc-app install --inline-builds` was failing on Windows runners with exit code 127 (command not found) at the start of the Resolution step.

A guess as to what the root cause might be is that it's a Corepack + Windows issue: when using `--cwd` to run yarn from a sub-directory that has no `packageManager` field in its `package.json`, Corepack possibly can't properly resolve the yarn binary for that directory context.

This was spotted in the Background Jobs E2E test: https://github.com/cedarjs/cedar/actions/runs/25642121026/job/75264311900

## Fix

Replace the `--cwd` invocation with a plain `cd` + `yarn install` in the same shell script. Yarn is already active in the shell from the first install, so the second invocation succeeds normally.