### PR TITLE
fix(ci): log yarn.lock state after tarsync (debug)

### DIFF
--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -68,7 +68,9 @@ export async function setUpTestProject({
   if (fs.existsSync(yarnLockPath)) {
     const lockfileContent = fs.readFileSync(yarnLockPath, 'utf-8')
     const lines = lockfileContent.split('\n')
-    console.log(`yarn.lock created (${lines.length} lines)`)
+    const lineCount =
+      lines[lines.length - 1] === '' ? lines.length - 1 : lines.length
+    console.log(`yarn.lock created (${lineCount} lines)`)
     const rootWorkspaceLine = lines.find((l) => l.startsWith('root-workspace-'))
     if (rootWorkspaceLine) {
       console.log(`Root workspace entry found: ${rootWorkspaceLine}`)

--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -64,6 +64,23 @@ export async function setUpTestProject({
     env: { CEDAR_CWD: testProjectPath },
   })
 
+  const yarnLockPath = path.join(testProjectPath, 'yarn.lock')
+  if (fs.existsSync(yarnLockPath)) {
+    const lockfileContent = fs.readFileSync(yarnLockPath, 'utf-8')
+    const lines = lockfileContent.split('\n')
+    console.log(`yarn.lock created (${lines.length} lines)`)
+    const rootWorkspaceLine = lines.find((l) => l.startsWith('root-workspace-'))
+    if (rootWorkspaceLine) {
+      console.log(`Root workspace entry found: ${rootWorkspaceLine}`)
+    } else {
+      console.error(
+        'WARNING: yarn.lock exists but has no root-workspace- entry!',
+      )
+    }
+  } else {
+    console.error('WARNING: yarn.lock was not created by tarsync!')
+  }
+
   console.log('Generating dbAuth secret')
   const secretResult = await execInProject('yarn cedar g secret --raw', {
     silent: true,

--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -71,7 +71,9 @@ export async function setUpTestProject({
     const lineCount =
       lines[lines.length - 1] === '' ? lines.length - 1 : lines.length
     console.log(`yarn.lock created (${lineCount} lines)`)
-    const rootWorkspaceLine = lines.find((l) => l.startsWith('"root-workspace-'))
+    const rootWorkspaceLine = lines.find((l) =>
+      l.startsWith('"root-workspace-'),
+    )
     if (rootWorkspaceLine) {
       console.log(`Root workspace entry found: ${rootWorkspaceLine}`)
     } else {

--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -71,7 +71,7 @@ export async function setUpTestProject({
     const lineCount =
       lines[lines.length - 1] === '' ? lines.length - 1 : lines.length
     console.log(`yarn.lock created (${lineCount} lines)`)
-    const rootWorkspaceLine = lines.find((l) => l.startsWith('root-workspace-'))
+    const rootWorkspaceLine = lines.find((l) => l.startsWith('"root-workspace-'))
     if (rootWorkspaceLine) {
       console.log(`Root workspace entry found: ${rootWorkspaceLine}`)
     } else {


### PR DESCRIPTION
## Summary

Adds diagnostic logging after `yarn project:tarsync --verbose` runs in the test project setup, to help understand the intermittent Windows CI failure where `yarn cedar g secret --raw` fails with:

```
Internal Error: root-workspace-0b6124@workspace:.: This package doesn't seem to be present in your lockfile
```

## What this adds

After tarsync completes, we now check:
1. **Did `yarn.lock` get created at all?** (tarsync's internal `yarn install` errors are silently swallowed — we'd never know if it didn't run)
2. **Does the lockfile contain the root-workspace- entry?** — the missing entry is exactly what causes the downstream failure

The next time this fails on Windows, the log will show one of:
- `WARNING: yarn.lock was not created by tarsync!` → tarsync's yarn install didn't run or failed very early
- `WARNING: yarn.lock exists but has no root-workspace- entry!` → yarn install ran but produced an incomplete lockfile
- `Root workspace entry found: root-workspace-...` → lockfile is fine, look elsewhere for the failure

Relates to the investigation in `docs/implementation-plans/flaky-windows-smoke-tests-investigation.md`.

## Test plan

- [ ] Merge and wait for next Windows CI failure to collect diagnostic info

🤖 Generated with [Claude Code](https://claude.com/claude-code)