### PR TITLE
fix(prisma): Explain schema.prisma config settings

### DIFF
--- a/__fixtures__/test-project-esm/api/db/schema.prisma
+++ b/__fixtures__/test-project-esm/api/db/schema.prisma
@@ -8,12 +8,9 @@ datasource db {
   provider = "sqlite"
 }
 
-// It might feel a little out of place to have .mts files in a CJS codebase,
-// especially importing them like we do in `src/lib/db`. Setting
-// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
-// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
-// The only reason this works is thanks to Node 24's support for require(esm).
-// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
+// This specific combination of settings is the only way to make Prisma 7 work
+// in both CJS and ESM Cedar apps.
+// See https://github.com/cedarjs/cedar/pull/1761 for more info
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/__fixtures__/test-project-esm/api/db/schema.prisma
+++ b/__fixtures__/test-project-esm/api/db/schema.prisma
@@ -8,6 +8,12 @@ datasource db {
   provider = "sqlite"
 }
 
+// It might feel a little out of place to have .mts files in a CJS codebase,
+// especially importing them like we do in `src/lib/db`. Setting
+// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
+// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
+// The only reason this works is thanks to Node 24's support for require(esm).
+// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/__fixtures__/test-project-live/api/db/schema.prisma
+++ b/__fixtures__/test-project-live/api/db/schema.prisma
@@ -8,18 +8,9 @@ datasource db {
   provider = "postgresql"
 }
 
-// For CJS Cedar apps:
-// It might feel a little out of place to have .mts files in the codebase, and
-// especially importing them like we do in `src/lib/db`.
-// For ESM Cedar apps:
-// It might feel a little weird to ask Prisma to generate CJS compatible format.
-//
-// Setting `moduleFormat = "cjs"` and using `.mts` extensions is however the
-// only combination that makes Prisma 7, which is ESM-only, work in CJS Cedar
-// apps while also having the same configuration work for ESM Cedar apps.
-//
-// The only reason this works is thanks to Node 24's support for require(esm).
-// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
+// This specific combination of settings is the only way to make Prisma 7 work
+// in both CJS and ESM Cedar apps.
+// See https://github.com/cedarjs/cedar/pull/1761 for more info
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/__fixtures__/test-project-live/api/db/schema.prisma
+++ b/__fixtures__/test-project-live/api/db/schema.prisma
@@ -8,6 +8,18 @@ datasource db {
   provider = "postgresql"
 }
 
+// For CJS Cedar apps:
+// It might feel a little out of place to have .mts files in the codebase, and
+// especially importing them like we do in `src/lib/db`.
+// For ESM Cedar apps:
+// It might feel a little weird to ask Prisma to generate CJS compatible format.
+//
+// Setting `moduleFormat = "cjs"` and using `.mts` extensions is however the
+// only combination that makes Prisma 7, which is ESM-only, work in CJS Cedar
+// apps while also having the same configuration work for ESM Cedar apps.
+//
+// The only reason this works is thanks to Node 24's support for require(esm).
+// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/__fixtures__/test-project/api/db/schema.prisma
+++ b/__fixtures__/test-project/api/db/schema.prisma
@@ -8,12 +8,9 @@ datasource db {
   provider = "sqlite"
 }
 
-// It might feel a little out of place to have .mts files in a CJS codebase,
-// especially importing them like we do in `src/lib/db`. Setting
-// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
-// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
-// The only reason this works is thanks to Node 24's support for require(esm).
-// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
+// This specific combination of settings is the only way to make Prisma 7 work
+// in both CJS and ESM Cedar apps.
+// See https://github.com/cedarjs/cedar/pull/1761 for more info
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/__fixtures__/test-project/api/db/schema.prisma
+++ b/__fixtures__/test-project/api/db/schema.prisma
@@ -8,6 +8,12 @@ datasource db {
   provider = "sqlite"
 }
 
+// It might feel a little out of place to have .mts files in a CJS codebase,
+// especially importing them like we do in `src/lib/db`. Setting
+// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
+// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
+// The only reason this works is thanks to Node 24's support for require(esm).
+// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/local-testing-project-live/api/db/schema.prisma
+++ b/local-testing-project-live/api/db/schema.prisma
@@ -8,6 +8,9 @@ datasource db {
   provider = "postgresql"
 }
 
+// This specific combination of settings is the only way to make Prisma 7 work
+// in both CJS and ESM Cedar apps.
+// See https://github.com/cedarjs/cedar/pull/1761 for more info
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/local-testing-project/api/db/schema.prisma
+++ b/local-testing-project/api/db/schema.prisma
@@ -8,6 +8,9 @@ datasource db {
   provider = "sqlite"
 }
 
+// This specific combination of settings is the only way to make Prisma 7 work
+// in both CJS and ESM Cedar apps.
+// See https://github.com/cedarjs/cedar/pull/1761 for more info
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/packages/create-cedar-app/templates/esm-js/api/db/schema.prisma
+++ b/packages/create-cedar-app/templates/esm-js/api/db/schema.prisma
@@ -8,12 +8,9 @@ datasource db {
   provider = "sqlite"
 }
 
-// It might feel a little out of place to have .mts files in a CJS codebase,
-// especially importing them like we do in `src/lib/db`. Setting
-// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
-// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
-// The only reason this works is thanks to Node 24's support for require(esm).
-// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
+// This specific combination of settings is the only way to make Prisma 7 work
+// in both CJS and ESM Cedar apps.
+// See https://github.com/cedarjs/cedar/pull/1761 for more info
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/packages/create-cedar-app/templates/esm-js/api/db/schema.prisma
+++ b/packages/create-cedar-app/templates/esm-js/api/db/schema.prisma
@@ -8,6 +8,12 @@ datasource db {
   provider = "sqlite"
 }
 
+// It might feel a little out of place to have .mts files in a CJS codebase,
+// especially importing them like we do in `src/lib/db`. Setting
+// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
+// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
+// The only reason this works is thanks to Node 24's support for require(esm).
+// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/packages/create-cedar-app/templates/esm-ts/api/db/schema.prisma
+++ b/packages/create-cedar-app/templates/esm-ts/api/db/schema.prisma
@@ -8,12 +8,9 @@ datasource db {
   provider = "sqlite"
 }
 
-// It might feel a little out of place to have .mts files in a CJS codebase,
-// especially importing them like we do in `src/lib/db`. Setting
-// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
-// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
-// The only reason this works is thanks to Node 24's support for require(esm).
-// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
+// This specific combination of settings is the only way to make Prisma 7 work
+// in both CJS and ESM Cedar apps.
+// See https://github.com/cedarjs/cedar/pull/1761 for more info
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/packages/create-cedar-app/templates/esm-ts/api/db/schema.prisma
+++ b/packages/create-cedar-app/templates/esm-ts/api/db/schema.prisma
@@ -8,6 +8,12 @@ datasource db {
   provider = "sqlite"
 }
 
+// It might feel a little out of place to have .mts files in a CJS codebase,
+// especially importing them like we do in `src/lib/db`. Setting
+// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
+// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
+// The only reason this works is thanks to Node 24's support for require(esm).
+// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/packages/create-cedar-app/templates/js/api/db/schema.prisma
+++ b/packages/create-cedar-app/templates/js/api/db/schema.prisma
@@ -8,12 +8,9 @@ datasource db {
   provider = "sqlite"
 }
 
-// It might feel a little out of place to have .mts files in a CJS codebase,
-// especially importing them like we do in `src/lib/db`. Setting
-// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
-// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
-// The only reason this works is thanks to Node 24's support for require(esm).
-// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
+// This specific combination of settings is the only way to make Prisma 7 work
+// in both CJS and ESM Cedar apps.
+// See https://github.com/cedarjs/cedar/pull/1761 for more info
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/packages/create-cedar-app/templates/js/api/db/schema.prisma
+++ b/packages/create-cedar-app/templates/js/api/db/schema.prisma
@@ -8,6 +8,12 @@ datasource db {
   provider = "sqlite"
 }
 
+// It might feel a little out of place to have .mts files in a CJS codebase,
+// especially importing them like we do in `src/lib/db`. Setting
+// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
+// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
+// The only reason this works is thanks to Node 24's support for require(esm).
+// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/packages/create-cedar-app/templates/ts/api/db/schema.prisma
+++ b/packages/create-cedar-app/templates/ts/api/db/schema.prisma
@@ -8,12 +8,9 @@ datasource db {
   provider = "sqlite"
 }
 
-// It might feel a little out of place to have .mts files in a CJS codebase,
-// especially importing them like we do in `src/lib/db`. Setting
-// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
-// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
-// The only reason this works is thanks to Node 24's support for require(esm).
-// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
+// This specific combination of settings is the only way to make Prisma 7 work
+// in both CJS and ESM Cedar apps.
+// See https://github.com/cedarjs/cedar/pull/1761 for more info
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"

--- a/packages/create-cedar-app/templates/ts/api/db/schema.prisma
+++ b/packages/create-cedar-app/templates/ts/api/db/schema.prisma
@@ -8,6 +8,12 @@ datasource db {
   provider = "sqlite"
 }
 
+// It might feel a little out of place to have .mts files in a CJS codebase,
+// especially importing them like we do in `src/lib/db`. Setting
+// `moduleFormat = "cjs"` and using `.mts` extensions is however the only
+// combination that makes Prisma 7, which is ESM-only, work in CJS Cedar apps.
+// The only reason this works is thanks to Node 24's support for require(esm).
+// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
 generator client {
   provider               = "prisma-client"
   output                 = "./generated/prisma"


### PR DESCRIPTION
Had this comment first, but it felt like it was too long

```js
// For CJS Cedar apps:
// It might feel a little out of place to have .mts files in the codebase, and
// especially importing them like we do in `src/lib/db`.
// For ESM Cedar apps:
// It might feel a little weird to ask Prisma to generate CJS compatible format.
//
// Setting `moduleFormat = "cjs"` and using `.mts` extensions is however the
// only combination that makes Prisma 7, which is ESM-only, work in CJS Cedar
// apps while also having the same configuration work for ESM Cedar apps.
//
// The only reason this works is thanks to Node 24's support for require(esm).
// https://www.prisma.io/docs/orm/prisma-schema/overview/generators
```
So I shortened it to what we have now, and then pointing here for more info.

This all came out of the discussion on PR https://github.com/cedarjs/cedar/pull/1752