### PR TITLE
chore(ci): surface tarsync failures that were silently absorbed

### DIFF
--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -64,25 +64,38 @@ export async function setUpTestProject({
     env: { CEDAR_CWD: testProjectPath },
   })
 
+  // Verify tarsync produced a lockfile. A missing lockfile means the
+  // `yarn install` inside tarsync failed (possibly due to the V8 Maglev JIT
+  // crash on Windows). Fail here with a clear message rather than letting the
+  // next `yarn cedar g secret --raw` call fail with a confusing
+  // "root-workspace not in lockfile" error.
   const yarnLockPath = path.join(testProjectPath, 'yarn.lock')
-  if (fs.existsSync(yarnLockPath)) {
-    const lockfileContent = fs.readFileSync(yarnLockPath, 'utf-8')
-    const lines = lockfileContent.split('\n')
-    const lineCount =
-      lines[lines.length - 1] === '' ? lines.length - 1 : lines.length
-    console.log(`yarn.lock created (${lineCount} lines)`)
-    const rootWorkspaceLine = lines.find((l) =>
-      l.startsWith('"root-workspace-'),
+  if (!fs.existsSync(yarnLockPath)) {
+    throw new Error(
+      'yarn.lock was not created by tarsync. The yarn install step likely ' +
+        'crashed silently (check the tarsync output above for ERROR lines). ' +
+        'On Windows this is often caused by the V8 Maglev JIT bug ' +
+        '(exit code 0xC0000409 / STATUS_STACK_BUFFER_OVERRUN).',
     )
-    if (rootWorkspaceLine) {
-      console.log(`Root workspace entry found: ${rootWorkspaceLine}`)
-    } else {
-      console.error(
-        'WARNING: yarn.lock exists but has no root-workspace- entry!',
-      )
-    }
+  }
+
+  const lockfileContent = fs.readFileSync(yarnLockPath, 'utf-8')
+  const lines = lockfileContent.split('\n')
+  const lineCount =
+    lines[lines.length - 1] === '' ? lines.length - 1 : lines.length
+  console.log(`yarn.lock created (${lineCount} lines)`)
+  const rootWorkspaceLine = lines.find((l) => l.startsWith('"root-workspace-'))
+  if (rootWorkspaceLine) {
+    console.log(`Root workspace entry found: ${rootWorkspaceLine}`)
   } else {
-    console.error('WARNING: yarn.lock was not created by tarsync!')
+    // The root-workspace entry is required by yarn 4 hardened mode. Without it,
+    // any subsequent `yarn cedar ...` invocation will fail with
+    // "This package doesn't seem to be present in your lockfile".
+    throw new Error(
+      'yarn.lock exists but has no root-workspace- entry. ' +
+        'The lockfile is incomplete — tarsync may have been interrupted ' +
+        'or yarn install may have partially failed.',
+    )
   }
 
   console.log('Generating dbAuth secret')

--- a/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
@@ -706,3 +706,85 @@ visible in the CI log.
 - A race condition or lock contention from the preceding `yarn install` not fully
   releasing file locks before `yarn cedar` starts
 - A transient yarn registry or filesystem error on the Windows runner
+
+---
+
+## Update 2026-05-20 — Root cause of CLI smoke test failure identified
+
+### Evidence from PR #1806
+
+With the debug improvement from 2026-05-15 now active, the captured stdout from
+`yarn cedar g secret --raw` was visible for the first time:
+
+```
+stdout: Internal Error: root-workspace-0b6124@workspace:.: This package doesn't
+seem to be present in your lockfile; run "yarn install" to update the lockfile
+    at DT.getCandidates (yarn.js:204:4607)
+    at em.getCandidates (yarn.js:141:1311)
+    ...
+    at async e.resolveEverything (yarn.js:209:7138)
+```
+
+And, crucially, the preceding warning that was already present:
+
+```
+WARNING: yarn.lock was not created by tarsync!
+```
+
+### Root cause
+
+The `__fixtures__/test-project` fixture has no committed `yarn.lock`. Tarsync is
+responsible for creating it via `pmInstall`. When `yarn.lock` is absent, yarn 4's
+hardened mode (active on public PRs) rejects any subsequent yarn invocation —
+including `yarn cedar g secret --raw` — with "not present in your lockfile".
+
+So the question becomes: **why does tarsync's `yarn install` step sometimes
+fail to produce `yarn.lock`?**
+
+The answer is the same V8 Maglev JIT bug documented above. The `yarn install`
+call inside tarsync's `pmInstall` is a long-running process (58+ seconds in
+observed runs). The JIT crash (`0xC0000409`) can occur at any point during that
+execution. When it does, Node exits hard and `yarn.lock` is never written.
+
+**Why tarsync silently absorbed the failure:** In verbose/CI mode (`verbose=true`
+or non-TTY), `OutputManager` is constructed with `disabled=true`. Its `start()`
+method returns early without setting `this.running = true`. Consequently, every
+`outputManager.stop(error)` call also returns early (`!this.running`). The error
+is stored in `this.error` but never rendered and never re-thrown — tarsync exits
+with code 0 despite the failure.
+
+### Why it's intermittent
+
+The V8 Maglev JIT crash is non-deterministic. Whether a given code path gets
+Maglev-compiled depends on runtime heuristics. Most runs complete the
+`yarn install` before any vulnerable code path triggers JIT compilation at the
+Maglev tier; occasionally it does, and the process hard-crashes.
+
+### Fixes applied in this PR
+
+**`tasks/framework-tools/tarsync/tarsync.mts`**
+
+- Added `stageLog()` helper that emits plain `console.log` lines in verbose/CI
+  mode, so each stage transition is visible in CI logs even when the spinner is
+  disabled.
+- Changed all `catch` blocks to re-throw after logging, so tarsync exits
+  non-zero when any stage fails. Previously the error was absorbed and tarsync
+  reported success.
+
+**`tasks/framework-tools/tarsync/lib.mts`** (`pmInstall`)
+
+- Added entry/exit console logs with elapsed time.
+- Added a post-install lockfile existence check. If the lockfile is absent after
+  `yarn install` returns, `pmInstall` now throws immediately with an explanation.
+  This catches the case where the install process crashes but zx somehow sees a
+  zero exit code (possible if the crash occurs in a subprocess that zx doesn't
+  track directly).
+
+**`.github/actions/set-up-test-project/setUpTestProject.mts`**
+
+- Changed the "WARNING: yarn.lock was not created by tarsync!" path from a
+  warning-and-continue to a hard throw. Failing fast here gives a clear error
+  message with context, rather than the confusing downstream
+  "not present in your lockfile" error from `yarn cedar g secret --raw`.
+- Similarly, if `yarn.lock` exists but has no `root-workspace-` entry, now
+  throws instead of warning.

--- a/tasks/framework-tools/tarsync/lib.mts
+++ b/tasks/framework-tools/tarsync/lib.mts
@@ -223,7 +223,9 @@ export async function pmInstall(projectPath: string, verbose = false) {
   const packageManager = await detectPackageManager(projectPath)
 
   if (verbose) {
-    console.log(`[tarsync] Running '${packageManager} install' in ${projectPath}`)
+    console.log(
+      `[tarsync] Running '${packageManager} install' in ${projectPath}`,
+    )
   }
   const start = Date.now()
 
@@ -234,7 +236,9 @@ export async function pmInstall(projectPath: string, verbose = false) {
 
   if (verbose) {
     const elapsed = Date.now() - start
-    console.log(`[tarsync] '${packageManager} install' completed in ${elapsed}ms`)
+    console.log(
+      `[tarsync] '${packageManager} install' completed in ${elapsed}ms`,
+    )
   }
 
   // Verify that the install actually produced a lockfile. On Windows the
@@ -242,7 +246,8 @@ export async function pmInstall(projectPath: string, verbose = false) {
   // without zx detecting a non-zero exit code. If the lockfile is still
   // missing after install, fail loudly here rather than silently producing a
   // broken project that fails at a later, less obvious step.
-  const lockfileName = packageManager === 'pnpm' ? 'pnpm-lock.yaml' : 'yarn.lock'
+  const lockfileName =
+    packageManager === 'pnpm' ? 'pnpm-lock.yaml' : 'yarn.lock'
   const lockfilePath = path.join(projectPath, lockfileName)
   if (!fs.existsSync(lockfilePath)) {
     throw new Error(

--- a/tasks/framework-tools/tarsync/lib.mts
+++ b/tasks/framework-tools/tarsync/lib.mts
@@ -222,8 +222,34 @@ export async function getReactResolutions() {
 export async function pmInstall(projectPath: string) {
   const packageManager = await detectPackageManager(projectPath)
 
+  console.log(
+    `[tarsync] Running '${packageManager} install' in ${projectPath}`,
+  )
+  const start = Date.now()
+
   await within(async () => {
     cd(projectPath)
     await $`${packageManager} install`
   })
+
+  const elapsed = Date.now() - start
+  console.log(`[tarsync] '${packageManager} install' completed in ${elapsed}ms`)
+
+  // Verify that the install actually produced a lockfile. On Windows the
+  // install process can crash (e.g. V8 Maglev JIT bug, exit code 0xC0000409)
+  // without zx detecting a non-zero exit code. If the lockfile is still
+  // missing after install, fail loudly here rather than silently producing a
+  // broken project that fails at a later, less obvious step.
+  const lockfileName =
+    packageManager === 'pnpm' ? 'pnpm-lock.yaml' : 'yarn.lock'
+  const lockfilePath = path.join(projectPath, lockfileName)
+  if (!fs.existsSync(lockfilePath)) {
+    throw new Error(
+      `[tarsync] '${packageManager} install' completed but ${lockfileName} was not created in ${projectPath}. ` +
+        `The install process likely crashed silently (e.g. V8 Maglev JIT bug on Windows). ` +
+        `Check the install output above for clues.`,
+    )
+  }
+
+  console.log(`[tarsync] ${lockfileName} exists after install — OK`)
 }

--- a/tasks/framework-tools/tarsync/lib.mts
+++ b/tasks/framework-tools/tarsync/lib.mts
@@ -219,12 +219,12 @@ export async function getReactResolutions() {
   }
 }
 
-export async function pmInstall(projectPath: string) {
+export async function pmInstall(projectPath: string, verbose = false) {
   const packageManager = await detectPackageManager(projectPath)
 
-  console.log(
-    `[tarsync] Running '${packageManager} install' in ${projectPath}`,
-  )
+  if (verbose) {
+    console.log(`[tarsync] Running '${packageManager} install' in ${projectPath}`)
+  }
   const start = Date.now()
 
   await within(async () => {
@@ -232,16 +232,17 @@ export async function pmInstall(projectPath: string) {
     await $`${packageManager} install`
   })
 
-  const elapsed = Date.now() - start
-  console.log(`[tarsync] '${packageManager} install' completed in ${elapsed}ms`)
+  if (verbose) {
+    const elapsed = Date.now() - start
+    console.log(`[tarsync] '${packageManager} install' completed in ${elapsed}ms`)
+  }
 
   // Verify that the install actually produced a lockfile. On Windows the
   // install process can crash (e.g. V8 Maglev JIT bug, exit code 0xC0000409)
   // without zx detecting a non-zero exit code. If the lockfile is still
   // missing after install, fail loudly here rather than silently producing a
   // broken project that fails at a later, less obvious step.
-  const lockfileName =
-    packageManager === 'pnpm' ? 'pnpm-lock.yaml' : 'yarn.lock'
+  const lockfileName = packageManager === 'pnpm' ? 'pnpm-lock.yaml' : 'yarn.lock'
   const lockfilePath = path.join(projectPath, lockfileName)
   if (!fs.existsSync(lockfilePath)) {
     throw new Error(
@@ -251,5 +252,7 @@ export async function pmInstall(projectPath: string) {
     )
   }
 
-  console.log(`[tarsync] ${lockfileName} exists after install — OK`)
+  if (verbose) {
+    console.log(`[tarsync] ${lockfileName} exists after install — OK`)
+  }
 }

--- a/tasks/framework-tools/tarsync/tarsync.mts
+++ b/tasks/framework-tools/tarsync/tarsync.mts
@@ -11,6 +11,14 @@ import {
 } from './lib.mjs'
 import { OutputManager, Stage } from './output.mjs'
 
+function stageLog(verboseOutput: boolean, message: string) {
+  // In verbose/CI mode the OutputManager spinner is disabled, so we emit
+  // plain console lines so stage transitions are visible in CI logs.
+  if (verboseOutput) {
+    console.log(`[tarsync] ${message}`)
+  }
+}
+
 export async function tarsync(
   { projectPath, verbose }: Omit<Options, 'watch'>,
   triggeredBy: string,
@@ -26,41 +34,53 @@ export async function tarsync(
   })
 
   outputManager.start({ triggeredBy })
+  stageLog(verboseOutput, `starting (triggered by: ${triggeredBy})`)
+  stageLog(verboseOutput, `project path: ${projectPath}`)
+  stageLog(verboseOutput, `package manager: ${packageManager}`)
 
   cd(FRAMEWORK_PATH)
 
   outputManager.switchStage(Stage.BUILD_PACK)
+  stageLog(verboseOutput, 'stage: build and pack tarballs')
   try {
     await buildTarballs()
   } catch (error) {
     outputManager.stop(error)
-    return
+    console.error('[tarsync] ERROR in build:pack stage:', error)
+    throw error
   }
 
   outputManager.switchStage(Stage.MOVE)
+  stageLog(verboseOutput, 'stage: copy tarballs to project')
   try {
     await copyTarballs(projectPath)
   } catch (error) {
     outputManager.stop(error)
-    return
+    console.error('[tarsync] ERROR in copy tarballs stage:', error)
+    throw error
   }
 
   outputManager.switchStage(Stage.RESOLUTIONS)
+  stageLog(verboseOutput, 'stage: update resolutions in package.json')
   try {
     await updateResolutions(projectPath)
   } catch (error) {
     outputManager.stop(error)
-    return
+    console.error('[tarsync] ERROR in update resolutions stage:', error)
+    throw error
   }
 
   outputManager.switchStage(Stage.INSTALL)
+  stageLog(verboseOutput, `stage: run ${packageManager} install`)
   try {
     await pmInstall(projectPath)
   } catch (error) {
     outputManager.stop(error)
-    return
+    console.error(`[tarsync] ERROR in ${packageManager} install stage:`, error)
+    throw error
   }
 
   outputManager.switchStage(Stage.DONE)
   outputManager.stop()
+  stageLog(verboseOutput, 'done')
 }

--- a/tasks/framework-tools/tarsync/tarsync.mts
+++ b/tasks/framework-tools/tarsync/tarsync.mts
@@ -73,7 +73,7 @@ export async function tarsync(
   outputManager.switchStage(Stage.INSTALL)
   stageLog(verboseOutput, `stage: run ${packageManager} install`)
   try {
-    await pmInstall(projectPath)
+    await pmInstall(projectPath, verboseOutput)
   } catch (error) {
     outputManager.stop(error)
     console.error(`[tarsync] ERROR in ${packageManager} install stage:`, error)


### PR DESCRIPTION
## Summary

Fixes the root cause of the recurring **"Generating dbAuth secret" CLI smoke test failure** on Windows CI.

**Root cause chain:**
1. `yarn install` inside tarsync's `pmInstall` step crashes hard on Windows (V8 Maglev JIT bug, exit code `0xC0000409`) — `yarn.lock` never gets written
2. Tarsync catches the error, calls `outputManager.stop(error)`, and returns — but in verbose/CI mode `OutputManager` is constructed with `disabled=true`, so `start()` never sets `this.running = true`, so `stop()` also returns immediately. The error is silently dropped and tarsync exits 0.
3. `yarn cedar g secret --raw` then fails with yarn 4 hardened mode's "root-workspace not in lockfile" error — the real cause nowhere in sight.

**Changes:**
- **`tarsync.mts`**: Re-throw after logging in all `catch` blocks so tarsync exits non-zero on failure. Add `stageLog()` helper that emits plain `console.log` lines in CI/verbose mode so stage transitions are visible in logs.
- **`lib.mts`** (`pmInstall`): Log entry/exit with elapsed time. Add a post-install check — if `yarn.lock` is absent after `yarn install` returns, throw immediately with an explanation (catches the case where the process crashes but zx sees exit 0).
- **`setUpTestProject.mts`**: Fail fast (throw) if `yarn.lock` is absent or missing the `root-workspace-` entry after tarsync, instead of printing a warning and continuing to the next step.
- **Investigation doc**: Updated with root cause analysis, explanation of intermittency, and description of fixes.

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Next time the V8 Maglev crash hits, the CI log should show `[tarsync] ERROR in yarn install stage:` with the crash details, and the job should fail at the tarsync step (not at `yarn cedar g secret --raw`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)