### PR TITLE
fix(rename): Cedar prefixed telemetry env vars

### DIFF
--- a/.github/actions/telemetry_check/check.mjs
+++ b/.github/actions/telemetry_check/check.mjs
@@ -5,9 +5,10 @@ import path from 'path'
 
 import { exec } from '@actions/exec'
 
-console.log(
-  `Telemetry is being redirected to ${process.env.REDWOOD_REDIRECT_TELEMETRY}`,
-)
+const redirectUrl =
+  process.env.CEDAR_REDIRECT_TELEMETRY || process.env.REDWOOD_REDIRECT_TELEMETRY
+
+console.log(`Telemetry is being redirected to ${redirectUrl}`)
 
 // Setup fake telemetry server
 const server = http.createServer((req, res) => {
@@ -27,8 +28,8 @@ const server = http.createServer((req, res) => {
 })
 
 // Run the fake telemetry server at the redirected location
-const host = process.env.REDWOOD_REDIRECT_TELEMETRY.split(':')[1].slice(2)
-const port = parseInt(process.env.REDWOOD_REDIRECT_TELEMETRY.split(':')[2])
+const host = redirectUrl.split(':')[1].slice(2)
+const port = parseInt(redirectUrl.split(':')[2])
 server.listen(port, host, () => {
   console.log(`Telemetry listener is running on http://${host}:${port}`)
 })

--- a/.github/workflows/background-jobs-e2e.yml
+++ b/.github/workflows/background-jobs-e2e.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       CEDAR_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
+      CEDAR_VERBOSE_TELEMETRY: 1
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -32,4 +32,4 @@ jobs:
       - name: Run E2E test script
         run: yarn e2e:background-jobs ${{ steps.set-up-test-project.outputs.test-project-path }}
         env:
-          REDWOOD_VERBOSE_TELEMETRY: ''
+          CEDAR_VERBOSE_TELEMETRY: ''

--- a/.github/workflows/cli-smoke-tests.yml
+++ b/.github/workflows/cli-smoke-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       CEDAR_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
+      CEDAR_VERBOSE_TELEMETRY: 1
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/e2e-netlify.yml
+++ b/.github/workflows/e2e-netlify.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      REDWOOD_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
+      CEDAR_CI: 1
+      CEDAR_VERBOSE_TELEMETRY: 1
       YARN_ENABLE_HARDENED_MODE: 0
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/fragments-smoke-tests.yml
+++ b/.github/workflows/fragments-smoke-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       CEDAR_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
+      CEDAR_VERBOSE_TELEMETRY: 1
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/live-smoke-tests.yml
+++ b/.github/workflows/live-smoke-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       CEDAR_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
+      CEDAR_VERBOSE_TELEMETRY: 1
 
     steps:
       - name: Checkout the framework code

--- a/.github/workflows/rsc-smoke-tests.yml
+++ b/.github/workflows/rsc-smoke-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       CEDAR_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
+      CEDAR_VERBOSE_TELEMETRY: 1
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/smoke-tests-react-18-test.yml
+++ b/.github/workflows/smoke-tests-react-18-test.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       CEDAR_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
+      CEDAR_VERBOSE_TELEMETRY: 1
 
     steps:
       - name: Checkout the framework code

--- a/.github/workflows/smoke-tests-test-esm.yml
+++ b/.github/workflows/smoke-tests-test-esm.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       CEDAR_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
+      CEDAR_VERBOSE_TELEMETRY: 1
 
     steps:
       - name: Checkout the framework code

--- a/.github/workflows/smoke-tests-test.yml
+++ b/.github/workflows/smoke-tests-test.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       CEDAR_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
+      CEDAR_VERBOSE_TELEMETRY: 1
 
     steps:
       - name: Checkout the framework code

--- a/.github/workflows/ssr-smoke-tests.yml
+++ b/.github/workflows/ssr-smoke-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       CEDAR_CI: 1
-      REDWOOD_VERBOSE_TELEMETRY: 1
+      CEDAR_VERBOSE_TELEMETRY: 1
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -17,7 +17,7 @@ tasks:
       - postDevcontainerStart
     command: |
       export CFW_PATH="/workspaces/cedar"
-      export REDWOOD_DISABLE_TELEMETRY=1
+      export CEDAR_DISABLE_TELEMETRY=1
       echo "Setting up CedarJS development environment..."
       mkdir -p /workspaces/cedar-test-app
       cd /workspaces/cedar

--- a/packages/adapters/fastify/web/vitest.setup.mts
+++ b/packages/adapters/fastify/web/vitest.setup.mts
@@ -2,5 +2,5 @@ import { beforeAll } from 'vitest'
 
 // Disable telemetry within framework tests
 beforeAll(() => {
-  process.env.REDWOOD_DISABLE_TELEMETRY = '1'
+  process.env.CEDAR_DISABLE_TELEMETRY = '1'
 })

--- a/packages/cli/src/cfw.ts
+++ b/packages/cli/src/cfw.ts
@@ -50,7 +50,8 @@ try {
   execa.sync('yarn', [...command], {
     stdio: 'inherit',
     cwd: absCfwPath,
-    // @ts-expect-error - testUtils.d.ts augments ProcessEnv with REDWOOD_DISABLE_TELEMETRY
+    // @ts-expect-error - testUtils.d.ts augments ProcessEnv with
+    // CEDAR_DISABLE_TELEMETRY
     env: { CEDAR_CWD: projectPath },
   })
 } catch {

--- a/packages/cli/src/commands/deploy/render.js
+++ b/packages/cli/src/commands/deploy/render.js
@@ -4,7 +4,7 @@ import { terminalLink } from 'termi-link'
 // Because telemetryMiddleware is added to Yargs as middleware,
 // we need to set the env var here outside the handler to correctly disable it.
 if (process.argv.slice(2).includes('api')) {
-  process.env.REDWOOD_DISABLE_TELEMETRY = '1'
+  process.env.CEDAR_DISABLE_TELEMETRY = '1'
 }
 
 export const command = 'render <side>'

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -68,12 +68,14 @@ import { startTelemetry, shutdownTelemetry } from './telemetry/index.js'
 let { cwd, telemetry, help, version } = Parser(hideBin(process.argv), {
   // Telemetry is enabled by default, but can be disabled in two ways
   // - by passing a `--telemetry false` option
-  // - by setting a `REDWOOD_DISABLE_TELEMETRY` env var
+  // - by setting a `CEDAR_DISABLE_TELEMETRY` env var
   boolean: ['telemetry'],
   default: {
     telemetry:
-      process.env.REDWOOD_DISABLE_TELEMETRY === undefined ||
-      process.env.REDWOOD_DISABLE_TELEMETRY === '',
+      (process.env.CEDAR_DISABLE_TELEMETRY === undefined ||
+        process.env.CEDAR_DISABLE_TELEMETRY === '') &&
+      (process.env.REDWOOD_DISABLE_TELEMETRY === undefined ||
+        process.env.REDWOOD_DISABLE_TELEMETRY === ''),
   },
 })
 cwd ??= process.env.CEDAR_CWD

--- a/packages/cli/src/telemetry/send.ts
+++ b/packages/cli/src/telemetry/send.ts
@@ -36,6 +36,7 @@ async function main() {
   const resource = Resource.default().merge(new Resource(customResourceData))
 
   const url =
+    process.env.CEDAR_REDIRECT_TELEMETRY ||
     process.env.REDWOOD_REDIRECT_TELEMETRY ||
     'https://quark.quantumparticle.io/v1/traces'
   const traceExporter = new OTLPTraceExporter({

--- a/packages/cli/src/telemetry/send.ts
+++ b/packages/cli/src/telemetry/send.ts
@@ -13,7 +13,9 @@ import { getResources } from './resource.js'
 async function main() {
   // Log out the telemetry notice
   console.log(
-    "You can disable telemetry by:\n - setting the 'REDWOOD_DISABLE_TELEMETRY' environment variable\n - passing the '--no-telemetry' flag when using the CLI",
+    'You can disable telemetry by:\n' +
+      " - setting the 'CEDAR_DISABLE_TELEMETRY' environment variable\n" +
+      " - passing the '--no-telemetry' flag when using the CLI",
   )
   console.log(
     'Information about Redwood telemetry can be found at:\n - https://telemetry.redwoodjs.com\n',

--- a/packages/cli/src/telemetry/send.ts
+++ b/packages/cli/src/telemetry/send.ts
@@ -18,7 +18,7 @@ async function main() {
       " - passing the '--no-telemetry' flag when using the CLI",
   )
   console.log(
-    'Information about Redwood telemetry can be found at:\n - https://telemetry.redwoodjs.com\n',
+    'Information about Cedar telemetry can be found at:\n - https://telemetry.redwoodjs.com\n',
   )
 
   // Get all telemetry files

--- a/packages/cli/testUtils.d.ts
+++ b/packages/cli/testUtils.d.ts
@@ -69,6 +69,7 @@ declare global {
 
   namespace NodeJS {
     interface ProcessEnv {
+      CEDAR_DISABLE_TELEMETRY: string
       REDWOOD_DISABLE_TELEMETRY: string
     }
   }

--- a/packages/cli/vitest.codemods.setup.ts
+++ b/packages/cli/vitest.codemods.setup.ts
@@ -1,7 +1,7 @@
 /* eslint-env node, vitest */
 
 // Disable telemetry within framework tests
-process.env.REDWOOD_DISABLE_TELEMETRY = '1'
+process.env.CEDAR_DISABLE_TELEMETRY = '1'
 
 import fs from 'node:fs'
 import path from 'path'

--- a/packages/cli/vitest.setup.mts
+++ b/packages/cli/vitest.setup.mts
@@ -15,5 +15,5 @@ vi.mock('prisma/config', () => {
 
 // Disable telemetry within framework tests
 beforeAll(() => {
-  process.env.REDWOOD_DISABLE_TELEMETRY = '1'
+  process.env.CEDAR_DISABLE_TELEMETRY = '1'
 })

--- a/packages/create-cedar-app/src/create-cedar-app.ts
+++ b/packages/create-cedar-app/src/create-cedar-app.ts
@@ -40,13 +40,15 @@ import { tui } from './tui.js'
 
 // Telemetry can be disabled in two ways:
 // - by passing `--telemetry false`  or `--no-telemetry`
-// - by setting the `REDWOOD_DISABLE_TELEMETRY` env var to `1`
+// - by setting the `CEDAR_DISABLE_TELEMETRY` env var to `1`
 const { telemetry } = Parser(hideBin(process.argv), {
   boolean: ['telemetry'],
   default: {
     telemetry:
-      process.env.REDWOOD_DISABLE_TELEMETRY === undefined ||
-      process.env.REDWOOD_DISABLE_TELEMETRY === '',
+      (process.env.CEDAR_DISABLE_TELEMETRY === undefined ||
+        process.env.CEDAR_DISABLE_TELEMETRY === '') &&
+      (process.env.REDWOOD_DISABLE_TELEMETRY === undefined ||
+        process.env.REDWOOD_DISABLE_TELEMETRY === ''),
   },
 })
 

--- a/packages/create-cedar-app/src/telemetry.ts
+++ b/packages/create-cedar-app/src/telemetry.ts
@@ -86,6 +86,7 @@ export async function startTelemetry(): Promise<void> {
   // Tracing
   traceExporter = new OTLPTraceExporter({
     url:
+      process.env.CEDAR_REDIRECT_TELEMETRY ||
       process.env.REDWOOD_REDIRECT_TELEMETRY ||
       'https://quark.quantumparticle.io/v1/traces',
   })

--- a/packages/create-cedar-app/src/telemetry.ts
+++ b/packages/create-cedar-app/src/telemetry.ts
@@ -111,7 +111,10 @@ export async function shutdownTelemetry(): Promise<void> {
   } catch (error) {
     // We silence this error for user experience unless verbose telemetry is
     // enabled
-    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
+    if (
+      process.env.CEDAR_VERBOSE_TELEMETRY ||
+      process.env.REDWOOD_VERBOSE_TELEMETRY
+    ) {
       console.error('Telemetry: shutdown error', error)
     }
   }

--- a/packages/create-cedar-app/src/telemetry.ts
+++ b/packages/create-cedar-app/src/telemetry.ts
@@ -110,7 +110,7 @@ export async function shutdownTelemetry(): Promise<void> {
   } catch (error) {
     // We silence this error for user experience unless verbose telemetry is
     // enabled
-    if (process.env.REDWOOD_VERBOSE_TELEMETRY) {
+    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
       console.error('Telemetry: shutdown error', error)
     }
   }

--- a/packages/create-cedar-rsc-app/src/telemetry.ts
+++ b/packages/create-cedar-rsc-app/src/telemetry.ts
@@ -2,6 +2,7 @@ import ci from 'ci-info'
 import fetch from 'node-fetch'
 
 const TELEMETRY_URL =
+  process.env.CEDAR_REDIRECT_TELEMETRY ??
   process.env.REDWOOD_REDIRECT_TELEMETRY ??
   'https://telemetry.redwoodjs.com/api/v1/telemetry'
 

--- a/packages/create-cedar-rsc-app/src/telemetry.ts
+++ b/packages/create-cedar-rsc-app/src/telemetry.ts
@@ -71,10 +71,13 @@ export async function sendTelemetry(
     return
   }
 
+  const verboseTelemetry =
+    process.env.CEDAR_VERBOSE_TELEMETRY ?? process.env.REDWOOD_VERBOSE_TELEMETRY
+
   try {
     const payload = buildPayload(telemetryInfo, duration)
 
-    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
+    if (verboseTelemetry) {
       console.info('Cedar Telemetry Payload', payload)
     }
 
@@ -84,20 +87,20 @@ export async function sendTelemetry(
       headers: { 'Content-Type': 'application/json' },
     })
 
-    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
+    if (verboseTelemetry) {
       console.info('Cedar Telemetry Response:', response)
     }
 
     // Normally we would report on any non-error response here (like a 500)
     // but since the process is spawned and stdout/stderr is ignored, it can
     // never be seen by the user, so ignore.
-    if (process.env.CEDAR_VERBOSE_TELEMETRY && response.status !== 200) {
+    if (verboseTelemetry && response.status !== 200) {
       console.error('Error from telemetry insert:', await response.text())
     }
   } catch (e) {
     // service interruption: network down or telemetry API not responding
     // don't let telemetry errors bubble up to user, just do nothing.
-    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
+    if (verboseTelemetry) {
       console.error('Uncaught error in telemetry:', e)
     }
   }

--- a/packages/create-cedar-rsc-app/src/telemetry.ts
+++ b/packages/create-cedar-rsc-app/src/telemetry.ts
@@ -63,15 +63,18 @@ export async function sendTelemetry(
   telemetryInfo: TelemetryInfo,
   duration: number,
 ) {
-  if (process.env.REDWOOD_DISABLE_TELEMETRY) {
+  if (
+    process.env.CEDAR_DISABLE_TELEMETRY ||
+    process.env.REDWOOD_DISABLE_TELEMETRY
+  ) {
     return
   }
 
   try {
     const payload = buildPayload(telemetryInfo, duration)
 
-    if (process.env.REDWOOD_VERBOSE_TELEMETRY) {
-      console.info('Redwood Telemetry Payload', payload)
+    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
+      console.info('Cedar Telemetry Payload', payload)
     }
 
     const response = await fetch(TELEMETRY_URL, {
@@ -80,20 +83,20 @@ export async function sendTelemetry(
       headers: { 'Content-Type': 'application/json' },
     })
 
-    if (process.env.REDWOOD_VERBOSE_TELEMETRY) {
-      console.info('Redwood Telemetry Response:', response)
+    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
+      console.info('Cedar Telemetry Response:', response)
     }
 
     // Normally we would report on any non-error response here (like a 500)
     // but since the process is spawned and stdout/stderr is ignored, it can
     // never be seen by the user, so ignore.
-    if (process.env.REDWOOD_VERBOSE_TELEMETRY && response.status !== 200) {
+    if (process.env.CEDAR_VERBOSE_TELEMETRY && response.status !== 200) {
       console.error('Error from telemetry insert:', await response.text())
     }
   } catch (e) {
     // service interruption: network down or telemetry API not responding
     // don't let telemetry errors bubble up to user, just do nothing.
-    if (process.env.REDWOOD_VERBOSE_TELEMETRY) {
+    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
       console.error('Uncaught error in telemetry:', e)
     }
   }

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -32,7 +32,7 @@ Set an environment variable, either in your app's .env file, or anywhere that
 creates variables for your user space, like `.bashrc` or `.bash_profile`:
 
 ```terminal
-REDWOOD_DISABLE_TELEMETRY=1
+CEDAR_DISABLE_TELEMETRY=1
 ```
 
 ## About
@@ -41,10 +41,11 @@ See: https://telemetry.redwoodjs.com
 
 ## Troubleshooting
 
-If you suspect problems with telemetry when running CRWA, you can set the verbose flag to help diagnose issues.
+If you suspect problems with telemetry when running CCA, you can set the verbose
+flag to help diagnose issues.
 
 For example,
 
 ```terminal
-REDWOOD_VERBOSE_TELEMETRY=true yarn create-cedar-app bazinga
+CEDAR_VERBOSE_TELEMETRY=true yarn create-cedar-app bazinga
 ```

--- a/packages/telemetry/src/sendTelemetry.ts
+++ b/packages/telemetry/src/sendTelemetry.ts
@@ -272,7 +272,7 @@ export const sendTelemetry = async () => {
     const payload = await buildPayload()
 
     if (verboseTelemetry) {
-      console.info('Redwood Telemetry Payload', payload)
+      console.info('Cedar Telemetry Payload', payload)
     }
 
     const response = await fetch(telemetryUrl, {
@@ -282,7 +282,7 @@ export const sendTelemetry = async () => {
     })
 
     if (verboseTelemetry) {
-      console.info('Redwood Telemetry Response:', response)
+      console.info('Cedar Telemetry Response:', response)
     }
 
     // Normally we would report on any non-error response here (like a 500)

--- a/packages/telemetry/src/sendTelemetry.ts
+++ b/packages/telemetry/src/sendTelemetry.ts
@@ -265,11 +265,13 @@ export const sendTelemetry = async () => {
     process.env.CEDAR_REDIRECT_TELEMETRY ||
     process.env.REDWOOD_REDIRECT_TELEMETRY ||
     'https://telemetry.redwoodjs.com/api/v1/telemetry'
+  const verboseTelemetry =
+    process.env.CEDAR_VERBOSE_TELEMETRY || process.env.REDWOOD_VERBOSE_TELEMETRY
 
   try {
     const payload = await buildPayload()
 
-    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
+    if (verboseTelemetry) {
       console.info('Redwood Telemetry Payload', payload)
     }
 
@@ -279,20 +281,20 @@ export const sendTelemetry = async () => {
       headers: { 'Content-Type': 'application/json' },
     })
 
-    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
+    if (verboseTelemetry) {
       console.info('Redwood Telemetry Response:', response)
     }
 
     // Normally we would report on any non-error response here (like a 500)
     // but since the process is spawned and stdout/stderr is ignored, it can
     // never be seen by the user, so ignore.
-    if (process.env.CEDAR_VERBOSE_TELEMETRY && response.status !== 200) {
+    if (verboseTelemetry && response.status !== 200) {
       console.error('Error from telemetry insert:', await response.text())
     }
   } catch (e) {
     // service interruption: network down or telemetry API not responding
     // don't let telemetry errors bubble up to user, just do nothing.
-    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
+    if (verboseTelemetry) {
       console.error('Uncaught error in telemetry:', e)
     }
   }

--- a/packages/telemetry/src/sendTelemetry.ts
+++ b/packages/telemetry/src/sendTelemetry.ts
@@ -268,7 +268,7 @@ export const sendTelemetry = async () => {
   try {
     const payload = await buildPayload()
 
-    if (process.env.REDWOOD_VERBOSE_TELEMETRY) {
+    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
       console.info('Redwood Telemetry Payload', payload)
     }
 
@@ -278,20 +278,20 @@ export const sendTelemetry = async () => {
       headers: { 'Content-Type': 'application/json' },
     })
 
-    if (process.env.REDWOOD_VERBOSE_TELEMETRY) {
+    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
       console.info('Redwood Telemetry Response:', response)
     }
 
     // Normally we would report on any non-error response here (like a 500)
     // but since the process is spawned and stdout/stderr is ignored, it can
     // never be seen by the user, so ignore.
-    if (process.env.REDWOOD_VERBOSE_TELEMETRY && response.status !== 200) {
+    if (process.env.CEDAR_VERBOSE_TELEMETRY && response.status !== 200) {
       console.error('Error from telemetry insert:', await response.text())
     }
   } catch (e) {
     // service interruption: network down or telemetry API not responding
     // don't let telemetry errors bubble up to user, just do nothing.
-    if (process.env.REDWOOD_VERBOSE_TELEMETRY) {
+    if (process.env.CEDAR_VERBOSE_TELEMETRY) {
       console.error('Uncaught error in telemetry:', e)
     }
   }

--- a/packages/telemetry/src/sendTelemetry.ts
+++ b/packages/telemetry/src/sendTelemetry.ts
@@ -262,6 +262,7 @@ function uniqueId() {
 // actually call the API with telemetry data
 export const sendTelemetry = async () => {
   const telemetryUrl =
+    process.env.CEDAR_REDIRECT_TELEMETRY ||
     process.env.REDWOOD_REDIRECT_TELEMETRY ||
     'https://telemetry.redwoodjs.com/api/v1/telemetry'
 

--- a/packages/telemetry/src/telemetry.ts
+++ b/packages/telemetry/src/telemetry.ts
@@ -11,7 +11,7 @@ const spawnProcess = (...args: string[]) => {
 
   const spawnOptions: Partial<SpawnOptions> = isWindows
     ? {
-        stdio: process.env.REDWOOD_VERBOSE_TELEMETRY
+        stdio: process.env.CEDAR_VERBOSE_TELEMETRY
           ? ['ignore', 'inherit', 'inherit']
           : 'ignore',
         // The following options run the process in the background without a console window, even though they don't look like they would.
@@ -21,10 +21,10 @@ const spawnProcess = (...args: string[]) => {
         shell: true,
       }
     : {
-        stdio: process.env.REDWOOD_VERBOSE_TELEMETRY
+        stdio: process.env.CEDAR_VERBOSE_TELEMETRY
           ? ['ignore', 'inherit', 'inherit']
           : 'ignore',
-        detached: process.env.REDWOOD_VERBOSE_TELEMETRY ? false : true,
+        detached: process.env.CEDAR_VERBOSE_TELEMETRY ? false : true,
         windowsHide: true,
       }
 
@@ -46,7 +46,10 @@ export const timedTelemetry = async (
   options: Record<string, unknown>,
   func: (...args: any[]) => any,
 ) => {
-  if (process.env.REDWOOD_DISABLE_TELEMETRY) {
+  if (
+    process.env.CEDAR_DISABLE_TELEMETRY ||
+    process.env.REDWOOD_DISABLE_TELEMETRY
+  ) {
     return func.call(this)
   }
 
@@ -67,7 +70,10 @@ export const timedTelemetry = async (
 }
 
 export const errorTelemetry = async (argv: string[], error: any) => {
-  if (process.env.REDWOOD_DISABLE_TELEMETRY) {
+  if (
+    process.env.CEDAR_DISABLE_TELEMETRY ||
+    process.env.REDWOOD_DISABLE_TELEMETRY
+  ) {
     return
   }
 
@@ -76,7 +82,10 @@ export const errorTelemetry = async (argv: string[], error: any) => {
 
 // used as yargs middleware when any command is invoked
 export const telemetryMiddleware = async () => {
-  if (process.env.REDWOOD_DISABLE_TELEMETRY) {
+  if (
+    process.env.CEDAR_DISABLE_TELEMETRY ||
+    process.env.REDWOOD_DISABLE_TELEMETRY
+  ) {
     return
   }
 

--- a/packages/telemetry/src/telemetry.ts
+++ b/packages/telemetry/src/telemetry.ts
@@ -11,9 +11,11 @@ const spawnProcess = (...args: string[]) => {
 
   const spawnOptions: Partial<SpawnOptions> = isWindows
     ? {
-        stdio: process.env.CEDAR_VERBOSE_TELEMETRY
-          ? ['ignore', 'inherit', 'inherit']
-          : 'ignore',
+        stdio:
+          process.env.CEDAR_VERBOSE_TELEMETRY ||
+          process.env.REDWOOD_VERBOSE_TELEMETRY
+            ? ['ignore', 'inherit', 'inherit']
+            : 'ignore',
         // The following options run the process in the background without a console window, even though they don't look like they would.
         // See https://github.com/nodejs/node/issues/21825#issuecomment-503766781 for information
         detached: false,
@@ -21,10 +23,16 @@ const spawnProcess = (...args: string[]) => {
         shell: true,
       }
     : {
-        stdio: process.env.CEDAR_VERBOSE_TELEMETRY
-          ? ['ignore', 'inherit', 'inherit']
-          : 'ignore',
-        detached: process.env.CEDAR_VERBOSE_TELEMETRY ? false : true,
+        stdio:
+          process.env.CEDAR_VERBOSE_TELEMETRY ||
+          process.env.REDWOOD_VERBOSE_TELEMETRY
+            ? ['ignore', 'inherit', 'inherit']
+            : 'ignore',
+        detached:
+          process.env.CEDAR_VERBOSE_TELEMETRY ||
+          process.env.REDWOOD_VERBOSE_TELEMETRY
+            ? false
+            : true,
         windowsHide: true,
       }
 

--- a/upgrade-scripts/5.x.ts
+++ b/upgrade-scripts/5.x.ts
@@ -1,0 +1,137 @@
+import { glob, readFile } from 'node:fs/promises'
+import * as path from 'node:path'
+import { styleText } from 'node:util'
+
+import { getPaths } from '@cedarjs/project-config'
+
+const projectRoot = getPaths().base
+
+const patterns = [
+  '**/*.{js,cjs,mjs,ts,cts,mts}',
+  '**/.env',
+  '**/.env.*',
+  '**/*.sh',
+  '**/*.py',
+  '**/*.json',
+  '**/*.{yaml,yml}',
+  '**/Dockerfile',
+  '**/Dockerfile.*',
+  '**/docker-compose.{yml,yaml}',
+  '**/.dockerignore',
+  '**/*.tf',
+  '**/*.tfvars',
+  '**/*.bicep',
+]
+
+const exclude = ['**/node_modules/**', '**/dist/**']
+
+async function main() {
+  const filesWithOldDelayRestartVar: string[] = []
+  const filesWithOldRedirectTelemetryVar: string[] = []
+  const filesWithOldDisableTelemetryVar: string[] = []
+  const filesWithOldVerboseTelemetryVar: string[] = []
+
+  for await (const file of glob(patterns, { cwd: projectRoot, exclude })) {
+    const content = await readFile(path.join(projectRoot, file), 'utf8')
+
+    if (content.includes('RWJS_DELAY_RESTART')) {
+      filesWithOldDelayRestartVar.push(file)
+    }
+
+    if (content.includes('REDWOOD_REDIRECT_TELEMETRY')) {
+      filesWithOldRedirectTelemetryVar.push(file)
+    }
+
+    if (content.includes('REDWOOD_DISABLE_TELEMETRY')) {
+      filesWithOldDisableTelemetryVar.push(file)
+    }
+
+    if (content.includes('REDWOOD_VERBOSE_TELEMETRY')) {
+      filesWithOldVerboseTelemetryVar.push(file)
+    }
+  }
+
+  if (filesWithOldDelayRestartVar.length > 0) {
+    console.log(
+      styleText('yellow', 'Deprecated env var detected: RWJS_DELAY_RESTART') +
+        '\n',
+    )
+    console.log(
+      'Found RWJS_DELAY_RESTART in: ' +
+        filesWithOldDelayRestartVar.join(', ') +
+        '\n',
+    )
+    console.log(
+      'RWJS_DELAY_RESTART has been renamed to CEDAR_DELAY_API_RESTART and will\n' +
+        'be removed in the next major release of CedarJS.\n',
+    )
+    console.log(
+      'Please rename it in the files listed above before the next major upgrade.\n',
+    )
+  }
+
+  if (filesWithOldRedirectTelemetryVar.length > 0) {
+    console.log(
+      styleText(
+        'yellow',
+        'Deprecated env var detected: REDWOOD_REDIRECT_TELEMETRY',
+      ) + '\n',
+    )
+    console.log(
+      'Found REDWOOD_REDIRECT_TELEMETRY in: ' +
+        filesWithOldRedirectTelemetryVar.join(', ') +
+        '\n',
+    )
+    console.log(
+      'REDWOOD_REDIRECT_TELEMETRY has been renamed to CEDAR_REDIRECT_TELEMETRY and will\n' +
+        'be removed in the next major release of CedarJS.\n',
+    )
+    console.log(
+      'Please rename it in the files listed above before the next major upgrade.\n',
+    )
+  }
+
+  if (filesWithOldDisableTelemetryVar.length > 0) {
+    console.log(
+      styleText(
+        'yellow',
+        'Deprecated env var detected: REDWOOD_DISABLE_TELEMETRY',
+      ) + '\n',
+    )
+    console.log(
+      'Found REDWOOD_DISABLE_TELEMETRY in: ' +
+        filesWithOldDisableTelemetryVar.join(', ') +
+        '\n',
+    )
+    console.log(
+      'REDWOOD_DISABLE_TELEMETRY has been renamed to CEDAR_DISABLE_TELEMETRY and will\n' +
+        'be removed in the next major release of CedarJS.\n',
+    )
+    console.log(
+      'Please rename it in the files listed above before the next major upgrade.\n',
+    )
+  }
+
+  if (filesWithOldVerboseTelemetryVar.length > 0) {
+    console.log(
+      styleText(
+        'yellow',
+        'Deprecated env var detected: REDWOOD_VERBOSE_TELEMETRY',
+      ) + '\n',
+    )
+    console.log(
+      'Found REDWOOD_VERBOSE_TELEMETRY in: ' +
+        filesWithOldVerboseTelemetryVar.join(', ') +
+        '\n',
+    )
+    console.log(
+      'REDWOOD_VERBOSE_TELEMETRY has been renamed to CEDAR_VERBOSE_TELEMETRY and will\n' +
+        'be removed in the next major release of CedarJS.\n',
+    )
+    console.log(
+      'Please rename it in the files listed above before the next major upgrade.\n',
+    )
+  }
+}
+
+main()

--- a/upgrade-scripts/manifest.json
+++ b/upgrade-scripts/manifest.json
@@ -1,1 +1,1 @@
-["canary.ts", "2.3.x.ts", "2.7.x.ts", "2.8.x.ts", "3.x.ts", "4.x.ts"]
+["canary.ts", "2.3.x.ts", "2.7.x.ts", "2.8.x.ts", "3.x.ts", "4.x.ts", "5.x.ts"]


### PR DESCRIPTION
Rename telemetry related env vars to CEDAR_*
Old REDWOOD_* names still work for now, but will be removed in a future (major) version of Cedar