### PR TITLE
docs(tutorial): update chapters 3 & 4 to use Cedar CLI commands

### DIFF
--- a/docs/docs/tutorial/chapter3/forms.md
+++ b/docs/docs/tutorial/chapter3/forms.md
@@ -21,7 +21,7 @@ Let's build the simplest form that still makes sense for our blog, a "Contact Us
 ### The Page
 
 ```bash
-yarn rw g page contact
+yarn cedar g page contact
 ```
 
 We can put a link to Contact in our layout's header:

--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -44,7 +44,7 @@ To mark a field as optional (that is, allowing `NULL` as a value) you can suffix
 Next we create and apply a migration:
 
 ```bash
-yarn rw prisma migrate dev
+yarn cedar prisma migrate dev
 ```
 
 We can name this one something like "create contact".
@@ -54,7 +54,7 @@ We can name this one something like "create contact".
 Now we'll create the GraphQL interface to access this table. We haven't used this `generate` command yet (although the `scaffold` command did use it behind the scenes):
 
 ```bash
-yarn rw g sdl Contact
+yarn cedar g sdl Contact
 ```
 
 Just like the `scaffold` command, this will create a few new files under the `api` directory:
@@ -169,7 +169,7 @@ As described in [Side Quest: How Cedar Deals with Data](../chapter2/side-quest.m
 
 _Psssstttt_ I'll let you in on a little secret: if you just need a simple read-only SDL, you can skip creating the create/update/delete mutations by passing a flag to the SDL generator like so:
 
-`yarn rw g sdl Contact --no-crud`
+`yarn cedar g sdl Contact --no-crud`
 
 You'd only get a single `contacts` type to return them all.
 
@@ -335,13 +335,13 @@ Pretty simple. You can see here how the `createContact()` function expects the `
 
 You can delete `updateContact` and `deleteContact` here if you want, but since there's no longer an accessible GraphQL field for them they can't be used by the client anyway.
 
-Before we plug this into the UI, let's take a look at a nifty GUI you get just by running `yarn redwood dev`.
+Before we plug this into the UI, let's take a look at a nifty GUI you get just by running `yarn cedar dev`.
 
 ### GraphQL Playground
 
 Often it's nice to experiment and call your API in a more "raw" form before you get too far down the path of implementation only to find out something is missing. Is there a typo in the API layer or the web layer? Let's find out by accessing just the API layer.
 
-When you started development with `yarn redwood dev` (or `yarn rw dev`) you actually started a second process running at the same time. Open a new browser tab and head to [http://localhost:8911/graphql](http://localhost:8911/graphql) This is GraphQL Yoga's [GraphiQL](https://www.graphql-yoga.com/docs/features/graphiql), a web-based GUI for GraphQL APIs:
+When you started development with `yarn cedar dev` you actually started a second process running at the same time. Open a new browser tab and head to [http://localhost:8911/graphql](http://localhost:8911/graphql) This is GraphQL Yoga's [GraphiQL](https://www.graphql-yoga.com/docs/features/graphiql), a web-based GUI for GraphQL APIs:
 
 <img
   width="1410"
@@ -730,7 +730,7 @@ export default ContactPage
 
 :::tip Reminder about generated types
 
-Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn rw generate types`).
+Just a quick reminder that Cedar will automatically generate types for your GraphQL queries and mutations if you have the dev server running (or if you run `yarn cedar generate types`).
 
 Once you define the `CreateContactMutation` (the GraphQL one), Cedar will generate the `CreateContactMutation` and `CreateContactMutationVariables` types from it for you.
 

--- a/docs/docs/tutorial/chapter4/authentication.md
+++ b/docs/docs/tutorial/chapter4/authentication.md
@@ -124,7 +124,7 @@ As you probably have guessed, Cedar has a couple of generators to get you going.
 Run this setup command to get the internals of dbAuth added to our app:
 
 ```bash
-yarn rw setup auth dbAuth
+yarn cedar setup auth dbAuth
 ```
 
 When prompted to "Enable WebAuthn support", pick no—this is a separate piece of functionality we won't need for the tutorial. You'll see that the process creates several files and includes some post-install instructions for the last couple of customizations you'll need to make. Let's go through them now.
@@ -186,7 +186,7 @@ This gives us a user with a name and email, as well as four fields that dbAuth w
 Let's create the user model by migrating the database, naming it something like "create user":
 
 ```bash
-yarn rw prisma migrate dev
+yarn cedar prisma migrate dev
 ```
 
 That's it for the database setup!
@@ -473,7 +473,7 @@ It would be more future-proof to create a _new_ endpoint for public display of p
 Yet another generator is here for you, this time one that will create pages for login, signup and forgot password pages:
 
 ```bash
-yarn rw g dbAuth
+yarn cedar g dbAuth
 ```
 
 :::warning
@@ -894,7 +894,7 @@ Before we leave this file, take a look at `requireAuth()`. Remember when we talk
 
 After the initial `setup` command, which installed dbAuth, you may have noticed that an edit was made to the `.env` file in the root of your project. The `setup` script appended a new ENV var called `SESSION_SECRET` along with a big random string of numbers and letters. This is the encryption key for the cookies that are stored in the user's browser when they log in. This secret should never be shared, never checked into your repo, and should be re-generated for each environment you deploy to.
 
-You can generate a new value with the `yarn rw g secret` command. It only outputs it to the terminal, you'll need to copy/paste to your `.env` file. Note that if you change this secret in a production environment, all users will be logged out on their next request because the cookie they currently have cannot be decrypted with the new key! They'll need to log in again to a new cookie encrypted with the new key.
+You can generate a new value with the `yarn cedar g secret` command. It only outputs it to the terminal, you'll need to copy/paste to your `.env` file. Note that if you change this secret in a production environment, all users will be logged out on their next request because the cookie they currently have cannot be decrypted with the new key! They'll need to log in again to a new cookie encrypted with the new key.
 
 ## Wrapping Up
 

--- a/docs/docs/tutorial/chapter4/deployment.md
+++ b/docs/docs/tutorial/chapter4/deployment.md
@@ -171,11 +171,11 @@ If you view a deploy via the **Preview** button notice that the URL contains a h
 
 Did it work? If you see "Empty" under the About and Contact links then it did! Yay! You're seeing "Empty" because you don't have any posts in your brand new production database so head to `/admin/posts` and create a couple, then go back to the homepage to see them.
 
-If the deploy failed, check the log output in Netlify and see if you can make sense of the error. If the deploy was successful but the site doesn't come up, try opening the web inspector and look for errors. Are you sure you pasted the entire Postgres connection string correctly? If you're really, really stuck head over to the [Cedar Community](https://community.redwoodjs.com) and ask for help.
+If the deploy failed, check the log output in Netlify and see if you can make sense of the error. If the deploy was successful but the site doesn't come up, try opening the web inspector and look for errors. Are you sure you pasted the entire Postgres connection string correctly? If you're really, really stuck head over to the [Cedar Discord](https://cedarjs.com/discord) and ask for help.
 
 #### Custom Subdomain
 
-You can customize the subdomain that your site is published at (who wants to go to `agitated-mongoose-849e99.netlify.app`??) by going to **Site Settings > Domain Management > Domains > Custom Domains**. Open up the **Options** menu and select **Edit site name**. Your site should be available at your custom subdomain (`redwood-tutorial.netlify.app` is much nicer) almost immediately.
+You can customize the subdomain that your site is published at (who wants to go to `agitated-mongoose-849e99.netlify.app`??) by going to **Site Settings > Domain Management > Domains > Custom Domains**. Open up the **Options** menu and select **Edit site name**. Your site should be available at your custom subdomain (`cedar-tutorial.netlify.app` is much nicer) almost immediately.
 
 ![image](https://user-images.githubusercontent.com/300/154521450-ee64c77c-e658-4045-9dd6-119858b6739e.png)
 


### PR DESCRIPTION
## Summary

- Replace all `yarn rw` / `yarn redwood` references with `yarn cedar` in tutorial chapters 3 & 4
- Update community link from `community.redwoodjs.com` to Cedar Discord
- Change example deployment URL from `redwood-tutorial.netlify.app` to `cedar-tutorial.netlify.app`

**Files changed:**
- `docs/docs/tutorial/chapter3/forms.md` — 1 CLI reference
- `docs/docs/tutorial/chapter3/saving-data.md` — 5 CLI references
- `docs/docs/tutorial/chapter4/authentication.md` — 4 CLI references
- `docs/docs/tutorial/chapter4/deployment.md` — community link + example URL