### PR TITLE
fix(cli): collapse isLockSet existsSync/statSync race

### DIFF
--- a/packages/cli/src/lib/__tests__/locking.test.ts
+++ b/packages/cli/src/lib/__tests__/locking.test.ts
@@ -31,7 +31,14 @@ beforeEach(() => {
   vol.reset()
 
   // @ts-expect-error - This is assignable in tests
-  fs.statSync = vi.fn(() => {
+  fs.statSync = vi.fn((lockfilePath) => {
+    if (!vol.existsSync(lockfilePath as string)) {
+      const error = new Error(
+        `ENOENT: no such file or directory, stat '${lockfilePath}'`,
+      ) as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      throw error
+    }
     return {
       birthtimeMs: Date.now(),
     }
@@ -99,6 +106,32 @@ it('Detects a stale lock', () => {
   expect(fs.rmSync).toHaveBeenCalled()
 
   spy.mockRestore()
+})
+
+it('Returns false when statSync throws ENOENT', () => {
+  // Simulate a stale `existsSync`/`statSync` race (or a broken symlink, as
+  // seen in Vercel's cached builds) where the lockfile disappears between
+  // the existence check and the stat call.
+  // @ts-expect-error - Partial mock for what's needed in our test
+  vi.mocked(fs).statSync.mockImplementation(() => {
+    const error = new Error('ENOENT') as NodeJS.ErrnoException
+    error.code = 'ENOENT'
+    throw error
+  })
+
+  const isSet = isLockSet('TEST')
+  expect(isSet).toBe(false)
+})
+
+it('Re-throws non-ENOENT statSync errors', () => {
+  // @ts-expect-error - Partial mock for what's needed in our test
+  vi.mocked(fs).statSync.mockImplementation(() => {
+    const error = new Error('EACCES') as NodeJS.ErrnoException
+    error.code = 'EACCES'
+    throw error
+  })
+
+  expect(() => isLockSet('TEST')).toThrow('EACCES')
 })
 
 it('Clear a list of locks', () => {

--- a/packages/cli/src/lib/__tests__/locking.test.ts
+++ b/packages/cli/src/lib/__tests__/locking.test.ts
@@ -37,8 +37,10 @@ beforeEach(() => {
         `ENOENT: no such file or directory, stat '${lockfilePath}'`,
       ) as NodeJS.ErrnoException
       error.code = 'ENOENT'
+
       throw error
     }
+
     return {
       birthtimeMs: Date.now(),
     }
@@ -112,7 +114,6 @@ it('Returns false when statSync throws ENOENT', () => {
   // Simulate a stale `existsSync`/`statSync` race (or a broken symlink, as
   // seen in Vercel's cached builds) where the lockfile disappears between
   // the existence check and the stat call.
-  // @ts-expect-error - Partial mock for what's needed in our test
   vi.mocked(fs).statSync.mockImplementation(() => {
     const error = new Error('ENOENT') as NodeJS.ErrnoException
     error.code = 'ENOENT'
@@ -124,7 +125,6 @@ it('Returns false when statSync throws ENOENT', () => {
 })
 
 it('Re-throws non-ENOENT statSync errors', () => {
-  // @ts-expect-error - Partial mock for what's needed in our test
   vi.mocked(fs).statSync.mockImplementation(() => {
     const error = new Error('EACCES') as NodeJS.ErrnoException
     error.code = 'EACCES'

--- a/packages/cli/src/lib/__tests__/updateCheck.test.ts
+++ b/packages/cli/src/lib/__tests__/updateCheck.test.ts
@@ -73,9 +73,18 @@ describe('Update is not available (1.0.0 -> 1.0.0)', () => {
       },
     })
 
-    // Prevent the appearance of stale locks
+    // Prevent the appearance of stale locks. Throw ENOENT when the underlying
+    // memfs filesystem doesn't have the path so `isLockSet` can distinguish
+    // a missing lock from a fresh one.
     // @ts-expect-error - This is assignable in tests
-    fs.statSync = vi.fn(() => {
+    fs.statSync = vi.fn((lockfilePath) => {
+      if (!vol.existsSync(lockfilePath as string)) {
+        const error = new Error(
+          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
+        ) as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }
       return {
         birthtimeMs: Date.now(),
       }
@@ -160,9 +169,18 @@ describe('Update is available (1.0.0 -> 2.0.0)', () => {
       },
     })
 
-    // Prevent the appearance of stale locks
+    // Prevent the appearance of stale locks. Throw ENOENT when the underlying
+    // memfs filesystem doesn't have the path so `isLockSet` can distinguish
+    // a missing lock from a fresh one.
     // @ts-expect-error - This is assignable in tests
-    fs.statSync = vi.fn(() => {
+    fs.statSync = vi.fn((lockfilePath) => {
+      if (!vol.existsSync(lockfilePath as string)) {
+        const error = new Error(
+          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
+        ) as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }
       return {
         birthtimeMs: Date.now(),
       }
@@ -249,9 +267,18 @@ describe('Update is available with rc tag (1.0.0-rc.1 -> 1.0.1-rc.58)', () => {
       },
     })
 
-    // Prevent the appearance of stale locks
+    // Prevent the appearance of stale locks. Throw ENOENT when the underlying
+    // memfs filesystem doesn't have the path so `isLockSet` can distinguish
+    // a missing lock from a fresh one.
     // @ts-expect-error - This is assignable in tests
-    fs.statSync = vi.fn(() => {
+    fs.statSync = vi.fn((lockfilePath) => {
+      if (!vol.existsSync(lockfilePath as string)) {
+        const error = new Error(
+          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
+        ) as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }
       return {
         birthtimeMs: Date.now(),
       }
@@ -330,9 +357,18 @@ describe('Update middleware', () => {
   })
 
   beforeEach(() => {
-    // Prevent the appearance of stale locks
+    // Prevent the appearance of stale locks. Throw ENOENT when the underlying
+    // memfs filesystem doesn't have the path so `isLockSet` can distinguish
+    // a missing lock from a fresh one.
     // @ts-expect-error - This is assignable in tests
-    fs.statSync = vi.fn(() => {
+    fs.statSync = vi.fn((lockfilePath) => {
+      if (!vol.existsSync(lockfilePath as string)) {
+        const error = new Error(
+          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
+        ) as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }
       return {
         birthtimeMs: Date.now(),
       }

--- a/packages/cli/src/lib/locking.ts
+++ b/packages/cli/src/lib/locking.ts
@@ -67,15 +67,23 @@ export function unsetLock(identifier: string) {
 export function isLockSet(identifier: string): boolean {
   const lockfilePath = path.join(getPaths().generated.base, 'locks', identifier)
 
-  // Check if the lock file exists
-  const exists = fs.existsSync(lockfilePath)
-  if (!exists) {
-    return false
+  // Stat the lockfile directly so that we don't race against another process
+  // removing it between an `existsSync` check and the subsequent `statSync`
+  // call. This race surfaces on environments with aggressive build caches
+  // (e.g. Vercel), where a broken symlink can satisfy `existsSync` but make
+  // `statSync` throw ENOENT.
+  let createdAt: number
+  try {
+    createdAt = fs.statSync(lockfilePath).birthtimeMs
+  } catch (error) {
+    if (isErrorWithCode(error, 'ENOENT')) {
+      return false
+    }
+    throw error
   }
 
   // Ensure this lock isn't stale due to some error
   // Locks are only valid for 1 hour
-  const createdAt = fs.statSync(lockfilePath).birthtimeMs
   if (Date.now() - createdAt > 3600000) {
     unsetLock(identifier)
     return false

--- a/packages/cli/src/lib/locking.ts
+++ b/packages/cli/src/lib/locking.ts
@@ -67,11 +67,13 @@ export function unsetLock(identifier: string) {
 export function isLockSet(identifier: string): boolean {
   const lockfilePath = path.join(getPaths().generated.base, 'locks', identifier)
 
-  // Stat the lockfile directly so that we don't race against another process
-  // removing it between an `existsSync` check and the subsequent `statSync`
-  // call. This race surfaces on environments with aggressive build caches
-  // (e.g. Vercel), where a broken symlink can satisfy `existsSync` but make
-  // `statSync` throw ENOENT.
+  // We stat the lockfile directly here instead of doing `existsSync` +
+  // `statSync` so that we don't race against another process removing it
+  // between the `existsSync` check and the subsequent `stat` call
+  //
+  // This also helps in environments with aggressive build caches (e.g. Vercel),
+  // where cache restoration can restore a dangling symlink which satisfies
+  // `existsSync` but makes `statSync` throw ENOENT
   let createdAt: number
   try {
     createdAt = fs.statSync(lockfilePath).birthtimeMs
@@ -79,6 +81,7 @@ export function isLockSet(identifier: string): boolean {
     if (isErrorWithCode(error, 'ENOENT')) {
       return false
     }
+
     throw error
   }
 


### PR DESCRIPTION
## Problem

`cedar build` (and any other command that goes through `setLock` / `isLockSet` — including the update-check middleware that runs on most CLI commands) can crash with:

```
Error: ENOENT: no such file or directory, stat '.cedar/locks/<id>'
    at Object.statSync (node:fs:1626:25)
    at isLockSet (.../@cedarjs/cli/dist/lib/locking.js:…)
    at setLock (.../@cedarjs/cli/dist/lib/locking.js:…)
```

We hit it consistently on Vercel deploys, where the build cache restores `.cedar/locks/<id>` as a dangling symlink — but the underlying race exists on any host. The error propagates up through every caller (there is no `try/catch` around `setLock` in the CLI plumbing) and aborts the build before it produces any output.

## Root cause

`isLockSet` (in `packages/cli/src/lib/locking.ts`) is a classic check-then-act:

```ts
const exists = fs.existsSync(lockfilePath)
if (!exists) {
  return false
}

const createdAt = fs.statSync(lockfilePath).birthtimeMs   // ← can throw ENOENT
```

The two filesystem calls aren't atomic, so the lockfile can disappear between them in two realistic ways:

1. **Concurrent unset.** Another process unsets the lock between the `existsSync` and the `statSync`. `unsetLock` in this same file already wraps its `fs.rmSync` in a try/catch that swallows ENOENT for exactly this reason, but `isLockSet` doesn't.
2. **Broken symlink restored by a build cache.** Vercel's incremental builds restore `.cedar/locks/<id>` as a dangling symlink. `existsSync` returns `true` (the symlink node itself exists), but `statSync` follows the link and throws ENOENT because the target file is gone.

Either case throws straight through `isLockSet`, which is on the hot path of every long-running CLI command via `setLock` and the update-check middleware. The result is a build that fails on the very first lock query.

## Fix

Drop the `existsSync` pre-check and `statSync` directly, treating ENOENT as "not locked" and re-throwing anything else. This is exactly the pattern `unsetLock` in the same file already uses for the analogous `rmSync` call, so it lines up with the existing style and pairs naturally with the existing `isErrorWithCode` helper:

```ts
let createdAt: number
try {
  createdAt = fs.statSync(lockfilePath).birthtimeMs
} catch (error) {
  if (isErrorWithCode(error, 'ENOENT')) {
    return false
  }
  throw error
}

if (Date.now() - createdAt > 3600000) {
  unsetLock(identifier)
  return false
}

return true
```

Real `fs` errors that aren't ENOENT — permission errors, EIO, etc. — are still surfaced unchanged, so the lock layer doesn't paper over genuine filesystem problems.

### Test changes

`locking.test.ts` and `updateCheck.test.ts` both had a `fs.statSync` mock of the form:

```ts
fs.statSync = vi.fn(() => ({ birthtimeMs: Date.now() }))
```

…with the comment "Prevent the appearance of stale locks". That mock returned a fresh `birthtimeMs` for every call, regardless of whether the lockfile actually existed in the underlying memfs filesystem — which only worked because the production code happened to gate on `existsSync` first. Now that `statSync` is the gating call, the mock has to mirror real `fs` semantics:

```ts
fs.statSync = vi.fn((lockfilePath) => {
  if (!vol.existsSync(lockfilePath as string)) {
    const error = new Error(
      `ENOENT: no such file or directory, stat '${lockfilePath}'`,
    ) as NodeJS.ErrnoException
    error.code = 'ENOENT'
    throw error
  }
  return { birthtimeMs: Date.now() }
})
```

Same change applied in both files. Without it the `updateCheck` tests would assume the lock is always set, which masks the bug being fixed here.

Two new regression tests in `locking.test.ts` cover the production code paths:

- `Returns false when statSync throws ENOENT` — simulates the broken-symlink / concurrent-unset race directly.
- `Re-throws non-ENOENT statSync errors` — guards against the obvious over-correction of swallowing all errors.

## Checks

Per `CONTRIBUTING.md`:

- `yarn check` — clean (no constraint or dedupe issues)
- `yarn test src/lib/__tests__/locking.test.ts src/lib/__tests__/updateCheck.test.ts` in `packages/cli` — 30 passing (11 locking + 19 updateCheck)
- `yarn build` in `packages/cli` — clean
- `yarn lint` — clean (via pre-commit hook)

No new dependencies. Pre-existing failures in unrelated CLI tests (`cwd.test.js`) reproduce on `main` and are not introduced by this PR.