### PR TITLE
fix(vite): register ~__CEDAR__USER_ROUTES_FOR_MOCK alias in Vitest

### DIFF
--- a/packages/vite/src/lib/getMergedConfig.ts
+++ b/packages/vite/src/lib/getMergedConfig.ts
@@ -209,4 +209,3 @@ function getRollupInput(userConfig: ViteUserConfig, ssr: boolean) {
 
   return cedarPaths.web.html
 }
-

--- a/packages/vite/src/lib/getMergedConfig.ts
+++ b/packages/vite/src/lib/getMergedConfig.ts
@@ -52,8 +52,7 @@ export function getMergedConfig(cedarConfig: Config, cedarPaths: Paths) {
         alias: {
           ...workspaceAliases,
           // In test mode, register the virtual module alias so that
-          // MockProviders can resolve the user's Routes file. This mirrors
-          // what Jest's moduleNameMapper does for the same module name.
+          // MockProviders can resolve the user's Routes file
           ...(env.mode === 'test'
             ? { '~__CEDAR__USER_ROUTES_FOR_MOCK': cedarPaths.web.routes }
             : {}),

--- a/packages/vite/src/lib/getMergedConfig.ts
+++ b/packages/vite/src/lib/getMergedConfig.ts
@@ -49,7 +49,15 @@ export function getMergedConfig(cedarConfig: Config, cedarPaths: Paths) {
     const defaultCedarViteConfig: ViteUserConfig = {
       root: cedarPaths.web.base,
       resolve: {
-        alias: workspaceAliases,
+        alias: {
+          ...workspaceAliases,
+          // In test mode, register the virtual module alias so that
+          // MockProviders can resolve the user's Routes file. This mirrors
+          // what Jest's moduleNameMapper does for the same module name.
+          ...(env.mode === 'test'
+            ? { '~__CEDAR__USER_ROUTES_FOR_MOCK': cedarPaths.web.routes }
+            : {}),
+        },
       },
       // @MARK: when we have these aliases, the warnings from the FE server go
       // away BUT, if you have imports like this:
@@ -201,3 +209,4 @@ function getRollupInput(userConfig: ViteUserConfig, ssr: boolean) {
 
   return cedarPaths.web.html
 }
+


### PR DESCRIPTION
Fixes #427

## Problem

Web-side tests that don't use the router log a spurious error:

```
Error: Cannot find module '~__CEDAR__USER_ROUTES_FOR_MOCK'
Require stack:
- .../node_modules/@cedarjs/testing/dist/web/MockProviders.js
```

`MockProviders.tsx` does a `require('~__CEDAR__USER_ROUTES_FOR_MOCK')` wrapped in a try/catch, intending it to be silent when the module isn't found. The catch checks `error.code === 'MODULE_NOT_FOUND' && error.moduleName === module` — but this check doesn't hold in Vitest's environment, so the error leaks through to `console.warn`.

The root cause is that `~__CEDAR__USER_ROUTES_FOR_MOCK` is registered as a Jest `moduleNameMapper` entry in `jest-preset.ts`, but there's no equivalent alias registered in the Vite/Vitest config. Vitest handles routes via `globRoutesImporter.ts` (`import.meta.glob`), but the `require()` path in `MockProviders` runs unconditionally before that and fails.

## Fix

Add `~__CEDAR__USER_ROUTES_FOR_MOCK` to `getMergedConfig`'s `resolve.alias` when running in test mode (`env.mode === 'test'`), pointing to `cedarPaths.web.routes` — the same target Jest uses.

```ts
// packages/vite/src/lib/getMergedConfig.ts
resolve: {
  alias: {
    ...workspaceAliases,
    ...(env.mode === 'test'
      ? { '~__CEDAR__USER_ROUTES_FOR_MOCK': cedarPaths.web.routes }
      : {}),
  },
},
```

This is the same one-line fix that the Storybook preset already applies in its own Vite config for the same alias.