### PR TITLE
feat(ud): Use srvx only

### DIFF
--- a/docs/implementation-plans/universal-deploy-serve-refactoring.md
+++ b/docs/implementation-plans/universal-deploy-serve-refactoring.md
@@ -244,6 +244,55 @@ means use plugin config.
 - The plugin still works standalone in dev mode with its own config.
 - CI can set a different prefix without modifying tracked files.
 
+### Drop Fastify from `cedar serve --ud` (two-port, srvx only)
+
+**Date:** 2026-05-15
+
+**Context:** `cedar serve --ud` uses a two-port topology: a Fastify web server
+(serving the SPA) on the web port, and srvx (hosting the UD Fetchable) on the
+API port. The Fastify proxy strips `apiUrl` from request paths before
+forwarding to srvx, meaning the Fetchable receives a different path locally
+than it does on deployment targets like Netlify, Vercel, or Cloudflare
+(where no proxy strips the prefix). This forces users to track
+`apiRootPath` across plugin config, `cedar.toml`, and the `--apiRootPath`
+CLI flag — too many knobs that must be kept in sync.
+
+The original rationale for keeping Fastify was "production-like split
+topology for local testing," mirroring a VPS/baremetal reverse-proxy setup.
+But the deployment targets that benefit most from UD (Netlify, Vercel,
+Cloudflare) do not use a reverse-proxy that strips prefixes — the function
+receives the full request path. The two-port Fastify model is not
+production-like for those targets.
+
+With no proxy stripping prefixes, the Fetchable receives the same path locally
+as it does on Netlify — meaning the same `apiRootPath` works everywhere, and the
+`--apiRootPath` CLI flag is only needed for CI overrides, not for environment-
+specific path tracking.
+
+**Decision:** Start by replacing the Fastify web server with srvx hosting both
+the UD Fetchable and static files (`web/dist/`) on a single listener per port.
+Keep two ports: one for the web server (srvx + static files) and one for
+the API server (srvx + the Fetchable). This simplifies the server topology
+and eliminates a server-technology boundary (Fastify ↔ srvx) that has no
+equivalent in production UD deployments.
+
+**Rationale:** srvx can already serve static files (the UD Node adapter
+uses `sirv` for this). The Fetchable already returns `undefined` for
+non-API paths, so the static fallback is natural. Not using Fastify means one
+less server-technology boundary to maintain.
+
+**Consequences:**
+
+- Static file serving (`web/dist/`) moves from Fastify to srvx (or srvx +
+  `sirv`). This needs to be implemented and tested.
+- The Fastify web server is no longer part of `cedar serve --ud`. Apps
+  that rely on Fastify-specific customization (compression, custom
+  middleware) must use the non-UD path or a Lane B compatibility option.
+- The `cedar serve --ud` UX does not change: same two ports, same CLI
+  flags, same developer workflows.
+- A future single-port option is still possible (as noted in the "Future
+  work" section) but is not required by this change.
+
 ## Current state
 
 From the current code:

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -170,30 +170,59 @@ export const builder = async (yargs: Argv) => {
           const webHost = argv.webHost ?? getWebHost()
 
           const apiRootPath = argv.apiRootPath ?? '/'
-          const apiProxyTarget = [
-            'http://',
-            apiHost.includes(':') ? `[${apiHost}]` : apiHost,
-            ':',
-            apiPort,
-            apiRootPath,
-          ].join('')
+          const apiTarget = `http://${apiHost.includes(':') ? `[${apiHost}]` : apiHost}:${apiPort}`
 
-          // Start the Fastify web server (same as before)
-          const { redwoodFastifyWeb } = await import('@cedarjs/fastify-web')
-          const { createFastifyInstance } =
-            await import('@cedarjs/api-server/fastify')
+          // Start the srvx web server (replaces Fastify + proxy).
+          // Middleware chain:
+          // 1. serveStatic: serve files from web/dist/ (SPA assets)
+          // 2. apiProxy: forward API-prefixed requests to UD Fetchable on API
+          //    port
+          // 3. spaFallback: serve index.html for client-side routing
+          const { serveStatic } = await import('srvx/static')
+          const apiUrl = getConfig().web.apiUrl
+          const webDist = getPaths().web.dist
 
-          const webFastify = await createFastifyInstance()
-          webFastify.register(redwoodFastifyWeb, {
-            redwood: {
-              apiProxyTarget,
-            },
-          })
+          const webServer = serveSrvx({
+            // Dummy fetch handler. All requests are handled by middleware
+            fetch: async () => new Response('Not Found', { status: 404 }),
+            middleware: [
+              serveStatic({ dir: webDist }),
+              async (req, next) => {
+                const url = new URL(req.url, 'http://localhost')
 
-          await webFastify.listen({
+                if (!url.pathname.startsWith(apiUrl)) {
+                  return next()
+                }
+
+                // Strip the apiUrl prefix and forward to the API server
+                const targetPath = url.pathname.slice(apiUrl.length) || '/'
+                const targetUrl = `${apiTarget}${apiRootPath}${targetPath}${url.search}`
+
+                return fetch(targetUrl, {
+                  method: req.method,
+                  headers: req.headers,
+                  body: req.body,
+                })
+              },
+              () => {
+                const html = fs.readFileSync(
+                  path.join(webDist, 'index.html'),
+                  'utf-8',
+                )
+
+                return new Response(html, {
+                  headers: { 'Content-Type': 'text/html' },
+                })
+              },
+            ],
             port: webPort,
-            host: webHost,
+            hostname: webHost,
+            gracefulShutdown: false,
+            manual: true,
           })
+
+          webServer.serve()
+          await webServer.ready()
 
           // Import and host the UD Fetchable in-process with srvx
           console.log(`Web server listening at http://${webHost}:${webPort}`)

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -182,6 +182,11 @@ export const builder = async (yargs: Argv) => {
           const apiUrl = getConfig().web.apiUrl
           const webDist = getPaths().web.dist
 
+          const indexHtml = fs.readFileSync(
+            path.join(webDist, 'index.html'),
+            'utf-8',
+          )
+
           const webServer = serveSrvx({
             // Dummy fetch handler. All requests are handled by middleware
             fetch: async () => new Response('Not Found', { status: 404 }),
@@ -194,9 +199,12 @@ export const builder = async (yargs: Argv) => {
                   return next()
                 }
 
-                // Strip the apiUrl prefix and forward to the API server
+                // Strip the apiUrl prefix and forward to the API server.
+                // Normalise apiRootPath to avoid double-slash when it's '/'
+                // and targetPath already starts with '/'.
                 const targetPath = url.pathname.slice(apiUrl.length) || '/'
-                const targetUrl = `${apiTarget}${apiRootPath}${targetPath}${url.search}`
+                const root = apiRootPath === '/' ? '' : apiRootPath
+                const targetUrl = `${apiTarget}${root}${targetPath}${url.search}`
 
                 return fetch(targetUrl, {
                   method: req.method,
@@ -205,14 +213,8 @@ export const builder = async (yargs: Argv) => {
                 })
               },
               () => {
-                const html = fs.readFileSync(
-                  path.join(webDist, 'index.html'),
-                  'utf-8',
-                )
-
-                return new Response(html, {
-                  headers: { 'Content-Type': 'text/html' },
-                })
+                const headers = { 'Content-Type': 'text/html' }
+                return new Response(indexHtml, { headers })
               },
             ],
             port: webPort,


### PR DESCRIPTION
Don't use Fastify for the new `--ud` code path