### PR TITLE
chore(ci): add workflow to warm better-sqlite3 prebuild cache on main

### DIFF
--- a/.github/workflows/warm-prebuild-cache.yml
+++ b/.github/workflows/warm-prebuild-cache.yml
@@ -1,0 +1,28 @@
+name: 🔥 Warm prebuild cache
+
+# Runs on every push to main so that PRs can fall back to a warm cache.
+# This avoids cold-start cache misses on Windows, where building better-sqlite3
+# from source is broken (Python 3.12+ removed distutils).
+
+on:
+  push:
+    branches: ['main']
+
+permissions: {}
+
+jobs:
+  warm-prebuild-cache:
+    name: 🔥 Warm prebuild cache / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
+        with:
+          build: false

--- a/.github/workflows/warm-prebuild-cache.yml
+++ b/.github/workflows/warm-prebuild-cache.yml
@@ -10,12 +10,21 @@ on:
 
 permissions: {}
 
+# Only keep the latest run per OS to avoid redundant cache writes,
+# but don't cancel in-progress runs since a partial run leaves the cache cold.
+concurrency:
+  group: warm-prebuild-cache-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   warm-prebuild-cache:
     name: 🔥 Warm prebuild cache / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
+      # Let each OS run independently — a flaky Ubuntu run must not cancel
+      # the Windows job, which would leave the Windows cache cold.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
 


### PR DESCRIPTION
## Problem

The `prebuild-install` cache is saved per-branch, and CI only runs on PRs (not on pushes to `main`). This means every new PR starts with a cold cache:

- **Ubuntu** — degrades gracefully: falls back to a source build via `node-gyp` (slower but works)
- **Windows** — broken: Python 3.12+ removed `distutils`, so the `node-gyp` source build fails deterministically

## Solution

Add a minimal workflow that runs on every push to `main` and warms the prebuild-install cache for both runners. Once the cache exists on `main`, all PR branches can fall back to it, so Windows gets a cache hit and Ubuntu skips the slow source build.

The workflow reuses the existing `set-up-job` action with `build: false` — just checkout + yarn install, nothing more.

## How it works

```
push to main
  → warm-prebuild-cache runs (ubuntu + windows)
  → yarn install downloads better-sqlite3 prebuilt binary
  → cache saved under prebuild-cache-{os}-{version}

new PR opens
  → CI restore step: miss on PR branch → fallback to main's cache → HIT
  → Windows CI passes, Ubuntu skips source build
```