### PR TITLE
feat(cli): add --migrations and --verbose flags to setup neon

### DIFF
--- a/.changesets/1830.md
+++ b/.changesets/1830.md
@@ -1,0 +1,8 @@
+- feat(cli): add `--migrations`/`--verbose` flags to `cedar setup neon`
+  (#1830) by @lisa-assistant
+
+`cedar setup neon` now supports `--migrations`/`--no-migrations` to control
+whether Prisma migrations run after provisioning (prompting when omitted in
+an interactive terminal, and erroring instead of hanging when omitted in a
+non-interactive one), and `--verbose`/`-v` to stream the full migration
+output instead of only showing it on failure.

--- a/packages/cli/src/commands/setup/neon/__tests__/neonHandler.test.ts
+++ b/packages/cli/src/commands/setup/neon/__tests__/neonHandler.test.ts
@@ -132,7 +132,7 @@ describe('neon handler', () => {
   it('provisions a database, converts the project, and runs migrations', async () => {
     seedSqliteProject()
 
-    await handler({ force: false })
+    await handler({ force: false, migrations: true, verbose: false })
 
     const prismaSchemaPath = path.join(BASE_PATH, 'api/db/schema.prisma')
     const prismaSchema = memfsFs.readFileSync(prismaSchemaPath, 'utf-8')
@@ -168,7 +168,7 @@ describe('neon handler', () => {
       'module.exports = defineConfig({ datasource: { url: someCustomFn() } })',
     )
 
-    await handler({ force: false })
+    await handler({ force: false, migrations: true, verbose: false })
 
     expect(global.fetch).toHaveBeenCalled()
     expect(Listr2Mock.skippedTaskTitles).toContain(
@@ -248,7 +248,7 @@ describe('neon handler', () => {
       'DATABASE_URL=file:./db/dev.db\n',
     )
 
-    await handler({ force: false })
+    await handler({ force: false, migrations: true, verbose: false })
 
     expect(global.fetch).toHaveBeenCalled()
     expect(Listr2Mock.skippedTaskTitles).not.toContain(
@@ -272,7 +272,7 @@ describe('neon handler', () => {
     seedSqliteProject()
     memfsFs.writeFileSync(path.join(BASE_PATH, '.env'), 'DATABASE_URL=\n')
 
-    await handler({ force: false })
+    await handler({ force: false, migrations: true, verbose: false })
 
     expect(global.fetch).toHaveBeenCalled()
     expect(Listr2Mock.skippedTaskTitles).not.toContain(
@@ -299,7 +299,7 @@ describe('neon handler', () => {
       'DATABASE_URL=postgres://\n',
     )
 
-    await handler({ force: false })
+    await handler({ force: false, migrations: true, verbose: false })
 
     expect(global.fetch).toHaveBeenCalled()
     expect(Listr2Mock.skippedTaskTitles).not.toContain(
@@ -351,7 +351,7 @@ describe('neon handler', () => {
       }),
     })) as unknown as typeof fetch
 
-    await handler({ force: true })
+    await handler({ force: true, migrations: true, verbose: false })
 
     expect(global.fetch).toHaveBeenCalled()
     const envContent = memfsFs.readFileSync(
@@ -434,15 +434,88 @@ describe('neon handler', () => {
     })
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    await expect(handler({ force: false })).rejects.toThrow(
-      'process.exit called',
-    )
+    await expect(
+      handler({ force: false, migrations: true, verbose: false }),
+    ).rejects.toThrow('process.exit called')
 
     expect(exitSpy).toHaveBeenCalledWith(1)
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Prisma migration failed'),
     )
     expect(memfsFs.existsSync(path.join(BASE_PATH, '.env'))).toBe(false)
+
+    exitSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('exits with an error instead of prompting when migrations is omitted in a non-interactive terminal', async () => {
+    seedSqliteProject()
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // vitest doesn't run with a TTY attached to stdin, so omitting
+    // `migrations` here exercises the same non-interactive guard a real
+    // CI/script invocation would hit.
+    await expect(handler({ force: false, verbose: false })).rejects.toThrow(
+      'process.exit called',
+    )
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Cannot prompt for confirmation in a non-interactive terminal',
+      ),
+    )
+    expect(commandSync).not.toHaveBeenCalled()
+    // Provisioning itself never got a chance to run either, since the
+    // guard fires before the task list is even built.
+    expect(global.fetch).not.toHaveBeenCalled()
+
+    exitSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('skips migrations without prompting when --no-migrations is passed, but still provisions and writes .env', async () => {
+    seedSqliteProject()
+
+    await handler({ force: false, migrations: false, verbose: false })
+
+    expect(global.fetch).toHaveBeenCalled()
+    expect(commandSync).not.toHaveBeenCalled()
+    expect(Listr2Mock.skippedTaskTitles).toContain('Skipped (--no-migrations)')
+
+    const envContent = memfsFs.readFileSync(
+      path.join(BASE_PATH, '.env'),
+      'utf-8',
+    )
+    expect(envContent).toContain(
+      'DATABASE_URL=postgresql://user:pass@ep-abc-pooler.neon.tech/db',
+    )
+  })
+
+  it('runs migrations with inherited stdio and a shorter error message when --verbose is passed', async () => {
+    seedSqliteProject()
+
+    commandSync.mockReturnValueOnce({ exitCode: 1, stderr: 'P1013: boom' })
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(
+      handler({ force: false, migrations: true, verbose: true }),
+    ).rejects.toThrow('process.exit called')
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Prisma migration failed. You can try running'),
+    )
+    // The verbose error message doesn't repeat captured stderr - inherited
+    // stdio already streamed it straight to the terminal.
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('boom'))
 
     exitSpy.mockRestore()
     errorSpy.mockRestore()

--- a/packages/cli/src/commands/setup/neon/neon.ts
+++ b/packages/cli/src/commands/setup/neon/neon.ts
@@ -7,24 +7,41 @@ export const description =
   'Provision a Neon Postgres database and configure your project'
 
 export function builder(yargs: Argv) {
-  return yargs.option('force', {
-    alias: 'f',
-    default: false,
-    description: 'Overwrite existing DATABASE_URL in .env',
-    type: 'boolean',
-  })
+  return yargs
+    .option('force', {
+      alias: 'f',
+      default: false,
+      description: 'Overwrite existing DATABASE_URL in .env',
+      type: 'boolean',
+    })
+    .option('migrations', {
+      description:
+        'Run Prisma migrations after setup. Omit to be prompted. Use --no-migrations to skip.',
+      type: 'boolean',
+    })
+    .option('verbose', {
+      alias: 'v',
+      default: false,
+      description:
+        'Show full output from migration commands (stderr visible in terminal)',
+      type: 'boolean',
+    })
 }
 
 export interface Args {
   force: boolean
+  migrations?: boolean
+  verbose: boolean
 }
 
-export async function handler({ force }: Args) {
+export async function handler({ force, migrations, verbose }: Args) {
   recordTelemetryAttributes({
     command: 'setup neon',
     force,
+    migrations,
+    verbose,
   })
 
   const { handler } = await import('./neonHandler.js')
-  return handler({ force })
+  return handler({ force, migrations, verbose })
 }

--- a/packages/cli/src/commands/setup/neon/neonHandler.ts
+++ b/packages/cli/src/commands/setup/neon/neonHandler.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import execa from 'execa'
 import { Listr } from 'listr2'
+import prompts from 'prompts'
 
 import { colors, getPaths, installPackages } from '@cedarjs/cli-helpers'
 import { prettyPrintCedarCommand } from '@cedarjs/cli-helpers/packageManager'
@@ -50,7 +51,7 @@ function isPostgresConnectionString(rawValue: string): boolean {
   }
 }
 
-export async function handler({ force }: Args) {
+export async function handler({ force, migrations, verbose }: Args) {
   const cedarPaths = getPaths()
 
   const shape = checkProjectShape(cedarPaths)
@@ -100,6 +101,36 @@ export async function handler({ force }: Args) {
         'DATABASE_URL is already set in .env. Use --force to overwrite.',
       ),
     )
+  }
+
+  // Resolve whether to run migrations: flag > prompt. Only relevant when
+  // provisioning is actually going to happen - the migrations task is
+  // unconditionally skipped otherwise, so prompting would be pointless.
+  let runMigrations = migrations
+  if (!skipProvisioning && runMigrations === undefined) {
+    if (!process.stdin.isTTY) {
+      const error = new Error(
+        'Cannot prompt for confirmation in a non-interactive terminal. ' +
+          'Please pass --migrations or --no-migrations explicitly.',
+      )
+      errorTelemetry(process.argv, error.message)
+      console.error(colors.error(error.message))
+      process.exit(1)
+    }
+
+    const response = await prompts({
+      type: 'toggle',
+      name: 'runMigrations',
+      message: 'Run Prisma migrations now?',
+      initial: true,
+      active: 'Yes',
+      inactive: 'No',
+    })
+    // prompts returns undefined for the value if the user ctrl-c's
+    if (response.runMigrations === undefined) {
+      process.exit(0)
+    }
+    runMigrations = response.runMigrations
   }
 
   const tasks = new Listr<NeonCtx>(
@@ -197,6 +228,12 @@ export async function handler({ force }: Args) {
             return true
           }
 
+          if (!runMigrations) {
+            return migrations === false
+              ? 'Skipped (--no-migrations)'
+              : 'Skipped'
+          }
+
           if (ctx.directDatabaseUrlNotSet) {
             return (
               'Skipping migrations — could not confirm prisma.config is ' +
@@ -218,7 +255,7 @@ export async function handler({ force }: Args) {
             'yarn cedar prisma migrate dev --name init-neon',
             {
               cwd: cedarPaths.base,
-              stdio: ['inherit', 'inherit', 'pipe'],
+              stdio: verbose ? 'inherit' : ['inherit', 'inherit', 'pipe'],
               reject: false,
               env: {
                 ...process.env,
@@ -229,10 +266,13 @@ export async function handler({ force }: Args) {
 
           if (result.exitCode !== 0) {
             throw new Error(
-              'Prisma migration failed:\n\n' +
-                result.stderr +
-                '\n\nYou can try running it manually:\n' +
-                `  ${prettyPrintCedarCommand(['prisma', 'migrate', 'dev', '--name', 'init-neon'])}`,
+              verbose
+                ? 'Prisma migration failed. You can try running it manually:\n' +
+                    `  ${prettyPrintCedarCommand(['prisma', 'migrate', 'dev', '--name', 'init-neon'])}`
+                : 'Prisma migration failed:\n\n' +
+                    result.stderr +
+                    '\n\nYou can try running it manually:\n' +
+                    `  ${prettyPrintCedarCommand(['prisma', 'migrate', 'dev', '--name', 'init-neon'])}`,
             )
           }
         },


### PR DESCRIPTION
## What

Adds two new flags to `yarn cedar setup neon` and changes the default migration behavior:

**Before:** migrations always ran automatically after setup.

**After:** the command prompts whether to run migrations. The prompt can be bypassed with flags:
- `--migrations` / `--no-migrations` — skip the prompt, run or skip migrations explicitly
- `--verbose` / `-v` — pipe migration command stderr to stdout for better diagnostics (useful when debugging migration failures)

Note: this is a breaking change for non-interactive/scripted usage — `cedar setup neon` run bare (no `--migrations`/`--no-migrations`) now exits 1 in a non-TTY shell instead of running migrations like before. Confirmed by a real regression it caused in our own E2E CI (fixed in #2452).

## Changes

- `neon.ts`: added `--migrations` (optional boolean, no default → prompts when absent) and `--verbose` (boolean, default false) to yargs builder and `Args` interface
- `neonHandler.ts`:
  - Added `import prompts from 'prompts'` (already a dep of `@cedarjs/cli`)
  - Prompt user with a toggle before the task list runs
  - Migration task `skip` checks `!runMigrations` → `'Skipped (--no-migrations)'`
  - Migration task `stdio` switches between `'inherit'` (verbose) and `['inherit', 'inherit', 'pipe']` (non-verbose)
  - Error message omits captured stderr when verbose (since it already went to terminal)