### PR TITLE
fix(api): lazy-load picoquery to keep CJS runtime loadable

### DIFF
--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -5,9 +5,21 @@ import type {
   Context as LambdaContext,
 } from 'aws-lambda'
 import * as cookie from 'cookie'
-import { parse } from 'picoquery'
+import type { parse as picoqueryParse } from 'picoquery'
 
 import { getAuthenticationContext } from './auth/index.js'
+
+// `picoquery` is published as ESM-only (`"type": "module"`), so requiring it
+// from the CJS build of this file throws `ERR_REQUIRE_ESM` on Node runtimes
+// that don't enable `require(esm)` (e.g. Vercel's serverless runtime).
+// Lazy-load it via dynamic import so the CJS bundle stays loadable.
+let picoqueryParsePromise: Promise<typeof picoqueryParse> | undefined
+const getPicoqueryParse = () => {
+  if (!picoqueryParsePromise) {
+    picoqueryParsePromise = import('picoquery').then((m) => m.parse)
+  }
+  return picoqueryParsePromise
+}
 
 export interface CedarRequestContext {
   params: Record<string, string>
@@ -157,6 +169,7 @@ export async function requestToLegacyEvent(
   const url = new URL(request.url)
   const bodyText = await request.clone().text()
   const headers = Object.fromEntries(request.headers.entries())
+  const parse = await getPicoqueryParse()
   // @ts-expect-error - picoquery returns nested objects and arrays for
   // bracket-notation params (e.g. ids[]=1&ids[]=2, user[name]=alice).
   // APIGatewayProxyEventQueryStringParameters is too narrow for this richer


### PR DESCRIPTION
## Problem

Any CJS bundle that imports anything from `@cedarjs/api/runtime` (e.g. the api bundle produced by `@cedarjs/vite` for serverless deploys) crashes on load — before a single handler runs — with:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module
.../node_modules/picoquery/dist/main.js from .../runtime.cjs not supported.
Instead change the require of picoquery in .../runtime.cjs to a dynamic
import() which is available in all CommonJS modules.
```

We hit it consistently on Vercel's Node serverless runtime (24, 22, 20), but the same crash will surface on any runtime that ships the CJS bundle and doesn't enable `require(esm)` (i.e. anything older than Node 22.12 without `--experimental-require-module`).

The practical effect is that a project building for Vercel after upgrading to Cedar 4.x cannot start its api functions at all — the module never finishes loading, so there's nothing for the platform to invoke.

## Root cause

`packages/api/src/runtime.ts` has:

```ts
import { parse } from 'picoquery'
```

at the top of the file. The ESM build emits a normal `import` and resolves fine. The CJS build (`dist/cjs/runtime.js`) emits the corresponding `require('picoquery')`. `picoquery` is published ESM-only (`"type": "module"` in its `package.json`), so the synchronous `require` throws `ERR_REQUIRE_ESM` at load time.

Because the offending `require` is at the top of `runtime.ts`, anyone who imports `@cedarjs/api/runtime` (directly or transitively, via the legacy-handler-wrapper paths) crashes before any application code runs.

## Fix

Lazy-load `picoquery` with a dynamic `import()` inside `requestToLegacyEvent`, which is already `async`:

```ts
import type { parse as picoqueryParse } from 'picoquery'

let picoqueryParsePromise: Promise<typeof picoqueryParse> | undefined
const getPicoqueryParse = () => {
  if (!picoqueryParsePromise) {
    picoqueryParsePromise = import('picoquery').then((m) => m.parse)
  }
  return picoqueryParsePromise
}

// …inside requestToLegacyEvent
const parse = await getPicoqueryParse()
```

The import promise is cached at module scope, so we only resolve it once per process — the dynamic-import cost is paid on the first request and amortised for every subsequent one. The type import stays at the top, so call sites keep their existing types with no `any`-casts.

The ESM build is unaffected (dynamic `import()` works identically in ESM). The CJS build no longer references `picoquery` at module-evaluation time, so the `require(esm)` mismatch never occurs — the dynamic `import()` is the supported way to load ESM from CJS on every Node runtime we target.

## Checks

Per `CONTRIBUTING.md`:

- `yarn check` — clean (no constraint or dedupe issues)
- `yarn test` in `packages/api` — 244 passing
- `yarn build` in `packages/api` — clean (ESM + CJS)
- `yarn lint` — clean (via pre-commit hook)

No new dependencies. Verified end-to-end on a real Vercel deploy: the function now loads and serves requests, where the previous `runtime.cjs` would crash on import.