### PR TITLE
fix(api): import.meta.resolve

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
 
 export * from './auth/index.js'
 export * from './errors.js'
@@ -9,24 +10,50 @@ export * from './transforms.js'
 export * from './cors.js'
 export * from './event.js'
 
-// Locate the package.json of @cedarjs/api by walking up from this file's
-// directory. Because of how we nest cjs and esm build output we have to walk
-// up one or two levels to find the correct package.json file
+// Locate the package.json for @cedarjs/api.
+//
+// We use import.meta.resolve (ESM, uses the import export condition) to find
+// the package entry point URL, then derive the package root from that path.
+// This is correct both when this file is loaded directly from node_modules AND
+// when it has been inlined by esbuild into a UD handler bundle - in the latter
+// case import.meta.dirname would point to the bundle file rather than the
+// @cedarjs/api package dir, but import.meta.resolve always resolves relative
+// to this source file's original URL regardless of bundling.
+//
+// In the CJS build the bundler replaces import.meta with {}, so we fall back
+// to the CJS globals __dirname and __filename.
 
-const currentDir = import.meta.dirname ?? __dirname
-const cedarApiRequire = createRequire(import.meta.url ?? __filename)
-
-let packageJson = cedarApiRequire(`${currentDir}/package.json`)
-
-if (packageJson?.name !== '@cedarjs/api') {
-  packageJson = cedarApiRequire(`${currentDir}/../package.json`)
+type PackageJson = {
+  name?: string
+  version?: string
+  dependencies?: Record<string, string>
 }
 
-if (packageJson?.name !== '@cedarjs/api') {
-  packageJson = cedarApiRequire(`${currentDir}/../../package.json`)
+let packageJson: PackageJson | undefined
+
+if ((import.meta as { resolve?: unknown }).resolve) {
+  const cedarApiEntryUrl = import.meta.resolve('@cedarjs/api')
+  const cedarApiDir = fileURLToPath(new URL('.', cedarApiEntryUrl))
+  const cedarApiRequire = createRequire(cedarApiEntryUrl)
+  packageJson = cedarApiRequire(`${cedarApiDir}/package.json`)
+
+  if (packageJson?.name !== '@cedarjs/api') {
+    packageJson = cedarApiRequire(`${cedarApiDir}../package.json`)
+  }
+} else {
+  const cedarApiRequire = createRequire(__filename)
+  packageJson = cedarApiRequire(`${__dirname}/package.json`)
+
+  if (packageJson?.name !== '@cedarjs/api') {
+    packageJson = cedarApiRequire(`${__dirname}/../package.json`)
+  }
+
+  if (packageJson?.name !== '@cedarjs/api') {
+    packageJson = cedarApiRequire(`${__dirname}/../../package.json`)
+  }
 }
 
-export const prismaVersion = packageJson?.dependencies['@prisma/client']
+export const prismaVersion = packageJson?.dependencies?.['@prisma/client']
 /** @deprecated - use `cedarVersion` instead */
 export const redwoodVersion = packageJson?.version
 /** @deprecated - use `cedarVersion` instead */

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,28 +9,21 @@ export * from './transforms.js'
 export * from './cors.js'
 export * from './event.js'
 
-// Use native `require` for CJS builds, and create a require function with the
-// base dir set to the dir of this file for ESM builds
-const customRequire =
-  // Look out for a stubbed require function (@rollup will stub it)
-  // @ts-expect-error - Using `0, ` to work around bundler magic
-  typeof require === 'function' && !(0, require).toString().includes('@rollup')
-    ? require
-    : createRequire(import.meta.url)
+// Locate the package.json of @cedarjs/api by walking up from this file's
+// directory. Because of how we nest cjs and esm build output we have to walk
+// up one or two levels to find the correct package.json file
 
-const cedarApiPath = customRequire.resolve('@cedarjs/api')
-const cedarApiRequire = createRequire(cedarApiPath)
+const currentDir = import.meta.dirname ?? __dirname
+const cedarApiRequire = createRequire(import.meta.url ?? __filename)
 
-let packageJson = cedarApiRequire('./package.json')
+let packageJson = cedarApiRequire(`${currentDir}/package.json`)
 
-// Because of how we build the package we might have to walk up the directory
-// tree a few times to find the correct package.json file
 if (packageJson?.name !== '@cedarjs/api') {
-  packageJson = cedarApiRequire('../package.json')
+  packageJson = cedarApiRequire(`${currentDir}/../package.json`)
 }
 
 if (packageJson?.name !== '@cedarjs/api') {
-  packageJson = cedarApiRequire('../../package.json')
+  packageJson = cedarApiRequire(`${currentDir}/../../package.json`)
 }
 
 export const prismaVersion = packageJson?.dependencies['@prisma/client']

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -31,7 +31,9 @@ type PackageJson = {
 
 let packageJson: PackageJson | undefined
 
-if ((import.meta as { resolve?: unknown }).resolve) {
+// @ts-expect-error - import.meta is replaced with {} in CJS build, so .resolve
+// is undefined, but TS's typings declare it as always present
+if (import.meta.resolve) {
   const cedarApiEntryUrl = import.meta.resolve('@cedarjs/api')
   const cedarApiDir = fileURLToPath(new URL('.', cedarApiEntryUrl))
   const cedarApiRequire = createRequire(cedarApiEntryUrl)


### PR DESCRIPTION
The old condition, `typeof require === 'function' && !(0, require).toString().includes('@rollup')`, was designed to distinguish two cases:

1. **Real CJS `require`** → use it directly
2. **Rollup's stubbed `require`** (its `.toString()` contains `'@rollup'`) → fall back to `createRequire(import.meta.url)`

But there's a third case it didn't account for: **Netlify bootstrap's `require`**, which is created via `createRequire(import.meta.url)` in the bootstrap's ESM context. That require function:
- passes `typeof require === 'function'` ✓
- doesn't contain `'@rollup'` in its `.toString()` ✓

So the code incorrectly treated it as a real CJS `require` and used it. Then `customRequire.resolve('@cedarjs/api')` asked *that* require — which resolves using the `"require"` condition from `package.json` exports — to find `@cedarjs/api`, and it returned `dist/cjs/index.js`, which wasn't in the bundle.

---

The bug has always been latent in the ESM `dist/index.js`, but before UD we just never tried that path. For CJS, because every caller that needed `@cedarjs/api` was in a CJS bundle and used `require("@cedarjs/api")`, which goes straight to `dist/cjs/index.js`, we were completely bypassing `dist/index.js`. 

UD is the first time we try ESM on Netlify and `@cedarjs/api` gets loaded as ESM in a Netlify deployment, which is what finally surfaced the bug.

