### PR TITLE
docs(mdx): migrate all admonitions to bracket title syntax (:::info[Title])

### DIFF
--- a/docs/docs/app-configuration-cedar-toml.md
+++ b/docs/docs/app-configuration-cedar-toml.md
@@ -100,7 +100,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/docs/auth/azure.md
+++ b/docs/docs/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/docs/auth/clerk.md
+++ b/docs/docs/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/docs/auth/custom.md
+++ b/docs/docs/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/docs/auth/dbauth.md
+++ b/docs/docs/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -539,7 +539,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/docs/background-jobs.md
+++ b/docs/docs/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/docs/deploy/baremetal.md
+++ b/docs/docs/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/docs/deploy/coherence.md
+++ b/docs/docs/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/docs/deploy/serverless.md
+++ b/docs/docs/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/docs/deploy/vercel.md
+++ b/docs/docs/deploy/vercel.md
@@ -128,7 +128,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/docs/docker.md
+++ b/docs/docs/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `cedar.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/docs/graphql/fragments.md
+++ b/docs/docs/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/docs/graphql/mocking-graphql-requests.md
+++ b/docs/docs/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/docs/graphql/trusted-documents.md
+++ b/docs/docs/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/docs/how-to/test-in-github-actions.md
+++ b/docs/docs/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/docs/intro-to-servers.md
+++ b/docs/docs/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/docs/prerender.md
+++ b/docs/docs/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/docs/router.md
+++ b/docs/docs/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/docs/seo-head.md
+++ b/docs/docs/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/docs/server-file.md
+++ b/docs/docs/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/docs/serverless-functions.md
+++ b/docs/docs/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -285,7 +285,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1051,7 +1051,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1326,7 +1326,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1837,7 +1837,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -2020,7 +2020,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/docs/tutorial/chapter3/forms.md
+++ b/docs/docs/tutorial/chapter3/forms.md
@@ -1220,7 +1220,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/docs/tutorial/chapter3/forms.md
+++ b/docs/docs/tutorial/chapter3/forms.md
@@ -21,7 +21,7 @@ Let's build the simplest form that still makes sense for our blog, a "Contact Us
 ### The Page
 
 ```bash
-yarn cedar g page contact
+yarn rw g page contact
 ```
 
 We can put a link to Contact in our layout's header:

--- a/docs/docs/tutorial/chapter3/forms.md
+++ b/docs/docs/tutorial/chapter3/forms.md
@@ -21,7 +21,7 @@ Let's build the simplest form that still makes sense for our blog, a "Contact Us
 ### The Page
 
 ```bash
-yarn rw g page contact
+yarn cedar g page contact
 ```
 
 We can put a link to Contact in our layout's header:

--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -44,7 +44,7 @@ To mark a field as optional (that is, allowing `NULL` as a value) you can suffix
 Next we create and apply a migration:
 
 ```bash
-yarn cedar prisma migrate dev
+yarn rw prisma migrate dev
 ```
 
 We can name this one something like "create contact".
@@ -54,7 +54,7 @@ We can name this one something like "create contact".
 Now we'll create the GraphQL interface to access this table. We haven't used this `generate` command yet (although the `scaffold` command did use it behind the scenes):
 
 ```bash
-yarn cedar g sdl Contact
+yarn rw g sdl Contact
 ```
 
 Just like the `scaffold` command, this will create a few new files under the `api` directory:
@@ -169,7 +169,7 @@ As described in [Side Quest: How Cedar Deals with Data](../chapter2/side-quest.m
 
 _Psssstttt_ I'll let you in on a little secret: if you just need a simple read-only SDL, you can skip creating the create/update/delete mutations by passing a flag to the SDL generator like so:
 
-`yarn cedar g sdl Contact --no-crud`
+`yarn rw g sdl Contact --no-crud`
 
 You'd only get a single `contacts` type to return them all.
 
@@ -335,13 +335,13 @@ Pretty simple. You can see here how the `createContact()` function expects the `
 
 You can delete `updateContact` and `deleteContact` here if you want, but since there's no longer an accessible GraphQL field for them they can't be used by the client anyway.
 
-Before we plug this into the UI, let's take a look at a nifty GUI you get just by running `yarn cedar dev`.
+Before we plug this into the UI, let's take a look at a nifty GUI you get just by running `yarn redwood dev`.
 
 ### GraphQL Playground
 
 Often it's nice to experiment and call your API in a more "raw" form before you get too far down the path of implementation only to find out something is missing. Is there a typo in the API layer or the web layer? Let's find out by accessing just the API layer.
 
-When you started development with `yarn cedar dev` you actually started a second process running at the same time. Open a new browser tab and head to [http://localhost:8911/graphql](http://localhost:8911/graphql) This is GraphQL Yoga's [GraphiQL](https://www.graphql-yoga.com/docs/features/graphiql), a web-based GUI for GraphQL APIs:
+When you started development with `yarn redwood dev` (or `yarn rw dev`) you actually started a second process running at the same time. Open a new browser tab and head to [http://localhost:8911/graphql](http://localhost:8911/graphql) This is GraphQL Yoga's [GraphiQL](https://www.graphql-yoga.com/docs/features/graphiql), a web-based GUI for GraphQL APIs:
 
 <img
   width="1410"
@@ -730,7 +730,7 @@ export default ContactPage
 
 :::tip Reminder about generated types
 
-Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn cedar generate types`).
+Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
 Once you define the `CreateContactMutation` (the GraphQL one), Cedar will generate the `CreateContactMutation` and `CreateContactMutationVariables` types from it for you.
 

--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -728,7 +728,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -944,7 +944,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
   src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png"
 />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1258,7 +1258,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -44,7 +44,7 @@ To mark a field as optional (that is, allowing `NULL` as a value) you can suffix
 Next we create and apply a migration:
 
 ```bash
-yarn rw prisma migrate dev
+yarn cedar prisma migrate dev
 ```
 
 We can name this one something like "create contact".
@@ -54,7 +54,7 @@ We can name this one something like "create contact".
 Now we'll create the GraphQL interface to access this table. We haven't used this `generate` command yet (although the `scaffold` command did use it behind the scenes):
 
 ```bash
-yarn rw g sdl Contact
+yarn cedar g sdl Contact
 ```
 
 Just like the `scaffold` command, this will create a few new files under the `api` directory:
@@ -169,7 +169,7 @@ As described in [Side Quest: How Cedar Deals with Data](../chapter2/side-quest.m
 
 _Psssstttt_ I'll let you in on a little secret: if you just need a simple read-only SDL, you can skip creating the create/update/delete mutations by passing a flag to the SDL generator like so:
 
-`yarn rw g sdl Contact --no-crud`
+`yarn cedar g sdl Contact --no-crud`
 
 You'd only get a single `contacts` type to return them all.
 
@@ -335,13 +335,13 @@ Pretty simple. You can see here how the `createContact()` function expects the `
 
 You can delete `updateContact` and `deleteContact` here if you want, but since there's no longer an accessible GraphQL field for them they can't be used by the client anyway.
 
-Before we plug this into the UI, let's take a look at a nifty GUI you get just by running `yarn redwood dev`.
+Before we plug this into the UI, let's take a look at a nifty GUI you get just by running `yarn cedar dev`.
 
 ### GraphQL Playground
 
 Often it's nice to experiment and call your API in a more "raw" form before you get too far down the path of implementation only to find out something is missing. Is there a typo in the API layer or the web layer? Let's find out by accessing just the API layer.
 
-When you started development with `yarn redwood dev` (or `yarn rw dev`) you actually started a second process running at the same time. Open a new browser tab and head to [http://localhost:8911/graphql](http://localhost:8911/graphql) This is GraphQL Yoga's [GraphiQL](https://www.graphql-yoga.com/docs/features/graphiql), a web-based GUI for GraphQL APIs:
+When you started development with `yarn cedar dev` you actually started a second process running at the same time. Open a new browser tab and head to [http://localhost:8911/graphql](http://localhost:8911/graphql) This is GraphQL Yoga's [GraphiQL](https://www.graphql-yoga.com/docs/features/graphiql), a web-based GUI for GraphQL APIs:
 
 <img
   width="1410"
@@ -730,7 +730,7 @@ export default ContactPage
 
 :::tip Reminder about generated types
 
-Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
+Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn cedar generate types`).
 
 Once you define the `CreateContactMutation` (the GraphQL one), Cedar will generate the `CreateContactMutation` and `CreateContactMutationVariables` types from it for you.
 

--- a/docs/docs/tutorial/chapter4/authentication.md
+++ b/docs/docs/tutorial/chapter4/authentication.md
@@ -124,7 +124,7 @@ As you probably have guessed, Cedar has a couple of generators to get you going.
 Run this setup command to get the internals of dbAuth added to our app:
 
 ```bash
-yarn rw setup auth dbAuth
+yarn cedar setup auth dbAuth
 ```
 
 When prompted to "Enable WebAuthn support", pick no—this is a separate piece of functionality we won't need for the tutorial. You'll see that the process creates several files and includes some post-install instructions for the last couple of customizations you'll need to make. Let's go through them now.
@@ -186,7 +186,7 @@ This gives us a user with a name and email, as well as four fields that dbAuth w
 Let's create the user model by migrating the database, naming it something like "create user":
 
 ```bash
-yarn rw prisma migrate dev
+yarn cedar prisma migrate dev
 ```
 
 That's it for the database setup!
@@ -473,7 +473,7 @@ It would be more future-proof to create a _new_ endpoint for public display of p
 Yet another generator is here for you, this time one that will create pages for login, signup and forgot password pages:
 
 ```bash
-yarn rw g dbAuth
+yarn cedar g dbAuth
 ```
 
 :::warning
@@ -894,7 +894,7 @@ Before we leave this file, take a look at `requireAuth()`. Remember when we talk
 
 After the initial `setup` command, which installed dbAuth, you may have noticed that an edit was made to the `.env` file in the root of your project. The `setup` script appended a new ENV var called `SESSION_SECRET` along with a big random string of numbers and letters. This is the encryption key for the cookies that are stored in the user's browser when they log in. This secret should never be shared, never checked into your repo, and should be re-generated for each environment you deploy to.
 
-You can generate a new value with the `yarn rw g secret` command. It only outputs it to the terminal, you'll need to copy/paste to your `.env` file. Note that if you change this secret in a production environment, all users will be logged out on their next request because the cookie they currently have cannot be decrypted with the new key! They'll need to log in again to a new cookie encrypted with the new key.
+You can generate a new value with the `yarn cedar g secret` command. It only outputs it to the terminal, you'll need to copy/paste to your `.env` file. Note that if you change this secret in a production environment, all users will be logged out on their next request because the cookie they currently have cannot be decrypted with the new key! They'll need to log in again to a new cookie encrypted with the new key.
 
 ## Wrapping Up
 

--- a/docs/docs/tutorial/chapter4/authentication.md
+++ b/docs/docs/tutorial/chapter4/authentication.md
@@ -124,7 +124,7 @@ As you probably have guessed, Cedar has a couple of generators to get you going.
 Run this setup command to get the internals of dbAuth added to our app:
 
 ```bash
-yarn cedar setup auth dbAuth
+yarn rw setup auth dbAuth
 ```
 
 When prompted to "Enable WebAuthn support", pick no—this is a separate piece of functionality we won't need for the tutorial. You'll see that the process creates several files and includes some post-install instructions for the last couple of customizations you'll need to make. Let's go through them now.
@@ -186,7 +186,7 @@ This gives us a user with a name and email, as well as four fields that dbAuth w
 Let's create the user model by migrating the database, naming it something like "create user":
 
 ```bash
-yarn cedar prisma migrate dev
+yarn rw prisma migrate dev
 ```
 
 That's it for the database setup!
@@ -473,7 +473,7 @@ It would be more future-proof to create a _new_ endpoint for public display of p
 Yet another generator is here for you, this time one that will create pages for login, signup and forgot password pages:
 
 ```bash
-yarn cedar g dbAuth
+yarn rw g dbAuth
 ```
 
 :::warning
@@ -894,7 +894,7 @@ Before we leave this file, take a look at `requireAuth()`. Remember when we talk
 
 After the initial `setup` command, which installed dbAuth, you may have noticed that an edit was made to the `.env` file in the root of your project. The `setup` script appended a new ENV var called `SESSION_SECRET` along with a big random string of numbers and letters. This is the encryption key for the cookies that are stored in the user's browser when they log in. This secret should never be shared, never checked into your repo, and should be re-generated for each environment you deploy to.
 
-You can generate a new value with the `yarn cedar g secret` command. It only outputs it to the terminal, you'll need to copy/paste to your `.env` file. Note that if you change this secret in a production environment, all users will be logged out on their next request because the cookie they currently have cannot be decrypted with the new key! They'll need to log in again to a new cookie encrypted with the new key.
+You can generate a new value with the `yarn rw g secret` command. It only outputs it to the terminal, you'll need to copy/paste to your `.env` file. Note that if you change this secret in a production environment, all users will be logged out on their next request because the cookie they currently have cannot be decrypted with the new key! They'll need to log in again to a new cookie encrypted with the new key.
 
 ## Wrapping Up
 

--- a/docs/docs/tutorial/chapter4/authentication.md
+++ b/docs/docs/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -460,7 +460,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/docs/tutorial/chapter4/deployment.md
+++ b/docs/docs/tutorial/chapter4/deployment.md
@@ -171,11 +171,11 @@ If you view a deploy via the **Preview** button notice that the URL contains a h
 
 Did it work? If you see "Empty" under the About and Contact links then it did! Yay! You're seeing "Empty" because you don't have any posts in your brand new production database so head to `/admin/posts` and create a couple, then go back to the homepage to see them.
 
-If the deploy failed, check the log output in Netlify and see if you can make sense of the error. If the deploy was successful but the site doesn't come up, try opening the web inspector and look for errors. Are you sure you pasted the entire Postgres connection string correctly? If you're really, really stuck head over to the [Cedar Discord](https://cedarjs.com/discord) and ask for help.
+If the deploy failed, check the log output in Netlify and see if you can make sense of the error. If the deploy was successful but the site doesn't come up, try opening the web inspector and look for errors. Are you sure you pasted the entire Postgres connection string correctly? If you're really, really stuck head over to the [Cedar Community](https://community.redwoodjs.com) and ask for help.
 
 #### Custom Subdomain
 
-You can customize the subdomain that your site is published at (who wants to go to `agitated-mongoose-849e99.netlify.app`??) by going to **Site Settings > Domain Management > Domains > Custom Domains**. Open up the **Options** menu and select **Edit site name**. Your site should be available at your custom subdomain (`cedar-tutorial.netlify.app` is much nicer) almost immediately.
+You can customize the subdomain that your site is published at (who wants to go to `agitated-mongoose-849e99.netlify.app`??) by going to **Site Settings > Domain Management > Domains > Custom Domains**. Open up the **Options** menu and select **Edit site name**. Your site should be available at your custom subdomain (`redwood-tutorial.netlify.app` is much nicer) almost immediately.
 
 ![image](https://user-images.githubusercontent.com/300/154521450-ee64c77c-e658-4045-9dd6-119858b6739e.png)
 

--- a/docs/docs/tutorial/chapter4/deployment.md
+++ b/docs/docs/tutorial/chapter4/deployment.md
@@ -171,11 +171,11 @@ If you view a deploy via the **Preview** button notice that the URL contains a h
 
 Did it work? If you see "Empty" under the About and Contact links then it did! Yay! You're seeing "Empty" because you don't have any posts in your brand new production database so head to `/admin/posts` and create a couple, then go back to the homepage to see them.
 
-If the deploy failed, check the log output in Netlify and see if you can make sense of the error. If the deploy was successful but the site doesn't come up, try opening the web inspector and look for errors. Are you sure you pasted the entire Postgres connection string correctly? If you're really, really stuck head over to the [Cedar Community](https://community.redwoodjs.com) and ask for help.
+If the deploy failed, check the log output in Netlify and see if you can make sense of the error. If the deploy was successful but the site doesn't come up, try opening the web inspector and look for errors. Are you sure you pasted the entire Postgres connection string correctly? If you're really, really stuck head over to the [Cedar Discord](https://cedarjs.com/discord) and ask for help.
 
 #### Custom Subdomain
 
-You can customize the subdomain that your site is published at (who wants to go to `agitated-mongoose-849e99.netlify.app`??) by going to **Site Settings > Domain Management > Domains > Custom Domains**. Open up the **Options** menu and select **Edit site name**. Your site should be available at your custom subdomain (`redwood-tutorial.netlify.app` is much nicer) almost immediately.
+You can customize the subdomain that your site is published at (who wants to go to `agitated-mongoose-849e99.netlify.app`??) by going to **Site Settings > Domain Management > Domains > Custom Domains**. Open up the **Options** menu and select **Edit site name**. Your site should be available at your custom subdomain (`cedar-tutorial.netlify.app` is much nicer) almost immediately.
 
 ![image](https://user-images.githubusercontent.com/300/154521450-ee64c77c-e658-4045-9dd6-119858b6739e.png)
 

--- a/docs/docs/tutorial/chapter5/first-test.md
+++ b/docs/docs/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/docs/tutorial/chapter5/storybook.md
+++ b/docs/docs/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/docs/tutorial/chapter6/comment-form.md
+++ b/docs/docs/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/docs/tutorial/chapter6/comments-schema.md
+++ b/docs/docs/tutorial/chapter6/comments-schema.md
@@ -555,7 +555,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -624,7 +624,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -640,7 +640,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -876,7 +876,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -908,7 +908,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -924,7 +924,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/docs/tutorial/chapter6/multiple-comments.md
+++ b/docs/docs/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/docs/tutorial/chapter6/the-redwood-way.md
+++ b/docs/docs/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/docs/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/docs/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -116,7 +116,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -128,7 +128,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -202,7 +202,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -280,7 +280,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -474,7 +474,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/docs/tutorial/chapter7/rbac.md
+++ b/docs/docs/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/docs/tutorial/intermission.md
+++ b/docs/docs/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/docs/typescript/generated-types.md
+++ b/docs/docs/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.cedar/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/docs/typescript/strict-mode.md
+++ b/docs/docs/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/docs/uploads.md
+++ b/docs/docs/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -24,6 +24,12 @@ const config: Config = {
     hooks: {
       onBrokenMarkdownLinks: 'warn',
     },
+    // future.v4 disables mdx1Compat.admonitions by default, which breaks the
+    // old :::info Title syntax (requires :::info[Title] in v4). Re-enable it
+    // here until all docs are migrated to the bracket syntax.
+    mdx1Compat: {
+      admonitions: true,
+    },
   },
   favicon: '/img/favicon.ico',
   organizationName: 'cedarjs', // Usually your GitHub org/user name.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -24,12 +24,6 @@ const config: Config = {
     hooks: {
       onBrokenMarkdownLinks: 'warn',
     },
-    // future.v4 disables mdx1Compat.admonitions by default, which breaks the
-    // old :::info Title syntax (requires :::info[Title] in v4). Re-enable it
-    // here until all docs are migrated to the bracket syntax.
-    mdx1Compat: {
-      admonitions: true,
-    },
   },
   favicon: '/img/favicon.ico',
   organizationName: 'cedarjs', // Usually your GitHub org/user name.

--- a/docs/versioned_docs/version-0.x/app-configuration-redwood-toml.md
+++ b/docs/versioned_docs/version-0.x/app-configuration-redwood-toml.md
@@ -97,7 +97,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 
@@ -118,7 +118,7 @@ Additional server configuration can be done using [Server File](docker.md#using-
 
 Prisma's `prismaSchemaFolder` [feature](https://www.prisma.io/docs/orm/prisma-schema/overview/location#multi-file-prisma-schema) allows you to define multiple files in a schema subdirectory of your prisma directory.
 
-:::note Important
+:::note[Important]
 If you wish to [organize your Prisma Schema into multiple files](https://www.prisma.io/blog/organize-your-prisma-schema-with-multi-file-support), you will need [enable](https://www.prisma.io/docs/orm/prisma-schema/overview/location#multi-file-prisma-schema) that feature in Prisma, move your `schema.prisma` file into a new directory such as `./api/db/schema` and then set `schemaPath` in the api toml config.
 :::
 

--- a/docs/versioned_docs/version-0.x/auth/azure.md
+++ b/docs/versioned_docs/version-0.x/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Redwood uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-0.x/auth/clerk.md
+++ b/docs/versioned_docs/version-0.x/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-0.x/auth/custom.md
+++ b/docs/versioned_docs/version-0.x/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Redwood doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Redwood has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Redwood used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-0.x/auth/dbauth.md
+++ b/docs/versioned_docs/version-0.x/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-0.x/authentication.md
+++ b/docs/versioned_docs/version-0.x/authentication.md
@@ -28,7 +28,7 @@ Redwood has a simple API to integrate any auth provider you can think of. But to
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Redwood's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-0.x/background-jobs.md
+++ b/docs/versioned_docs/version-0.x/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Redwood:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-0.x/cli-commands.md
+++ b/docs/versioned_docs/version-0.x/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-0.x/deploy/baremetal.md
+++ b/docs/versioned_docs/version-0.x/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://discord.gg/redwoodjs) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-0.x/deploy/coherence.md
+++ b/docs/versioned_docs/version-0.x/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Redwood project needs to be hosted on GitHub and yo
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-0.x/deploy/serverless.md
+++ b/docs/versioned_docs/version-0.x/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-0.x/deploy/vercel.md
+++ b/docs/versioned_docs/version-0.x/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Redwood has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Redwood.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-0.x/docker.md
+++ b/docs/versioned_docs/version-0.x/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Redwood t
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `redwood.toml` file is Redwood's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-0.x/graphql/fragments.md
+++ b/docs/versioned_docs/version-0.x/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-0.x/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-0.x/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-0.x/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-0.x/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-0.x/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-0.x/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Redwood app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Redwood app knows where to store the data
 

--- a/docs/versioned_docs/version-0.x/intro-to-servers.md
+++ b/docs/versioned_docs/version-0.x/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-0.x/prerender.md
+++ b/docs/versioned_docs/version-0.x/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Redwood currently supports prerendering at _build_ time. So before you deploy your web side, Redwood will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-0.x/quick-start.md
+++ b/docs/versioned_docs/version-0.x/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=20.19.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-0.x/router.md
+++ b/docs/versioned_docs/version-0.x/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-0.x/seo-head.md
+++ b/docs/versioned_docs/version-0.x/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Redwood also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-he
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Redwood's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -284,7 +284,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -310,7 +310,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 As of v3.x, Redwood supports prerendering your [Cells](https://redwoodjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://redwoodjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-0.x/server-file.md
+++ b/docs/versioned_docs/version-0.x/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-0.x/serverless-functions.md
+++ b/docs/versioned_docs/version-0.x/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-0.x/services.md
+++ b/docs/versioned_docs/version-0.x/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-0.x/testing.md
+++ b/docs/versioned_docs/version-0.x/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Redwood's `render` function is based on React Testing Library's. The only difference is that Redwood's wraps everything with mock providers for the various providers in Redwood, such as auth, the GraphQL client, the router, etc.
@@ -1020,7 +1020,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1295,7 +1295,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Redwood will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/redwoodjs/redwood/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1798,7 +1798,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1981,7 +1981,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-0.x/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Redwood automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Redwood: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Redwood's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Redwood installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Redwood will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Redwood will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Redwood comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Redwood is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Redwood will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Redwood CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Redwood will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Redwood includes [integrations](../../authentication.md) for several of the most
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Redwood) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Redwood intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Redwood console does it for you—Redwood `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Redwood that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Redwood would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Redwood) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -874,7 +874,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -905,7 +905,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -921,7 +921,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Redwood has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Redwood's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Redwood Tutorial repo](https://github.com/redwoodjs/redwood-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-0.x/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-0.x/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-0.x/tutorial/intermission.md
+++ b/docs/versioned_docs/version-0.x/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-0.x/typescript/generated-types.md
+++ b/docs/versioned_docs/version-0.x/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Redwood uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (a
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Redwood's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Redwood generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-0.x/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-0.x/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-0.x/uploads.md
+++ b/docs/versioned_docs/version-0.x/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-1.x/app-configuration-redwood-toml.md
+++ b/docs/versioned_docs/version-1.x/app-configuration-redwood-toml.md
@@ -97,7 +97,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 
@@ -118,7 +118,7 @@ Additional server configuration can be done using [Server File](docker.md#using-
 
 Prisma's `prismaSchemaFolder` [feature](https://www.prisma.io/docs/orm/prisma-schema/overview/location#multi-file-prisma-schema) allows you to define multiple files in a schema subdirectory of your prisma directory.
 
-:::note Important
+:::note[Important]
 If you wish to [organize your Prisma Schema into multiple files](https://www.prisma.io/blog/organize-your-prisma-schema-with-multi-file-support), you will need [enable](https://www.prisma.io/docs/orm/prisma-schema/overview/location#multi-file-prisma-schema) that feature in Prisma, move your `schema.prisma` file into a new directory such as `./api/db/schema` and then set `schemaPath` in the api toml config.
 :::
 

--- a/docs/versioned_docs/version-1.x/auth/azure.md
+++ b/docs/versioned_docs/version-1.x/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Redwood uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-1.x/auth/clerk.md
+++ b/docs/versioned_docs/version-1.x/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-1.x/auth/custom.md
+++ b/docs/versioned_docs/version-1.x/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Redwood doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Redwood has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Redwood used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-1.x/auth/dbauth.md
+++ b/docs/versioned_docs/version-1.x/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-1.x/authentication.md
+++ b/docs/versioned_docs/version-1.x/authentication.md
@@ -28,7 +28,7 @@ Redwood has a simple API to integrate any auth provider you can think of. But to
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Redwood's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-1.x/background-jobs.md
+++ b/docs/versioned_docs/version-1.x/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Redwood:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-1.x/cli-commands.md
+++ b/docs/versioned_docs/version-1.x/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-1.x/deploy/baremetal.md
+++ b/docs/versioned_docs/version-1.x/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://discord.gg/redwoodjs) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-1.x/deploy/coherence.md
+++ b/docs/versioned_docs/version-1.x/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Redwood project needs to be hosted on GitHub and yo
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-1.x/deploy/serverless.md
+++ b/docs/versioned_docs/version-1.x/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-1.x/deploy/vercel.md
+++ b/docs/versioned_docs/version-1.x/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Redwood has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Redwood.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-1.x/docker.md
+++ b/docs/versioned_docs/version-1.x/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Redwood t
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `redwood.toml` file is Redwood's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-1.x/graphql/fragments.md
+++ b/docs/versioned_docs/version-1.x/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-1.x/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-1.x/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-1.x/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-1.x/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-1.x/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-1.x/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Redwood app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Redwood app knows where to store the data
 

--- a/docs/versioned_docs/version-1.x/intro-to-servers.md
+++ b/docs/versioned_docs/version-1.x/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-1.x/prerender.md
+++ b/docs/versioned_docs/version-1.x/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Redwood currently supports prerendering at _build_ time. So before you deploy your web side, Redwood will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-1.x/quick-start.md
+++ b/docs/versioned_docs/version-1.x/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=20.19.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-1.x/router.md
+++ b/docs/versioned_docs/version-1.x/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-1.x/seo-head.md
+++ b/docs/versioned_docs/version-1.x/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Redwood also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-he
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Redwood's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -284,7 +284,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -310,7 +310,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 As of v3.x, Redwood supports prerendering your [Cells](https://redwoodjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://redwoodjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-1.x/server-file.md
+++ b/docs/versioned_docs/version-1.x/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-1.x/serverless-functions.md
+++ b/docs/versioned_docs/version-1.x/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-1.x/services.md
+++ b/docs/versioned_docs/version-1.x/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-1.x/testing.md
+++ b/docs/versioned_docs/version-1.x/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Redwood's `render` function is based on React Testing Library's. The only difference is that Redwood's wraps everything with mock providers for the various providers in Redwood, such as auth, the GraphQL client, the router, etc.
@@ -1020,7 +1020,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1295,7 +1295,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Redwood will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/redwoodjs/redwood/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1798,7 +1798,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1981,7 +1981,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-1.x/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Redwood automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Redwood: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Redwood's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Redwood installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Redwood will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Redwood will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Redwood comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Redwood is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Redwood will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Redwood CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Redwood will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Redwood includes [integrations](../../authentication.md) for several of the most
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Redwood) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Redwood intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Redwood console does it for you—Redwood `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Redwood that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Redwood would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Redwood) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -874,7 +874,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -905,7 +905,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -921,7 +921,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Redwood has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Redwood's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Redwood Tutorial repo](https://github.com/redwoodjs/redwood-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-1.x/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-1.x/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-1.x/tutorial/intermission.md
+++ b/docs/versioned_docs/version-1.x/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-1.x/typescript/generated-types.md
+++ b/docs/versioned_docs/version-1.x/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Redwood uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (a
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Redwood's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Redwood generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-1.x/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-1.x/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-1.x/uploads.md
+++ b/docs/versioned_docs/version-1.x/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-2.0/app-configuration-redwood-toml.md
+++ b/docs/versioned_docs/version-2.0/app-configuration-redwood-toml.md
@@ -97,7 +97,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-2.0/auth/azure.md
+++ b/docs/versioned_docs/version-2.0/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-2.0/auth/clerk.md
+++ b/docs/versioned_docs/version-2.0/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-2.0/auth/custom.md
+++ b/docs/versioned_docs/version-2.0/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-2.0/auth/dbauth.md
+++ b/docs/versioned_docs/version-2.0/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-2.0/authentication.md
+++ b/docs/versioned_docs/version-2.0/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-2.0/background-jobs.md
+++ b/docs/versioned_docs/version-2.0/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-2.0/cli-commands.md
+++ b/docs/versioned_docs/version-2.0/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-2.0/deploy/baremetal.md
+++ b/docs/versioned_docs/version-2.0/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-2.0/deploy/coherence.md
+++ b/docs/versioned_docs/version-2.0/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-2.0/deploy/serverless.md
+++ b/docs/versioned_docs/version-2.0/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-2.0/deploy/vercel.md
+++ b/docs/versioned_docs/version-2.0/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-2.0/docker.md
+++ b/docs/versioned_docs/version-2.0/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `redwood.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-2.0/graphql/fragments.md
+++ b/docs/versioned_docs/version-2.0/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.0/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-2.0/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.0/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-2.0/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-2.0/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-2.0/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-2.0/intro-to-servers.md
+++ b/docs/versioned_docs/version-2.0/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-2.0/prerender.md
+++ b/docs/versioned_docs/version-2.0/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-2.0/quick-start.md
+++ b/docs/versioned_docs/version-2.0/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-2.0/router.md
+++ b/docs/versioned_docs/version-2.0/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-2.0/seo-head.md
+++ b/docs/versioned_docs/version-2.0/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -284,7 +284,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -310,7 +310,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-2.0/server-file.md
+++ b/docs/versioned_docs/version-2.0/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-2.0/serverless-functions.md
+++ b/docs/versioned_docs/version-2.0/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-2.0/services.md
+++ b/docs/versioned_docs/version-2.0/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-2.0/testing.md
+++ b/docs/versioned_docs/version-2.0/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1020,7 +1020,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1295,7 +1295,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1798,7 +1798,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1981,7 +1981,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-2.0/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -874,7 +874,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -905,7 +905,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -921,7 +921,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-2.0/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-2.0/tutorial/intermission.md
+++ b/docs/versioned_docs/version-2.0/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-2.0/typescript/generated-types.md
+++ b/docs/versioned_docs/version-2.0/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-2.0/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-2.0/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-2.0/uploads.md
+++ b/docs/versioned_docs/version-2.0/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-2.1/app-configuration-redwood-toml.md
+++ b/docs/versioned_docs/version-2.1/app-configuration-redwood-toml.md
@@ -97,7 +97,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-2.1/auth/azure.md
+++ b/docs/versioned_docs/version-2.1/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-2.1/auth/clerk.md
+++ b/docs/versioned_docs/version-2.1/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-2.1/auth/custom.md
+++ b/docs/versioned_docs/version-2.1/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-2.1/auth/dbauth.md
+++ b/docs/versioned_docs/version-2.1/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-2.1/authentication.md
+++ b/docs/versioned_docs/version-2.1/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-2.1/background-jobs.md
+++ b/docs/versioned_docs/version-2.1/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-2.1/cli-commands.md
+++ b/docs/versioned_docs/version-2.1/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-2.1/deploy/baremetal.md
+++ b/docs/versioned_docs/version-2.1/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-2.1/deploy/coherence.md
+++ b/docs/versioned_docs/version-2.1/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-2.1/deploy/serverless.md
+++ b/docs/versioned_docs/version-2.1/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-2.1/deploy/vercel.md
+++ b/docs/versioned_docs/version-2.1/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-2.1/docker.md
+++ b/docs/versioned_docs/version-2.1/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `redwood.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-2.1/graphql/fragments.md
+++ b/docs/versioned_docs/version-2.1/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.1/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-2.1/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.1/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-2.1/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-2.1/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-2.1/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-2.1/intro-to-servers.md
+++ b/docs/versioned_docs/version-2.1/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-2.1/prerender.md
+++ b/docs/versioned_docs/version-2.1/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-2.1/quick-start.md
+++ b/docs/versioned_docs/version-2.1/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-2.1/router.md
+++ b/docs/versioned_docs/version-2.1/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-2.1/seo-head.md
+++ b/docs/versioned_docs/version-2.1/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-2.1/server-file.md
+++ b/docs/versioned_docs/version-2.1/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-2.1/serverless-functions.md
+++ b/docs/versioned_docs/version-2.1/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-2.1/services.md
+++ b/docs/versioned_docs/version-2.1/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-2.1/testing.md
+++ b/docs/versioned_docs/version-2.1/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1019,7 +1019,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1294,7 +1294,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1797,7 +1797,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1980,7 +1980,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-2.1/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -874,7 +874,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -905,7 +905,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -921,7 +921,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-2.1/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-2.1/tutorial/intermission.md
+++ b/docs/versioned_docs/version-2.1/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-2.1/typescript/generated-types.md
+++ b/docs/versioned_docs/version-2.1/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-2.1/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-2.1/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-2.1/uploads.md
+++ b/docs/versioned_docs/version-2.1/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-2.2/app-configuration-redwood-toml.md
+++ b/docs/versioned_docs/version-2.2/app-configuration-redwood-toml.md
@@ -97,7 +97,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-2.2/auth/azure.md
+++ b/docs/versioned_docs/version-2.2/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-2.2/auth/clerk.md
+++ b/docs/versioned_docs/version-2.2/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-2.2/auth/custom.md
+++ b/docs/versioned_docs/version-2.2/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-2.2/auth/dbauth.md
+++ b/docs/versioned_docs/version-2.2/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-2.2/authentication.md
+++ b/docs/versioned_docs/version-2.2/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-2.2/background-jobs.md
+++ b/docs/versioned_docs/version-2.2/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-2.2/cli-commands.md
+++ b/docs/versioned_docs/version-2.2/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-2.2/deploy/baremetal.md
+++ b/docs/versioned_docs/version-2.2/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-2.2/deploy/coherence.md
+++ b/docs/versioned_docs/version-2.2/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-2.2/deploy/serverless.md
+++ b/docs/versioned_docs/version-2.2/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-2.2/deploy/vercel.md
+++ b/docs/versioned_docs/version-2.2/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-2.2/docker.md
+++ b/docs/versioned_docs/version-2.2/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `redwood.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-2.2/graphql/fragments.md
+++ b/docs/versioned_docs/version-2.2/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.2/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-2.2/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.2/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-2.2/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-2.2/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-2.2/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-2.2/intro-to-servers.md
+++ b/docs/versioned_docs/version-2.2/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-2.2/prerender.md
+++ b/docs/versioned_docs/version-2.2/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-2.2/quick-start.md
+++ b/docs/versioned_docs/version-2.2/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-2.2/router.md
+++ b/docs/versioned_docs/version-2.2/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-2.2/seo-head.md
+++ b/docs/versioned_docs/version-2.2/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-2.2/server-file.md
+++ b/docs/versioned_docs/version-2.2/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-2.2/serverless-functions.md
+++ b/docs/versioned_docs/version-2.2/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-2.2/services.md
+++ b/docs/versioned_docs/version-2.2/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-2.2/testing.md
+++ b/docs/versioned_docs/version-2.2/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1019,7 +1019,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1294,7 +1294,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1797,7 +1797,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1980,7 +1980,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-2.2/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -874,7 +874,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -905,7 +905,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -921,7 +921,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-2.2/tutorial/intermission.md
+++ b/docs/versioned_docs/version-2.2/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-2.2/typescript/generated-types.md
+++ b/docs/versioned_docs/version-2.2/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-2.2/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-2.2/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-2.2/uploads.md
+++ b/docs/versioned_docs/version-2.2/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-2.3/app-configuration-redwood-toml.md
+++ b/docs/versioned_docs/version-2.3/app-configuration-redwood-toml.md
@@ -97,7 +97,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-2.3/auth/azure.md
+++ b/docs/versioned_docs/version-2.3/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-2.3/auth/clerk.md
+++ b/docs/versioned_docs/version-2.3/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-2.3/auth/custom.md
+++ b/docs/versioned_docs/version-2.3/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-2.3/auth/dbauth.md
+++ b/docs/versioned_docs/version-2.3/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-2.3/authentication.md
+++ b/docs/versioned_docs/version-2.3/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-2.3/background-jobs.md
+++ b/docs/versioned_docs/version-2.3/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-2.3/cli-commands.md
+++ b/docs/versioned_docs/version-2.3/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-2.3/deploy/baremetal.md
+++ b/docs/versioned_docs/version-2.3/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-2.3/deploy/coherence.md
+++ b/docs/versioned_docs/version-2.3/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-2.3/deploy/serverless.md
+++ b/docs/versioned_docs/version-2.3/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-2.3/deploy/vercel.md
+++ b/docs/versioned_docs/version-2.3/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-2.3/docker.md
+++ b/docs/versioned_docs/version-2.3/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `redwood.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-2.3/graphql/fragments.md
+++ b/docs/versioned_docs/version-2.3/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.3/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-2.3/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.3/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-2.3/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-2.3/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-2.3/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-2.3/intro-to-servers.md
+++ b/docs/versioned_docs/version-2.3/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-2.3/prerender.md
+++ b/docs/versioned_docs/version-2.3/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-2.3/quick-start.md
+++ b/docs/versioned_docs/version-2.3/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-2.3/router.md
+++ b/docs/versioned_docs/version-2.3/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-2.3/seo-head.md
+++ b/docs/versioned_docs/version-2.3/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-2.3/server-file.md
+++ b/docs/versioned_docs/version-2.3/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-2.3/serverless-functions.md
+++ b/docs/versioned_docs/version-2.3/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-2.3/services.md
+++ b/docs/versioned_docs/version-2.3/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-2.3/testing.md
+++ b/docs/versioned_docs/version-2.3/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1019,7 +1019,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1294,7 +1294,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1797,7 +1797,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1980,7 +1980,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-2.3/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -874,7 +874,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -905,7 +905,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -921,7 +921,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-2.3/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-2.3/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-2.3/tutorial/intermission.md
+++ b/docs/versioned_docs/version-2.3/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-2.3/typescript/generated-types.md
+++ b/docs/versioned_docs/version-2.3/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-2.3/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-2.3/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-2.3/uploads.md
+++ b/docs/versioned_docs/version-2.3/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-2.4/app-configuration-redwood-toml.md
+++ b/docs/versioned_docs/version-2.4/app-configuration-redwood-toml.md
@@ -97,7 +97,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-2.4/auth/azure.md
+++ b/docs/versioned_docs/version-2.4/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-2.4/auth/clerk.md
+++ b/docs/versioned_docs/version-2.4/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-2.4/auth/custom.md
+++ b/docs/versioned_docs/version-2.4/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-2.4/auth/dbauth.md
+++ b/docs/versioned_docs/version-2.4/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-2.4/authentication.md
+++ b/docs/versioned_docs/version-2.4/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-2.4/background-jobs.md
+++ b/docs/versioned_docs/version-2.4/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-2.4/cli-commands.md
+++ b/docs/versioned_docs/version-2.4/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-2.4/deploy/baremetal.md
+++ b/docs/versioned_docs/version-2.4/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-2.4/deploy/coherence.md
+++ b/docs/versioned_docs/version-2.4/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-2.4/deploy/serverless.md
+++ b/docs/versioned_docs/version-2.4/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-2.4/deploy/vercel.md
+++ b/docs/versioned_docs/version-2.4/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-2.4/docker.md
+++ b/docs/versioned_docs/version-2.4/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `redwood.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-2.4/graphql/fragments.md
+++ b/docs/versioned_docs/version-2.4/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.4/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-2.4/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.4/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-2.4/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-2.4/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-2.4/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-2.4/intro-to-servers.md
+++ b/docs/versioned_docs/version-2.4/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-2.4/prerender.md
+++ b/docs/versioned_docs/version-2.4/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-2.4/quick-start.md
+++ b/docs/versioned_docs/version-2.4/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-2.4/router.md
+++ b/docs/versioned_docs/version-2.4/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-2.4/seo-head.md
+++ b/docs/versioned_docs/version-2.4/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-2.4/server-file.md
+++ b/docs/versioned_docs/version-2.4/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-2.4/serverless-functions.md
+++ b/docs/versioned_docs/version-2.4/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-2.4/services.md
+++ b/docs/versioned_docs/version-2.4/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-2.4/testing.md
+++ b/docs/versioned_docs/version-2.4/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1019,7 +1019,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1294,7 +1294,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1797,7 +1797,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1980,7 +1980,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-2.4/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -874,7 +874,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -905,7 +905,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -921,7 +921,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-2.4/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-2.4/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-2.4/tutorial/intermission.md
+++ b/docs/versioned_docs/version-2.4/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-2.4/typescript/generated-types.md
+++ b/docs/versioned_docs/version-2.4/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-2.4/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-2.4/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-2.4/uploads.md
+++ b/docs/versioned_docs/version-2.4/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-2.5/app-configuration-cedar-toml.md
+++ b/docs/versioned_docs/version-2.5/app-configuration-cedar-toml.md
@@ -100,7 +100,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-2.5/auth/azure.md
+++ b/docs/versioned_docs/version-2.5/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-2.5/auth/clerk.md
+++ b/docs/versioned_docs/version-2.5/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-2.5/auth/custom.md
+++ b/docs/versioned_docs/version-2.5/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-2.5/auth/dbauth.md
+++ b/docs/versioned_docs/version-2.5/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-2.5/authentication.md
+++ b/docs/versioned_docs/version-2.5/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-2.5/background-jobs.md
+++ b/docs/versioned_docs/version-2.5/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-2.5/cli-commands.md
+++ b/docs/versioned_docs/version-2.5/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-2.5/deploy/baremetal.md
+++ b/docs/versioned_docs/version-2.5/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-2.5/deploy/coherence.md
+++ b/docs/versioned_docs/version-2.5/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-2.5/deploy/serverless.md
+++ b/docs/versioned_docs/version-2.5/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-2.5/deploy/vercel.md
+++ b/docs/versioned_docs/version-2.5/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-2.5/docker.md
+++ b/docs/versioned_docs/version-2.5/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `cedar.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-2.5/graphql/fragments.md
+++ b/docs/versioned_docs/version-2.5/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.5/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-2.5/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.5/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-2.5/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-2.5/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-2.5/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-2.5/intro-to-servers.md
+++ b/docs/versioned_docs/version-2.5/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-2.5/prerender.md
+++ b/docs/versioned_docs/version-2.5/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-2.5/quick-start.md
+++ b/docs/versioned_docs/version-2.5/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-2.5/router.md
+++ b/docs/versioned_docs/version-2.5/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-2.5/seo-head.md
+++ b/docs/versioned_docs/version-2.5/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-2.5/server-file.md
+++ b/docs/versioned_docs/version-2.5/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-2.5/serverless-functions.md
+++ b/docs/versioned_docs/version-2.5/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-2.5/services.md
+++ b/docs/versioned_docs/version-2.5/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-2.5/testing.md
+++ b/docs/versioned_docs/version-2.5/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1019,7 +1019,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1294,7 +1294,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1797,7 +1797,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1980,7 +1980,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-2.5/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -874,7 +874,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -905,7 +905,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -921,7 +921,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-2.5/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-2.5/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-2.5/tutorial/intermission.md
+++ b/docs/versioned_docs/version-2.5/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-2.5/typescript/generated-types.md
+++ b/docs/versioned_docs/version-2.5/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-2.5/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-2.5/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-2.5/uploads.md
+++ b/docs/versioned_docs/version-2.5/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-2.6/app-configuration-cedar-toml.md
+++ b/docs/versioned_docs/version-2.6/app-configuration-cedar-toml.md
@@ -100,7 +100,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-2.6/auth/azure.md
+++ b/docs/versioned_docs/version-2.6/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-2.6/auth/clerk.md
+++ b/docs/versioned_docs/version-2.6/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-2.6/auth/custom.md
+++ b/docs/versioned_docs/version-2.6/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-2.6/auth/dbauth.md
+++ b/docs/versioned_docs/version-2.6/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-2.6/authentication.md
+++ b/docs/versioned_docs/version-2.6/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-2.6/background-jobs.md
+++ b/docs/versioned_docs/version-2.6/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-2.6/cli-commands.md
+++ b/docs/versioned_docs/version-2.6/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-2.6/deploy/baremetal.md
+++ b/docs/versioned_docs/version-2.6/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-2.6/deploy/coherence.md
+++ b/docs/versioned_docs/version-2.6/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-2.6/deploy/serverless.md
+++ b/docs/versioned_docs/version-2.6/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-2.6/deploy/vercel.md
+++ b/docs/versioned_docs/version-2.6/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-2.6/docker.md
+++ b/docs/versioned_docs/version-2.6/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `cedar.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-2.6/graphql/fragments.md
+++ b/docs/versioned_docs/version-2.6/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.6/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-2.6/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.6/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-2.6/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-2.6/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-2.6/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-2.6/intro-to-servers.md
+++ b/docs/versioned_docs/version-2.6/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-2.6/prerender.md
+++ b/docs/versioned_docs/version-2.6/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-2.6/quick-start.md
+++ b/docs/versioned_docs/version-2.6/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-2.6/router.md
+++ b/docs/versioned_docs/version-2.6/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-2.6/seo-head.md
+++ b/docs/versioned_docs/version-2.6/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-2.6/server-file.md
+++ b/docs/versioned_docs/version-2.6/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-2.6/serverless-functions.md
+++ b/docs/versioned_docs/version-2.6/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-2.6/services.md
+++ b/docs/versioned_docs/version-2.6/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-2.6/testing.md
+++ b/docs/versioned_docs/version-2.6/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1019,7 +1019,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1294,7 +1294,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1797,7 +1797,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1980,7 +1980,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-2.6/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -874,7 +874,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -905,7 +905,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -921,7 +921,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-2.6/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-2.6/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-2.6/tutorial/intermission.md
+++ b/docs/versioned_docs/version-2.6/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-2.6/typescript/generated-types.md
+++ b/docs/versioned_docs/version-2.6/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-2.6/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-2.6/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-2.6/uploads.md
+++ b/docs/versioned_docs/version-2.6/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-2.7/app-configuration-cedar-toml.md
+++ b/docs/versioned_docs/version-2.7/app-configuration-cedar-toml.md
@@ -100,7 +100,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-2.7/auth/azure.md
+++ b/docs/versioned_docs/version-2.7/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-2.7/auth/clerk.md
+++ b/docs/versioned_docs/version-2.7/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-2.7/auth/custom.md
+++ b/docs/versioned_docs/version-2.7/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-2.7/auth/dbauth.md
+++ b/docs/versioned_docs/version-2.7/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-2.7/authentication.md
+++ b/docs/versioned_docs/version-2.7/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-2.7/background-jobs.md
+++ b/docs/versioned_docs/version-2.7/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-2.7/cli-commands.md
+++ b/docs/versioned_docs/version-2.7/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-2.7/deploy/baremetal.md
+++ b/docs/versioned_docs/version-2.7/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-2.7/deploy/coherence.md
+++ b/docs/versioned_docs/version-2.7/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-2.7/deploy/serverless.md
+++ b/docs/versioned_docs/version-2.7/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-2.7/deploy/vercel.md
+++ b/docs/versioned_docs/version-2.7/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-2.7/docker.md
+++ b/docs/versioned_docs/version-2.7/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `cedar.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-2.7/graphql/fragments.md
+++ b/docs/versioned_docs/version-2.7/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.7/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-2.7/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.7/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-2.7/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-2.7/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-2.7/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-2.7/intro-to-servers.md
+++ b/docs/versioned_docs/version-2.7/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-2.7/prerender.md
+++ b/docs/versioned_docs/version-2.7/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-2.7/quick-start.md
+++ b/docs/versioned_docs/version-2.7/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-2.7/router.md
+++ b/docs/versioned_docs/version-2.7/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-2.7/seo-head.md
+++ b/docs/versioned_docs/version-2.7/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-2.7/server-file.md
+++ b/docs/versioned_docs/version-2.7/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-2.7/serverless-functions.md
+++ b/docs/versioned_docs/version-2.7/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-2.7/services.md
+++ b/docs/versioned_docs/version-2.7/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-2.7/testing.md
+++ b/docs/versioned_docs/version-2.7/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1019,7 +1019,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1294,7 +1294,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1797,7 +1797,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1980,7 +1980,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-2.7/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -874,7 +874,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -905,7 +905,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -921,7 +921,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-2.7/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-2.7/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-2.7/tutorial/intermission.md
+++ b/docs/versioned_docs/version-2.7/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-2.7/typescript/generated-types.md
+++ b/docs/versioned_docs/version-2.7/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-2.7/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-2.7/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-2.7/uploads.md
+++ b/docs/versioned_docs/version-2.7/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-2.8/app-configuration-cedar-toml.md
+++ b/docs/versioned_docs/version-2.8/app-configuration-cedar-toml.md
@@ -100,7 +100,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-2.8/auth/azure.md
+++ b/docs/versioned_docs/version-2.8/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-2.8/auth/clerk.md
+++ b/docs/versioned_docs/version-2.8/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-2.8/auth/custom.md
+++ b/docs/versioned_docs/version-2.8/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-2.8/auth/dbauth.md
+++ b/docs/versioned_docs/version-2.8/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-2.8/authentication.md
+++ b/docs/versioned_docs/version-2.8/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-2.8/background-jobs.md
+++ b/docs/versioned_docs/version-2.8/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-2.8/cli-commands.md
+++ b/docs/versioned_docs/version-2.8/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-2.8/deploy/baremetal.md
+++ b/docs/versioned_docs/version-2.8/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-2.8/deploy/coherence.md
+++ b/docs/versioned_docs/version-2.8/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-2.8/deploy/serverless.md
+++ b/docs/versioned_docs/version-2.8/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-2.8/deploy/vercel.md
+++ b/docs/versioned_docs/version-2.8/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-2.8/docker.md
+++ b/docs/versioned_docs/version-2.8/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `cedar.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-2.8/graphql/fragments.md
+++ b/docs/versioned_docs/version-2.8/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.8/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-2.8/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-2.8/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-2.8/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-2.8/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-2.8/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-2.8/intro-to-servers.md
+++ b/docs/versioned_docs/version-2.8/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-2.8/prerender.md
+++ b/docs/versioned_docs/version-2.8/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-2.8/quick-start.md
+++ b/docs/versioned_docs/version-2.8/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-2.8/router.md
+++ b/docs/versioned_docs/version-2.8/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-2.8/seo-head.md
+++ b/docs/versioned_docs/version-2.8/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-2.8/server-file.md
+++ b/docs/versioned_docs/version-2.8/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-2.8/serverless-functions.md
+++ b/docs/versioned_docs/version-2.8/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-2.8/services.md
+++ b/docs/versioned_docs/version-2.8/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-2.8/testing.md
+++ b/docs/versioned_docs/version-2.8/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1019,7 +1019,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1294,7 +1294,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1797,7 +1797,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1980,7 +1980,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-2.8/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -874,7 +874,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -905,7 +905,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -921,7 +921,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-2.8/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-2.8/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-2.8/tutorial/intermission.md
+++ b/docs/versioned_docs/version-2.8/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-2.8/typescript/generated-types.md
+++ b/docs/versioned_docs/version-2.8/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-2.8/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-2.8/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-2.8/uploads.md
+++ b/docs/versioned_docs/version-2.8/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-3.0/app-configuration-cedar-toml.md
+++ b/docs/versioned_docs/version-3.0/app-configuration-cedar-toml.md
@@ -100,7 +100,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-3.0/auth/azure.md
+++ b/docs/versioned_docs/version-3.0/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-3.0/auth/clerk.md
+++ b/docs/versioned_docs/version-3.0/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-3.0/auth/custom.md
+++ b/docs/versioned_docs/version-3.0/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-3.0/auth/dbauth.md
+++ b/docs/versioned_docs/version-3.0/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -519,7 +519,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-3.0/authentication.md
+++ b/docs/versioned_docs/version-3.0/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-3.0/background-jobs.md
+++ b/docs/versioned_docs/version-3.0/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-3.0/cli-commands.md
+++ b/docs/versioned_docs/version-3.0/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-3.0/deploy/baremetal.md
+++ b/docs/versioned_docs/version-3.0/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-3.0/deploy/coherence.md
+++ b/docs/versioned_docs/version-3.0/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-3.0/deploy/serverless.md
+++ b/docs/versioned_docs/version-3.0/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-3.0/deploy/vercel.md
+++ b/docs/versioned_docs/version-3.0/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-3.0/docker.md
+++ b/docs/versioned_docs/version-3.0/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `cedar.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-3.0/graphql/fragments.md
+++ b/docs/versioned_docs/version-3.0/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-3.0/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-3.0/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-3.0/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-3.0/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-3.0/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-3.0/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-3.0/intro-to-servers.md
+++ b/docs/versioned_docs/version-3.0/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-3.0/prerender.md
+++ b/docs/versioned_docs/version-3.0/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-3.0/quick-start.md
+++ b/docs/versioned_docs/version-3.0/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-3.0/router.md
+++ b/docs/versioned_docs/version-3.0/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-3.0/seo-head.md
+++ b/docs/versioned_docs/version-3.0/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-3.0/server-file.md
+++ b/docs/versioned_docs/version-3.0/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-3.0/serverless-functions.md
+++ b/docs/versioned_docs/version-3.0/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-3.0/services.md
+++ b/docs/versioned_docs/version-3.0/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-3.0/testing.md
+++ b/docs/versioned_docs/version-3.0/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1019,7 +1019,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1294,7 +1294,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1797,7 +1797,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1980,7 +1980,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-3.0/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter1/prerequisites.md
@@ -27,7 +27,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter2/getting-dynamic.md
@@ -51,7 +51,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -171,7 +171,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter3/saving-data.md
@@ -716,7 +716,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -928,7 +928,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1242,7 +1242,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -460,7 +460,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter6/comments-schema.md
@@ -555,7 +555,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -624,7 +624,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -640,7 +640,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -876,7 +876,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -907,7 +907,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -923,7 +923,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-3.0/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-3.0/tutorial/intermission.md
+++ b/docs/versioned_docs/version-3.0/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-3.0/typescript/generated-types.md
+++ b/docs/versioned_docs/version-3.0/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-3.0/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-3.0/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-3.0/uploads.md
+++ b/docs/versioned_docs/version-3.0/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-3.1/app-configuration-cedar-toml.md
+++ b/docs/versioned_docs/version-3.1/app-configuration-cedar-toml.md
@@ -100,7 +100,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-3.1/auth/azure.md
+++ b/docs/versioned_docs/version-3.1/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-3.1/auth/clerk.md
+++ b/docs/versioned_docs/version-3.1/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-3.1/auth/custom.md
+++ b/docs/versioned_docs/version-3.1/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-3.1/auth/dbauth.md
+++ b/docs/versioned_docs/version-3.1/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -519,7 +519,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-3.1/authentication.md
+++ b/docs/versioned_docs/version-3.1/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-3.1/background-jobs.md
+++ b/docs/versioned_docs/version-3.1/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-3.1/cli-commands.md
+++ b/docs/versioned_docs/version-3.1/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-3.1/deploy/baremetal.md
+++ b/docs/versioned_docs/version-3.1/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-3.1/deploy/coherence.md
+++ b/docs/versioned_docs/version-3.1/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-3.1/deploy/serverless.md
+++ b/docs/versioned_docs/version-3.1/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-3.1/deploy/vercel.md
+++ b/docs/versioned_docs/version-3.1/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-3.1/docker.md
+++ b/docs/versioned_docs/version-3.1/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `cedar.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-3.1/graphql/fragments.md
+++ b/docs/versioned_docs/version-3.1/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-3.1/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-3.1/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-3.1/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-3.1/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-3.1/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-3.1/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-3.1/intro-to-servers.md
+++ b/docs/versioned_docs/version-3.1/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-3.1/prerender.md
+++ b/docs/versioned_docs/version-3.1/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-3.1/quick-start.md
+++ b/docs/versioned_docs/version-3.1/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-3.1/router.md
+++ b/docs/versioned_docs/version-3.1/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-3.1/seo-head.md
+++ b/docs/versioned_docs/version-3.1/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-3.1/server-file.md
+++ b/docs/versioned_docs/version-3.1/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-3.1/serverless-functions.md
+++ b/docs/versioned_docs/version-3.1/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-3.1/services.md
+++ b/docs/versioned_docs/version-3.1/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-3.1/testing.md
+++ b/docs/versioned_docs/version-3.1/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1019,7 +1019,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1294,7 +1294,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1797,7 +1797,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1980,7 +1980,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-3.1/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter1/prerequisites.md
@@ -27,7 +27,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter2/getting-dynamic.md
@@ -51,7 +51,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -171,7 +171,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter3/saving-data.md
@@ -716,7 +716,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -928,7 +928,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1242,7 +1242,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -460,7 +460,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter6/comments-schema.md
@@ -555,7 +555,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -624,7 +624,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -640,7 +640,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -876,7 +876,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -907,7 +907,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -923,7 +923,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-3.1/tutorial/intermission.md
+++ b/docs/versioned_docs/version-3.1/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-3.1/typescript/generated-types.md
+++ b/docs/versioned_docs/version-3.1/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-3.1/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-3.1/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-3.1/uploads.md
+++ b/docs/versioned_docs/version-3.1/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-4.0/app-configuration-cedar-toml.md
+++ b/docs/versioned_docs/version-4.0/app-configuration-cedar-toml.md
@@ -100,7 +100,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-4.0/auth/azure.md
+++ b/docs/versioned_docs/version-4.0/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-4.0/auth/clerk.md
+++ b/docs/versioned_docs/version-4.0/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-4.0/auth/custom.md
+++ b/docs/versioned_docs/version-4.0/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-4.0/auth/dbauth.md
+++ b/docs/versioned_docs/version-4.0/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -539,7 +539,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-4.0/authentication.md
+++ b/docs/versioned_docs/version-4.0/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-4.0/background-jobs.md
+++ b/docs/versioned_docs/version-4.0/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-4.0/cli-commands.md
+++ b/docs/versioned_docs/version-4.0/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-4.0/deploy/baremetal.md
+++ b/docs/versioned_docs/version-4.0/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-4.0/deploy/coherence.md
+++ b/docs/versioned_docs/version-4.0/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-4.0/deploy/serverless.md
+++ b/docs/versioned_docs/version-4.0/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-4.0/deploy/vercel.md
+++ b/docs/versioned_docs/version-4.0/deploy/vercel.md
@@ -128,7 +128,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-4.0/docker.md
+++ b/docs/versioned_docs/version-4.0/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `cedar.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-4.0/graphql/fragments.md
+++ b/docs/versioned_docs/version-4.0/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-4.0/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-4.0/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-4.0/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-4.0/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-4.0/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-4.0/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-4.0/intro-to-servers.md
+++ b/docs/versioned_docs/version-4.0/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-4.0/prerender.md
+++ b/docs/versioned_docs/version-4.0/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-4.0/quick-start.md
+++ b/docs/versioned_docs/version-4.0/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-4.0/router.md
+++ b/docs/versioned_docs/version-4.0/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-4.0/seo-head.md
+++ b/docs/versioned_docs/version-4.0/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-4.0/server-file.md
+++ b/docs/versioned_docs/version-4.0/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-4.0/serverless-functions.md
+++ b/docs/versioned_docs/version-4.0/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-4.0/services.md
+++ b/docs/versioned_docs/version-4.0/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-4.0/testing.md
+++ b/docs/versioned_docs/version-4.0/testing.md
@@ -285,7 +285,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1051,7 +1051,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1326,7 +1326,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1837,7 +1837,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -2020,7 +2020,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-4.0/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter1/layouts.md
@@ -242,7 +242,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -250,7 +250,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter1/prerequisites.md
@@ -27,7 +27,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter2/getting-dynamic.md
@@ -55,7 +55,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -175,7 +175,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter3/forms.md
@@ -1220,7 +1220,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter3/saving-data.md
@@ -728,7 +728,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -944,7 +944,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
   src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png"
 />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1258,7 +1258,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -460,7 +460,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter6/comments-schema.md
@@ -555,7 +555,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -624,7 +624,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -640,7 +640,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -876,7 +876,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -908,7 +908,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -924,7 +924,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -116,7 +116,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -128,7 +128,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -202,7 +202,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -280,7 +280,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -474,7 +474,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-4.0/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-4.0/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-4.0/tutorial/intermission.md
+++ b/docs/versioned_docs/version-4.0/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-4.0/typescript/generated-types.md
+++ b/docs/versioned_docs/version-4.0/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.cedar/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-4.0/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-4.0/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-4.0/uploads.md
+++ b/docs/versioned_docs/version-4.0/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-4.1/app-configuration-cedar-toml.md
+++ b/docs/versioned_docs/version-4.1/app-configuration-cedar-toml.md
@@ -100,7 +100,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-4.1/auth/azure.md
+++ b/docs/versioned_docs/version-4.1/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-4.1/auth/clerk.md
+++ b/docs/versioned_docs/version-4.1/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-4.1/auth/custom.md
+++ b/docs/versioned_docs/version-4.1/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-4.1/auth/dbauth.md
+++ b/docs/versioned_docs/version-4.1/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -539,7 +539,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-4.1/authentication.md
+++ b/docs/versioned_docs/version-4.1/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-4.1/background-jobs.md
+++ b/docs/versioned_docs/version-4.1/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-4.1/cli-commands.md
+++ b/docs/versioned_docs/version-4.1/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-4.1/deploy/baremetal.md
+++ b/docs/versioned_docs/version-4.1/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-4.1/deploy/coherence.md
+++ b/docs/versioned_docs/version-4.1/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-4.1/deploy/serverless.md
+++ b/docs/versioned_docs/version-4.1/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-4.1/deploy/vercel.md
+++ b/docs/versioned_docs/version-4.1/deploy/vercel.md
@@ -128,7 +128,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-4.1/docker.md
+++ b/docs/versioned_docs/version-4.1/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `cedar.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-4.1/graphql/fragments.md
+++ b/docs/versioned_docs/version-4.1/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-4.1/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-4.1/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-4.1/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-4.1/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-4.1/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-4.1/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-4.1/intro-to-servers.md
+++ b/docs/versioned_docs/version-4.1/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-4.1/prerender.md
+++ b/docs/versioned_docs/version-4.1/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-4.1/quick-start.md
+++ b/docs/versioned_docs/version-4.1/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-4.1/router.md
+++ b/docs/versioned_docs/version-4.1/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-4.1/seo-head.md
+++ b/docs/versioned_docs/version-4.1/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-4.1/server-file.md
+++ b/docs/versioned_docs/version-4.1/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-4.1/serverless-functions.md
+++ b/docs/versioned_docs/version-4.1/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-4.1/services.md
+++ b/docs/versioned_docs/version-4.1/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-4.1/testing.md
+++ b/docs/versioned_docs/version-4.1/testing.md
@@ -285,7 +285,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1051,7 +1051,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1326,7 +1326,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1837,7 +1837,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -2020,7 +2020,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-4.1/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Cedar automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter1/layouts.md
@@ -242,7 +242,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Cedar: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -250,7 +250,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Cedar's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter1/prerequisites.md
@@ -27,7 +27,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Cedar installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Cedar will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Cedar will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Cedar comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Cedar is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Cedar will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter2/getting-dynamic.md
@@ -55,7 +55,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -175,7 +175,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Cedar CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -494,7 +494,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter3/forms.md
@@ -1220,7 +1220,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter3/saving-data.md
@@ -728,7 +728,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -944,7 +944,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
   src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png"
 />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1258,7 +1258,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -460,7 +460,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter6/comments-schema.md
@@ -555,7 +555,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -624,7 +624,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -640,7 +640,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -876,7 +876,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -908,7 +908,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -924,7 +924,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -116,7 +116,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -128,7 +128,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -202,7 +202,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -280,7 +280,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -474,7 +474,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-4.1/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-4.1/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-4.1/tutorial/intermission.md
+++ b/docs/versioned_docs/version-4.1/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-4.1/typescript/generated-types.md
+++ b/docs/versioned_docs/version-4.1/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.cedar/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-4.1/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-4.1/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-4.1/uploads.md
+++ b/docs/versioned_docs/version-4.1/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-4.2/app-configuration-cedar-toml.md
+++ b/docs/versioned_docs/version-4.2/app-configuration-cedar-toml.md
@@ -100,7 +100,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 

--- a/docs/versioned_docs/version-4.2/auth/azure.md
+++ b/docs/versioned_docs/version-4.2/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Cedar uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-4.2/auth/clerk.md
+++ b/docs/versioned_docs/version-4.2/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-4.2/auth/custom.md
+++ b/docs/versioned_docs/version-4.2/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Cedar doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Cedar has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Cedar used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-4.2/auth/dbauth.md
+++ b/docs/versioned_docs/version-4.2/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -539,7 +539,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-4.2/authentication.md
+++ b/docs/versioned_docs/version-4.2/authentication.md
@@ -28,7 +28,7 @@ Cedar has a simple API to integrate any auth provider you can think of. But to m
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Cedar's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-4.2/background-jobs.md
+++ b/docs/versioned_docs/version-4.2/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Cedar:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -575,7 +575,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-4.2/cli-commands.md
+++ b/docs/versioned_docs/version-4.2/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-4.2/deploy/baremetal.md
+++ b/docs/versioned_docs/version-4.2/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://cedarjs.com/discord) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-4.2/deploy/coherence.md
+++ b/docs/versioned_docs/version-4.2/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Cedar project needs to be hosted on GitHub and you 
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-4.2/deploy/serverless.md
+++ b/docs/versioned_docs/version-4.2/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-4.2/deploy/vercel.md
+++ b/docs/versioned_docs/version-4.2/deploy/vercel.md
@@ -128,7 +128,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Cedar has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Cedar.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-4.2/docker.md
+++ b/docs/versioned_docs/version-4.2/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Cedar tar
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `cedar.toml` file is Cedar's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-4.2/graphql/fragments.md
+++ b/docs/versioned_docs/version-4.2/graphql/fragments.md
@@ -360,7 +360,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-4.2/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-4.2/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-4.2/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-4.2/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-4.2/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-4.2/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Cedar app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Cedar app knows where to store the data
 

--- a/docs/versioned_docs/version-4.2/intro-to-servers.md
+++ b/docs/versioned_docs/version-4.2/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-4.2/prerender.md
+++ b/docs/versioned_docs/version-4.2/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Cedar currently supports prerendering at _build_ time. So before you deploy your web side, Cedar will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-4.2/quick-start.md
+++ b/docs/versioned_docs/version-4.2/quick-start.md
@@ -4,7 +4,7 @@ description: CedarJS quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - CedarJS requires [Node.js](https://nodejs.org/en/) (=24.x) and
   [Yarn](https://yarnpkg.com/) (>=1.22.21)
@@ -19,7 +19,7 @@ Create a Cedar project with `yarn create cedar-app`:
 yarn create cedar-app my-cedar-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 CedarJS comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-4.2/router.md
+++ b/docs/versioned_docs/version-4.2/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the CedarJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-4.2/seo-head.md
+++ b/docs/versioned_docs/version-4.2/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Cedar also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Cedar 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Cedar uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-helm
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Cedar's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -287,7 +287,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -313,7 +313,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 Cedar supports prerendering your [Cells](https://cedarjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://cedarjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-4.2/server-file.md
+++ b/docs/versioned_docs/version-4.2/server-file.md
@@ -207,7 +207,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that CedarJS's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-4.2/serverless-functions.md
+++ b/docs/versioned_docs/version-4.2/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-4.2/services.md
+++ b/docs/versioned_docs/version-4.2/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-4.2/testing.md
+++ b/docs/versioned_docs/version-4.2/testing.md
@@ -285,7 +285,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Cedar's `render` function is based on React Testing Library's. The only difference is that Cedar's wraps everything with mock providers for the various providers in Cedar, such as auth, the GraphQL client, the router, etc.
@@ -1051,7 +1051,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1326,7 +1326,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Cedar will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/cedarjs/cedar/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1837,7 +1837,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -2020,7 +2020,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-4.2/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-4.2/tutorial/chapter3/forms.md
@@ -1220,7 +1220,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-4.2/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-4.2/tutorial/chapter3/saving-data.md
@@ -728,7 +728,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -944,7 +944,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
   src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png"
 />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1258,7 +1258,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-4.2/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-4.2/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Cedar includes [integrations](../../authentication.md) for several of the most p
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Cedar) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -460,7 +460,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-4.2/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-4.2/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Cedar intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-4.2/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-4.2/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-4.2/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-4.2/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Cedar console does it for you—Cedar `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-4.2/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-4.2/tutorial/chapter6/comments-schema.md
@@ -555,7 +555,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Cedar that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -624,7 +624,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Cedar would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -640,7 +640,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Cedar) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -876,7 +876,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -908,7 +908,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -924,7 +924,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-4.2/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-4.2/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Cedar has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-4.2/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-4.2/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-4.2/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-4.2/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Cedar's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -116,7 +116,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -128,7 +128,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Cedar Tutorial repo](https://github.com/cedarjs/cedar-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -202,7 +202,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -280,7 +280,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -474,7 +474,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-4.2/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-4.2/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-4.2/tutorial/intermission.md
+++ b/docs/versioned_docs/version-4.2/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first part of the tutorial you can clone [this repo](https://github.com/cedarjs/cedar-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-4.2/typescript/generated-types.md
+++ b/docs/versioned_docs/version-4.2/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Cedar uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (aka
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Cedar's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Cedar generates in `.cedar/schema.graphql`.
 You can configure it further in `graphql.config.cjs` at the root of your project.

--- a/docs/versioned_docs/version-4.2/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-4.2/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-4.2/uploads.md
+++ b/docs/versioned_docs/version-4.2/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 

--- a/docs/versioned_docs/version-8.x/app-configuration-redwood-toml.md
+++ b/docs/versioned_docs/version-8.x/app-configuration-redwood-toml.md
@@ -97,7 +97,7 @@ PUBLIC_KEY=...
 
 Instead of including them in `includeEnvironmentVariables`, you can also prefix them with `REDWOOD_ENV_` (see [Environment Variables](environment-variables.md#web)).
 
-:::caution `includeEnvironmentVariables` isn't for secrets
+:::caution[`includeEnvironmentVariables` isn't for secrets]
 
 Don't make secrets available to your web side. Everything in `includeEnvironmentVariables` is included in the bundle.
 
@@ -118,7 +118,7 @@ Additional server configuration can be done using [Server File](docker.md#using-
 
 Prisma's `prismaSchemaFolder` [feature](https://www.prisma.io/docs/orm/prisma-schema/overview/location#multi-file-prisma-schema) allows you to define multiple files in a schema subdirectory of your prisma directory.
 
-:::note Important
+:::note[Important]
 If you wish to [organize your Prisma Schema into multiple files](https://www.prisma.io/blog/organize-your-prisma-schema-with-multi-file-support), you will need [enable](https://www.prisma.io/docs/orm/prisma-schema/overview/location#multi-file-prisma-schema) that feature in Prisma, move your `schema.prisma` file into a new directory such as `./api/db/schema` and then set `schemaPath` in the api toml config.
 :::
 

--- a/docs/versioned_docs/version-8.x/auth/azure.md
+++ b/docs/versioned_docs/version-8.x/auth/azure.md
@@ -47,7 +47,7 @@ At the end, it says...
 Redwood uses [MSAL.js 2.0 with auth code flow](https://learn.microsoft.com/en-us/azure/active-directory/develop/scenario-spa-app-registration#redirect-uri-msaljs-20-with-auth-code-flow), so follow the steps there next.
 When it asks you for a Redirect URI, enter `http://localhost:8910` and `http://localhost:8910/login`, and copy these into your `.env` file as `AZURE_ACTIVE_DIRECTORY_REDIRECT_URI` and `AZURE_ACTIVE_DIRECTORY_LOGOUT_REDIRECT_URI`:
 
-:::tip Can't add multiple URI's?
+:::tip[Can't add multiple URI's?]
 
 Configure one, then you'll be able to configure another.
 

--- a/docs/versioned_docs/version-8.x/auth/clerk.md
+++ b/docs/versioned_docs/version-8.x/auth/clerk.md
@@ -4,7 +4,7 @@ sidebar_label: Clerk
 
 # Clerk Authentication
 
-:::warning Did you set up Clerk a while ago?
+:::warning[Did you set up Clerk a while ago?]
 
 If you set up Clerk a while ago, you may be using a deprecated `authDecoder` that's subject to rate limiting.
 This decoder will be removed in the next major.
@@ -27,7 +27,7 @@ If you don't have a Clerk account yet, now's the time to make one: navigate to h
 The defaults are good enough to get us going, but feel free to configure things as you wish.
 We'll get the application's API keys from its dashboard next.
 
-:::note we'll only focus on the development instance
+:::note[we'll only focus on the development instance]
 
 By default, Clerk applications have two instances, "Development" and "Production".
 We'll only focus on the "Development" instance here, which is used for local development.

--- a/docs/versioned_docs/version-8.x/auth/custom.md
+++ b/docs/versioned_docs/version-8.x/auth/custom.md
@@ -6,7 +6,7 @@ sidebar_label: Custom
 
 If Redwood doesn't officially integrate with the auth provider you want to use, you're not out of luck just yet: Redwood has an API you can use to integrate your auth provider of choice.
 
-:::tip Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?
+:::tip[Were you using Nhost, magic.link, GoTrue, Okta or Wallet Connect (ethereum)?]
 
 If you're here because you're using one of the providers Redwood used to support (Nhost, magic.link, GoTrue, Okta or Wallet Connect (Ethereum)), we've moved the code for them out into their own separate repos:
 

--- a/docs/versioned_docs/version-8.x/auth/dbauth.md
+++ b/docs/versioned_docs/version-8.x/auth/dbauth.md
@@ -379,7 +379,7 @@ yarn rw g secret
 
 Note that the secret that's output is _not_ appended to your `.env` file or anything else, it's merely output to the screen. You'll need to put it in the right place after that.
 
-:::warning .env and Version Control
+:::warning[.env and Version Control]
 
 The `.env` file is set to be ignored by git and not committed to version control. There is another file, `.env.defaults`, which is meant to be safe to commit and contain simple ENV vars that your dev team can share. The encryption key for the session cookie is NOT one of these shareable vars!
 
@@ -517,7 +517,7 @@ model UserCredential {
 
 Run `yarn rw prisma migrate dev` to apply the changes to your database.
 
-:::warning Do Not Allow GraphQL Access to `UserCredential`
+:::warning[Do Not Allow GraphQL Access to `UserCredential`]
 
 As you can probably tell by the name, this new model contains secret credential info for the user. You **should not** make this data publicly available by adding an SDL file to `api/src/graphql`.
 

--- a/docs/versioned_docs/version-8.x/authentication.md
+++ b/docs/versioned_docs/version-8.x/authentication.md
@@ -28,7 +28,7 @@ Redwood has a simple API to integrate any auth provider you can think of. But to
 - [Supabase](./auth/supabase.md)
 - [SuperTokens](./auth/supertokens.md)
 
-:::tip how to tell if an integration is official
+:::tip[how to tell if an integration is official]
 
 To tell if an integration is official, look for the `@cedarjs` scope.
 For example, Redwood's Auth0 integration comprises two npm packages: `@cedarjs/auth-auth0-web` and `@cedarjs/auth-auth0-api`.
@@ -165,7 +165,7 @@ const Routes = () => {
 }
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
 :::
 

--- a/docs/versioned_docs/version-8.x/background-jobs.md
+++ b/docs/versioned_docs/version-8.x/background-jobs.md
@@ -34,7 +34,7 @@ There are three components to the Background Job system in Redwood:
 
 **Execution** is handled by a **job worker**, which takes a job from storage, executes it, and then does something with the result, whether it was a success or failure.
 
-:::info Job execution time is never guaranteed
+:::info[Job execution time is never guaranteed]
 
 When scheduling a job, you're really saying "this is the earliest possible time I want this job to run": based on what other jobs are in the queue, and how busy the workers are, they may not get a chance to execute this one particular job for an indeterminate amount of time.
 
@@ -228,7 +228,7 @@ At a minimum, a job must contain the name of the `queue` the job should be saved
 
 Note that `perform()` can take any argument(s) you want (or none at all), but it's a best practice to keep them as simple as possible. With the `PrismaAdapter` the arguments are stored in the database, so the list of arguments must be serializable to and from a string of JSON.
 
-:::info Keeping Arguments Simple
+:::info[Keeping Arguments Simple]
 
 Most jobs will probably act against data in your database, so it makes sense to have the arguments simply be the `id` of those database records. When the job executes it will look up the full database record and then proceed from there.
 
@@ -307,7 +307,7 @@ Because we're using the `PrismaAdapter` here all jobs are stored in the database
 
 The `handler` column contains the name of the job, file path to find it, and the arguments its `perform()` function will receive. Where did the `name` and `path` come from? We have a babel plugin that adds them to your job when they are built!
 
-:::warning Jobs Must Be Built
+:::warning[Jobs Must Be Built]
 
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn rw build api` or `yarn rw dev`. If you are working on a job in development, you're probably running `yarn rw dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn rw build api` (or start the dev server) to compile your job into `api/dist`.
 
@@ -558,7 +558,7 @@ yarn rw jobs work
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
 
-:::caution Long running jobs
+:::caution[Long running jobs]
 
 It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
 

--- a/docs/versioned_docs/version-8.x/cli-commands.md
+++ b/docs/versioned_docs/version-8.x/cli-commands.md
@@ -759,7 +759,7 @@ yarn redwood generate job WelcomeEmail
 yarn rw g job WelcomeEmail
 ```
 
-:::info Job naming
+:::info[Job naming]
 By convention a job filename and exported code ends in `Job` and the generate command enforces this. If you don't include "Job" at the end of the name, the generator will add it. For example, with the above command, the file generated would be `api/src/jobs/WelcomeEmailJob/WelcomeEmailJob.{js|ts}`.
 :::
 

--- a/docs/versioned_docs/version-8.x/deploy/baremetal.md
+++ b/docs/versioned_docs/version-8.x/deploy/baremetal.md
@@ -22,7 +22,7 @@ Subsequent deploys:
 yarn rw deploy baremetal production
 ```
 
-:::warning Deploying to baremetal is an advanced topic
+:::warning[Deploying to baremetal is an advanced topic]
 
 If you haven't done any kind of remote server work before, you may be in a little over your head to start with. But don't worry: until relatively recently (cloud computing, serverless, lambda functions) this is how all websites were deployed, so we've got a good 30 years of experience getting this working!
 
@@ -277,7 +277,7 @@ sudo chown deploy:deploy /var/www/myapp
 
 You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
-:::warning SSH and Non-interactive Sessions
+:::warning[SSH and Non-interactive Sessions]
 
 The deployment process uses a '[non-interactive](https://tldp.org/LDP/abs/html/intandnonint.html)' SSH session to run commands on the remote server. A non-interactive session will often load a minimal amount of settings for better compatibility and speed. In some versions of Linux `.bashrc` by default does not load (by design) from a non-interactive session. This can lead to `yarn` (or other commands) not being found by the deployment script, even though they are in your path, because additional ENV vars are set in `~/.bashrc` which provide things like NPM paths and setup.
 
@@ -380,7 +380,7 @@ If so then your API side is up and running! The only thing left to test is that 
 
 Was the problem with starting your PM2 process? That will be harder to debug here in this doc, but visit us in the [forums](https://community.redwoodjs.com) or [Discord](https://discord.gg/redwoodjs) and we'll try to help!
 
-:::note My pm2 processes are running but your app has errors, how do I see them?
+:::note[My pm2 processes are running but your app has errors, how do I see them?]
 
 If your processes are up and running in pm2 you can monitor their log output. Run `pm2 monit` and get a nice graphical interface for watching the logs on your processes. Press the up/down arrows to move through the processes and left/right to switch panes.
 

--- a/docs/versioned_docs/version-8.x/deploy/coherence.md
+++ b/docs/versioned_docs/version-8.x/deploy/coherence.md
@@ -17,7 +17,7 @@ To deploy to Coherence, your Redwood project needs to be hosted on GitHub and yo
 
 ## Coherence Deploy
 
-:::warning Prerender doesn't work with Coherence yet
+:::warning[Prerender doesn't work with Coherence yet]
 
 You can see its current status and follow updates here on GitHub: https://github.com/redwoodjs/redwood/issues/8333.
 

--- a/docs/versioned_docs/version-8.x/deploy/serverless.md
+++ b/docs/versioned_docs/version-8.x/deploy/serverless.md
@@ -115,7 +115,7 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-:::tip Pro tip
+:::tip[Pro tip]
 If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
 :::
 

--- a/docs/versioned_docs/version-8.x/deploy/vercel.md
+++ b/docs/versioned_docs/version-8.x/deploy/vercel.md
@@ -127,7 +127,7 @@ export const handler = async (event: APIGatewayEvent, _context: Context) => {
 }
 ```
 
-:::tip important
+:::tip[important]
 Since Redwood has it's own handling of the api directory, the Vercel flavored api directory is disabled. Therefore you don't use the "functions" config in `vercel.json` with Redwood.
 
 Also, be sure to use Node version 20.x or greater or set the `runtime` in the function config:

--- a/docs/versioned_docs/version-8.x/docker.md
+++ b/docs/versioned_docs/version-8.x/docker.md
@@ -34,7 +34,7 @@ And the prod compose file with:
 docker compose -f ./docker-compose.prod.yml up
 ```
 
-:::info make sure to specify build args
+:::info[make sure to specify build args]
 
 If your api side or web side depend on env vars at build time, you may need to supply them as `--build-args`, or in the compose files.
 
@@ -49,7 +49,7 @@ docker compose -f ./docker-compose.dev.yml run --rm -it console /bin/bash
 root@...:/home/node/app# yarn rw prisma migrate dev
 ```
 
-:::info database choice
+:::info[database choice]
 The docker setup command assumes that you are using Postgres as your database provider and sets up a local Postgres database for you. You may have to switch from SQLite to Postgres if you have not done so and want to continue with the default setup.
 :::
 
@@ -77,7 +77,7 @@ We use a Node.js 20 image as the base image because that's the version Redwood t
 "bookworm" is the codename for the current stable distribution of Debian (version 12).
 Lastly, the "slim" variant of the `node:20-bookworm` image only includes what Node.js needs which reduces the image's size while making it more secure.
 
-:::tip Why not alpine?
+:::tip[Why not alpine?]
 
 While alpine may be smaller, it uses musl, a different C standard library.
 In developing this Dockerfile, we prioritized security over size.
@@ -172,7 +172,7 @@ We'll need these config files for the build and production stages.
 The `redwood.toml` file is Redwood's de-facto config file.
 Both the build and serve stages read it to enable and configure functionality.
 
-:::warning `.env.defaults` is ok to include but `.env` is not
+:::warning[`.env.defaults` is ok to include but `.env` is not]
 
 If you add a secret to the Dockerfile, it can be excavated.
 While it's technically true that multi stage builds add a sort of security layer, it's not a best practice.

--- a/docs/versioned_docs/version-8.x/graphql/fragments.md
+++ b/docs/versioned_docs/version-8.x/graphql/fragments.md
@@ -363,7 +363,7 @@ export const standard = {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-8.x/graphql/mocking-graphql-requests.md
+++ b/docs/versioned_docs/version-8.x/graphql/mocking-graphql-requests.md
@@ -89,7 +89,7 @@ mockGraphQLQuery('OperationName', (_variables, { ctx }) => {
 
 If using [fragments](../graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 
-:::tip note
+:::tip[note]
 
 The `__typename: 'Book' as const` ensures that `'Book'` is considered to be a `type` and not a `string`.
 :::

--- a/docs/versioned_docs/version-8.x/graphql/trusted-documents.md
+++ b/docs/versioned_docs/version-8.x/graphql/trusted-documents.md
@@ -230,7 +230,7 @@ If you validate your persisted operations while building your store, we recommen
 
 Sometimes it is handy to allow non-persisted operations aside from the persisted ones. E.g. you want to allow developers to execute arbitrary GraphQL operations on your production server.
 
-:::note Info
+:::note[Info]
 To support authentication, the `redwood.currentUser` query is always allowed.
 
 Even if you define `allowArbitraryOperations` the plugin will always check for this request, so you don't need to add this check to any custom logic.
@@ -238,7 +238,7 @@ Even if you define `allowArbitraryOperations` the plugin will always check for t
 
 This can be achieved using the `allowArbitraryOperations` option.
 
-:::warning Important
+:::warning[Important]
 Override this option with caution!
 :::
 

--- a/docs/versioned_docs/version-8.x/how-to/test-in-github-actions.md
+++ b/docs/versioned_docs/version-8.x/how-to/test-in-github-actions.md
@@ -65,7 +65,7 @@ Watch Usage: Press w to show more.
 For the purpose of this how to, we'll use the `UserExample` model that comes with the Redwood app.
 We'll also change the database to Postgres since that's what we'll be using in our GitHub Actions.
 
-:::note Make sure you have a Postgres instance ready to use
+:::note[Make sure you have a Postgres instance ready to use]
 
 Here's a handy guide for how to [set it up locally](../local-postgres-setup). We'll need the connection string so our Redwood app knows where to store the data
 

--- a/docs/versioned_docs/version-8.x/intro-to-servers.md
+++ b/docs/versioned_docs/version-8.x/intro-to-servers.md
@@ -55,7 +55,7 @@ You can see a list of all known servers by looking in this file:
 ~/.ssh/known_hosts
 ```
 
-:::info Reusing IP addresses
+:::info[Reusing IP addresses]
 
 If you're connecting to cloud-based servers, turning them on and off, and potentially reusing IP addresses, you'll get an error message the next time you try to connect to that IP (because the signature of the server itself is now different than what's recorded in `known_hosts`. Find that line and delete it from `~/.ssh/known_hosts` and you'll be able to connect again.
 
@@ -63,7 +63,7 @@ If you're connecting to cloud-based servers, turning them on and off, and potent
 
 Once you're past that prompt you'll then either be prompted for your password, or logged in automatically (when using a private or public key). Let's look at each one in detail.
 
-:::warning Baremetal First Deploy Woes?
+:::warning[Baremetal First Deploy Woes?]
 
 If you're having trouble deploying to your server with Baremetal, and you've never connected to your server manually via SSH, this could be why: Baremetal provides no interactive prompt to accept this server fingerprint. You need to connect manually at least once before Baremetal can connect.
 
@@ -97,7 +97,7 @@ Whether or not you connected successfully, skip ahead to the [Connected](#connec
 
 Some providers, like AWS, will give you a private key at the time the server is created, rather than a password. This file usually ends in `.pem`. Make sure you know where you put this file on your computer because, for now, it's the only way you'll be able to connect to your server. If you lose it, you'll need to terminate that instance and start a new one. I generally put them in the `~/.ssh` folder to keep all SSH-related stuff together, usually in a subdirectory. (I also move this directory to iCloud and then create a symlink back to `~/.ssh` so that it's synchronized across all of my systems.)
 
-:::info More About Public/Private Keypairs
+:::info[More About Public/Private Keypairs]
 
 Learn more about [public/private key authentication](https://www.ssh.com/academy/ssh/public-key-authentication). But the gist is that you create two keys, one public and one private. Either one can encrypt a document, but, only the private key can _decrypt_ it. This means that anyone can have the public key and it can be freely distrubted (thus the "public" name), and the owner of the private key can always verify that it was encrypted using the related public key. A related technique can happen in reverse: the private key can be used to create a signature of a document, and the public key can be used to _verify_ that the signature was created by the matching private key. So you can get the original message, and after verifying the signature, trust that it was sent by the owner of the private key.
 
@@ -280,7 +280,7 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
-:::info What's this randomart thing?
+:::info[What's this randomart thing?]
 
 From this [Super User answer](https://superuser.com/a/22541):
 
@@ -306,7 +306,7 @@ ssh-add ~/.ssh/id_ed25519
 
 Now running `ssh-add -L` should list our key.
 
-:::info Missing key after computer restart
+:::info[Missing key after computer restart]
 
 I've had cases where my key was unknown to `ssh-agent` after a computer restart. I added the following to the `~/.zshrc` file on my computer (not the server) so that the key is added every time I start a new terminal session:
 

--- a/docs/versioned_docs/version-8.x/prerender.md
+++ b/docs/versioned_docs/version-8.x/prerender.md
@@ -8,7 +8,7 @@ Prerendering is great for providing a faster experience for your end users. Your
 
 We thought a lot about what the developer experience should be for route-based prerendering. The result is one of the smallest APIs imaginable!
 
-:::info How's Prerendering different from SSR/SSG/SWR/ISSG/...?
+:::info[How's Prerendering different from SSR/SSG/SWR/ISSG/...?]
 As Danny said in his [Prerender demo](https://www.youtube.com/watch?v=iorKyMlASZc&t=2844s) at our Community Meetup, the thing all of these have in common is that they render your markup in a Node.js context to produce HTML. The difference is when (build or runtime) and how often.
 
 Redwood currently supports prerendering at _build_ time. So before you deploy your web side, Redwood will render your pages into HTML, and once the JavaScript has been loaded on the browser, the page becomes dynamic.
@@ -155,7 +155,7 @@ Sometimes you need more fine-grained control over whether something gets prerend
 - `useIsBrowser`
 - `isBrowser`
 
-:::tip Heads-up!
+:::tip[Heads-up!]
 If you're prerendering a page that uses a third-party library, make sure it's "universal". If it's not, try calling the library after doing a browser check using one of the utils above.
 
 Look for these key words when choosing a library: _universal module, SSR compatible, server compatible_&mdash;all these indicate that the library also works in Node.js.

--- a/docs/versioned_docs/version-8.x/quick-start.md
+++ b/docs/versioned_docs/version-8.x/quick-start.md
@@ -4,7 +4,7 @@ description: Redwood quick start
 
 # Quick Start
 
-:::info Prerequisites
+:::info[Prerequisites]
 
 - Redwood requires [Node.js](https://nodejs.org/en/) (=20.x) and [Yarn](https://yarnpkg.com/) (>=1.22.21)
 - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
@@ -17,7 +17,7 @@ Create a Redwood project with `yarn create redwood-app`:
 yarn create redwood-app my-redwood-project
 ```
 
-:::tip Prefer TypeScript?
+:::tip[Prefer TypeScript?]
 
 Redwood comes with full TypeScript support from the get-go:
 

--- a/docs/versioned_docs/version-8.x/router.md
+++ b/docs/versioned_docs/version-8.x/router.md
@@ -12,7 +12,7 @@ The router is designed to list all routes in a single file, with limited nesting
 
 The first thing you need is a `Router`. It will contain all of your routes. The router will attempt to match the current URL to each route in turn, and only render those with a matching `path`. The only exception to this is the `notfound` route, which can be placed anywhere in the list and only matches when no other routes do.
 
-:::note The `notfound` route can't be nested in a `Set`
+:::note[The `notfound` route can't be nested in a `Set`]
 
 If you want to wrap your custom notfound page in a `Layout`, then you should add the `Layout` to the page instead. See [customizing the NotFoundPage](#customizing-the-notfoundpage).
 
@@ -199,7 +199,7 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
-:::note Note about roles
+:::note[Note about roles]
 A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
 :::
 
@@ -846,7 +846,7 @@ export default RedwoodDevFatalErrorPage ||
 
 Note that if you're copy-pasting this example, it uses [Tailwind CSS](https://tailwindcss.com), so you'll have to set that up first. See the [setup ui](./cli-commands.md#setup-ui) CLI command to add it to your project.
 
-:::note Can I customize the development one?
+:::note[Can I customize the development one?]
 
 As it's part of the RedwoodJS framework, you can't _change_ the dev fatal error page, but you can always build your own that takes the same props. If there's a feature you want to add to the built-in version, let us know on the [forums](https://community.redwoodjs.com/).
 

--- a/docs/versioned_docs/version-8.x/seo-head.md
+++ b/docs/versioned_docs/version-8.x/seo-head.md
@@ -64,7 +64,7 @@ const AboutPage = () => {
 
 You can include any valid `<head>` tag in here that you like. However, Redwood also provides a utility component [&lt;Metadata&gt;](#setting-meta-tags-and-opengraph-directives-with-metadata).
 
-:::caution `<MetaTags>` Deprecation
+:::caution[`<MetaTags>` Deprecation]
 
 Prior to Redwood 6.6.0 this component was called `<MetaTags>` and had several special hard-coded props like `ogContentUrl`, which didn't properly map to the OpenGraph spec. We'll still render `<MetaTags>` for the foreseeable future, but it's deprecated and you should migrate to `<Metadata>` if you have an existing app.
 
@@ -76,7 +76,7 @@ Redwood uses [@dr.pogodin/react-helmet](https://github.com/birdofpreyru/react-he
 
 For example, if you set title in your Layout, and a title in your Page, it'll render the one in Page - this way you can override the tags you wish, while sharing the tags defined in Layout.
 
-:::info Bots & `<meta>` Tags
+:::info[Bots & `<meta>` Tags]
 
 For these headers to appear to bots and scrapers e.g. for twitter to show your title, you have to make sure your page is prerendered. If your content is static you can use Redwood's built-in [Prerender](prerender.md). For dynamic tags, check the [Dynamic head tags](#dynamic-tags)
 
@@ -284,7 +284,7 @@ We simplified some of the examples above by excluding the generated `<title>` an
 
 ```
 
-:::info Do I need to apply these same tags over and over in every page?
+:::info[Do I need to apply these same tags over and over in every page?]
 
 Some `<meta>` tags, like `charset` or `locale` are probably applicable to the entire site, in which case it would be simpler to just include these once in your `index.html` instead of having to set them manually on each and every page/cell of your site.
 
@@ -310,7 +310,7 @@ This should allow you to create a fairly full-featured set of `<meta>` tags with
 
 Bots will pick up our tags if we've prerendered the page, but what if we want to set the `<meta>` based on the output of the Cell?
 
-:::info Prerendering
+:::info[Prerendering]
 
 As of v3.x, Redwood supports prerendering your [Cells](https://redwoodjs.com/docs/cells) with the data you were querying. For more information please refer [to this section](https://redwoodjs.com/docs/prerender#cell-prerendering).
 

--- a/docs/versioned_docs/version-8.x/server-file.md
+++ b/docs/versioned_docs/version-8.x/server-file.md
@@ -176,7 +176,7 @@ const server = await createServer({
 server.register(myFastifyPlugin)
 ```
 
-:::note Fastify encapsulation
+:::note[Fastify encapsulation]
 
 Fastify is built around the concept of [encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/). It is important to note that redwood's API plugin cannot be mutated after it is registered, see [here](https://fastify.dev/docs/latest/Reference/Plugins/#asyncawait). This is why you must use the `configureApiServer` option to do as shown above.
 

--- a/docs/versioned_docs/version-8.x/serverless-functions.md
+++ b/docs/versioned_docs/version-8.x/serverless-functions.md
@@ -377,7 +377,7 @@ Want to learn more about webhooks? See a [Detailed discussion of webhooks](webho
 
 In the following example, we'll have the webhook interact with our app's database, so we can see how we can use **scenario testing** to create data that the handler can access and modify.
 
-:::tip **Why testing webhooks is hard**
+:::tip[**Why testing webhooks is hard**]
 
 Because your webhook is typically sent from a third-party's system, manually testing webhooks can be difficult. For one thing, you often have to create some kind of event in their system that will trigger the event -- and you'll often have to do that in a production environment with real data. Second, for each case you'll have to find data that represents each case and issue a hook for each -- which can take a lot of time and is tedious.
 

--- a/docs/versioned_docs/version-8.x/services.md
+++ b/docs/versioned_docs/version-8.x/services.md
@@ -792,7 +792,7 @@ How does a cache work? At its simplest, a cache is just a big chunk of memory or
 
 Why use a cache? If you have an expensive or time-consuming process in your service that doesn't change on every request, this is a great candidate. For example, for a store front, you may want to show the most popular products. This may be computed by a combination of purchases, views, time spent on the product page, social media posts, or a whole host of additional information. Aggregating this data may take seconds or more, but the list of popular products probably doesn't change that often. There's no reason to make every user wait all that time just to see the same list of products. With service caching, just wrap this computation in the `cache()` function, and give it an expiration time of 24 hours, and now the result is returned in milliseconds for every user (except the first one in a 24 hour period, it has to be computed from scratch and then stored in the cache again). You can even remove this first user's wait by "warming" the cache: trigging the service function by a process you run on the server, rather than by a user's first visit, on a 24 hour schedule so that it's the one that ends up waiting for the results to be computed.
 
-:::info What about GraphQL caching?
+:::info[What about GraphQL caching?]
 
 You could also cache data at the [GraphQL layer](https://community.redwoodjs.com/t/guide-power-of-graphql-caching/2624) which has some of the same benefits. Using Envelop plugins you can add a response cache _after_ your services (resolver functions in the context of GraphQL) run - with a global configuration.
 

--- a/docs/versioned_docs/version-8.x/testing.md
+++ b/docs/versioned_docs/version-8.x/testing.md
@@ -253,7 +253,7 @@ describe('Article', () => {
 
 This test (if it worked) would prove that you are indeed rendering an article. But it's also extremely brittle: any change to the component, even adding a `className` attribute for styling, will cause the test to break. That's not ideal, especially when you're just starting out building your components and will constantly be making changes as you improve them.
 
-:::info Why do we keep saying this test won't work?
+:::info[Why do we keep saying this test won't work?]
 Because as far as we can tell there's no easy way to simply render to a string. `render` actually returns an object that has several functions for testing different parts of the output. Those are what we'll look into in the next section.
 
 Note that Redwood's `render` function is based on React Testing Library's. The only difference is that Redwood's wraps everything with mock providers for the various providers in Redwood, such as auth, the GraphQL client, the router, etc.
@@ -1020,7 +1020,7 @@ describe('ArticleCell', () => {
 
 Note that this second mock simply returns an object instead of a function. In the simplest case all you need your mock to return is an object. But there are cases where you may want to include logic in your mock, and in these cases you'll appreciate the function container. Especially in the following scenario...
 
-:::tip important
+:::tip[important]
 If using [fragments](./graphql/fragments.md) it is important to include the `__typename` otherwise Apollo client will not be able to map the mocked data to the fragment attributes.
 :::
 
@@ -1295,7 +1295,7 @@ Does anyone else find it confusing that the software itself is called a "databas
 
 When you start your test suite you may notice some output from Prisma talking about migrating the database. Redwood will automatically run `yarn rw prisma db push` against your test database to make sure it's up-to-date.
 
-:::warning What if I have custom migration SQL?
+:::warning[What if I have custom migration SQL?]
 
 The `prisma db push` command only restores a snapshot of the current database schema (so that it runs as fast as possible). **It does not actually run migrations in sequence.** This can cause a [problem](https://github.com/redwoodjs/redwood/issues/5818) if you have certain database configuration that _must_ occur as a result of the SQL statements inside the migration files.
 
@@ -1798,7 +1798,7 @@ describeScenario<StandardScenario>('user query service', (getScenario) => {
 })
 ```
 
-:::tip Using named scenarios with describeScenario
+:::tip[Using named scenarios with describeScenario]
 
 If you have multiple scenarios, you can also use named scenario with `describeScenario`
 
@@ -1981,7 +1981,7 @@ scenario('returns a single product', async (scenario: StandardScenario) => {
   )
 ```
 
-:::info Serialized Objects in Cache
+:::info[Serialized Objects in Cache]
 Remember that the cache only ever contains serialized objects. So if you passed an object like this:
 
 ```js

--- a/docs/versioned_docs/version-8.x/tutorial/chapter1/first-page.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter1/first-page.md
@@ -13,7 +13,7 @@ The command above does four things:
 - Creates a Storybook file for this component at `web/src/pages/HomePage/HomePage.stories.{jsx,tsx}`. Storybook is a wonderful tool for efficiently developing and organizing UI components. (If you want to take a peek ahead, we learn about Storybook in [chapter 5 of the tutorial](../chapter5/storybook.md)).
 - Adds a `<Route>` in `web/src/Routes.{jsx,tsx}` that maps the path `/` to the new _HomePage_ page.
 
-:::info Automatic import of pages in the Routes file
+:::info[Automatic import of pages in the Routes file]
 
 If you look in Routes you'll notice that we're referencing a component, `HomePage`, that isn't imported anywhere. Redwood automatically imports all pages in the Routes file since we're going to need to reference them all anyway. It saves a potentially huge `import` declaration from cluttering up the routes file.
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter1/layouts.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter1/layouts.md
@@ -238,7 +238,7 @@ export default Routes
 </TabItem>
 </Tabs>
 
-:::info The `src` alias
+:::info[The `src` alias]
 
 Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/layouts/BlogLayout` or `./src/layouts/BlogLayout`. Being able to use just `src` is a convenience feature provided by Redwood: `src` is an alias to the `src` path in the current workspace. So if you're working in `web` then `src` points to `web/src` and in `api` it points to `api/src`.
 
@@ -246,7 +246,7 @@ Notice that the import statement uses `src/layouts/BlogLayout` and not `../src/l
 
 Back to the browser (you may need to manually refresh) and you should see...nothing different. But that's good, it means our layout is working!
 
-:::info Why are things named the way they are?
+:::info[Why are things named the way they are?]
 
 You may have noticed some duplication in Redwood's file names. Pages live in a directory called `/pages` and also contain `Page` in their name. Same with Layouts. What's the deal?
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter1/prerequisites.md
@@ -42,7 +42,7 @@ yarn --version
 
 Please do upgrade accordingly. Then proceed to the Redwood installation when you're ready!
 
-:::info Installing Node and Yarn
+:::info[Installing Node and Yarn]
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter1/second-page.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter1/second-page.md
@@ -8,7 +8,7 @@ yarn redwood generate page about
 
 Notice that we didn't specify a route path this time. If you leave it off the `redwood generate page` command, Redwood will create a `Route` and give it a path that is the same as the page name you specified, prepended with a slash. In this case it will be `/about`.
 
-:::info Code-splitting each page
+:::info[Code-splitting each page]
 
 As you add more pages to your app, you may start to worry that more and more code has to be downloaded by the client on any initial page load. Fear not! Redwood will automatically code-split on each Page, which means that initial page loads can be blazingly fast, and you can create as many Pages as you want without having to worry about impacting overall bundle size. If, however, you do want specific Pages to be included in the main bundle, you can [override the default behavior](../../router.md#not-code-splitting).
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter2/cells.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter2/cells.md
@@ -101,7 +101,7 @@ A guideline for when to use cells is if your component needs some data from the 
 
 <ShowForTs>
 
-:::tip Wait... what are those types?
+:::tip[Wait... what are those types?]
 
 Redwood comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
@@ -115,7 +115,7 @@ Also notice the `FindPosts` type imported from `types/graphql`. This and other t
 
 Usually in a blog the homepage will display a list of recent posts. This list is a perfect candidate for our first cell.
 
-:::info Wait, don't we already have a home page?
+:::info[Wait, don't we already have a home page?]
 
 We do, but you will generally want to use a _cell_ when you need data from the database. A best practice for Redwood is to create a Page for each unique URL your app has, but that you fetch and display data in Cells. So the existing HomePage will render this new cell as a child.
 
@@ -207,7 +207,7 @@ export const Success = ({
 </TabItem>
 </Tabs>
 
-:::info Indicating Multiplicity to the Cell Generator
+:::info[Indicating Multiplicity to the Cell Generator]
 
 When generating a cell you can use any case you'd like and Redwood will do the right thing when it comes to naming. These will all create the same filename (`web/src/components/BlogArticlesCell/BlogArticlesCell.{jsx,tsx}`):
 
@@ -348,7 +348,7 @@ export const Success = ({
 
 <ShowForTs>
 
-:::tip Using generated types
+:::tip[Using generated types]
 
 At this point, you might see an error in your Cell while trying to import from `types/graphql`: "The type ArticlesQuery does not exist"
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter2/getting-dynamic.md
@@ -49,7 +49,7 @@ This says that we want a table called `Post` and it should have:
 - A `body` field that will contain a `String`
 - A `createdAt` field that will be a `DateTime` and will `@default` to `now()` when we create a new record (so we don't have to set the time manually in our app, the database will do it for us)
 
-:::info Integer vs. String IDs
+:::info[Integer vs. String IDs]
 
 For the tutorial we're keeping things simple and using an integer for our ID column. Some apps may want to use a CUID or a UUID, which Prisma supports. In that case you would use `String` for the datatype instead of `Int` and use `cuid()` or `uuid()` instead of `autoincrement()`:
 
@@ -169,7 +169,7 @@ Pages and components/cells are nicely contained in `Post` directories to keep th
 
 Whew! That may seem like a lot of stuff but we wanted to follow best-practices and separate out common functionality into individual components, just like you'd do in a real app. Sure we could have crammed all of this functionality into a single component, but we wanted these scaffolds to set an example of good development habits: we have to practice what we preach!
 
-:::info Generator Naming Conventions
+:::info[Generator Naming Conventions]
 
 You'll notice that some of the generated parts have plural names and some have singular. This convention is borrowed from Ruby on Rails which uses a more "human" naming convention: if you're dealing with multiple of something (like the list of all posts) it will be plural. If you're only dealing with a single something (like creating a new post) it will be singular. It sounds natural when speaking, too: "show me a list of all the posts" and "I'm going to create a new post."
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter2/routing-params.md
@@ -186,7 +186,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 <ShowForTs>
 
-:::info Wait... why am I getting a TypeScript error?
+:::info[Wait... why am I getting a TypeScript error?]
 
 When you have your dev server running, the Redwood CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
 
@@ -491,7 +491,7 @@ What if you could request the conversion right in the route's path? Introducing 
 
 Voilà! Not only will this convert the `id` param to a number before passing it to your Page, it will prevent the route from matching unless the `id` path segment consists entirely of digits. If any non-digits are found, the router will keep trying other routes, eventually showing the `NotFoundPage` if no routes match.
 
-:::info What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?
+:::info[What if I want to pass some other prop to the cell that I don't need in the query, but do need in the Success/Loader/etc. components?]
 
 All of the props you give to the cell will be automatically available as props in the render components. Only the ones that match the GraphQL variables list will be given to the query. You get the best of both worlds! In our post display above, if you wanted to display some random number along with the post (for some contrived, tutorial-like reason), just pass that prop:
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter3/forms.md
@@ -1216,7 +1216,7 @@ export default ContactPage
 
 <img src="https://user-images.githubusercontent.com/300/146104647-25f1b2cf-a3cd-4737-aa2d-9aa984c08e39.png" />
 
-:::info Error styling
+:::info[Error styling]
 
 In addition to `className` and `errorClassName` you can also use `style` and `errorStyle`. Check out the [Form docs](../../forms.md) for more details on error styling.
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter3/saving-data.md
@@ -714,7 +714,7 @@ export default ContactPage
 
 <ShowForTs>
 
-:::tip Reminder about generated types
+:::tip[Reminder about generated types]
 
 Just a quick reminder that Redwood will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
 
@@ -926,7 +926,7 @@ Try filling out the form and submitting—you should have a new Contact in the d
 
 <img width="1410" alt="image" src="https://user-images.githubusercontent.com/32992335/161488540-a7ad1a57-7432-4171-bd75-500eeaa17bcb.png" />
 
-:::info Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?
+:::info[Wait, I thought you said this was secure by default and someone couldn't view all contacts without being logged in?]
 
 Remember: we haven't added authentication yet, so the concept of someone being logged in is meaningless right now. In order to prevent frustrating errors in a new application, the `@requireAuth` directive simply returns `true` until you setup an authentication system. At that point the directive will use real logic for determining if the user is logged in or not and behave accordingly.
 
@@ -1240,7 +1240,7 @@ Next we'll inform the user of any server errors. So far we've only notified the 
 
 We have email validation on the client, but any developer worth their silicon knows [never trust the client](https://www.codebyamir.com/blog/never-trust-data-from-the-browser). Let's add the email validation into the api side as well to be sure no bad data gets into our database, even if someone somehow bypassed our client-side validation (l33t hackers do this all the time).
 
-:::info No server-side validation for some fields?
+:::info[No server-side validation for some fields?]
 
 Why don't we need server-side validation for the existence of name, email and message? Because GraphQL is already doing that for us! You may remember the `String!` declaration in our SDL file for the `Contact` type: that adds a constraint that those fields cannot be `null` as soon as it arrives on the api side. If it is, GraphQL would reject the request and throw an error back to us on the client.
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter4/authentication.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter4/authentication.md
@@ -101,7 +101,7 @@ Redwood includes [integrations](../../authentication.md) for several of the most
 
 As for our blog, we're going to use self-hosted authentication (named _dbAuth_ in Redwood) since it's the simplest to get started with and doesn't involve any third party signups.
 
-:::info Authentication vs. Authorization
+:::info[Authentication vs. Authorization]
 
 There are two terms which contain a lot of letters, starting with an "A" and ending in "ation" (which means you could rhyme them if you wanted to) that become involved in most discussions about login:
 
@@ -458,7 +458,7 @@ We're back in business! Once you add authentication into your app you'll probabl
 
 Now that our pages are behind login, let's actually create a login page so that we can see them again.
 
-:::info Skipping auth altogether for `posts` and `post` feels bad somehow...
+:::info[Skipping auth altogether for `posts` and `post` feels bad somehow...]
 
 Ahh, good eye. While posts don't currently expose any particularly secret information, what if we eventually add a field like `publishStatus` where you could mark a post as `draft` so that it doesn't show on the homepage. But, if you knew enough about GraphQL, you could easily request all posts in the database and be able to read all the drafts!
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter5/first-test.md
@@ -218,7 +218,7 @@ expect(ellipsis).toBeInTheDocument()
 
 Assert that the ellipsis is present.
 
-:::info What's the difference between `getByText()` and `queryByText()`?
+:::info[What's the difference between `getByText()` and `queryByText()`?]
 
 `getByText()` will throw an error if the text isn't found in the document, whereas `queryByText()` will return `null` and let you continue with your testing (and is one way to test that some text is _not_ present on the page). You can read more about these in the [DOM Testing Library Queries](https://testing-library.com/docs/dom-testing-library/api-queries) docs.
 
@@ -232,7 +232,7 @@ To double check that we're testing what we think we're testing, open up `Article
 
 Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and is returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Redwood intercepts those GraphQL calls and returns the data from the mock instead.
 
-:::info If the server is being mocked, how do we test the api-side code?
+:::info[If the server is being mocked, how do we test the api-side code?]
 
 We'll get to that next when we create a new feature for our blog from scratch!
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter5/storybook.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter5/storybook.md
@@ -105,7 +105,7 @@ Components
 
 This makes it easy to create variants of your component and have them all displayed together.
 
-:::info Where did that sample blog post data come from?
+:::info[Where did that sample blog post data come from?]
 
 In your actual app you'd use this component like so:
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter6/comment-form.md
@@ -530,7 +530,7 @@ Now comes the ultimate test: creating a comment! LET'S DO IT:
 
 What happened here? Notice towards the end of the error message: `Field "postId" of required type "Int!" was not provided`. When we created our data schema we said that a post belongs to a comment via the `postId` field. And that field is required, so the GraphQL server is rejecting the request because we're not including that field. We're only sending `name` and `body`. Luckily we have access to the ID of the post we're commenting on thanks to the `article` object that's being passed into `Article` itself!
 
-:::info Why didn't the Storybook story we wrote earlier expose this problem?
+:::info[Why didn't the Storybook story we wrote earlier expose this problem?]
 
 We manually mocked the GraphQL response in the story, and our mock always returns a correct response, regardless of the input!
 
@@ -1261,7 +1261,7 @@ Now we'll try our comment query again, once with each `postId`:
 
 Great! Now that we've tested out the syntax let's use that in the service. You can exit the console by pressing Ctrl-C twice or typing `.exit`
 
-:::info Where's the `await`?
+:::info[Where's the `await`?]
 
 Calls to `db` return a Promise, which you would normally need to add an `await` to in order to get the results right away. Having to add `await` every time is pretty annoying though, so the Redwood console does it for you—Redwood `await`s so you don't have to!
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter6/comments-schema.md
@@ -553,7 +553,7 @@ describe('comments', () => {
 
 What is this `scenario()` function? That's made available by Redwood that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
-:::info In the section on mocks you said relying on data in the database for testing was dumb?
+:::info[In the section on mocks you said relying on data in the database for testing was dumb?]
 
 Yes, all things being equal it would be great to not have these tests depend on a piece of software outside of our control.
 
@@ -622,7 +622,7 @@ export const standard = defineScenario<Prisma.CommentCreateArgs>({
 
 This calls a `defineScenario()` function which checks that your data structure matches what's defined in Prisma. Each scenario data object (for example, `scenario.comment.one`) is passed as-is to Prisma's [`create`](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#create). That way you can customize the scenario object using any of Prisma's supported options.
 
-:::info The "standard" scenario
+:::info[The "standard" scenario]
 
 The exported scenario here is named "standard." Remember when we worked on component tests and mocks, there was a special mock named `standard` which Redwood would use by default if you didn't specify a name? The same rule applies here! When we add a test for `createComment()` we'll see an example of using a different scenario with a unique name.
 
@@ -638,7 +638,7 @@ The nested structure of a scenario is defined like this:
 
 When you receive the `scenario` argument in your test, the `data` key gets unwrapped so that you can reference fields like `scenario.comment.one.name`.
 
-:::info Why does every field just contain the string "String"?
+:::info[Why does every field just contain the string "String"?]
 
 When generating the service (and the test and scenarios) all we (Redwood) knows about your data is the types for each field as defined in `schema.prisma`, namely `String`, `Integer` or `DateTime`. So we add the simplest data possible that fulfills the type requirement by Prisma to get the data into the database. You should definitely replace this data with something that looks more like the real data your app will be expecting. In fact...
 
@@ -870,7 +870,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
+:::info[What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?]
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -901,7 +901,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the JavaScript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right _now_, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? `posts.bark`? Really?
+:::info[What's up with the names for scenario data? `posts.bark`? Really?]
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -917,7 +917,7 @@ If you said the second one, remember: you're not writing your code for the compu
 
 Okay, our comments service is feeling pretty solid now that we have our tests in place. The last step is add a form so that users can actually leave a comment on a blog post.
 
-:::info Mocks vs. Scenarios
+:::info[Mocks vs. Scenarios]
 
 Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter6/multiple-comments.md
@@ -4,7 +4,7 @@ Our amazing blog posts will obviously garner a huge and passionate fanbase and w
 
 Let's think about where our comments are being displayed. Probably not on the homepage, since that only shows a summary of each post. A user would need to go to the full page to show the comments for that blog post. But that page is only fetching the data for the single blog post itself, nothing else. We'll need to get the comments and since we'll be fetching _and_ displaying them, that sounds like a job for a Cell.
 
-:::info Couldn't the query for the blog post page also fetch the comments?
+:::info[Couldn't the query for the blog post page also fetch the comments?]
 
 Yes, it could! But the idea behind Cells is to make components even more [composable](https://en.wikipedia.org/wiki/Composability) by having them be responsible for their own data fetching _and_ display. If we rely on a blog post to fetch the comments then the new Comments component we're about to create now requires something _else_ to fetch the comments and pass them in. If we re-use the Comments component somewhere, now we're fetching comments in two different places.
 
@@ -191,7 +191,7 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info What's this `standard` thing?
+:::info[What's this `standard` thing?]
 
 Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in JavaScript!
 
@@ -326,7 +326,7 @@ export default Article
 
 If we are _not_ showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
+:::info[Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?]
 
 Redwood has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter6/the-redwood-way.md
@@ -309,7 +309,7 @@ If your tests aren't already running in another terminal window, you can start t
 yarn rw test
 ```
 
-:::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
+:::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]
 
 Yes, just like we'd have to change the truncation text if we changed the length of the truncation. One alternative approach to testing for the formatted output could be to move the date formatting formula into a function that you can export from the `Comment` component. Then you can import that in your test and use it to check the formatted output. Now if you change the formula the test keeps passing because it's sharing the function with `Comment`.
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter7/api-side-currentuser.md
@@ -57,7 +57,7 @@ model User {
 }
 ```
 
-:::info User SDL
+:::info[User SDL]
 We created a User model in Chapter 4 when we set up authentication for our blog. Redwood's `setup auth dbAuth` command generated two files for us that manage authentication: the `auth` file in `api/src/lib/`, and the `auth` file in `api/src/functions/`. Both of these files use our PrismaClient directly to work with the User model, so we didn't need to set up an SDL or services for the User model.
 
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
@@ -112,7 +112,7 @@ Whoops!
 
 Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
 
-:::warning Why don't we just set `@default(1)` in the schema?
+:::warning[Why don't we just set `@default(1)` in the schema?]
 
 This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
 
@@ -124,7 +124,7 @@ Since we're in development, let's just blow away the database and start over:
 yarn rw prisma migrate reset
 ```
 
-:::info Database Seeds
+:::info[Database Seeds]
 
 If you started the second half the tutorial from the [Redwood Tutorial repo](https://github.com/redwoodjs/redwood-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
 
@@ -198,7 +198,7 @@ To enable this we'll need to make two modifications on the api side:
   }
 ```
 
-:::info What about the mutations?
+:::info[What about the mutations?]
 
 We did _not_ add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
 
@@ -276,7 +276,7 @@ export const Post = {
 
 Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
 
-:::info Prisma and the N+1 Problem
+:::info[Prisma and the N+1 Problem]
 
 If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an _additional_ query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
 
@@ -462,7 +462,7 @@ export const Post = {
 }
 ```
 
-:::info Prisma's `findUnique()` vs. `findFirst()`
+:::info[Prisma's `findUnique()` vs. `findFirst()`]
 
 Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` _in addition_ to `userId`.
 

--- a/docs/versioned_docs/version-8.x/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-8.x/tutorial/chapter7/rbac.md
@@ -253,7 +253,7 @@ Now head back to [http://localhost:8910/admin/posts](http://localhost:8910/admin
 
 Let's create a new user that will represent the comment moderator. Since this is in development you can just make up an email address, but if you needed to do this in a real system that verified email addresses you could use **The Plus Trick** to create a new, unique email address that is actually the same as your original email address!
 
-:::tip The Plus Trick
+:::tip[The Plus Trick]
 
 The Plus Trick is a very handy feature of the email standard known as a "boxname", the idea being that you may have other incoming boxes besides one just named "Inbox" and by adding `+something` to your email address you can specify which box the mail should be sorted into. They don't appear to be in common use these days, but they are ridiculously helpful for us developers when we're constantly needing new email addresses for testing: it gives us an infinite number of _valid_ email addresses—they all come to your regular inbox!
 
@@ -780,7 +780,7 @@ export const moderatorView = () => {
 </TabItem>
 </Tabs>
 
-:::info Where did `mockCurrentUser()` come from?
+:::info[Where did `mockCurrentUser()` come from?]
 
 Similar to `mockGraphQLQuery()` and `mockGraphQLMutation()`, `mockCurrentUser()` is a global available in Storybook automatically, no need to import.
 
@@ -916,7 +916,7 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-:::warning Seeing errors in your test suite?
+:::warning[Seeing errors in your test suite?]
 
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 

--- a/docs/versioned_docs/version-8.x/tutorial/intermission.md
+++ b/docs/versioned_docs/version-8.x/tutorial/intermission.md
@@ -34,7 +34,7 @@ yarn rw dev
 
 If you haven't been through the first tutorial, or maybe you went through it on an older version of Redwood (anything pre-0.41) you can clone [this repo](https://github.com/redwoodjs/redwood-tutorial) which contains everything built so far and also adds a little styling so it isn't quite so...tough to look at. The example repo includes [TailwindCSS](https://tailwindcss.com) to style things up and adds a `<div>` or two to give us some additional hooks to hang styling on.
 
-:::warning The TypeScript version of the Example Repo is currently in progress
+:::warning[The TypeScript version of the Example Repo is currently in progress]
 
 If you want to complete the tutorial in TypeScript, continue with your own repo, making any necessary edits. Don't worry, the remainder of the tutorial continues to offer both TypeScript and JavaScript example code changes.
 

--- a/docs/versioned_docs/version-8.x/typescript/generated-types.md
+++ b/docs/versioned_docs/version-8.x/typescript/generated-types.md
@@ -15,7 +15,7 @@ yarn rw g types
 # yarn redwood generate types
 ```
 
-:::tip Getting errors trying to generate types?
+:::tip[Getting errors trying to generate types?]
 
 If you're getting errors trying to generate types, it's worth checking the GraphQL operations in your Cells and SDLs.
 Make sure that they're syntactically valid, and that every query and mutation on the web side is defined in an `*.sdl.js` file on the api side.
@@ -51,7 +51,7 @@ const getCurrentUser = ({ decoded }): MyCurrentUser => {
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
-:::info Type of `context.currentUser` unknown?
+:::info[Type of `context.currentUser` unknown?]
 This usually happens when you don't have the various generated and utility types in your project.
 Run `yarn rw g types`, and just to be sure, restart your TS server.
 In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
@@ -120,7 +120,7 @@ If the type doesn't match your Prisma models (by name), the TypeScript type will
 
 The resolver types help you by making sure you're returning an object in the shape of what you've defined in your SDL.
 
-:::note A note on union types
+:::note[A note on union types]
 
 Lets say that in one of your SDLs, you define a union type
 
@@ -149,7 +149,7 @@ Redwood uses [GraphQL Code Generator](https://www.graphql-code-generator.com) (a
 
 While the default settings are configured so that things just work️, you can customize them to your liking by adding a `./codegen.yml` file to the root of your project.
 
-:::info Curious about the defaults?
+:::info[Curious about the defaults?]
 
 You can find them [here](https://github.com/cedarjs/cedar/blob/main/packages/internal/src/generate/graphqlCodeGen.ts) in Redwood's source. Look for the `generateTypeDefGraphQLWeb` and `generateTypeDefGraphQLApi` functions.
 
@@ -198,7 +198,7 @@ Running `yarn rw g types` will generate types for your resolvers on a per-file b
    },
 ```
 
-:::tip Using VSCode?
+:::tip[Using VSCode?]
 
 As a part of type generation, the extension [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) configures itself based on the merged schema Redwood generates in `.redwood/schema.graphql`.
 You can configure it further in `graphql.config.js` at the root of your project.

--- a/docs/versioned_docs/version-8.x/typescript/strict-mode.md
+++ b/docs/versioned_docs/version-8.x/typescript/strict-mode.md
@@ -108,7 +108,7 @@ export const Post: PostRelationResolvers = {
 }
 ```
 
-:::tip An optimization tip
+:::tip[An optimization tip]
 
 If the relation truly is required, it may make more sense to include `author` in your `post` Service's Prisma query and modify the `Post.author` resolver accordingly:
 

--- a/docs/versioned_docs/version-8.x/uploads.md
+++ b/docs/versioned_docs/version-8.x/uploads.md
@@ -1,6 +1,6 @@
 # Uploads & Storage
 
-:::warning Experimental
+:::warning[Experimental]
 
 The storage and upload functionality is currently experimental.
 


### PR DESCRIPTION
## Summary

Converts all admonition blocks that use the old space-separated title syntax to the new bracket syntax required by Docusaurus v4.

**Before:** `:::info Prerequisites`
**After:** `:::info[Prerequisites]`

With `future.v4: true` in `docusaurus.config.ts`, the `mdx1Compat.admonitions` preprocessor is disabled by default — meaning the old `:::info Title` format is no longer auto-converted before remark-directive parsing, causing callout boxes to render as literal text.

This migrates all 851 affected files (current docs + versioned docs) to the bracket syntax, fixing the rendering without relying on the compatibility shim.