### PR TITLE
fix(storage): select only upload fields before deleting old files

### DIFF
--- a/packages/storage/src/prismaExtension.ts
+++ b/packages/storage/src/prismaExtension.ts
@@ -209,9 +209,13 @@ export const createUploadsExtension = <
               // We only need to check for existing records if we're updating
               existingRecord = await (client as any)[model].findUnique({
                 where: args.where,
-                select: Object.fromEntries(
-                  uploadFieldsToUpdate.map((f) => [f, true]),
-                ),
+                ...(uploadFieldsToUpdate.length > 0
+                  ? {
+                      select: Object.fromEntries(
+                        uploadFieldsToUpdate.map((f) => [f, true]),
+                      ),
+                    }
+                  : {}),
               })
               isUpdate = !!existingRecord
             }

--- a/packages/storage/src/prismaExtension.ts
+++ b/packages/storage/src/prismaExtension.ts
@@ -130,7 +130,9 @@ export const createUploadsExtension = <
               model
             ].findFirstOrThrow({
               where: args.where,
-              // @TODO: should we select here to reduce the amount of data we're handling
+              select: Object.fromEntries(
+                uploadFieldsToUpdate.map((f) => [f, true]),
+              ),
             })
 
             // Similar, but not same as create
@@ -167,7 +169,9 @@ export const createUploadsExtension = <
             // MULTIPLE!
             const originalRecords = await (client as any)[model].findMany({
               where: args.where,
-              // @TODO: should we select here to reduce the amount of data we're handling
+              select: Object.fromEntries(
+                uploadFieldsToUpdate.map((f) => [f, true]),
+              ),
             })
 
             try {
@@ -205,6 +209,9 @@ export const createUploadsExtension = <
               // We only need to check for existing records if we're updating
               existingRecord = await (client as any)[model].findUnique({
                 where: args.where,
+                select: Object.fromEntries(
+                  uploadFieldsToUpdate.map((f) => [f, true]),
+                ),
               })
               isUpdate = !!existingRecord
             }


### PR DESCRIPTION
## Summary

Resolves #1639.

When `update`, `updateMany`, or `upsert` are called with upload fields, the extension fetches the existing record(s) first so it can delete the old uploaded files afterward. Previously these queries fetched all columns — only the upload field values are actually needed.

This PR adds `select` clauses to all three pre-fetch queries so Prisma returns only the relevant columns.

The `@TODO` comments in `update` and `updateMany` are replaced by the actual fix.

## Changes

- `update`: `findFirstOrThrow` now selects only `uploadFieldsToUpdate`
- `updateMany`: `findMany` now selects only `uploadFieldsToUpdate`
- `upsert`: `findUnique` now selects only `uploadFieldsToUpdate`

## Test plan

- [ ] Existing upload storage tests pass
- [ ] Verify that `update`/`updateMany`/`upsert` still correctly delete old uploaded files

🤖 Generated with [Claude Code](https://claude.com/claude-code)