### PR TITLE
chore(ci): Work on improving flaky Windows playwright smoke tests

### DIFF
--- a/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
@@ -182,3 +182,67 @@ issue on Windows CI runners is eliminated for all suites.
 Still open: the root cause of the server crash (PID change mid-run) and the
 Apollo error during `/double` prerender remain uninvestigated. If flakiness
 continues, those are the next areas to focus on.
+
+---
+
+## Update 2026-05-12 — Vite native crash on React 18 + Windows
+
+### Evidence: buffer overrun in `cedar-vite-dev`
+
+From run
+[25729552439](https://github.com/cedarjs/cedar/actions/runs/25729552439/job/75551189080)
+(PR #1756, React 18 + Windows smoke tests), the Vite web server crashes hard
+two seconds after startup:
+
+```
+[WebServer] web | 10:57:56 AM [vite] (client) ✨ new dependencies optimized
+[WebServer] web | 10:57:56 AM [vite] (client) ✨ optimized dependencies changed. reloading
+[WebServer] web | yarn cross-env NODE_ENV=development cedar-vite-dev --no-open
+                 exited with code 3221226505
+```
+
+Exit code `3221226505` (`0xC0000409`) is Windows'
+`STATUS_STACK_BUFFER_OVERRUN` — a native stack corruption, typically caused by
+a native addon (esbuild, SWC, better-sqlite3, etc.) writing past a buffer
+boundary. This is a hard crash, not a Node.js exception.
+
+### Exit code 1 is not a crash
+
+The same run (and another renovate run) also showed `exited with code 1` from
+the Vite process, but these occur right after the last test passes — they're
+Playwright tearing down the `webServer` child process after the dev test step
+completes. Both the API server and Vite exit with code 1 simultaneously, which
+is normal clean-up behavior.
+
+### Prevalence check
+
+The `STATUS_STACK_BUFFER_OVERRUN` crash was systematically searched for across:
+
+- 7 recent failed PR runs: 0 occurrences
+- 20 recent main branch runs: 0 occurrences
+- All non-zero Vite exit codes in 40 runs: only clean teardowns (exit code 1)
+
+However, the crash recurred shortly after in an unrelated PR —
+`renovate/publint` (#1758, a trivial `publint` version bump). Same React 18 +
+Windows smoke test, same exit code `3221226505`. This confirms the crash is
+**not** a one-off — it's a recurring issue potentially related to the React 18
+downgrade on Windows runners.
+
+### Decision
+
+This is a framework-level bug in the React 18 + Vite + Windows combination, not
+a CI fluke. The next step is running the React 18 downgrade scenario locally on
+Windows with a debugger attached to identify which native addon (esbuild, SWC,
+better-sqlite3, etc.) is causing the stack corruption.
+
+---
+
+## Update 2026-05-12 — Current state
+
+The `localhost` → `127.0.0.1` change has been applied across all 12 Playwright
+configs and 3 test files. However, since the failures are flaky, a passing run
+is **not** sufficient proof that the change fixed anything — several passing
+runs could be coincidental.
+
+Still open: the root cause of the server crash (PID change mid-run) and the
+Apollo error during `/double` prerender remain uninvestigated.

--- a/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
@@ -62,9 +62,9 @@ The Playwright configs used `localhost` in both `webServer.url` and
 ### 2. Insufficient Server Startup Timeout (Mitigated)
 
 Playwright's `webServer` checks the URL to determine readiness, but the default
-60-second timeout may be too tight on Windows CI runners where `yarn cedar serve`
-performs a lot of work (compiling, generating, starting both API and web
-servers).
+60-second timeout may be too tight on slower Windows CI runners where
+`yarn cedar serve` needs to start both the API and web servers and bind to
+their ports.
 
 **Mitigation:** Increased `webServer.timeout` to 120 seconds on CI.
 
@@ -85,9 +85,9 @@ build artifact and test page.
 
 The Apollo error during `/double` prerender may produce a broken HTML file that
 the server then crashes trying to serve or that triggers a crash during client
-rehydration. The smoke test for `/double` (`Check that rehydration works for
-page not wrapped in Set`) uses `expect(errors).toMatchObject([])` which
-silently ignores errors.
+rehydration. The smoke test for `/double`
+(`Check that rehydration works for page not wrapped in Set`) uses
+`expect(errors).toMatchObject([])` which silently ignores errors.
 
 ## Applied Mitigations
 
@@ -122,3 +122,63 @@ silently ignores errors.
 3. Consider replacing `toMatchObject([])` with explicit error assertions in
    rehydration tests
 4. If confirmed fixed, promote this document to `docs/implementation-docs/`
+
+---
+
+## Update 2026-05-12 — Scope expanded, timeout reverted
+
+### Initial fix was incomplete
+
+Following the initial mitigation in PR #1756, CI flagged failures in
+`Smoke tests ESM` and `Smoke tests React 18` on both Ubuntu and Windows.
+These suites weren't affected by the original 3-file fix because they also use
+Playwright configs that hardcoded `localhost`.
+
+The `localhost` → `127.0.0.1` change needed to be applied across **all** smoke
+test configs (12 files total), not just the three serve-type configs:
+
+| Config                                                                                          | Type                     | Port                   |
+| ----------------------------------------------------------------------------------------------- | ------------------------ | ---------------------- |
+| `serve`, `fragments-serve`, `prerender`, `rsa`, `rsc`, `rsc-kitchen-sink`, `streaming-ssr-prod` | `yarn cedar serve`       | 8910                   |
+| `dev`, `fragments-dev`, `streaming-ssr-dev`                                                     | `yarn cedar dev`         | 8910 (web), 8911 (API) |
+| `rsc-dev`                                                                                       | `yarn cedar dev`         | 8910                   |
+| `live`                                                                                          | `yarn cedar dev` + setup | 8910 (web), 8911 (API) |
+| `storybook`                                                                                     | `yarn cedar storybook`   | 7910                   |
+
+### Test assertions also hardcoded `localhost`
+
+Changing `baseURL` from `localhost` to `127.0.0.1` broke URL assertions in test
+files that expected `http://localhost:8910/...`:
+
+- `tasks/smoke-tests/shared/common.ts` — three `expect(page.url()).toBe(...)`
+  assertions for `/about`, `/contact`, `/posts`
+- `tasks/smoke-tests/dev/tests/authChecks.spec.ts` — login redirect URL check
+- `tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts` — cookie
+  domain set to `localhost:8910` → changed to `127.0.0.1`
+
+### 120s timeout reverted
+
+The `webServer.timeout` increase from 60s to 120s was removed from all configs.
+`yarn cedar serve` only starts servers and binds ports — it does not compile or
+generate anything. The default 60-second Playwright timeout for `webServer.url`
+readiness is sufficient.
+
+### Greptile review
+
+Greptile flagged an issue in the initial PR:
+
+1. This investigation doc originally described `yarn cedar serve` as
+   "compiling, generating, starting both API and web servers" — corrected:
+   `cedar serve` only serves pre-built assets from `api/dist/` and
+   `web/dist/`.
+
+### Current state
+
+After the full set of changes across 12 config files and 3 test files, all CI
+smoke test suites that use Playwright with a `webServer` now resolve to
+`127.0.0.1` instead of `localhost`. The `localhost` → `::1` (IPv6) resolution
+issue on Windows CI runners is eliminated for all suites.
+
+Still open: the root cause of the server crash (PID change mid-run) and the
+Apollo error during `/double` prerender remain uninvestigated. If flakiness
+continues, those are the next areas to focus on.

--- a/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
@@ -180,8 +180,34 @@ smoke test suites that use Playwright with a `webServer` now resolve to
 issue on Windows CI runners is eliminated for all suites.
 
 Still open: the root cause of the server crash (PID change mid-run) and the
-Apollo error during `/double` prerender remain uninvestigated. If flakiness
-continues, those are the next areas to focus on.
+Apollo error during `/double` prerender remain uninvestigated.
+
+---
+
+## Update 2026-05-12 — CLI smoke test failure: "Generating dbAuth secret"
+
+### Evidence
+
+From run
+[25732654425](https://github.com/cedarjs/cedar/actions/runs/25732654425/job/75561731517)
+(PR #1757, CLI smoke tests on Windows):
+
+```
+Generating dbAuth secret
+Error: The process 'C:\npm\prefix\yarn.cmd' failed with exit code 1
+    at ChildProcess._handle.onexit (node:internal/child_process:306:5)
+```
+
+The `yarn.cmd` process fails during the `cedar build` step of the CLI smoke
+test, specifically at the "Generating dbAuth secret" phase. This is a different
+failure mode from the `ERR_CONNECTION_REFUSED` and Vite crashes — it's a build
+infrastructure issue, not a runtime server crash.
+
+### Prevalence
+
+I (@tobbe) think I've seen this before. Needs tracking if it appears again to
+determine if it's specific to Windows or certain dependency versions. If
+flakiness continues, those are the next areas to focus on.
 
 ---
 

--- a/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
@@ -1,0 +1,124 @@
+# Investigation: Flaky Windows Smoke Tests (`ERR_CONNECTION_REFUSED`)
+
+## Summary
+
+Multiple smoke test suites (`serve`, `fragments-serve`, `prerender`) fail
+intermittently on Windows CI runners with `net::ERR_CONNECTION_REFUSED` when
+trying to reach `http://localhost:8910`. The failure is not deterministic —
+sometimes the suite passes entirely, sometimes it fails partway through.
+
+This document tracks the investigation and applied mitigations.
+
+## Observed Failure Pattern
+
+From run
+[25702624909](https://github.com/cedarjs/cedar/actions/runs/25702624909/job/75468866374)
+(PR #1754, Windows fragments smoke tests):
+
+- 10 tests total, 3 passed, 7 failed across all retries
+- The 3 passing tests use `noJsBrowser` to navigate to pre-rendered pages
+- Every `page.goto()` call fails with `ERR_CONNECTION_REFUSED`
+- `page.waitForResponse()` times out after 30 seconds
+- All 3 retries per test produce the same error — the server does not recover
+
+### Chronology from CI Logs
+
+| Time (UTC) | Event                                                  |
+| ---------- | ------------------------------------------------------ |
+| 23:40:48   | First API server starts on port 8911                   |
+| 23:41:05   | `yarn cedar build` prerendering begins                 |
+| 23:41:09   | **Apollo GraphQL error** during prerender of `/double` |
+| 23:41:18   | `yarn cedar serve` starts for tests (PID 6460)         |
+| 23:41:19   | Web server reports listening on `127.0.0.1:8910`       |
+| 23:42:08   | Server **restarts** — new process (PID 5924)           |
+| 23:42:09   | Web server listening again                             |
+| 23:44:32   | All remaining tests fail with `ERR_CONNECTION_REFUSED` |
+
+### Apollo Error During Build
+
+```
+An error occurred! For more details, see the full error text at
+https://go.apollo.dev/c/err#%7B%22version%22%3A%223.14.1%22%2C%22message%22%3A17%2C%22args%22%3A%5B%5D%7D
+❯ Prerendering /double -> web/dist/double.html
+✔ Prerendering /double -> web/dist/double.html
+```
+
+The error occurs during `yarn cedar build` (prerender phase) when fetching
+GraphQL data for the `/double` page. Despite the error, the prerender step
+completes and produces `web/dist/double.html`. The error code (`"message":17`)
+is an Apollo Client internal error from version 3.14.1.
+
+## Potential Root Causes
+
+### 1. `localhost` DNS Resolution (Mitigated)
+
+On Windows, `localhost` can resolve to `::1` (IPv6) instead of `127.0.0.1`
+(IPv4). If the web server binds to IPv4 only, connections via `localhost` fail.
+The Playwright configs used `localhost` in both `webServer.url` and
+`use.baseURL`.
+
+**Mitigation:** Changed all three configs to use `127.0.0.1` directly.
+
+### 2. Insufficient Server Startup Timeout (Mitigated)
+
+Playwright's `webServer` checks the URL to determine readiness, but the default
+60-second timeout may be too tight on Windows CI runners where `yarn cedar serve`
+performs a lot of work (compiling, generating, starting both API and web
+servers).
+
+**Mitigation:** Increased `webServer.timeout` to 120 seconds on CI.
+
+### 3. Server Crash During Test Execution (Unresolved)
+
+The server restart at 23:42:08 (different PID) indicates the original process
+died. Possible causes:
+
+- A specific page (`/double` with the Apollo error) triggers an unhandled
+  exception in the web server
+- Memory pressure on the CI runner causes the OS to kill the process
+- The prerender build step leaves port 8910 in a bad state
+
+This needs further investigation — reproduce the crash locally with the same
+build artifact and test page.
+
+### 4. Apollo Error in Prerender Build (Needs Investigation)
+
+The Apollo error during `/double` prerender may produce a broken HTML file that
+the server then crashes trying to serve or that triggers a crash during client
+rehydration. The smoke test for `/double` (`Check that rehydration works for
+page not wrapped in Set`) uses `expect(errors).toMatchObject([])` which
+silently ignores errors.
+
+## Applied Mitigations
+
+### Changed Files
+
+- `tasks/smoke-tests/serve/playwright.config.ts`
+- `tasks/smoke-tests/fragments-serve/playwright.config.ts`
+- `tasks/smoke-tests/prerender/playwright.config.ts`
+
+### Changes
+
+1. `localhost` → `127.0.0.1` in both `baseURL` and `webServer.url`
+2. Added `timeout: process.env.CI ? 120_000 : 60_000` to `webServer`
+
+## Open Questions
+
+- What is Apollo Client error code 17, and why does it occur during `/double`
+  prerender?
+- Does the broken `/double` prerendered HTML cause the server to crash at
+  runtime?
+- Why does the server restart once (PID change) but then die permanently?
+- Can we add a health-check endpoint to `cedar serve` so Playwright can verify
+  the server is truly ready before tests start?
+- Should the `expect(errors).toMatchObject([])` pattern be replaced with an
+  explicit `expect(errors).toEqual([])` to catch hidden errors?
+
+## Next Steps
+
+1. Monitor CI runs after the `127.0.0.1` and timeout mitigations are merged
+2. If flakiness persists, investigate the Apollo error during `/double`
+   prerender
+3. Consider replacing `toMatchObject([])` with explicit error assertions in
+   rehydration tests
+4. If confirmed fixed, promote this document to `docs/implementation-docs/`

--- a/tasks/smoke-tests/dev/playwright.config.ts
+++ b/tasks/smoke-tests/dev/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   timeout: 30_000 * 2,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   // Run your local dev server before starting the tests
@@ -18,7 +18,7 @@ export default defineConfig({
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
     // We wait for the api server to be ready instead of the web server
     // because web starts much faster with Vite.
-    url: 'http://localhost:8911/graphql?query={redwood{version}}',
+    url: 'http://127.0.0.1:8911/graphql?query={redwood{version}}',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
   },

--- a/tasks/smoke-tests/dev/tests/authChecks.spec.ts
+++ b/tasks/smoke-tests/dev/tests/authChecks.spec.ts
@@ -21,7 +21,7 @@ test('useAuth hook, auth redirects checks', async ({ page }) => {
 
   // To check redirects to the login page
   await expect(page).toHaveURL(
-    `http://localhost:8910/login?redirectTo=/profile`,
+    `http://127.0.0.1:8910/login?redirectTo=/profile`,
   )
 
   await loginAsTestUser({ page, ...testUser })

--- a/tasks/smoke-tests/fragments-dev/playwright.config.ts
+++ b/tasks/smoke-tests/fragments-dev/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   timeout: 30_000 * 2,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   // Run your local dev server before starting the tests
@@ -18,7 +18,7 @@ export default defineConfig({
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
     // We wait for the api server to be ready instead of the web server
     // because web starts much faster with Vite.
-    url: 'http://localhost:8911/graphql?query={redwood{version}}',
+    url: 'http://127.0.0.1:8911/graphql?query={redwood{version}}',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
   },

--- a/tasks/smoke-tests/fragments-serve/playwright.config.ts
+++ b/tasks/smoke-tests/fragments-serve/playwright.config.ts
@@ -18,6 +18,5 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
     // Give the server more time to start on CI
-    timeout: process.env.CI ? 120_000 : 60_000,
   },
 })

--- a/tasks/smoke-tests/fragments-serve/playwright.config.ts
+++ b/tasks/smoke-tests/fragments-serve/playwright.config.ts
@@ -7,15 +7,17 @@ export default defineConfig({
   ...basePlaywrightConfig,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   // Run your local dev server before starting the tests
   webServer: {
     command: 'yarn cedar serve',
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
-    url: 'http://localhost:8910',
+    url: 'http://127.0.0.1:8910',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
+    // Give the server more time to start on CI
+    timeout: process.env.CI ? 120_000 : 60_000,
   },
 })

--- a/tasks/smoke-tests/live/playwright.config.mts
+++ b/tasks/smoke-tests/live/playwright.config.mts
@@ -8,13 +8,13 @@ export default defineConfig({
   timeout: 60_000,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   webServer: {
     command: `node ${import.meta.dirname}/setup.mts && yarn cedar dev --fwd="--no-open"`,
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
-    url: 'http://localhost:8911/graphql?query={cedar{version}}',
+    url: 'http://127.0.0.1:8911/graphql?query={cedar{version}}',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
   },

--- a/tasks/smoke-tests/prerender/playwright.config.ts
+++ b/tasks/smoke-tests/prerender/playwright.config.ts
@@ -18,6 +18,5 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
     // Give the server more time to start on CI
-    timeout: process.env.CI ? 120_000 : 60_000,
   },
 })

--- a/tasks/smoke-tests/prerender/playwright.config.ts
+++ b/tasks/smoke-tests/prerender/playwright.config.ts
@@ -7,15 +7,17 @@ export default defineConfig({
   ...basePlaywrightConfig,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   // Run your local dev server before starting the tests
   webServer: {
     command: 'yarn cedar serve',
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
-    url: 'http://localhost:8910',
+    url: 'http://127.0.0.1:8910',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
+    // Give the server more time to start on CI
+    timeout: process.env.CI ? 120_000 : 60_000,
   },
 })

--- a/tasks/smoke-tests/rsa/playwright.config.ts
+++ b/tasks/smoke-tests/rsa/playwright.config.ts
@@ -7,14 +7,14 @@ export default defineConfig({
   ...basePlaywrightConfig,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   // Run your local dev server before starting the tests
   webServer: {
     command: 'yarn cedar serve',
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
-    url: 'http://localhost:8910',
+    url: 'http://127.0.0.1:8910',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
   },

--- a/tasks/smoke-tests/rsc-dev/playwright.config.ts
+++ b/tasks/smoke-tests/rsc-dev/playwright.config.ts
@@ -7,14 +7,14 @@ export default defineConfig({
   ...basePlaywrightConfig,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   // Run your local dev server before starting the tests
   webServer: {
     command: 'yarn cedar dev',
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
-    url: 'http://localhost:8910',
+    url: 'http://127.0.0.1:8910',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
   },

--- a/tasks/smoke-tests/rsc-kitchen-sink/playwright.config.ts
+++ b/tasks/smoke-tests/rsc-kitchen-sink/playwright.config.ts
@@ -7,14 +7,14 @@ export default defineConfig({
   ...basePlaywrightConfig,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   // Run your local dev server before starting the tests
   webServer: {
     command: 'yarn cedar serve',
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
-    url: 'http://localhost:8910',
+    url: 'http://127.0.0.1:8910',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
   },

--- a/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
+++ b/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-import { loginAsTestUser } from '../../shared/common'
+import { loginAsTestUser } from '../../shared/common.ts'
 
 const testUser = {
   email: 'testuser@bazinga.com',
@@ -264,7 +264,7 @@ test('Retrieving request details in a', async ({ page }) => {
       name: 'smoke-test-cookie',
       value: 'this-cookie-is-set-by-smoke-tests',
       path: '/',
-      domain: 'localhost:8910',
+      domain: '127.0.0.1',
       expires: Math.floor(Date.now() / 1000) + 300, // 5 minutes from now in seconds
       secure: true,
       httpOnly: true,
@@ -285,7 +285,7 @@ test('Retrieving request details in a', async ({ page }) => {
   expect(userAgentLine).toMatch(/User-Agent Header:.*Chrome\/.*/)
   expect(userAgentLine).not.toContain('NO USER AGENT!')
 
-  await expect(
-    await page.getByTestId('smoke-test-cookie').textContent(),
-  ).toEqual('Smoke Test Cookie: this-cookie-is-set-by-smoke-tests')
+  expect(await page.getByTestId('smoke-test-cookie').textContent()).toEqual(
+    'Smoke Test Cookie: this-cookie-is-set-by-smoke-tests',
+  )
 })

--- a/tasks/smoke-tests/rsc/playwright.config.ts
+++ b/tasks/smoke-tests/rsc/playwright.config.ts
@@ -7,14 +7,14 @@ export default defineConfig({
   ...basePlaywrightConfig,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   // Run your local dev server before starting the tests
   webServer: {
     command: 'yarn cedar serve',
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
-    url: 'http://localhost:8910',
+    url: 'http://127.0.0.1:8910',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
   },

--- a/tasks/smoke-tests/serve/playwright.config.ts
+++ b/tasks/smoke-tests/serve/playwright.config.ts
@@ -18,6 +18,5 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
     // Give the server more time to start on CI
-    timeout: process.env.CI ? 120_000 : 60_000,
   },
 })

--- a/tasks/smoke-tests/serve/playwright.config.ts
+++ b/tasks/smoke-tests/serve/playwright.config.ts
@@ -7,15 +7,17 @@ export default defineConfig({
   ...basePlaywrightConfig,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   // Run your local dev server before starting the tests
   webServer: {
     command: 'yarn cedar serve',
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
-    url: 'http://localhost:8910',
+    url: 'http://127.0.0.1:8910',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
+    // Give the server more time to start on CI
+    timeout: process.env.CI ? 120_000 : 60_000,
   },
 })

--- a/tasks/smoke-tests/shared/common.ts
+++ b/tasks/smoke-tests/shared/common.ts
@@ -37,7 +37,7 @@ export async function smokeTest({ page }: PlaywrightTestArgs) {
 
   // Check the about page.
   await page.getByRole('link', { name: 'About', exact: true }).click()
-  expect(page.url()).toBe('http://localhost:8910/about')
+  expect(page.url()).toBe('http://127.0.0.1:8910/about')
   await expect(
     page.getByText(
       'This site was created to demonstrate my mastery of Cedar: Look on my works, ye',
@@ -46,11 +46,11 @@ export async function smokeTest({ page }: PlaywrightTestArgs) {
 
   // Check the contact us page.
   await page.getByRole('link', { name: 'Contact Us' }).click()
-  expect(page.url()).toBe('http://localhost:8910/contact')
+  expect(page.url()).toBe('http://127.0.0.1:8910/contact')
 
   // Check the admin page.
   await page.getByRole('link', { name: 'Admin' }).click()
-  expect(page.url()).toBe('http://localhost:8910/posts')
+  expect(page.url()).toBe('http://127.0.0.1:8910/posts')
 }
 
 interface AuthUtilsParams {

--- a/tasks/smoke-tests/storybook/playwright.config.ts
+++ b/tasks/smoke-tests/storybook/playwright.config.ts
@@ -7,14 +7,14 @@ export default defineConfig({
   ...basePlaywrightConfig,
 
   use: {
-    baseURL: 'http://localhost:7910',
+    baseURL: 'http://127.0.0.1:7910',
   },
 
   // Run your local dev server before starting the tests
   webServer: {
     command: 'yarn cedar storybook --ci --no-open',
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
-    url: 'http://localhost:7910',
+    url: 'http://127.0.0.1:7910',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
     // The Storybook v7 CLI seems noticeably slower, and it times out in Windows CI.

--- a/tasks/smoke-tests/storybook/tests/storybook.spec.ts
+++ b/tasks/smoke-tests/storybook/tests/storybook.spec.ts
@@ -12,7 +12,7 @@ test('Loads Cell stories', async ({ page }: PlaywrightTestArgs) => {
   await page.getByRole('link', { name: 'Loading' }).click()
 
   await expect(page).toHaveURL(
-    `http://localhost:7910/?path=/story/cells-blogpostcell--loading`,
+    `http://127.0.0.1:7910/?path=/story/cells-blogpostcell--loading`,
   )
 
   await expect(
@@ -24,7 +24,7 @@ test('Loads Cell stories', async ({ page }: PlaywrightTestArgs) => {
   // Click text=Failure
   await page.locator('text=Failure').click()
   await expect(page).toHaveURL(
-    `http://localhost:7910/?path=/story/cells-blogpostcell--failure`,
+    `http://127.0.0.1:7910/?path=/story/cells-blogpostcell--failure`,
   )
 
   await expect(
@@ -34,7 +34,7 @@ test('Loads Cell stories', async ({ page }: PlaywrightTestArgs) => {
   // Check Loading
   await page.locator('text=Empty').click()
   await expect(page).toHaveURL(
-    `http://localhost:7910/?path=/story/cells-blogpostcell--empty`,
+    `http://127.0.0.1:7910/?path=/story/cells-blogpostcell--empty`,
   )
 
   await expect(
@@ -45,7 +45,7 @@ test('Loads Cell stories', async ({ page }: PlaywrightTestArgs) => {
   // And make sure MSW Cell mocks are loaded as expected
   await page.locator('text=Success').click()
   await expect(page).toHaveURL(
-    `http://localhost:7910/?path=/story/cells-blogpostcell--success`,
+    `http://127.0.0.1:7910/?path=/story/cells-blogpostcell--success`,
   )
 
   await expect(
@@ -67,7 +67,7 @@ test('Loads Cell mocks when Cell is nested in another story', async ({
 
   // Click text=Empty
   await expect(page).toHaveURL(
-    `http://localhost:7910/?path=/story/pages-blogpostpage--primary`,
+    `http://127.0.0.1:7910/?path=/story/pages-blogpostpage--primary`,
   )
 
   await expect(
@@ -158,7 +158,7 @@ test('Loads MDX Stories', async ({ page }: PlaywrightTestArgs) => {
   await page.locator('id=cedarjs--docs').click()
 
   await expect(page).toHaveURL(
-    `http://localhost:7910/?path=/docs/cedarjs--docs`,
+    `http://127.0.0.1:7910/?path=/docs/cedarjs--docs`,
   )
 
   await expect(

--- a/tasks/smoke-tests/streaming-ssr-dev/playwright.config.ts
+++ b/tasks/smoke-tests/streaming-ssr-dev/playwright.config.ts
@@ -7,14 +7,14 @@ export default defineConfig({
   ...basePlaywrightConfig,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   // Run your local dev server before starting the tests
   webServer: {
     command: 'yarn cedar dev --no-generate --fwd="--no-open"',
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
-    url: 'http://localhost:8911/graphql?query={redwood{version}}',
+    url: 'http://127.0.0.1:8911/graphql?query={redwood{version}}',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
   },

--- a/tasks/smoke-tests/streaming-ssr-prod/playwright.config.ts
+++ b/tasks/smoke-tests/streaming-ssr-prod/playwright.config.ts
@@ -7,14 +7,14 @@ export default defineConfig({
   ...basePlaywrightConfig,
 
   use: {
-    baseURL: 'http://localhost:8910',
+    baseURL: 'http://127.0.0.1:8910',
   },
 
   // Run your local dev server before starting the tests
   webServer: {
     command: 'yarn cedar serve',
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
-    url: 'http://localhost:8910',
+    url: 'http://127.0.0.1:8910',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
   },


### PR DESCRIPTION
From run
[25702624909](https://github.com/cedarjs/cedar/actions/runs/25702624909/job/75468866374)
(PR #1754, Windows fragments smoke tests):

- 10 tests total, 3 passed, 7 failed across all retries
- The 3 passing tests use `noJsBrowser` to navigate to pre-rendered pages
- Every `page.goto()` call fails with `ERR_CONNECTION_REFUSED`
- `page.waitForResponse()` times out after 30 seconds
- All 3 retries per test produce the same error — the server does not recover