### PR TITLE
fix(web): eliminate Vite build warnings for FatalErrorPage

### DIFF
--- a/packages/babel-config/src/plugins/babel-plugin-redwood-routes-auto-loader.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-routes-auto-loader.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import type { PluginObj, types } from '@babel/core'
@@ -160,6 +161,25 @@ export default function (
       Program: {
         enter() {
           pages = processPagesDir().map(withRelativeImports)
+
+          // De-register pages that are already statically imported outside of
+          // Routes.tsx (e.g. FatalErrorPage in App.tsx). If we leave them in
+          // the list, the auto-loader adds a `lazy(() => import(...))` for
+          // them here in Routes.tsx, which produces a Vite warning:
+          // "dynamically imported by Routes.tsx but also statically imported
+          // by App.tsx – dynamic import will not move module into another chunk"
+          const appPath = resolveFile(path.join(getPaths().web.src, 'App'))
+          if (appPath) {
+            const appSource = fs.readFileSync(appPath, 'utf8')
+            const importRe = /^import\s+\w+\s+from\s+['"]([^'"]+)['"]/gm
+            let m: RegExpExecArray | null
+            while ((m = importRe.exec(appSource)) !== null) {
+              const rel = ensurePosixPath(
+                getPathRelativeToSrc(importStatementPath(m[1])),
+              )
+              pages = pages.filter((page) => page.relativeImport !== rel)
+            }
+          }
         },
         exit(p) {
           if (pages.length === 0) {

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -130,10 +130,6 @@ export const buildApiWithVite = async () => {
           preserveModules: true,
           preserveModulesRoot: cedarPaths.api.src,
           entryFileNames: '[name].js',
-          // Directives (and other entry modules) intentionally use both named
-          // and default exports (e.g. `export const schema` + `export default`).
-          // Tell Rollup to expect this so it doesn't warn about mixed exports.
-          exports: 'named',
         },
         external: (id) => {
           // Externalize as much as possible to mimic esbuild's bundle: false

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -130,6 +130,10 @@ export const buildApiWithVite = async () => {
           preserveModules: true,
           preserveModulesRoot: cedarPaths.api.src,
           entryFileNames: '[name].js',
+          // Directives (and other entry modules) intentionally use both named
+          // and default exports (e.g. `export const schema` + `export default`).
+          // Tell Rollup to expect this so it doesn't warn about mixed exports.
+          exports: 'named',
         },
         external: (id) => {
           // Externalize as much as possible to mimic esbuild's bundle: false


### PR DESCRIPTION
Fixes this warning you see when you build your Cedar app:

```
(!) FatalErrorPage is dynamically imported by Routes.tsx but also statically
imported by App.tsx — dynamic import will not move module into another chunk.
```

**Root cause:** `babel-plugin-redwood-routes-auto-loader` wraps every page in `src/pages/` in a `lazy(() => import(...))` spec. It already de-registers pages that are explicitly imported in `Routes.tsx`, but not pages imported in other files like `App.tsx`. `FatalErrorPage` lives in `src/pages/` and gets a lazy spec injected into `Routes.tsx`, but `App.tsx` also statically imports it for the `<FatalErrorBoundary>`.

**Fix:** In `Program.enter()`, read `App.tsx` and strip any of its page imports from the lazy-loading list before the lazy specs are emitted.

**File:** `packages/babel-config/src/plugins/babel-plugin-redwood-routes-auto-loader.ts`