### PR TITLE
fix(ud): Deps correction. Explicitly depend on srvx

### DIFF
--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -146,7 +146,6 @@
     "@cedarjs/web-server": "workspace:*",
     "@fastify/multipart": "9.4.0",
     "@fastify/url-data": "6.0.3",
-    "@universal-deploy/node": "^0.1.6",
     "ansis": "4.2.0",
     "chokidar": "3.6.0",
     "dotenv-defaults": "5.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -83,6 +83,7 @@
     "rimraf": "6.1.3",
     "semver": "7.7.4",
     "smol-toml": "1.6.1",
+    "srvx": "0.11.15",
     "string-env-interpolation": "1.0.1",
     "systeminformation": "5.31.5",
     "termi-link": "1.1.0",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -113,7 +113,6 @@
     "@cedarjs/web": "workspace:*",
     "@fastify/url-data": "6.0.3",
     "@swc/core": "1.15.33",
-    "@universal-deploy/node": "^0.1.6",
     "@universal-deploy/store": "^0.2.1",
     "@universal-deploy/vite": "^0.1.9",
     "@vitejs/plugin-react": "4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2184,7 +2184,6 @@ __metadata:
     "@types/dotenv-defaults": "npm:^5.0.0"
     "@types/split2": "npm:4.2.3"
     "@types/yargs": "npm:17.0.35"
-    "@universal-deploy/node": "npm:^0.1.6"
     ansis: "npm:4.2.0"
     chokidar: "npm:3.6.0"
     dotenv-defaults: "npm:5.0.2"
@@ -2953,6 +2952,7 @@ __metadata:
     rimraf: "npm:6.1.3"
     semver: "npm:7.7.4"
     smol-toml: "npm:1.6.1"
+    srvx: "npm:0.11.15"
     string-env-interpolation: "npm:1.0.1"
     systeminformation: "npm:5.31.5"
     termi-link: "npm:1.1.0"
@@ -3791,7 +3791,6 @@ __metadata:
     "@types/react": "npm:^18.2.55"
     "@types/ws": "npm:^8"
     "@types/yargs-parser": "npm:21.0.3"
-    "@universal-deploy/node": "npm:^0.1.6"
     "@universal-deploy/store": "npm:^0.2.1"
     "@universal-deploy/vite": "npm:^0.1.9"
     "@vitejs/plugin-react": "npm:4.7.0"
@@ -26540,7 +26539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"srvx@npm:*, srvx@npm:^0.11.9":
+"srvx@npm:*, srvx@npm:0.11.15, srvx@npm:^0.11.9":
   version: 0.11.15
   resolution: "srvx@npm:0.11.15"
   bin:


### PR DESCRIPTION
We now explicitly use srvx from the cli package. This should be reflected in our deps. We also no longer directly use `@universal-deploy/node`