### PR TITLE
fix(api-server): ignore Prisma generator output in dev watcher

### DIFF
--- a/packages/api-server/src/watchPaths.ts
+++ b/packages/api-server/src/watchPaths.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import {
   getDbDir,
   getPaths,
+  getPrismaGeneratorOutputPath,
   importStatementPath,
 } from '@cedarjs/project-config'
 
@@ -93,6 +94,16 @@ async function apiIgnorePaths() {
     cedarPaths.api.types,
     dbDir,
   ]
+
+  // Always ignore the Prisma client generator output. It's usually inside
+  // `dbDir` (already ignored above), but projects that point the generator
+  // `output` outside the schema directory — e.g. into `api/src/lib/...` —
+  // otherwise trigger an infinite rebuild loop: each build regenerates the
+  // client, chokidar sees the writes, and another build is scheduled.
+  const prismaGeneratorOutputPath = await getPrismaGeneratorOutputPath()
+  if (prismaGeneratorOutputPath) {
+    ignoredApiPaths.push(prismaGeneratorOutputPath)
+  }
 
   return ignoredApiPaths
 }

--- a/packages/project-config/src/prisma.ts
+++ b/packages/project-config/src/prisma.ts
@@ -159,6 +159,36 @@ type ResolveReturnType =
   | { clientPath: string; error: undefined }
   | { clientPath: string | undefined; error: string }
 
+/**
+ * Resolves the absolute path the Prisma client generator writes to.
+ * Returns `undefined` if the schema or generator can't be read.
+ */
+export async function getPrismaGeneratorOutputPath(): Promise<
+  string | undefined
+> {
+  try {
+    const prismaInternalsMod = await import('@prisma/internals')
+    const { getConfig } = prismaInternalsMod.default || prismaInternalsMod
+
+    const { schemas, schemaRootDir } = await getPrismaSchemas()
+    const config = await getConfig({ datamodel: schemas })
+    const generator =
+      config.generators.find((entry) => entry.name === 'client') ??
+      config.generators[0]
+    const output = generator?.output?.value
+
+    if (!output) {
+      return undefined
+    }
+
+    return path.isAbsolute(output)
+      ? output
+      : path.resolve(schemaRootDir, output)
+  } catch {
+    return undefined
+  }
+}
+
 export async function resolveGeneratedPrismaClient(): Promise<ResolveReturnType> {
   let generatorOutputPath: string | undefined
   let ext = 'ts'


### PR DESCRIPTION
The dev watcher already ignores the directory containing schema.prisma (api/db by default), but if a project configures the generator output to point outside that directory — e.g. output = "../src/lib/db/generated" — the watcher sees every regenerated file and schedules another rebuild, trapping the dev server in an infinite build loop.

Resolves the generator output path from the Prisma config and appends it to chokidar's ignore list. When the output is undeclared or schema parsing fails, falls back to the existing behavior.