### PR TITLE
chore(api-server): warn when deprecated RWJS_DELAY_RESTART env var is used

### DIFF
--- a/.changesets/release_notes_major.md
+++ b/.changesets/release_notes_major.md
@@ -1,3 +1,9 @@
+## RWJS_DELAY_RESTART removed
+
+The `RWJS_DELAY_RESTART` environment variable has been removed. It was renamed
+to `CEDAR_DELAY_API_RESTART` in a previous release. If you still have
+`RWJS_DELAY_RESTART` in your `.env` file, rename it to `CEDAR_DELAY_API_RESTART`.
+
 ## cedar-gen
 
 Public:

--- a/packages/api-server/src/buildManager.ts
+++ b/packages/api-server/src/buildManager.ts
@@ -16,6 +16,12 @@ class BuildManager {
     this.shouldClean = false
     this.buildFn = buildFn
     // TODO: Remove process.env.RWJS_DELAY_RESTART in next major release
+    if (process.env.RWJS_DELAY_RESTART) {
+      console.warn(
+        '[DEPRECATED] RWJS_DELAY_RESTART is deprecated and will be removed in the next major release. ' +
+          'Please rename it to CEDAR_DELAY_API_RESTART in your .env file.',
+      )
+    }
     const delay =
       process.env.CEDAR_DELAY_API_RESTART || process.env.RWJS_DELAY_RESTART
     this.debouncedBuild = debounce(

--- a/upgrade-scripts/4.x.ts
+++ b/upgrade-scripts/4.x.ts
@@ -1,41 +1,56 @@
-import fs from 'node:fs'
-import path from 'node:path'
+import { glob, readFile } from 'node:fs/promises'
+import * as path from 'node:path'
 import { styleText } from 'node:util'
 
 import { getPaths } from '@cedarjs/project-config'
 
-const envFiles = [
-  '.env',
-  '.env.defaults',
-  '.env.production',
-  '.env.local',
-  '.env.development',
-  '.env.test',
-]
-
 const projectRoot = getPaths().base
 
-const filesWithOldVar = envFiles.filter((file) => {
-  const fullPath = path.join(projectRoot, file)
-  return (
-    fs.existsSync(fullPath) &&
-    fs.readFileSync(fullPath, 'utf8').includes('RWJS_DELAY_RESTART')
-  )
-})
+const patterns = [
+  '**/*.{js,cjs,mjs,ts,cts,mts}',
+  '**/.env',
+  '**/.env.*',
+  '**/*.sh',
+  '**/*.py',
+  '**/*.json',
+  '**/*.{yaml,yml}',
+  '**/Dockerfile',
+  '**/Dockerfile.*',
+  '**/docker-compose.{yml,yaml}',
+  '**/.dockerignore',
+  '**/*.tf',
+  '**/*.tfvars',
+  '**/*.bicep',
+]
 
-if (filesWithOldVar.length > 0) {
-  console.log(
-    styleText('yellow', 'Deprecated env var detected: RWJS_DELAY_RESTART') +
-      '\n',
-  )
-  console.log(
-    'Found RWJS_DELAY_RESTART in: ' + filesWithOldVar.join(', ') + '\n',
-  )
-  console.log(
-    'RWJS_DELAY_RESTART has been renamed to CEDAR_DELAY_API_RESTART and will\n' +
-      'be removed in the next major release of CedarJS.\n',
-  )
-  console.log(
-    'Please rename it in the files listed above before the next major upgrade.\n',
-  )
+const exclude = ['**/node_modules/**', '**/dist/**']
+
+async function main() {
+  const filesWithOldVar: string[] = []
+
+  for await (const file of glob(patterns, { cwd: projectRoot, exclude })) {
+    const content = await readFile(path.join(projectRoot, file), 'utf8')
+    if (content.includes('RWJS_DELAY_RESTART')) {
+      filesWithOldVar.push(file)
+    }
+  }
+
+  if (filesWithOldVar.length > 0) {
+    console.log(
+      styleText('yellow', 'Deprecated env var detected: RWJS_DELAY_RESTART') +
+        '\n',
+    )
+    console.log(
+      'Found RWJS_DELAY_RESTART in: ' + filesWithOldVar.join(', ') + '\n',
+    )
+    console.log(
+      'RWJS_DELAY_RESTART has been renamed to CEDAR_DELAY_API_RESTART and will\n' +
+        'be removed in the next major release of CedarJS.\n',
+    )
+    console.log(
+      'Please rename it in the files listed above before the next major upgrade.\n',
+    )
+  }
 }
+
+main()

--- a/upgrade-scripts/4.x.ts
+++ b/upgrade-scripts/4.x.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { styleText } from 'node:util'
+
+import { getPaths } from '@cedarjs/project-config'
+
+const envFiles = [
+  '.env',
+  '.env.defaults',
+  '.env.production',
+  '.env.local',
+  '.env.development',
+  '.env.test',
+]
+
+const projectRoot = getPaths().base
+
+const filesWithOldVar = envFiles.filter((file) => {
+  const fullPath = path.join(projectRoot, file)
+  return (
+    fs.existsSync(fullPath) &&
+    fs.readFileSync(fullPath, 'utf8').includes('RWJS_DELAY_RESTART')
+  )
+})
+
+if (filesWithOldVar.length > 0) {
+  console.log(
+    styleText('yellow', 'Deprecated env var detected: RWJS_DELAY_RESTART') +
+      '\n',
+  )
+  console.log(
+    'Found RWJS_DELAY_RESTART in: ' + filesWithOldVar.join(', ') + '\n',
+  )
+  console.log(
+    'RWJS_DELAY_RESTART has been renamed to CEDAR_DELAY_API_RESTART and will\n' +
+      'be removed in the next major release of CedarJS.\n',
+  )
+  console.log(
+    'Please rename it in the files listed above before the next major upgrade.\n',
+  )
+}

--- a/upgrade-scripts/README.md
+++ b/upgrade-scripts/README.md
@@ -59,3 +59,11 @@ To specify a specific version, use a comment directive at the top of the file:
 import memoize from 'lodash/memoize.js'
 import { getConfig } from '@cedarjs/project-config'
 ```
+
+## Manual Testing
+
+Do something like this
+
+```shell
+CEDAR_CWD=~/dev/cedar-app node upgrade-scripts/4.x.ts
+```

--- a/upgrade-scripts/manifest.json
+++ b/upgrade-scripts/manifest.json
@@ -1,1 +1,1 @@
-["canary.ts", "2.3.x.ts", "2.7.x.ts", "2.8.x.ts", "3.x.ts"]
+["canary.ts", "2.3.x.ts", "2.7.x.ts", "2.8.x.ts", "3.x.ts", "4.x.ts"]


### PR DESCRIPTION
## Summary

Phase 1 of #1564.

- Emits a runtime `console.warn` when `RWJS_DELAY_RESTART` is set, telling users to rename it to `CEDAR_DELAY_API_RESTART`
- Adds a note to `.changesets/release_notes_major.md` so the removal is highlighted in the next major release

The fallback (`|| process.env.RWJS_DELAY_RESTART`) remains in place — nothing breaks. This just gives users a heads-up before Phase 3 removes it.

## Test plan

- [ ] Set `RWJS_DELAY_RESTART=500` and start `yarn cedar dev` — confirm the deprecation warning appears in the output
- [ ] Confirm `CEDAR_DELAY_API_RESTART=500` still works silently (no warning)