### PR TITLE
fix(api): support Fetch Request in getAuthProviderHeader

### DIFF
--- a/packages/api/src/auth/__tests__/getAuthenticationContext.test.ts
+++ b/packages/api/src/auth/__tests__/getAuthenticationContext.test.ts
@@ -195,6 +195,56 @@ describe('getAuthenticationContext with bearer tokens', () => {
   })
 })
 
+describe('getAuthenticationContext with a Fetch Request and bearer token', () => {
+  const authDecoderOne = async (_token: string, type: string) => {
+    return new Promise<Decoded>((resolve) => {
+      if (type !== 'one') {
+        return resolve(null)
+      }
+
+      return resolve({
+        iss: 'one',
+        sub: 'user-id',
+      })
+    })
+  }
+
+  // Regression test: `Request.headers` is a `Headers` instance (a class),
+  // not a plain object. `Object.keys(headers)` returns `[]` for class
+  // instances, so the previous implementation silently treated authenticated
+  // requests as unauthenticated when no cookie was set.
+  it('Reads auth-provider header from a Fetch Request when no cookie is set', async () => {
+    const fetchRequest = new Request('http://localhost:3000', {
+      method: 'POST',
+      body: '',
+      headers: {
+        'auth-provider': 'one',
+        authorization: 'Bearer auth-test-token',
+      },
+    })
+
+    const result = await getAuthenticationContext({
+      authDecoder: authDecoderOne,
+      event: fetchRequest,
+      context: {} as Context,
+    })
+
+    if (!result) {
+      fail('Result is undefined')
+    }
+
+    const [decoded, { type, schema, token }] = result
+
+    expect(decoded).toMatchObject({
+      iss: 'one',
+      sub: 'user-id',
+    })
+    expect(type).toEqual('one')
+    expect(schema).toEqual('Bearer')
+    expect(token).toEqual('auth-test-token')
+  })
+})
+
 describe('getAuthenticationContext with cookies', () => {
   const authDecoderOne = async (_token: string, type: string) => {
     return new Promise<Decoded>((resolve) => {

--- a/packages/api/src/auth/__tests__/getAuthenticationContext.test.ts
+++ b/packages/api/src/auth/__tests__/getAuthenticationContext.test.ts
@@ -209,10 +209,9 @@ describe('getAuthenticationContext with a Fetch Request and bearer token', () =>
     })
   }
 
-  // Regression test: `Request.headers` is a `Headers` instance (a class),
-  // not a plain object. `Object.keys(headers)` returns `[]` for class
-  // instances, so the previous implementation silently treated authenticated
-  // requests as unauthenticated when no cookie was set.
+  // Reading from a Fetch Request means reading from a class instance. This
+  // works differently compared to Lambda events where `headers` is a plain
+  // object. So we need a specific test for Fetch requests.
   it('Reads auth-provider header from a Fetch Request when no cookie is set', async () => {
     const fetchRequest = new Request('http://localhost:3000', {
       method: 'POST',

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -22,14 +22,16 @@ export const getAuthProviderHeader = (
     return event.headers.get(AUTH_PROVIDER_HEADER) ?? undefined
   }
 
-  // Lambda `event.headers` is a plain object, but API Gateway preserves the
-  // header case the client sent — match case-insensitively.
+  // Lambda `event.headers` is a plain object. API Gateway preserves the header
+  // case the client sent, so we need to match case-insensitively
   const authProviderKey = Object.keys(event.headers ?? {}).find(
     (key) => key.toLowerCase() === AUTH_PROVIDER_HEADER,
   )
+
   if (authProviderKey) {
     return event.headers[authProviderKey]
   }
+
   return undefined
 }
 

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -4,6 +4,7 @@ import type { APIGatewayProxyEvent, Context as LambdaContext } from 'aws-lambda'
 import * as cookie from 'cookie'
 
 import { getEventHeader } from '../event.js'
+import { isFetchApiRequest } from '../transforms.js'
 
 import type { Decoded } from './parseJWT.js'
 export type { Decoded }
@@ -14,18 +15,20 @@ export const AUTH_PROVIDER_HEADER = 'auth-provider'
 export const getAuthProviderHeader = (
   event: APIGatewayProxyEvent | Request,
 ) => {
-  // `Request.headers` is a `Headers` instance, not a plain object — `Object.keys`
-  // returns `[]` for class instances, so look it up directly via the `.get()` API.
-  const headers = event?.headers
-  if (headers && typeof (headers as Headers).get === 'function') {
-    return (headers as Headers).get(AUTH_PROVIDER_HEADER) ?? undefined
+  // Fetch `Request.headers` is a `Headers` instance — `Object.keys()` returns
+  // `[]` for it, so we have to dispatch on the event type. `isFetchApiRequest`
+  // is the canonical dispatch helper, also used by `getEventHeader`.
+  if (isFetchApiRequest(event)) {
+    return event.headers.get(AUTH_PROVIDER_HEADER) ?? undefined
   }
 
-  const authProviderKey = Object.keys(headers ?? {}).find(
+  // Lambda `event.headers` is a plain object, but API Gateway preserves the
+  // header case the client sent — match case-insensitively.
+  const authProviderKey = Object.keys(event.headers ?? {}).find(
     (key) => key.toLowerCase() === AUTH_PROVIDER_HEADER,
   )
   if (authProviderKey) {
-    return getEventHeader(event, authProviderKey)
+    return event.headers[authProviderKey]
   }
   return undefined
 }

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -14,7 +14,14 @@ export const AUTH_PROVIDER_HEADER = 'auth-provider'
 export const getAuthProviderHeader = (
   event: APIGatewayProxyEvent | Request,
 ) => {
-  const authProviderKey = Object.keys(event?.headers ?? {}).find(
+  // `Request.headers` is a `Headers` instance, not a plain object — `Object.keys`
+  // returns `[]` for class instances, so look it up directly via the `.get()` API.
+  const headers = event?.headers
+  if (headers && typeof (headers as Headers).get === 'function') {
+    return (headers as Headers).get(AUTH_PROVIDER_HEADER) ?? undefined
+  }
+
+  const authProviderKey = Object.keys(headers ?? {}).find(
     (key) => key.toLowerCase() === AUTH_PROVIDER_HEADER,
   )
   if (authProviderKey) {


### PR DESCRIPTION
## Problem

Bearer-token auth silently fails when an `@cedarjs/api` handler is invoked via the Web Standard / middleware path (a Fetch `Request` rather than a Lambda `APIGatewayProxyEvent`). A request with valid `auth-provider` and `Authorization: Bearer …` headers comes back as unauthenticated, and `getAuthenticationContext` returns `undefined` — so any auth provider that uses Bearer tokens (Auth0, Supabase non-cookie, Clerk JWT, custom JWT, etc.) is broken on that path.

## Root cause

`getAuthProviderHeader` (in `packages/api/src/auth/index.ts`) does:

```ts
Object.keys(event?.headers ?? {}).find(
  (key) => key.toLowerCase() === AUTH_PROVIDER_HEADER,
)
```

For a Lambda event, `event.headers` is a plain object, so `Object.keys` returns the header names. For a Fetch `Request`, `event.headers` is a `Headers` instance — `Object.keys(headersInstance)` returns `[]`, the function returns `undefined`, and the short-circuit at the top of `getAuthenticationContext` decides the request is unauthenticated:

```ts
if (!typeFromHeader && !cookieHeader) {
  return undefined
}
```

So the Bearer-token code path is never even attempted on the middleware path.

## Fix

When `headers` exposes a `.get()` method (the `Headers` API), look the value up directly via `headers.get('auth-provider')`. Fall back to the existing plain-object iteration for Lambda callers, so existing handlers behave exactly as they do today.

Surface area is intentionally tiny — one function, one file — and the Lambda path is the explicit fallback, so the change is additive rather than a behaviour swap.

## Checks

Per `CONTRIBUTING.md`:

- `yarn check` — clean (no constraint or dedupe issues)
- `yarn test` in `packages/api` — 245 passing, including a new regression test in `packages/api/src/auth/__tests__/getAuthenticationContext.test.ts` that exercises `Request` + `auth-provider` header + `Authorization: Bearer …`
- `yarn build` in `packages/api` — clean (ESM + CJS)
- `yarn lint` — clean (via pre-commit hook)

No new dependencies.