### PR TITLE
chore(ci): Pin Node on Windows to work around libuv bug

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -33,7 +33,9 @@ runs:
     - name: ⬢ Set up Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: 24
+        # Pin Windows to 24.15.0 to avoid libuv 1.52.x assertion bug on file watching.
+        # See https://github.com/libuv/libuv/issues/5010
+        node-version: ${{ runner.os == 'Windows' && '24.15.0' || '24' }}
 
     # We have to enable Corepack again for Windows. 🤷
     # In general, we're waiting on [this issue](https://github.com/actions/setup-node/issues/531)


### PR DESCRIPTION
Workaround for: https://github.com/libuv/libuv/issues/5010
Fix found here: https://github.com/mizdra/css-modules-kit/pull/404

I saw it in our CI here: https://github.com/cedarjs/cedar/actions/runs/26578926408/job/78322552870?pr=1841

```
   RUN  v3.2.4 D:/a/cedar/cedar/packages/api-server
  
   ✓ src/__tests__/logFormatter.test.ts (27 tests) 13ms
  Assertion failed: !_wcsnicmp(filename, dir, dirlen), file src\win\fs-event.c, line 72


 NX   Running target test for 59 projects failed
 ```