### PR TITLE
chore(ci): Drop Playwright cache. Separate deps install step

### DIFF
--- a/.github/workflows/fragments-smoke-tests.yml
+++ b/.github/workflows/fragments-smoke-tests.yml
@@ -34,17 +34,12 @@ jobs:
         env:
           REDWOOD_DISABLE_TELEMETRY: 1
 
-      - name: 🎭 Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/ms-playwright
-            ~/Library/Caches/ms-playwright
-            ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: 🎭 Install playwright dependencies
+        if: runner.os == 'Windows'
+        run: npx playwright install chromium
 
       - name: 🎭 Install playwright dependencies
+        if: runner.os != 'Windows'
         run: npx playwright install --with-deps chromium
 
       - name: Run Fragments dev smoke tests

--- a/.github/workflows/fragments-smoke-tests.yml
+++ b/.github/workflows/fragments-smoke-tests.yml
@@ -34,13 +34,12 @@ jobs:
         env:
           REDWOOD_DISABLE_TELEMETRY: 1
 
-      - name: 🎭 Install playwright dependencies
-        if: runner.os == 'Windows'
-        run: npx playwright install chromium
+      - name: 🎭 Install Playwright OS dependencies
+        if: runner.os == 'Linux'
+        run: npx playwright install-deps chromium
 
       - name: 🎭 Install playwright dependencies
-        if: runner.os != 'Windows'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Run Fragments dev smoke tests
         working-directory: ./tasks/smoke-tests/fragments-dev

--- a/.github/workflows/live-smoke-tests.yml
+++ b/.github/workflows/live-smoke-tests.yml
@@ -29,13 +29,12 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
-      - name: 🎭 Install playwright dependencies
-        if: runner.os == 'Windows'
-        run: npx playwright install chromium
+      - name: 🎭 Install Playwright OS dependencies
+        if: runner.os == 'Linux'
+        run: npx playwright install-deps chromium
 
       - name: 🎭 Install playwright dependencies
-        if: runner.os != 'Windows'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: 🔄 Run live smoke tests
         working-directory: ./tasks/smoke-tests/live

--- a/.github/workflows/live-smoke-tests.yml
+++ b/.github/workflows/live-smoke-tests.yml
@@ -29,17 +29,12 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
-      - name: 🎭 Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/ms-playwright
-            ~/Library/Caches/ms-playwright
-            ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: 🎭 Install playwright dependencies
+        if: runner.os == 'Windows'
+        run: npx playwright install chromium
 
       - name: 🎭 Install playwright dependencies
+        if: runner.os != 'Windows'
         run: npx playwright install --with-deps chromium
 
       - name: 🔄 Run live smoke tests

--- a/.github/workflows/rsc-smoke-tests.yml
+++ b/.github/workflows/rsc-smoke-tests.yml
@@ -28,13 +28,12 @@ jobs:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: 🎭 Install playwright dependencies
-        if: runner.os == 'Windows'
-        run: npx playwright install chromium
+      - name: 🎭 Install Playwright OS dependencies
+        if: runner.os == 'Linux'
+        run: npx playwright install-deps chromium
 
       - name: 🎭 Install playwright dependencies
-        if: runner.os != 'Windows'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: 🐘 Run RSC serve smoke tests
         working-directory: tasks/smoke-tests/rsc

--- a/.github/workflows/rsc-smoke-tests.yml
+++ b/.github/workflows/rsc-smoke-tests.yml
@@ -28,17 +28,12 @@ jobs:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: 🎭 Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/ms-playwright
-            ~/Library/Caches/ms-playwright
-            ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: 🎭 Install playwright dependencies
+        if: runner.os == 'Windows'
+        run: npx playwright install chromium
 
       - name: 🎭 Install playwright dependencies
+        if: runner.os != 'Windows'
         run: npx playwright install --with-deps chromium
 
       - name: 🐘 Run RSC serve smoke tests

--- a/.github/workflows/smoke-tests-react-18-test.yml
+++ b/.github/workflows/smoke-tests-react-18-test.yml
@@ -55,17 +55,12 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
-      - name: 🎭 Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/ms-playwright
-            ~/Library/Caches/ms-playwright
-            ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: 🎭 Install playwright dependencies
+        if: runner.os == 'Windows'
+        run: npx playwright install chromium
 
       - name: 🎭 Install playwright dependencies
+        if: runner.os != 'Windows'
         run: npx playwright install --with-deps chromium
 
       - name: 🧑‍💻 Run dev smoke tests

--- a/.github/workflows/smoke-tests-react-18-test.yml
+++ b/.github/workflows/smoke-tests-react-18-test.yml
@@ -55,13 +55,12 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
-      - name: 🎭 Install playwright dependencies
-        if: runner.os == 'Windows'
-        run: npx playwright install chromium
+      - name: 🎭 Install Playwright OS dependencies
+        if: runner.os == 'Linux'
+        run: npx playwright install-deps chromium
 
       - name: 🎭 Install playwright dependencies
-        if: runner.os != 'Windows'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: 🧑‍💻 Run dev smoke tests
         working-directory: ./tasks/smoke-tests/dev

--- a/.github/workflows/smoke-tests-test-esm.yml
+++ b/.github/workflows/smoke-tests-test-esm.yml
@@ -29,17 +29,12 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
-      - name: 🎭 Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/ms-playwright
-            ~/Library/Caches/ms-playwright
-            ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: 🎭 Install playwright dependencies
+        if: runner.os == 'Windows'
+        run: npx playwright install chromium
 
       - name: 🎭 Install playwright dependencies
+        if: runner.os != 'Windows'
         run: npx playwright install --with-deps chromium
 
       - name: 🧑‍💻 Run dev smoke tests

--- a/.github/workflows/smoke-tests-test-esm.yml
+++ b/.github/workflows/smoke-tests-test-esm.yml
@@ -29,13 +29,12 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
-      - name: 🎭 Install playwright dependencies
-        if: runner.os == 'Windows'
-        run: npx playwright install chromium
+      - name: 🎭 Install Playwright OS dependencies
+        if: runner.os == 'Linux'
+        run: npx playwright install-deps chromium
 
       - name: 🎭 Install playwright dependencies
-        if: runner.os != 'Windows'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: 🧑‍💻 Run dev smoke tests
         working-directory: ./tasks/smoke-tests/dev

--- a/.github/workflows/smoke-tests-test.yml
+++ b/.github/workflows/smoke-tests-test.yml
@@ -29,17 +29,12 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
-      - name: 🎭 Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/ms-playwright
-            ~/Library/Caches/ms-playwright
-            ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: 🎭 Install playwright dependencies
+        if: runner.os == 'Windows'
+        run: npx playwright install chromium
 
       - name: 🎭 Install playwright dependencies
+        if: runner.os != 'Windows'
         run: npx playwright install --with-deps chromium
 
       - name: 🧑‍💻 Run dev smoke tests

--- a/.github/workflows/smoke-tests-test.yml
+++ b/.github/workflows/smoke-tests-test.yml
@@ -29,13 +29,12 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
-      - name: 🎭 Install playwright dependencies
-        if: runner.os == 'Windows'
-        run: npx playwright install chromium
+      - name: 🎭 Install Playwright OS dependencies
+        if: runner.os == 'Linux'
+        run: npx playwright install-deps chromium
 
       - name: 🎭 Install playwright dependencies
-        if: runner.os != 'Windows'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: 🧑‍💻 Run dev smoke tests
         working-directory: ./tasks/smoke-tests/dev

--- a/.github/workflows/ssr-smoke-tests.yml
+++ b/.github/workflows/ssr-smoke-tests.yml
@@ -34,13 +34,12 @@ jobs:
         env:
           REDWOOD_DISABLE_TELEMETRY: 1
 
-      - name: 🎭 Install playwright dependencies
-        if: runner.os == 'Windows'
-        run: npx playwright install chromium
+      - name: 🎭 Install Playwright OS dependencies
+        if: runner.os == 'Linux'
+        run: npx playwright install-deps chromium
 
       - name: 🎭 Install playwright dependencies
-        if: runner.os != 'Windows'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Run SSR [DEV] smoke tests
         working-directory: ./tasks/smoke-tests/streaming-ssr-dev

--- a/.github/workflows/ssr-smoke-tests.yml
+++ b/.github/workflows/ssr-smoke-tests.yml
@@ -34,17 +34,12 @@ jobs:
         env:
           REDWOOD_DISABLE_TELEMETRY: 1
 
-      - name: 🎭 Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/ms-playwright
-            ~/Library/Caches/ms-playwright
-            ~\AppData\Local\ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: 🎭 Install playwright dependencies
+        if: runner.os == 'Windows'
+        run: npx playwright install chromium
 
       - name: 🎭 Install playwright dependencies
+        if: runner.os != 'Windows'
         run: npx playwright install --with-deps chromium
 
       - name: Run SSR [DEV] smoke tests


### PR DESCRIPTION
> Caching browsers
>
> Caching browser binaries is not recommended, since the amount of time it takes to restore the cache is comparable to the time it takes to download the binaries. Especially under Linux, [operating system dependencies](https://playwright.dev/docs/browsers#install-system-dependencies) need to be installed, which are not cacheable.

https://playwright.dev/docs/ci#caching-browsers

> Azure Pipelines
> For Windows or macOS agents, no additional configuration is required, just install Playwright and run your tests.

https://playwright.dev/docs/ci#azure-pipelines

