### PR TITLE
chore(vite): suppress EVAL warnings from @prisma/internals

### DIFF
--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -94,6 +94,18 @@ export async function buildCedarApp({
             }
             return false
           },
+          // Prisma internals uses `eval()` for path resolution which Rollup
+          // warns about. The code is safe and works correctly at runtime.
+          // Tracked upstream: https://github.com/prisma/prisma/issues/20752
+          onwarn(warning, warn) {
+            if (
+              warning.code === 'EVAL' &&
+              warning.id?.includes('@prisma/internals')
+            ) {
+              return
+            }
+            warn(warning)
+          },
         },
       },
     }


### PR DESCRIPTION
Suppresses Rollup `EVAL` warnings from `@prisma/internals`.
Prisma uses `eval()` internally for path resolution. The code is safe and works correctly at runtime.

Tracked upstream: https://github.com/prisma/prisma/issues/20752

**Note:** This PR conflicts with #1833 (graphql-scalars suppression) because both add an `onwarn` handler in the same location. Resolve by combining both conditions into a single `onwarn` handler.