### PR TITLE
feat(ud): --apiRootPath support for build

### DIFF
--- a/docs/implementation-plans/universal-deploy-serve-refactoring.md
+++ b/docs/implementation-plans/universal-deploy-serve-refactoring.md
@@ -255,7 +255,7 @@ From the current code:
   hosts it with srvx via `startUDServer()`.
 - `cedar serve --ud` cleans up unused `net` import and `waitForPort`.
 
-The key change is architectural: \*\*build produces a Fetchable, serve wraps the
+The key change is architectural: **build produces a Fetchable, serve wraps the Fetchable**.
 
 ## Target state
 

--- a/docs/implementation-plans/universal-deploy-serve-refactoring.md
+++ b/docs/implementation-plans/universal-deploy-serve-refactoring.md
@@ -182,21 +182,80 @@ artifacts alongside Cedar's canonical one.
 - Using `universalDeploy()` and stripping the server startup code post-build
   — fragile and version-dependent.
 
+### `cedarUniversalDeployPlugin` is user-owned, not auto-injected
+
+**Date:** 2026-05-15
+
+**Context:** Earlier implementations had `buildUDApiServer()` inject
+`cedarUniversalDeployPlugin()` directly, so users didn't need to remember to
+add it to their vite config.
+
+**Decision:** Do not inject the plugin. The user must include
+`cedarUniversalDeployPlugin()` in their vite config alongside their provider
+plugins.
+
+**Rationale:** Auto-injection creates a silent conflict when the user also
+has `cedarUniversalDeployPlugin({ apiRootPath: '/foo' })` in their config.
+Our injected instance uses the default `apiRootPath: '/'`, calls
+`clearCedarEntries()`, and re-registers all routes with `/` — silently
+overwriting the user's prefix. The only safe approach is to let the user own
+the plugin instance. The `cedar-ud-verify-routes` warning catches the case
+where the plugin was forgotten entirely.
+
+**Consequences:**
+
+- Users who scaffold a new Cedar app need `cedarUniversalDeployPlugin()` in
+  their vite config for `--ud` builds. This should be included in project
+  templates and setup commands.
+- No conflicts or silent overwrites regardless of the user's `apiRootPath`.
+- The `cedar-ud-verify-routes` warning provides a clear error message if the
+  plugin is missing.
+
+### `apiRootPath` CLI flag overrides the plugin's value
+
+**Date:** 2026-05-15
+
+**Context:** The `apiRootPath` option on `cedarUniversalDeployPlugin()` is the
+user's vite-config source of truth — checked into the repo, shared by the team.
+But CI/deploy scenarios often need a different prefix (e.g., staging behind a
+gateway path) without editing vite config. The `build` command doesn't define
+`--apiRootPath`, so there's no way to override at build time.
+
+**Decision:** Add `--apiRootPath` to `cedar build` and wire it through to
+`buildUDApiServer()`, which sets `process.env.CEDAR_API_ROOT_PATH` before
+calling `vite.build()`. The plugin reads that env var as an override — if set,
+it wins over the plugin's option value.
+
+The template default stays in the user's config; the CLI flag is for
+one-off/CI overrides. `cedar serve --ud` does not get `--apiRootPath` (per the
+serve-time prefix verboten rule), and is correct by construction since the
+prefix is baked into the artifact.
+
+**Rationale:** An env var is the simplest mechanism that works across the
+plugin/Vite boundary without changing the plugin's API. No dead options on
+`buildUDApiServer` — it forwards CLI input to the env var. No conflicts,
+because the env var source is unambiguous: present means override, absent
+means use plugin config.
+
+**Consequences:**
+
+- `cedar build --ud --apiRootPath /foo` produces routes under `/foo/`.
+- `cedar serve --ud` serves the artifact as-built, no remapping.
+- The plugin still works standalone in dev mode with its own config.
+- CI can set a different prefix without modifying tracked files.
+
 ## Current state
 
 From the current code:
 
-- `packages/vite/src/buildUDApiServer.ts` already builds an adapter-free entry
-  with `cedarUniversalDeployPlugin()`, `catchAll()`, and `devServer()`.
-- `packages/cli/src/commands/serve.ts` still assumes the built UD entry is a
-  self-starting Node server and uses `fork()` to launch it.
-- `cedar serve --ud` currently uses two ports in the implementation: Fastify
-  serves web on one port and proxies to a forked UD API process on another
-  port.
-- `cedar serve api --ud` also forks the built UD entry as a child process.
+- `packages/vite/src/buildUDApiServer.ts` builds an adapter-free entry with
+  `catchAll()` and `devServer()`. The user's config (loaded via `configFile`)
+  provides `cedarUniversalDeployPlugin()`.
+- `packages/cli/src/commands/serve.ts` imports the Fetchable in-process and
+  hosts it with srvx via `startUDServer()`.
+- `cedar serve --ud` cleans up unused `net` import and `waitForPort`.
 
-So the build side is already partly aligned, while the serve side still targets
-an older self-starting-artifact model.
+The key change is architectural: \*\*build produces a Fetchable, serve wraps the
 
 ## Target state
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -50,6 +50,13 @@ export const builder = (yargs: Argv) => {
       default: false,
       description: 'Build the Universal Deploy server entry (api/dist/ud/).',
     })
+    .option('apiRootPath', {
+      type: 'string',
+      description:
+        'Root path where API functions are served. Overrides the ' +
+        'apiRootPath option on cedarUniversalDeployPlugin() in your ' +
+        'vite config. Defaults to "/".',
+    })
     .middleware(() => {
       const check = checkNodeVersion()
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -76,6 +76,15 @@ export const builder = (yargs: Argv) => {
         return 'Workspace must be an array'
       }
 
+      // --apiRootPath requires --ud; silently ignoring it would be confusing
+      if (argv.apiRootPath && !argv.ud) {
+        return (
+          c.error('Error:') +
+          ' --apiRootPath requires --ud.\n' +
+          '  Use --ud to build the Universal Deploy server entry.'
+        )
+      }
+
       // Remove all default workspace names and then check if there are any
       // remaining workspaces to build. This is an optimization to avoid calling
       // `workspaces({ includePackages: true }) as that's a somewhat expensive

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -121,6 +121,7 @@ export interface BuildHandlerOptions {
   prisma?: boolean
   prerender?: boolean
   ud?: boolean
+  apiRootPath?: string
 }
 
 export const handler = async ({
@@ -129,6 +130,7 @@ export const handler = async ({
   prisma = true,
   prerender = true,
   ud = false,
+  apiRootPath,
 }: BuildHandlerOptions) => {
   recordTelemetryAttributes({
     command: 'build',
@@ -136,6 +138,7 @@ export const handler = async ({
     verbose,
     prisma,
     prerender,
+    apiRootPath,
   })
 
   const cedarPaths: Paths = getPaths()
@@ -396,7 +399,7 @@ export const handler = async ({
       workspace.includes('api') && {
         title: 'Bundling API server entry (Universal Deploy)...',
         task: async () => {
-          await buildUDApiServer({ verbose })
+          await buildUDApiServer({ verbose, apiRootPath })
         },
       },
   ].filter((t): t is ListrTask => Boolean(t))

--- a/packages/vite/src/buildUDApiServer.ts
+++ b/packages/vite/src/buildUDApiServer.ts
@@ -15,11 +15,13 @@ export interface BuildUDApiServerOptions {
  * contains NO HTTP server startup code — the Fetchable is wrapped by
  * `cedar serve` at runtime.
  *
- * Loads the user's Vite config (`web/vite.config.ts`) so provider plugins
- * (Netlify, Vercel, etc.) can produce their own deployment artifacts
- * alongside Cedar's canonical local-serve artifact. Cedar's own UD plugins
- * (`cedarUniversalDeployPlugin`, `catchAll`, `devServer`) are injected
- * independently and are not affected by user config.
+ * Loads the user's Vite config (`web/vite.config.ts`) so both provider
+ * plugins (Netlify, Vercel, etc.) and Cedar's own UD plugin
+ * (`cedarUniversalDeployPlugin`) run during the build.
+ * Provider plugins produce their own deployment artifacts alongside Cedar's UD
+ * output.
+ * The user must include `cedarUniversalDeployPlugin()` in their Vite config to
+ * register API routes.
  *
  * The emitted server entry is placed under `api/dist/ud/` so it does not
  * collide with the existing esbuild output under `api/dist/`.
@@ -29,13 +31,11 @@ export interface BuildUDApiServerOptions {
  * simply means Vite produces a Node-compatible bundle rather than a browser
  * bundle.
  */
-export const buildUDApiServer = async ({
+export async function buildUDApiServer({
   verbose = false,
   apiRootPath,
-}: BuildUDApiServerOptions = {}) => {
+}: BuildUDApiServerOptions = {}) {
   const { build } = await import('vite')
-  const { cedarUniversalDeployPlugin } =
-    await import('./plugins/vite-plugin-cedar-universal-deploy.js')
   const { catchAll, devServer } = await import('@universal-deploy/vite')
   const { catchAllEntry, getAllEntries } =
     await import('@universal-deploy/store')
@@ -46,63 +46,73 @@ export const buildUDApiServer = async ({
   // collide with the existing esbuild output under api/dist/.
   const outDir = path.join(cedarPaths.api.dist, 'ud')
 
-  await build({
-    // Load the user's Vite config so provider plugins can run alongside
-    // Cedar's canonical UD build.
-    configFile: cedarPaths.web.viteConfig,
-    logLevel: verbose ? 'info' : 'warn',
+  // When --apiRootPath is passed via CLI, propagate it to the plugin via
+  // an env var so the plugin can override whatever value was set in the
+  // user's vite config. This avoids modifying the opaque plugin instance
+  // after vite loads the user's configFile.
+  if (apiRootPath !== undefined) {
+    process.env.CEDAR_API_ROOT_PATH = apiRootPath
+  }
 
-    plugins: [
-      // Registers per-route API entries with @universal-deploy/store.
-      // The apiRootPath is baked into the generated route patterns by
-      // cedarUniversalDeployPlugin's normaliseApiPrefix helper.
-      cedarUniversalDeployPlugin({ apiRootPath }),
+  try {
+    await build({
+      // Load the user's Vite config so all plugins (Cedar's UD plugin,
+      // provider plugins, etc.) run during the build.
+      configFile: cedarPaths.web.viteConfig,
+      logLevel: verbose ? 'info' : 'warn',
 
-      // catchAll() generates the rou3-based route dispatcher
-      // (virtual:ud:catch-all). devServer() provides Vite dev support for
-      // cedar dev --ud.
-      //
-      // NOTE: We intentionally do NOT use universalDeploy() here — that
-      // plugin auto-detects deployment targets and would embed the Node
-      // HTTP server startup code into the output. Our plugin list is
-      // adapter-free: the output is a pure Fetchable export, and cedar
-      // serve wraps it in srvx at runtime.
-      catchAll(),
-      devServer(),
+      plugins: [
+        // catchAll() generates the rou3-based route dispatcher
+        // (virtual:ud:catch-all). devServer() provides Vite dev support for
+        // cedar dev --ud.
+        //
+        // NOTE: We intentionally do NOT use universalDeploy() here — that
+        // plugin auto-detects deployment targets and would embed the Node
+        // HTTP server startup code into the output. Our plugin list is
+        // adapter-free: the output is a pure Fetchable export, and cedar
+        // serve wraps it in srvx at runtime.
+        catchAll(),
+        devServer(),
 
-      // Warn if no Cedar API routes were registered — likely means the
-      // user's vite config is missing cedarUniversalDeployPlugin or there
-      // are no API functions to serve.
-      {
-        name: 'cedar-ud-verify-routes',
-        configResolved() {
-          const entries = getAllEntries()
-          if (entries.length === 0) {
-            console.warn(
-              '\n  Warning: No Universal Deploy API routes were registered.',
-              '\n  The built server entry will be an empty router (404 for all',
-              '\n  requests). Check that you have API functions under',
-              '\n  `api/src/functions/`.\n',
-            )
-          }
+        // Warn if no Cedar API routes were registered — likely means the
+        // user's vite config is missing cedarUniversalDeployPlugin or there
+        // are no API functions to serve.
+        {
+          name: 'cedar-ud-verify-routes',
+          configResolved() {
+            const entries = getAllEntries()
+            if (entries.length === 0) {
+              console.warn(
+                '\n  Warning: No Universal Deploy API routes were registered.',
+                '\n  The built server entry will be an empty router (404 for all',
+                '\n  requests). Check that you have API functions under',
+                '\n  `api/src/functions/` and that your vite config includes',
+                '\n  `cedarUniversalDeployPlugin()`.\n',
+              )
+            }
+          },
+        },
+      ],
+
+      // Legacy ssr flag approach. The explicit rollupOptions.input prevents the
+      // "index.html as SSR entry" error. Vite will also build a 'client'
+      // environment from the user's config file (wasteful but harmless), and
+      // the 'ssr' environment produces our canonical Fetchable artifact at
+      // api/dist/ud/index.js.
+      build: {
+        ssr: true,
+        outDir,
+        rollupOptions: {
+          input: catchAllEntry,
+          output: {
+            entryFileNames: 'index.js',
+          },
         },
       },
-    ],
-
-    // Legacy ssr flag approach. The explicit rollupOptions.input prevents the
-    // "index.html as SSR entry" error. Vite will also build a 'client'
-    // environment from the user's config file (wasteful but harmless), and
-    // the 'ssr' environment produces our canonical Fetchable artifact at
-    // api/dist/ud/index.js.
-    build: {
-      ssr: true,
-      outDir,
-      rollupOptions: {
-        input: catchAllEntry,
-        output: {
-          entryFileNames: 'index.js',
-        },
-      },
-    },
-  })
+    })
+  } finally {
+    if (apiRootPath !== undefined) {
+      delete process.env.CEDAR_API_ROOT_PATH
+    }
+  }
 }

--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -178,10 +178,18 @@ export function cedarUniversalDeployPlugin(
 
     config: {
       order: 'pre',
-      handler() {
+      handler(_config, env) {
+        // Only register routes for SSR builds. During client builds the
+        // emitted chunks would reference paths that don't exist (e.g.
+        // new URL("./../functions/...")), causing Rollup resolution errors.
+        if (!env.isSsrBuild) {
+          return
+        }
+
         if (entriesInjected) {
           return
         }
+
         entriesInjected = true
 
         // Clear any stale Cedar entries from previous build steps (e.g. the web
@@ -196,7 +204,13 @@ export function cedarUniversalDeployPlugin(
       },
     },
 
-    buildStart(this) {
+    buildStart() {
+      // Skip during client builds — the emitted chunks reference Node.js
+      // builtins and paths that only exist during SSR builds.
+      if (this.environment?.name !== 'ssr') {
+        return
+      }
+
       // Emit each per-function virtual module as a chunk with a fixed output
       // path. This guarantees import.meta.url resolves from a predictable
       // location regardless of whether @universal-deploy/vite's catchAll()
@@ -215,6 +229,12 @@ export function cedarUniversalDeployPlugin(
     },
 
     resolveId(id) {
+      // Skip during client builds — the virtual modules reference Node.js
+      // APIs and paths that only work in an SSR context.
+      if (this.environment?.name !== 'ssr') {
+        return undefined
+      }
+
       // Match the null-byte-prefixed form that Rollup uses for already-resolved
       // virtual modules (e.g. when UD's catchAll generates dynamic imports).
       if (id.startsWith(RESOLVED_CEDAR_FN_PREFIX)) {
@@ -229,6 +249,11 @@ export function cedarUniversalDeployPlugin(
     },
 
     load(id) {
+      // Skip during client builds.
+      if (this.environment?.name !== 'ssr') {
+        return undefined
+      }
+
       // Per-function virtual modules
       if (id.startsWith(RESOLVED_CEDAR_FN_PREFIX)) {
         const routeId = id.slice(RESOLVED_CEDAR_FN_PREFIX.length)

--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -163,8 +163,12 @@ function clearCedarEntries(): void {
 export function cedarUniversalDeployPlugin(
   options: CedarUniversalDeployPluginOptions = {},
 ): Plugin {
-  const { apiRootPath } = options
-  const routes = discoverCedarRoutes(apiRootPath ?? '/')
+  // CEDAR_API_ROOT_PATH is set by buildUDApiServer when the --apiRootPath CLI
+  // flag is passed. It takes precedence over the option value in the user's
+  // vite config so CI/deploy can override without editing tracked files.
+  const effectiveApiRootPath =
+    process.env.CEDAR_API_ROOT_PATH ?? options.apiRootPath
+  const routes = discoverCedarRoutes(effectiveApiRootPath ?? '/')
 
   let entriesInjected = false
 

--- a/tasks/ud-tests/fixtures/cedar-app/web/vite.config.ts
+++ b/tasks/ud-tests/fixtures/cedar-app/web/vite.config.ts
@@ -1,9 +1,9 @@
 import dns from 'dns'
 import { defineConfig } from 'vite'
-import { cedar } from '@cedarjs/vite'
+import { cedar, cedarUniversalDeployPlugin } from '@cedarjs/vite'
 
 dns.setDefaultResultOrder('verbatim')
 
 export default defineConfig({
-  plugins: [cedar()],
+  plugins: [cedar(), cedarUniversalDeployPlugin()],
 })


### PR DESCRIPTION
This code snippet explains pretty well what this PR is about:

```ts
    .option('apiRootPath', {
      type: 'string',
      description:
        'Root path where API functions are served. Overrides the ' +
        'apiRootPath option on cedarUniversalDeployPlugin() in your ' +
        'vite config. Defaults to "/".',
    })
```

The `apiRootPath` option on `cedarUniversalDeployPlugin()` controls the URL prefix for all API routes. It feeds into `discoverCedarRoutes()` which generates entries like `/myPrefix/graphql`, `/myPrefix/hello` instead of the default `/graphql`, `/hello`.