### PR TITLE
chore(ci): skip create-cedar-rsc-app install on cache hit, retry on failure

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -81,10 +81,29 @@ runs:
       working-directory: ${{ inputs.yarn-install-directory }}
       env:
         GITHUB_TOKEN: ${{ github.token }}
+      run: yarn install --inline-builds
+
+    # Run create-cedar-rsc-app install separately so we can skip it on cache hit
+    # and retry on failure. The install has been flaky on Windows (exit code 127).
+    - name: 🐈 Yarn install (create-cedar-rsc-app)
+      if: inputs.set-up-yarn-cache != 'true' || steps.set-up-yarn-cache.outputs.create-cedar-rsc-app-cache-hit != 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
-        yarn install --inline-builds
         cd "$GITHUB_WORKSPACE/packages/create-cedar-rsc-app"
-        yarn install --inline-builds
+        for i in 1 2 3; do
+          yarn install --inline-builds
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -eq 0 ]; then
+            break
+          fi
+          if [ $i -eq 3 ]; then
+            exit $EXIT_CODE
+          fi
+          echo "Attempt $i failed (exit $EXIT_CODE), retrying in 10s..."
+          sleep 10
+        done
 
     - name: 💾 Save node_modules cache
       if: inputs.set-up-yarn-cache == 'true' && steps.set-up-yarn-cache.outputs.node-modules-cache-hit != 'true'

--- a/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
@@ -820,21 +820,40 @@ The ~2 second window before the crash is suspicious: it's long enough for Yarn
 to have started a subprocess (e.g. a lifecycle script or prebuild download) but
 short enough to suggest the process was killed before doing meaningful work.
 
-### Fix applied
+### Fixes applied
 
-Added `--verbose` to the `create-cedar-rsc-app` yarn install step in
-`.github/actions/set-up-job/action.yml`:
+Two mitigations added to `.github/actions/set-up-job/action.yml`:
+
+**1. Skip install on cache hit**
+
+The `create-cedar-rsc-app` install step is now a separate step gated on a cache
+miss:
 
 ```yaml
-cd "$GITHUB_WORKSPACE/packages/create-cedar-rsc-app"
-yarn install --inline-builds --verbose
+- name: 🐈 Yarn install (create-cedar-rsc-app)
+  if: inputs.set-up-yarn-cache != 'true' || steps.set-up-yarn-cache.outputs.create-cedar-rsc-app-cache-hit != 'true'
 ```
 
-This surfaces the actual failing package/command in the Resolution step output
-so the next occurrence can be diagnosed.
+The cache key covers `yarn.lock` + `package.json`, so a hit means the modules
+are already correct. Skipping avoids the crash entirely on cache-hit runs.
+
+**2. Retry on failure**
+
+For cache-miss runs, the install retries up to 3 times with a 10s delay:
+
+```bash
+for i in 1 2 3; do
+  yarn install --inline-builds
+  EXIT_CODE=$?
+  if [ $EXIT_CODE -eq 0 ]; then break; fi
+  if [ $i -eq 3 ]; then exit $EXIT_CODE; fi
+  echo "Attempt $i failed (exit $EXIT_CODE), retrying in 10s..."
+  sleep 10
+done
+```
 
 ### Open questions
 
-- What command triggers exit 127? (Needs next failure with `--verbose` to answer)
+- What command triggers exit 127? (Not yet known — the failing command is inside
+  a closed `##[group]` log block)
 - Is this the same intermittent failure as the V8 crash, or a separate issue?
-- Could skipping install when cache hits (conditionally) avoid the failure entirely?

--- a/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-windows-smoke-tests-investigation.md
@@ -788,3 +788,53 @@ Maglev tier; occasionally it does, and the process hard-crashes.
   "not present in your lockfile" error from `yarn cedar g secret --raw`.
 - Similarly, if `yarn.lock` exists but has no `root-workspace-` entry, now
   throws instead of warning.
+
+---
+
+## Update 2026-05-22 — Exit code 127 in `create-cedar-rsc-app` yarn install (PR #1811)
+
+### Evidence
+
+From run [26263998951](https://github.com/cedarjs/cedar/actions/runs/26263998951/job/77303444093)
+(PR #1811 `chore(ci): Fix flaky cca tests`, Windows):
+
+```
+➤ YN0000: · Yarn 4.14.1
+➤ YN0000: ┌ Resolution step
+##[error]Process completed with exit code 127.
+```
+
+The failure occurs in the `set-up-job` action's `🐈 Yarn install` step, during
+the second `yarn install --inline-builds` (for `packages/create-cedar-rsc-app`).
+The process exits with code 127 ("command not found") approximately 2 seconds
+into the Resolution step. The actual failing command is invisible because it's
+inside a closed `##[group]` log block.
+
+### Relation to previous entry
+
+This is the same `create-cedar-rsc-app` yarn install that has been flaky. Exit
+code 127 is distinct from the V8 Maglev JIT crash (exit code `3221226505`) —
+it indicates a missing binary or command during dependency resolution.
+
+The ~2 second window before the crash is suspicious: it's long enough for Yarn
+to have started a subprocess (e.g. a lifecycle script or prebuild download) but
+short enough to suggest the process was killed before doing meaningful work.
+
+### Fix applied
+
+Added `--verbose` to the `create-cedar-rsc-app` yarn install step in
+`.github/actions/set-up-job/action.yml`:
+
+```yaml
+cd "$GITHUB_WORKSPACE/packages/create-cedar-rsc-app"
+yarn install --inline-builds --verbose
+```
+
+This surfaces the actual failing package/command in the Resolution step output
+so the next occurrence can be diagnosed.
+
+### Open questions
+
+- What command triggers exit 127? (Needs next failure with `--verbose` to answer)
+- Is this the same intermittent failure as the V8 crash, or a separate issue?
+- Could skipping install when cache hits (conditionally) avoid the failure entirely?


### PR DESCRIPTION
## Summary

The `create-cedar-rsc-app` yarn install has been intermittently failing on Windows CI with exit code 127. Two mitigations in `.github/actions/set-up-job/action.yml`:

**Skip install on cache hit**

Splits the yarn install into two steps. The `create-cedar-rsc-app` step is gated on a cache miss:

```yaml
if: inputs.set-up-yarn-cache != 'true' || steps.set-up-yarn-cache.outputs.create-cedar-rsc-app-cache-hit != 'true'
```

The cache key includes `yarn.lock` + `package.json` hashes, so a hit means the modules are correct — no install needed. This avoids the crash entirely on cache-hit runs (most runs).

**Retry on failure**

Wraps the install in a 3-attempt retry loop with a 10s delay. For cache-miss runs, a transient failure (e.g. Windows Defender locking a binary mid-install) will be retried rather than failing the job.

Also includes a doc update to `docs/implementation-plans/flaky-windows-smoke-tests-investigation.md` documenting the 2026-05-22 failure.

## Test plan

- [ ] Verify CI passes (no regressions)
- [ ] Verify Windows smoke test jobs show the `create-cedar-rsc-app` install step skipped on cache hit