### PR TITLE
chore(ci): cache Playwright browsers to avoid hanging downloads

### DIFF
--- a/.github/workflows/fragments-smoke-tests.yml
+++ b/.github/workflows/fragments-smoke-tests.yml
@@ -42,7 +42,7 @@ jobs:
             ~/.cache/ms-playwright
             ~/Library/Caches/ms-playwright
             ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: 🎭 Install playwright dependencies
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/fragments-smoke-tests.yml
+++ b/.github/workflows/fragments-smoke-tests.yml
@@ -34,7 +34,18 @@ jobs:
         env:
           REDWOOD_DISABLE_TELEMETRY: 1
 
+      - name: 🎭 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~\AppData\Local\ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+
       - name: 🎭 Install playwright dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Run Fragments dev smoke tests

--- a/.github/workflows/fragments-smoke-tests.yml
+++ b/.github/workflows/fragments-smoke-tests.yml
@@ -45,7 +45,6 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
 
       - name: 🎭 Install playwright dependencies
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Run Fragments dev smoke tests

--- a/.github/workflows/live-smoke-tests.yml
+++ b/.github/workflows/live-smoke-tests.yml
@@ -37,7 +37,7 @@ jobs:
             ~/.cache/ms-playwright
             ~/Library/Caches/ms-playwright
             ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: 🎭 Install playwright dependencies
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/live-smoke-tests.yml
+++ b/.github/workflows/live-smoke-tests.yml
@@ -29,7 +29,18 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
+      - name: 🎭 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~\AppData\Local\ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+
       - name: 🎭 Install playwright dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: 🔄 Run live smoke tests

--- a/.github/workflows/live-smoke-tests.yml
+++ b/.github/workflows/live-smoke-tests.yml
@@ -40,7 +40,6 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
 
       - name: 🎭 Install playwright dependencies
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: 🔄 Run live smoke tests

--- a/.github/workflows/rsc-smoke-tests.yml
+++ b/.github/workflows/rsc-smoke-tests.yml
@@ -39,7 +39,6 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
 
       - name: 🎭 Install playwright dependencies
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: 🐘 Run RSC serve smoke tests

--- a/.github/workflows/rsc-smoke-tests.yml
+++ b/.github/workflows/rsc-smoke-tests.yml
@@ -28,7 +28,18 @@ jobs:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
           GITHUB_TOKEN: ${{ github.token }}
 
+      - name: 🎭 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~\AppData\Local\ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+
       - name: 🎭 Install playwright dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: 🐘 Run RSC serve smoke tests

--- a/.github/workflows/rsc-smoke-tests.yml
+++ b/.github/workflows/rsc-smoke-tests.yml
@@ -36,7 +36,7 @@ jobs:
             ~/.cache/ms-playwright
             ~/Library/Caches/ms-playwright
             ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: 🎭 Install playwright dependencies
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/smoke-tests-react-18-test.yml
+++ b/.github/workflows/smoke-tests-react-18-test.yml
@@ -55,7 +55,18 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
+      - name: 🎭 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~\AppData\Local\ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+
       - name: 🎭 Install playwright dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: 🧑‍💻 Run dev smoke tests

--- a/.github/workflows/smoke-tests-react-18-test.yml
+++ b/.github/workflows/smoke-tests-react-18-test.yml
@@ -66,7 +66,6 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
 
       - name: 🎭 Install playwright dependencies
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: 🧑‍💻 Run dev smoke tests

--- a/.github/workflows/smoke-tests-react-18-test.yml
+++ b/.github/workflows/smoke-tests-react-18-test.yml
@@ -63,7 +63,7 @@ jobs:
             ~/.cache/ms-playwright
             ~/Library/Caches/ms-playwright
             ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: 🎭 Install playwright dependencies
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/smoke-tests-test-esm.yml
+++ b/.github/workflows/smoke-tests-test-esm.yml
@@ -29,7 +29,18 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
+      - name: 🎭 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~\AppData\Local\ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+
       - name: 🎭 Install playwright dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: 🧑‍💻 Run dev smoke tests

--- a/.github/workflows/smoke-tests-test-esm.yml
+++ b/.github/workflows/smoke-tests-test-esm.yml
@@ -37,7 +37,7 @@ jobs:
             ~/.cache/ms-playwright
             ~/Library/Caches/ms-playwright
             ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: 🎭 Install playwright dependencies
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/smoke-tests-test-esm.yml
+++ b/.github/workflows/smoke-tests-test-esm.yml
@@ -40,7 +40,6 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
 
       - name: 🎭 Install playwright dependencies
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: 🧑‍💻 Run dev smoke tests

--- a/.github/workflows/smoke-tests-test.yml
+++ b/.github/workflows/smoke-tests-test.yml
@@ -29,7 +29,18 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
+      - name: 🎭 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~\AppData\Local\ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+
       - name: 🎭 Install playwright dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: 🧑‍💻 Run dev smoke tests

--- a/.github/workflows/smoke-tests-test.yml
+++ b/.github/workflows/smoke-tests-test.yml
@@ -37,7 +37,7 @@ jobs:
             ~/.cache/ms-playwright
             ~/Library/Caches/ms-playwright
             ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: 🎭 Install playwright dependencies
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/smoke-tests-test.yml
+++ b/.github/workflows/smoke-tests-test.yml
@@ -40,7 +40,6 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
 
       - name: 🎭 Install playwright dependencies
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: 🧑‍💻 Run dev smoke tests

--- a/.github/workflows/ssr-smoke-tests.yml
+++ b/.github/workflows/ssr-smoke-tests.yml
@@ -42,7 +42,7 @@ jobs:
             ~/.cache/ms-playwright
             ~/Library/Caches/ms-playwright
             ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: 🎭 Install playwright dependencies
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/ssr-smoke-tests.yml
+++ b/.github/workflows/ssr-smoke-tests.yml
@@ -34,7 +34,18 @@ jobs:
         env:
           REDWOOD_DISABLE_TELEMETRY: 1
 
+      - name: 🎭 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~\AppData\Local\ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
+
       - name: 🎭 Install playwright dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Run SSR [DEV] smoke tests

--- a/.github/workflows/ssr-smoke-tests.yml
+++ b/.github/workflows/ssr-smoke-tests.yml
@@ -45,7 +45,6 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
 
       - name: 🎭 Install playwright dependencies
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Run SSR [DEV] smoke tests


### PR DESCRIPTION
Caches Playwright Chromium browsers across CI runs using `actions/cache`. With caching, the browser is only downloaded once per cache key and restored on subsequent runs. Cache key is based on `package.json` — invalidates when Playwright (or any dep) is updated.

CI would often get to 100% download and then just get stuck. Leaving CI jobs running sometimes several hours until I catch it and manually cancel the job

```
Run npx playwright install --with-deps chromium
  npx playwright install --with-deps chromium
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    CEDAR_CI: 1
    REDWOOD_VERBOSE_TELEMETRY: 1
Success Restart Needed Exit Code      Feature Result                               
------- -------------- ---------      --------------                               
True    No             Success        {Media Foundation}                           
Downloading Chrome for Testing 147.0.7727.15 (playwright chromium v1217) from https://cdn.playwright.dev/builds/cft/147.0.7727.15/win64/chrome-win64.zip
|                                                                                |   0% of 179.4 MiB
|■■■■■■■■                                                                        |  10% of 179.4 MiB
|■■■■■■■■■■■■■■■■                                                                |  20% of 179.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 179.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 179.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 179.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 179.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 179.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 179.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 179.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 179.4 MiB 
```

And it's not just Windows. Here's Ubuntu:

```
Run npx playwright install --with-deps chromium
  npx playwright install --with-deps chromium
  shell: /usr/bin/bash -e {0}
  env:
    CEDAR_CI: 1
    REDWOOD_VERBOSE_TELEMETRY: 1
Installing dependencies...
Switching to root user to install dependencies...
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
Hit:6 https://packages.microsoft.com/repos/azure-cli noble InRelease
Get:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
Get:7 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease [3600 B]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
Get:8 https://dl.google.com/linux/chrome-stable/deb stable InRelease [1825 B]
Get:9 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [2008 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu noble-updates/main Translation-en [355 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [178 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1693 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe Translation-en [330 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [386 kB]
Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse Translation-en [11.1 kB]
Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Components [940 B]
Get:17 https://packages.microsoft.com/ubuntu/24.04/prod noble/main amd64 Packages [158 kB]
Get:18 https://packages.microsoft.com/ubuntu/24.04/prod noble/main arm64 Packages [130 kB]
Get:19 https://packages.microsoft.com/ubuntu/24.04/prod noble/main armhf Packages [11.6 kB]
Get:20 http://azure.archive.ubuntu.com/ubuntu noble-backports/main amd64 Components [5764 B]
Get:21 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Components [10.5 kB]
Get:22 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Packages [1704 kB]
Get:23 http://azure.archive.ubuntu.com/ubuntu noble-security/main Translation-en [268 kB]
Get:24 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Components [42.4 kB]
Get:25 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Packages [1191 kB]
Get:26 http://azure.archive.ubuntu.com/ubuntu noble-security/universe Translation-en [230 kB]
Get:27 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Components [74.3 kB]
Get:28 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [3006 kB]
Get:30 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages [1219 B]
Get:29 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted Translation-en [698 kB]
Fetched 12.9 MB in 2s (8109 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
libasound2t64 is already the newest version (1.2.11-1ubuntu0.2).
libasound2t64 set to manually installed.
libatk-bridge2.0-0t64 is already the newest version (2.52.0-1build1).
libatk-bridge2.0-0t64 set to manually installed.
libatk1.0-0t64 is already the newest version (2.52.0-1build1).
libatk1.0-0t64 set to manually installed.
libatspi2.0-0t64 is already the newest version (2.52.0-1build1).
libatspi2.0-0t64 set to manually installed.
libcairo2 is already the newest version (1.18.0-3build1).
libcairo2 set to manually installed.
libcups2t64 is already the newest version (2.4.7-1.2ubuntu7.9).
libcups2t64 set to manually installed.
libdbus-1-3 is already the newest version (1.14.10-4ubuntu4.1).
libdbus-1-3 set to manually installed.
libdrm2 is already the newest version (2.4.125-1ubuntu0.1~24.04.1).
libdrm2 set to manually installed.
libgbm1 is already the newest version (25.2.8-0ubuntu0.24.04.1).
libgbm1 set to manually installed.
libglib2.0-0t64 is already the newest version (2.80.0-6ubuntu3.8).
libglib2.0-0t64 set to manually installed.
libnspr4 is already the newest version (2:4.35-1.1build1).
libnspr4 set to manually installed.
libnss3 is already the newest version (2:3.98-1ubuntu0.1).
libnss3 set to manually installed.
libpango-1.0-0 is already the newest version (1.52.1+ds-1build1).
libpango-1.0-0 set to manually installed.
libx11-6 is already the newest version (2:1.8.7-1build1).
libx11-6 set to manually installed.
libxcb1 is already the newest version (1.15-1ubuntu2).
libxcb1 set to manually installed.
libxcomposite1 is already the newest version (1:0.4.5-1build3).
libxcomposite1 set to manually installed.
libxdamage1 is already the newest version (1:1.1.6-1build1).
libxdamage1 set to manually installed.
libxext6 is already the newest version (2:1.3.4-1build2).
libxext6 set to manually installed.
libxfixes3 is already the newest version (1:6.0.0-2build1).
libxfixes3 set to manually installed.
libxkbcommon0 is already the newest version (1.6.0-1build1).
libxkbcommon0 set to manually installed.
libxrandr2 is already the newest version (2:1.5.2-2build1).
libxrandr2 set to manually installed.
xvfb is already the newest version (2:21.1.12-1ubuntu1.5).
fonts-noto-color-emoji is already the newest version (2.047-0ubuntu0.24.04.1).
libfontconfig1 is already the newest version (2.15.0-1.1ubuntu2).
libfontconfig1 set to manually installed.
libfreetype6 is already the newest version (2.13.2+dfsg-1ubuntu0.1).
libfreetype6 set to manually installed.
fonts-liberation is already the newest version (1:2.1.5-3).
fonts-liberation set to manually installed.
The following additional packages will be installed:
  xfonts-encodings xfonts-utils
Recommended packages:
  fonts-ipafont-mincho fonts-tlwg-loma
The following NEW packages will be installed:
  fonts-freefont-ttf fonts-ipafont-gothic fonts-tlwg-loma-otf fonts-unifont
  fonts-wqy-zenhei xfonts-cyrillic xfonts-encodings xfonts-scalable
  xfonts-utils
0 upgraded, 9 newly installed, 0 to remove and 6 not upgraded.
Need to get 21.1 MB of archives.
After this operation, 79.5 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-ipafont-gothic all 00303-21ubuntu1 [3513 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 fonts-freefont-ttf all 20211204+svn4273-2 [5641 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-tlwg-loma-otf all 1:0.7.3-1 [107 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-unifont all 1:15.1.01-1build1 [2993 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-wqy-zenhei all 0.9.45-8 [7472 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-encodings all 1:1.0.5-0ubuntu2 [578 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-utils amd64 1:7.7+6build3 [94.4 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 xfonts-cyrillic all 1:1.0.5+nmu1 [384 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-scalable all 1:1.0.3-1.3 [304 kB]
Fetched 21.1 MB in 1s (34.3 MB/s)
Selecting previously unselected package fonts-ipafont-gothic.
(Reading database ... 
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 202271 files and directories currently installed.)
Preparing to unpack .../0-fonts-ipafont-gothic_00303-21ubuntu1_all.deb ...
Unpacking fonts-ipafont-gothic (00303-21ubuntu1) ...
Selecting previously unselected package fonts-freefont-ttf.
Preparing to unpack .../1-fonts-freefont-ttf_20211204+svn4273-2_all.deb ...
Unpacking fonts-freefont-ttf (20211204+svn4273-2) ...
Selecting previously unselected package fonts-tlwg-loma-otf.
Preparing to unpack .../2-fonts-tlwg-loma-otf_1%3a0.7.3-1_all.deb ...
Unpacking fonts-tlwg-loma-otf (1:0.7.3-1) ...
Selecting previously unselected package fonts-unifont.
Preparing to unpack .../3-fonts-unifont_1%3a15.1.01-1build1_all.deb ...
Unpacking fonts-unifont (1:15.1.01-1build1) ...
Selecting previously unselected package fonts-wqy-zenhei.
Preparing to unpack .../4-fonts-wqy-zenhei_0.9.45-8_all.deb ...
Unpacking fonts-wqy-zenhei (0.9.45-8) ...
Selecting previously unselected package xfonts-encodings.
Preparing to unpack .../5-xfonts-encodings_1%3a1.0.5-0ubuntu2_all.deb ...
Unpacking xfonts-encodings (1:1.0.5-0ubuntu2) ...
Selecting previously unselected package xfonts-utils.
Preparing to unpack .../6-xfonts-utils_1%3a7.7+6build3_amd64.deb ...
Unpacking xfonts-utils (1:7.7+6build3) ...
Selecting previously unselected package xfonts-cyrillic.
Preparing to unpack .../7-xfonts-cyrillic_1%3a1.0.5+nmu1_all.deb ...
Unpacking xfonts-cyrillic (1:1.0.5+nmu1) ...
Selecting previously unselected package xfonts-scalable.
Preparing to unpack .../8-xfonts-scalable_1%3a1.0.3-1.3_all.deb ...
Unpacking xfonts-scalable (1:1.0.3-1.3) ...
Setting up fonts-wqy-zenhei (0.9.45-8) ...
Setting up fonts-freefont-ttf (20211204+svn4273-2) ...
Setting up fonts-tlwg-loma-otf (1:0.7.3-1) ...
Setting up xfonts-encodings (1:1.0.5-0ubuntu2) ...
Setting up fonts-ipafont-gothic (00303-21ubuntu1) ...
update-alternatives: using /usr/share/fonts/opentype/ipafont-gothic/ipag.ttf to provide /usr/share/fonts/truetype/fonts-japanese-gothic.ttf (fonts-japanese-gothic.ttf) in auto mode
Setting up fonts-unifont (1:15.1.01-1build1) ...
Setting up xfonts-utils (1:7.7+6build3) ...
Setting up xfonts-cyrillic (1:1.0.5+nmu1) ...
Setting up xfonts-scalable (1:1.0.3-1.3) ...
Processing triggers for man-db (2.12.0-4build2) ...
Not building database; man-db/auto-update is not 'true'.
Processing triggers for fontconfig (2.15.0-1.1ubuntu2) ...
Running kernel seems to be up-to-date.
No services need to be restarted.
No containers need to be restarted.
No user sessions are running outdated binaries.
No VM guests are running outdated hypervisor (qemu) binaries on this host.
Downloading Chrome for Testing 147.0.7727.15 (playwright chromium v1217) from https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip
|                                                                                |   0% of 170.4 MiB
|■■■■■■■■                                                                        |  10% of 170.4 MiB
|■■■■■■■■■■■■■■■■                                                                |  20% of 170.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 170.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 170.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 170.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 170.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 170.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 170.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 170.4 MiB
|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 170.4 MiB
```

Someone else had the same problem here too: https://station.railway.com/questions/stuck-on-build-19e77e0b