### PR TITLE
fix(context): share AsyncLocalStorage across ESM+CJS variants via globalThis

### DIFF
--- a/packages/context/src/store.ts
+++ b/packages/context/src/store.ts
@@ -2,7 +2,27 @@ import { AsyncLocalStorage } from 'async_hooks'
 
 import type { GlobalContext } from './context.js'
 
-let CONTEXT_STORAGE: AsyncLocalStorage<Map<string, GlobalContext>>
+// The singleton lives on `globalThis` (keyed by a registered Symbol) so the
+// ESM and CJS variants of this package share the same `AsyncLocalStorage`
+// instance.
+//
+// `@cedarjs/context` ships dual ESM+CJS, and Node resolves the variant per
+// caller — ESM consumers (e.g. an ESM user-api package) load `dist/index.js`,
+// CJS consumers (e.g. cedar's CLI loading `@cedarjs/api-server`'s CJS entry)
+// load `dist/cjs/index.js`. Each variant is a separate module instance with
+// its own module-scoped state. If we kept the `AsyncLocalStorage` in a
+// module-scoped `let`, each variant would have its own store, and the
+// `currentUser` written into one would be invisible to the other — a
+// classic dual-package hazard. Stashing it on `globalThis` under a
+// `Symbol.for` key bridges them: both variants resolve the same key to the
+// same object, so they share the store and `context.currentUser` propagates
+// between framework code and user code regardless of which variant each
+// loaded.
+const STORAGE_KEY = Symbol.for('__cedarjs_context_storage__')
+
+type ContextStorageGlobal = typeof globalThis & {
+  [STORAGE_KEY]?: AsyncLocalStorage<Map<string, GlobalContext>>
+}
 
 /**
  * This returns a AsyncLocalStorage instance, not the actual store.
@@ -10,8 +30,11 @@ let CONTEXT_STORAGE: AsyncLocalStorage<Map<string, GlobalContext>>
  * this.
  */
 export const getAsyncStoreInstance = () => {
-  if (!CONTEXT_STORAGE) {
-    CONTEXT_STORAGE = new AsyncLocalStorage<Map<string, GlobalContext>>()
+  const g = globalThis as ContextStorageGlobal
+
+  if (!g[STORAGE_KEY]) {
+    g[STORAGE_KEY] = new AsyncLocalStorage<Map<string, GlobalContext>>()
   }
-  return CONTEXT_STORAGE
+
+  return g[STORAGE_KEY]
 }


### PR DESCRIPTION
`@cedarjs/context` ships dual ESM+CJS and Node resolves the variant per caller. In a mixed-variant load (e.g. an ESM user-api package alongside cedar tooling that loads `@cedarjs/api-server`'s CJS entry), each variant is a separate module instance with its own module-scoped state.

The `AsyncLocalStorage` singleton previously lived in a module-scoped `let`, so each variant had its own store. The framework's request handler writes `context.currentUser` into the variant it loaded; user code reading `context.currentUser` sees a different variant's empty store. Every `requireAuth`-gated query then fails with "You do not have permission to do that" even though `getCurrentUser` ran successfully — the user written to the framework's CJS store is invisible to user code reading from the ESM store (or vice versa).

Puts the singleton on `globalThis` under a `Symbol.for` key so both variants resolve to the same slot and share one store. Key is namespaced (`__cedarjs_context_storage__`).

No behaviour change for single-variant projects — they had one module instance and one store before, they have one module instance and one store after, just on `globalThis` instead of a module-scoped `let`.

The package doesn't have a test suite today, so I haven't added one. Happy to wire up vitest and add coverage if you'd like.