### PR TITLE
fix(ci): log stderr when yarn cedar g secret fails on Windows

### DIFF
--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -4,9 +4,7 @@ import path from 'node:path'
 interface Args {
   setOutput: (key: string, value: string) => void
   getInput: (key: string) => string
-  createExecWithEnvInCwd: (
-    cwd: string,
-  ) => (
+  createExecWithEnvInCwd: (cwd: string) => (
     command: string,
     options?: {
       silent?: boolean

--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -8,12 +8,16 @@ interface Args {
     cwd: string,
   ) => (
     command: string,
-    options?: { silent?: boolean; input?: Buffer },
-  ) => Promise<{ stdout: string; stderr: string }>
+    options?: {
+      silent?: boolean
+      input?: Buffer
+      ignoreReturnCode?: boolean
+    },
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>
   execInFramework: (
     command: string,
     options?: { env?: Record<string, string> },
-  ) => Promise<{ stdout: string; stderr: string }>
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>
   cedarFrameworkPath: string
   testProjectPath: string
 }
@@ -63,12 +67,23 @@ export async function setUpTestProject({
   })
 
   console.log('Generating dbAuth secret')
-  const { stdout } = await execInProject('yarn cedar g secret --raw', {
+  const secretResult = await execInProject('yarn cedar g secret --raw', {
     silent: true,
+    ignoreReturnCode: true,
   })
+  if (secretResult.exitCode !== 0) {
+    console.error(
+      `yarn cedar g secret --raw failed with exit code ${secretResult.exitCode}`,
+    )
+    console.error('stdout:', secretResult.stdout || '(empty)')
+    console.error('stderr:', secretResult.stderr || '(empty)')
+    throw new Error(
+      `yarn cedar g secret --raw failed with exit code ${secretResult.exitCode}`,
+    )
+  }
   fs.appendFileSync(
     path.join(testProjectPath, '.env'),
-    `SESSION_SECRET='${stdout}'`,
+    `SESSION_SECRET='${secretResult.stdout}'`,
   )
   console.log()
 

--- a/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
@@ -639,3 +639,70 @@ This failure mode (RSC project yarn install) has not been seen in prior runs.
 Could be a transient network issue, a lockfile incompatibility introduced by
 the version bump, or a hardened mode lockfile check rejection on the freshly
 scaffolded project's lockfile.
+
+---
+
+## Update 2026-05-15 — 4th occurrence of "Generating dbAuth secret" failure + debug improvement
+
+### New occurrence
+
+From run
+[25841578454](https://github.com/cedarjs/cedar/actions/runs/25841578454/job/75927972987)
+(PR #1773 `feat(gqlorm)`, Background jobs E2E on Windows):
+
+```
+$ cd D:\a\cedar\test-project
+$ yarn install
+➤ YN0000: ┌ Resolution step
+Generating dbAuth secret
+Error: The process 'C:\npm\prefix\yarn.cmd' failed with exit code 1
+    at ExecState._setResult (D:\a\cedar\cedar\node_modules\@actions\exec\lib\toolrunner.js:600:25)
+```
+
+Same pattern as runs 25732654425, 25850869052, and 25856361532 (PRs #1757,
+#1775, #1778). This is now the 4th occurrence across 4 different unrelated PRs,
+confirming it is a recurring environmental failure on Windows CI.
+
+### What's actually failing
+
+Despite the log appearance suggesting `yarn install` is the culprit, the failure
+is in `yarn cedar g secret --raw`, not in `yarn install`. The sequence inside the
+`set-up-test-project` action is:
+
+1. `yarn project:tarsync --verbose` runs (which internally calls `yarn install`
+   in the test project — this is the "Resolution step" shown in the log)
+2. `console.log('Generating dbAuth secret')` fires **after** tarsync finishes
+3. `yarn cedar g secret --raw` runs and fails with exit code 1 in ~0.5 seconds
+
+The `yarn install` output from step 1 and the "Generating dbAuth secret" line
+from step 2 appear interleaved in the GitHub Actions log due to log group
+handling — this is misleading.
+
+The actual failure in `yarn cedar g secret --raw` was invisible because it was
+called with `silent: true`, which buffers stdout/stderr but doesn't stream them.
+When `getExecOutput` throws on non-zero exit code, the buffered output is
+discarded — so nothing about the actual error was logged.
+
+### Debug improvement applied
+
+Changed `.github/actions/set-up-test-project/setUpTestProject.mts`:
+
+- Call `yarn cedar g secret --raw` with `ignoreReturnCode: true` instead of
+  relying on the default throw behaviour
+- On non-zero exit, explicitly log captured `stdout` and `stderr` before
+  throwing a descriptive error
+- Updated the `Args` TypeScript interface to expose `ignoreReturnCode?: boolean`
+  in options and `exitCode: number` in the return type (the underlying
+  `@actions/exec` `getExecOutput` already supports and returns both — the
+  interface was just incomplete)
+
+The next time this fails, the actual error output from yarn/Cedar CLI will be
+visible in the CI log.
+
+### Possible causes (still unknown)
+
+- A module resolution error in the Cedar CLI when loading the `g secret` command
+- A Windows path or permission issue with yarn's shim (`C:\npm\prefix\yarn.cmd`)
+- A race condition or lock contention from the preceding `yarn install` not fully
+  releasing file locks before `yarn cedar` starts
+- A transient yarn registry or filesystem error on the Windows runner


### PR DESCRIPTION
## Summary

Fixes a recurring flaky CI failure where `yarn cedar g secret --raw` exits with code 1 on Windows (seen in PRs #1757, #1775, #1778, #1773) but produces **no visible diagnostic output** — making it impossible to debug.

**Root cause of the silence:** the command was called with `silent: true`. When `getExecOutput` from `@actions/exec` throws on a non-zero exit code, the buffered stdout/stderr are discarded — so nothing about the actual failure was ever logged.

## Changes

**`.github/actions/set-up-test-project/setUpTestProject.mts`**
- Switch `yarn cedar g secret --raw` from `silent: true` to `ignoreReturnCode: true`
- Manually check the exit code and log captured `stdout` + `stderr` before re-throwing
- Update the `Args` TypeScript interface to expose `ignoreReturnCode?: boolean` in options and `exitCode: number` in the return type (the underlying `getExecOutput` already supports/returns both — the interface was just incomplete)

**`docs/implementation-plans/flaky-windows-smoke-tests-investigation.md`**
- Documents this as the 4th occurrence across 4 unrelated PRs
- Clarifies what's actually failing: `yarn cedar g secret --raw` (not `yarn install` — the log interleaving is misleading)
- Notes the debug improvement applied

## What this doesn't fix

The underlying cause of `yarn cedar g secret --raw` failing on Windows is still unknown. This PR just ensures the next failure will show the actual error output so we can diagnose it.