### PR TITLE
chore(vite): suppress INVALID_ANNOTATION warnings from graphql-scalars

### DIFF
--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -94,6 +94,18 @@ export async function buildCedarApp({
             }
             return false
           },
+          // graphql-scalars places `/*#__PURE__*/` on object literal exports
+          // which Rollup can't interpret (only valid before call/new expressions).
+          // Tracked upstream: https://github.com/graphql-hive/graphql-scalars/issues/2869
+          onwarn(warning, warn) {
+            if (
+              warning.code === 'INVALID_ANNOTATION' &&
+              warning.id?.includes('graphql-scalars')
+            ) {
+              return
+            }
+            warn(warning)
+          },
         },
       },
     }


### PR DESCRIPTION
Suppresses Rollup `INVALID_ANNOTATION` warnings from `graphql-scalars`.
They place `/*#__PURE__*/` before object literal exports, which Rollup doesn't recognize (only valid before call/new expressions). The warnings are harmless but noisy.

Tracked upstream: https://github.com/graphql-hive/graphql-scalars/issues/2869