### PR TITLE
feat(cli): Add `prisma generate` args to cedar.toml

### DIFF
--- a/packages/cli/src/commands/__tests__/type-check.test.ts
+++ b/packages/cli/src/commands/__tests__/type-check.test.ts
@@ -4,6 +4,8 @@ import concurrently from 'concurrently'
 import execa from 'execa'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 
+import type * as ProjecConfig from '@cedarjs/project-config'
+
 import '../../lib/mockTelemetry.js'
 
 vi.mock('execa', () => ({
@@ -22,6 +24,47 @@ vi.mock('concurrently', () => ({
     options,
   })),
 }))
+
+vi.mock('@cedarjs/project-config', async (importOriginal) => {
+  const actual = await importOriginal<typeof ProjecConfig>()
+
+  return {
+    ...actual,
+    getConfig: () => ({
+      api: {
+        prismaGenerateArgs: [],
+        prismaConfig: 'cedar-app/api/prisma.config.cjs',
+        port: 8911,
+        title: 'Cedar App',
+        path: './api',
+        target: 'node',
+        serverConfig: './api/server.config.js',
+      },
+      web: {
+        title: 'Cedar App',
+        port: 8910,
+        path: './web',
+        target: 'browser',
+        includeEnvironmentVariables: [],
+        apiUrl: '/.api/functions',
+        fastRefresh: true,
+        a11y: true,
+        sourceMap: false,
+      },
+      browser: { open: false },
+      generate: { tests: true, stories: true, nestScaffoldByModel: true },
+      graphql: {
+        fragments: false,
+        trustedDocuments: false,
+        includeScalars: { File: true },
+      },
+      notifications: { versionUpdates: [] },
+      studio: { basePort: 4318 },
+      eslintLegacyConfigWarning: true,
+      experimental: {},
+    }),
+  }
+})
 
 const mockedRedwoodConfig = {
   api: {},

--- a/packages/cli/src/commands/__tests__/type-check.test.ts
+++ b/packages/cli/src/commands/__tests__/type-check.test.ts
@@ -4,7 +4,7 @@ import concurrently from 'concurrently'
 import execa from 'execa'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 
-import type * as ProjecConfig from '@cedarjs/project-config'
+import type * as ProjectConfig from '@cedarjs/project-config'
 
 import '../../lib/mockTelemetry.js'
 
@@ -26,7 +26,7 @@ vi.mock('concurrently', () => ({
 }))
 
 vi.mock('@cedarjs/project-config', async (importOriginal) => {
-  const actual = await importOriginal<typeof ProjecConfig>()
+  const actual = await importOriginal<typeof ProjectConfig>()
 
   return {
     ...actual,

--- a/packages/cli/src/lib/generatePrismaClient.ts
+++ b/packages/cli/src/lib/generatePrismaClient.ts
@@ -3,7 +3,10 @@
 import fs from 'node:fs'
 import { createRequire } from 'node:module'
 
-import { resolveGeneratedPrismaClient } from '@cedarjs/project-config'
+import {
+  getConfig,
+  resolveGeneratedPrismaClient,
+} from '@cedarjs/project-config'
 
 // @ts-expect-error - No types for JS files
 import { runCommandTask, getPaths } from './index.js'
@@ -18,6 +21,7 @@ export const generatePrismaCommand = async (): Promise<{
   cmd: string
   args: string[]
 }> => {
+  const config = getConfig()
   const createdRequire = createRequire(import.meta.url)
 
   // I wanted to use `import.meta.resolve` here, but it's not supported by our
@@ -32,6 +36,7 @@ export const generatePrismaCommand = async (): Promise<{
       prismaIndexPath,
       'generate',
       `--config=${getPaths().api.prismaConfig}`,
+      ...config.api.prismaGenerateArgs,
     ],
   }
 }

--- a/packages/project-config/cedar-toml-schema-2.0.json
+++ b/packages/project-config/cedar-toml-schema-2.0.json
@@ -56,6 +56,10 @@
           "const": "node"
         },
         "prismaConfig": { "type": "string" },
+        "prismaGenerateArgs": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "serverConfig": { "type": "string" },
         "debugPort": {
           "anyOf": [{ "type": "integer" }, { "type": "boolean" }]

--- a/packages/project-config/src/__tests__/config.test.ts
+++ b/packages/project-config/src/__tests__/config.test.ts
@@ -52,6 +52,7 @@ describe('getConfig', () => {
           "path": "./api",
           "port": 8911,
           "prismaConfig": "./api/prisma.config.cjs",
+          "prismaGenerateArgs": [],
           "serverConfig": "./api/server.config.js",
           "target": "node",
           "title": "Cedar App",

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -21,6 +21,7 @@ export interface NodeTargetConfig {
   path: string
   target: TargetEnum.NODE
   prismaConfig: string
+  prismaGenerateArgs: string[]
   serverConfig: string
   debugPort?: number | boolean
 }
@@ -156,6 +157,7 @@ export const DEFAULT_CONFIG: Config = {
     path: './api',
     target: TargetEnum.NODE,
     prismaConfig: './api/prisma.config.cjs',
+    prismaGenerateArgs: [],
     serverConfig: './api/server.config.js',
     debugPort: undefined,
   },


### PR DESCRIPTION
Allow setting `"prismaGenerateArgs": ["--sql"]` in `cedar.toml`, which will be used when Cedar internally generates the Prisma Client