### PR TITLE
chore(ci): pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -31,7 +31,7 @@ runs:
       run: npm install --global --force corepack
 
     - name: ⬢ Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
 
@@ -68,7 +68,7 @@ runs:
 
     - name: ♻️ Restore prebuild-install cache
       id: cache-prebuild-install
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       continue-on-error: true
       with:
         path: ${{ steps.prebuild-cache-path.outputs.cache-path }}
@@ -88,7 +88,7 @@ runs:
 
     - name: 💾 Save node_modules cache
       if: inputs.set-up-yarn-cache == 'true' && steps.set-up-yarn-cache.outputs.node-modules-cache-hit != 'true'
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       continue-on-error: true
       with:
         path: node_modules
@@ -96,7 +96,7 @@ runs:
 
     - name: 💾 Save create-cedar-rsc-app node_modules cache
       if: inputs.set-up-yarn-cache == 'true' && steps.set-up-yarn-cache.outputs.create-cedar-rsc-app-cache-hit != 'true'
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       continue-on-error: true
       with:
         path: packages/create-cedar-rsc-app/node_modules
@@ -109,7 +109,7 @@ runs:
 
     - name: 💾 Save prebuild-install cache
       if: steps.cache-prebuild-install.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       continue-on-error: true
       with:
         path: ${{ steps.prebuild-cache-path.outputs.cache-path }}

--- a/.github/actions/set-up-yarn-cache/action.yml
+++ b/.github/actions/set-up-yarn-cache/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
 
     - name: ♻️ Cache yarn's cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.get-yarn-cache-directory.outputs.CACHE_DIRECTORY }}
         key: yarn-cache-${{ runner.os }}-${{ github.run_id }}
@@ -30,7 +30,7 @@ runs:
           yarn-cache-${{ runner.os }}-
 
     - name: ♻️ Cache yarn's install state
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .yarn/install-state.gz
         key: yarn-install-state-${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock', '.yarnrc.yml') }}-${{ github.run_id }}
@@ -38,7 +38,7 @@ runs:
           yarn-install-state-${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock', '.yarnrc.yml') }}-
 
     - name: ♻️ Restore node_modules
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: node-modules-cache
       with:
         path: node_modules
@@ -47,7 +47,7 @@ runs:
           node-modules-${{ runner.os }}-
 
     - name: ♻️ Restore create-cedar-rsc-app node_modules
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: node-modules-cache-create-cedar-rsc-app
       with:
         path: packages/create-cedar-rsc-app/node_modules

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'


### PR DESCRIPTION
## Summary

Pins all unpinned GitHub Actions to specific commit SHAs to protect against supply chain attacks (tag mutation).

| Action | Before | After |
|--------|--------|-------|
| `actions/stale` | `@v10` | `@b5d41d4e1d5dceea10e7104786b73624c18a190f` (v10.2.0) |
| `actions/setup-node` | `@v6` | `@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6.4.0) |
| `actions/cache` | `@v5` | `@27d5ce7f107fe9357f9df03efb73ab90386fccae` (v5.0.5) |
| `actions/cache/restore` | `@v5` | `@27d5ce7f107fe9357f9df03efb73ab90386fccae` (v5.0.5) |
| `actions/cache/save` | `@v5` | `@27d5ce7f107fe9357f9df03efb73ab90386fccae` (v5.0.5) |

All actions that were already pinned (e.g. `actions/checkout`, `actions/upload-artifact`) are unchanged.

**Files changed:**
- `.github/workflows/stale.yml`
- `.github/actions/set-up-job/action.yml`
- `.github/actions/set-up-yarn-cache/action.yml`