### PR TITLE
feat(web): Support "cedar-app" div id

### DIFF
--- a/__fixtures__/empty-project/web/index.html
+++ b/__fixtures__/empty-project/web/index.html
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-  <div id="redwood-app">
+  <div id="cedar-app">
     <!-- Please keep the line below for prerender support. -->
     <%= prerenderPlaceholder %>
   </div>

--- a/__fixtures__/example-todo-main-with-errors/web/index.html
+++ b/__fixtures__/example-todo-main-with-errors/web/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <title>Todo • A sample Redwood application</title>
+    <title>Todo • A sample Cedar application</title>
   </head>
 
   <body>
-    <div id="redwood-app"></div>
+    <div id="cedar-app"></div>
   </body>
 </html>

--- a/__fixtures__/example-todo-main/web/index.html
+++ b/__fixtures__/example-todo-main/web/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <title>Todo • A sample Redwood application</title>
+    <title>Todo • A sample Cedar application</title>
   </head>
 
   <body>
-    <div id="redwood-app"></div>
+    <div id="cedar-app"></div>
   </body>
 </html>

--- a/__fixtures__/rsc-caching/web/src/Document.tsx
+++ b/__fixtures__/rsc-caching/web/src/Document.tsx
@@ -20,7 +20,7 @@ export const Document: React.FC<DocumentProps> = ({ children, css, meta }) => {
         <Meta tags={meta} />
       </head>
       <body>
-        <div id="redwood-app">{children}</div>
+        <div id="cedar-app">{children}</div>
       </body>
     </html>
   )

--- a/__fixtures__/rsc-caching/web/src/entry.client.tsx
+++ b/__fixtures__/rsc-caching/web/src/entry.client.tsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/__fixtures__/test-project-esm/web/index.html
+++ b/__fixtures__/test-project-esm/web/index.html
@@ -9,7 +9,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/__fixtures__/test-project-esm/web/src/entry.client.tsx
+++ b/__fixtures__/test-project-esm/web/src/entry.client.tsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/__fixtures__/test-project-live/web/index.html
+++ b/__fixtures__/test-project-live/web/index.html
@@ -9,7 +9,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/__fixtures__/test-project-live/web/src/entry.client.tsx
+++ b/__fixtures__/test-project-live/web/src/entry.client.tsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/__fixtures__/test-project-rsa/web/src/Document.tsx
+++ b/__fixtures__/test-project-rsa/web/src/Document.tsx
@@ -20,7 +20,7 @@ export const Document: React.FC<DocumentProps> = ({ children, css, meta }) => {
         <Meta tags={meta} />
       </head>
       <body>
-        <div id="redwood-app">{children}</div>
+        <div id="cedar-app">{children}</div>
       </body>
     </html>
   )

--- a/__fixtures__/test-project-rsa/web/src/entry.client.tsx
+++ b/__fixtures__/test-project-rsa/web/src/entry.client.tsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/Document.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/Document.tsx
@@ -21,7 +21,7 @@ export const Document: React.FC<DocumentProps> = ({ children, css, meta }) => {
         <Meta tags={meta} />
       </head>
       <body>
-        <div id="redwood-app">{children}</div>
+        <div id="cedar-app">{children}</div>
       </body>
     </html>
   )

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/entry.client.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/entry.client.tsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/__fixtures__/test-project/web/index.html
+++ b/__fixtures__/test-project/web/index.html
@@ -9,7 +9,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/__fixtures__/test-project/web/src/entry.client.tsx
+++ b/__fixtures__/test-project/web/src/entry.client.tsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/local-testing-project-live/web/index.html
+++ b/local-testing-project-live/web/index.html
@@ -8,6 +8,6 @@
 
   <body>
     <!-- Please keep this div empty -->
-    <div id="redwood-app"></div>
+    <div id="cedar-app"></div>
   </body>
 </html>

--- a/local-testing-project-live/web/src/entry.client.tsx
+++ b/local-testing-project-live/web/src/entry.client.tsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/local-testing-project/web/index.html
+++ b/local-testing-project/web/index.html
@@ -8,6 +8,6 @@
 
   <body>
     <!-- Please keep this div empty -->
-    <div id="redwood-app"></div>
+    <div id="cedar-app"></div>
   </body>
 </html>

--- a/local-testing-project/web/src/entry.client.tsx
+++ b/local-testing-project/web/src/entry.client.tsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/packages/adapters/fastify/web/src/__fixtures__/fallback/web/dist/about.html
+++ b/packages/adapters/fastify/web/src/__fixtures__/fallback/web/dist/about.html
@@ -14,7 +14,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app">
+  <div id="cedar-app">
     <header class="relative flex items-center justify-between bg-blue-700 px-8 py-4 text-white">
       <h1 class="text-3xl font-semibold tracking-tight"><a href="/"
           class="text-blue-400 transition duration-100 hover:text-blue-100">Cedar Blog</a></h1>

--- a/packages/adapters/fastify/web/src/__fixtures__/fallback/web/dist/index.html
+++ b/packages/adapters/fastify/web/src/__fixtures__/fallback/web/dist/index.html
@@ -13,7 +13,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app">
+  <div id="cedar-app">
     <header class="relative flex items-center justify-between bg-blue-700 px-8 py-4 text-white">
       <h1 class="text-3xl font-semibold tracking-tight"><a href="/"
           class="text-blue-400 transition duration-100 hover:text-blue-100">Cedar Blog</a></h1>

--- a/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/200.html
+++ b/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/200.html
@@ -11,7 +11,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/404.html
+++ b/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/404.html
@@ -14,7 +14,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"><!--$-->
+  <div id="cedar-app"><!--$-->
     <main>
       <style>
         html,

--- a/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/about.html
+++ b/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/about.html
@@ -14,7 +14,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app">
+  <div id="cedar-app">
     <header class="relative flex items-center justify-between bg-blue-700 px-8 py-4 text-white">
       <h1 class="text-3xl font-semibold tracking-tight"><a href="/"
           class="text-blue-400 transition duration-100 hover:text-blue-100">Cedar Blog</a></h1>

--- a/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/contacts/new.html
+++ b/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/contacts/new.html
@@ -14,7 +14,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app">
+  <div id="cedar-app">
     <div class="rw-scaffold">
       <div style="position:fixed;z-index:9999;top:16px;left:16px;right:16px;bottom:16px;pointer-events:none"></div>
       <header class="rw-header">

--- a/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/index.html
+++ b/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/index.html
@@ -13,7 +13,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app">
+  <div id="cedar-app">
     <header class="relative flex items-center justify-between bg-blue-700 px-8 py-4 text-white">
       <h1 class="text-3xl font-semibold tracking-tight"><a href="/"
           class="text-blue-400 transition duration-100 hover:text-blue-100">Cedar Blog</a></h1>

--- a/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/nested/index.html
+++ b/packages/adapters/fastify/web/src/__fixtures__/main/web/dist/nested/index.html
@@ -11,7 +11,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/200.html
+++ b/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/200.html
@@ -11,7 +11,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/404.html
+++ b/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/404.html
@@ -14,7 +14,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"><!--$-->
+  <div id="cedar-app"><!--$-->
     <main>
       <style>
         html,

--- a/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/about.html
+++ b/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/about.html
@@ -14,7 +14,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app">
+  <div id="cedar-app">
     <header class="relative flex items-center justify-between bg-blue-700 px-8 py-4 text-white">
       <h1 class="text-3xl font-semibold tracking-tight"><a href="/"
           class="text-blue-400 transition duration-100 hover:text-blue-100">Cedar Blog</a></h1>

--- a/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/contacts/new.html
+++ b/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/contacts/new.html
@@ -14,7 +14,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app">
+  <div id="cedar-app">
     <div class="rw-scaffold">
       <div style="position:fixed;z-index:9999;top:16px;left:16px;right:16px;bottom:16px;pointer-events:none"></div>
       <header class="rw-header">

--- a/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/index.html
+++ b/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/index.html
@@ -13,7 +13,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app">
+  <div id="cedar-app">
     <header class="relative flex items-center justify-between bg-blue-700 px-8 py-4 text-white">
       <h1 class="text-3xl font-semibold tracking-tight"><a href="/"
           class="text-blue-400 transition duration-100 hover:text-blue-100">Cedar Blog</a></h1>

--- a/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/nested/index.html
+++ b/packages/api-server/src/__tests__/fixtures/graphql/cedar-app/web/dist/nested/index.html
@@ -11,7 +11,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/packages/cli-packages/storybook-vite/src/commands/templates/preview-body.html.template
+++ b/packages/cli-packages/storybook-vite/src/commands/templates/preview-body.html.template
@@ -1,1 +1,1 @@
-<div id="redwood-app"></div>
+<div id="cedar-app"></div>

--- a/packages/cli/src/commands/experimental/templates/rsc/Document.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/Document.tsx.template
@@ -20,7 +20,7 @@ export const Document: React.FC<DocumentProps> = ({ children, css, meta }) => {
         <Meta tags={meta} />
       </head>
       <body>
-        <div id="redwood-app">{children}</div>
+        <div id="cedar-app">{children}</div>
       </body>
     </html>
   )

--- a/packages/cli/src/commands/experimental/templates/rsc/entry.client.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/entry.client.tsx.template
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * pre-rendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/packages/cli/src/commands/experimental/templates/streamingSsr/Document.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/streamingSsr/Document.tsx.template
@@ -20,7 +20,7 @@ export const Document: React.FC<DocumentProps> = ({ children, css, meta }) => {
         <Meta tags={meta} />
       </head>
       <body>
-        <div id="redwood-app">{children}</div>
+        <div id="cedar-app">{children}</div>
       </body>
     </html>
   )

--- a/packages/cli/src/commands/experimental/templates/streamingSsr/entry.client.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/streamingSsr/entry.client.tsx.template
@@ -5,21 +5,21 @@ import { Document } from './Document'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
     document,
     <Document css={window.__assetMap?.()?.css}>

--- a/packages/create-cedar-app/templates/esm-js/web/index.html
+++ b/packages/create-cedar-app/templates/esm-js/web/index.html
@@ -9,7 +9,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/packages/create-cedar-app/templates/esm-js/web/src/entry.client.jsx
+++ b/packages/create-cedar-app/templates/esm-js/web/src/entry.client.jsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/packages/create-cedar-app/templates/esm-ts/web/index.html
+++ b/packages/create-cedar-app/templates/esm-ts/web/index.html
@@ -9,7 +9,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/packages/create-cedar-app/templates/esm-ts/web/src/entry.client.tsx
+++ b/packages/create-cedar-app/templates/esm-ts/web/src/entry.client.tsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/packages/create-cedar-app/templates/js/web/index.html
+++ b/packages/create-cedar-app/templates/js/web/index.html
@@ -9,7 +9,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/packages/create-cedar-app/templates/js/web/src/entry.client.jsx
+++ b/packages/create-cedar-app/templates/js/web/src/entry.client.jsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/packages/create-cedar-app/templates/ts/web/index.html
+++ b/packages/create-cedar-app/templates/ts/web/index.html
@@ -9,7 +9,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/packages/create-cedar-app/templates/ts/web/src/entry.client.tsx
+++ b/packages/create-cedar-app/templates/ts/web/src/entry.client.tsx
@@ -4,29 +4,29 @@ import App from './App'
 import Routes from './Routes'
 
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
+ * When `#cedar-app` isn't empty then it's very likely that you're using
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
+if (!cedarAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it " +
-      "exists in your 'web/index.html' file."
+    'Could not find an element with ID "cedar-app". Please ensure it exists ' +
+      'in your `web/index.html` file.'
   )
 }
 
-if (redwoodAppElement.children?.length > 0) {
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/packages/internal/src/__tests__/__fixtures__/nestedPages/web/index.html
+++ b/packages/internal/src/__tests__/__fixtures__/nestedPages/web/index.html
@@ -12,7 +12,7 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/atom-one-light.min.css" rel="stylesheet">
 </head>
 <body>
-<div id="redwood-app" class="flex flex-col text-stone-900" style="min-height: 100vh">
+<div id="cedar-app" class="flex flex-col text-stone-900" style="min-height: 100vh">
   <!-- Please keep the line below for prerender support. -->
   <%= prerenderPlaceholder %>
 </div>

--- a/packages/prerender/src/runPrerender.tsx
+++ b/packages/prerender/src/runPrerender.tsx
@@ -382,7 +382,7 @@ export const runPrerender = async ({
 
   insertChunkLoadingScript(indexHtmlTree, renderPath)
 
-  indexHtmlTree('#redwood-app').append(componentAsHtml)
+  indexHtmlTree('#cedar-app, #redwood-app').append(componentAsHtml)
 
   const renderOutput = indexHtmlTree.html()
 

--- a/packages/prerender/src/runPrerenderEsm.tsx
+++ b/packages/prerender/src/runPrerenderEsm.tsx
@@ -398,7 +398,7 @@ export const runPrerender = async ({
 
   insertChunkLoadingScript(indexHtmlTree, renderPath)
 
-  indexHtmlTree('#redwood-app').append(componentAsHtml)
+  indexHtmlTree('#cedar-app, #redwood-app').append(componentAsHtml)
 
   const renderOutput = indexHtmlTree.html()
 

--- a/packages/router/src/active-route-loader.tsx
+++ b/packages/router/src/active-route-loader.tsx
@@ -19,9 +19,11 @@ let isPrerendered = false
 // SSR and streaming changes how we mount the React app (we render the whole page, including head and body)
 // This logic is no longer valid and needs to be rethought
 if (typeof window !== 'undefined') {
-  const redwoodAppElement = document.getElementById('redwood-app')
+  const cedarAppElement =
+    document.getElementById('cedar-app') ??
+    document.getElementById('redwood-app')
 
-  if (redwoodAppElement && redwoodAppElement.children.length > 0) {
+  if (cedarAppElement && cedarAppElement.children.length > 0) {
     isPrerendered = true
   }
 }

--- a/packages/web/src/entry/index.jsx
+++ b/packages/web/src/entry/index.jsx
@@ -13,7 +13,7 @@ const cedarAppElement =
 
 if (!cedarAppElement) {
   throw new Error(
-    'Could not find an element with ID "cedar-app" or "redwood-app". Please' +
+    'Could not find an element with ID "cedar-app" or "redwood-app". Please ' +
       'ensure one exists in your `web/index.html` file.',
   )
 }

--- a/packages/web/src/entry/index.jsx
+++ b/packages/web/src/entry/index.jsx
@@ -3,22 +3,30 @@ import { hydrateRoot, createRoot } from 'react-dom/client'
 import App from '~redwood-app-root'
 import Routes from '~redwood-app-routes'
 /**
- * When `#redwood-app` isn't empty then it's very likely that you're using
- * prerendering. So React attaches event listeners to the existing markup
- * rather than replacing it.
+ * When `#cedar-app` or `#redwood-app` isn't empty then it's very likely that
+ * you're using prerendering. So React attaches event listeners to the existing
+ * markup rather than replacing it.
  * https://react.dev/reference/react-dom/client/hydrateRoot
  */
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement =
+  document.getElementById('cedar-app') ?? document.getElementById('redwood-app')
 
-if (redwoodAppElement.children?.length > 0) {
+if (!cedarAppElement) {
+  throw new Error(
+    'Could not find an element with ID "cedar-app" or "redwood-app". Please' +
+      'ensure one exists in your `web/index.html` file.',
+  )
+}
+
+if (cedarAppElement.children?.length > 0) {
   hydrateRoot(
-    redwoodAppElement,
+    cedarAppElement,
     <App>
       <Routes />
     </App>,
   )
 } else {
-  const root = createRoot(redwoodAppElement)
+  const root = createRoot(cedarAppElement)
   root.render(
     <App>
       <Routes />

--- a/tasks/netlify-tests/netlify.test.mts
+++ b/tasks/netlify-tests/netlify.test.mts
@@ -61,6 +61,6 @@ describe('Netlify deployment', () => {
     const res = await fetch(url('/'))
     expect(res.status).toEqual(200)
     const text = await res.text()
-    expect(text).toContain('<div id="redwood-app">')
+    expect(text).toContain('<div id="cedar-app">')
   })
 })

--- a/tasks/server-tests/fixtures/redwood-app/web/dist/200.html
+++ b/tasks/server-tests/fixtures/redwood-app/web/dist/200.html
@@ -11,7 +11,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/tasks/server-tests/fixtures/redwood-app/web/dist/404.html
+++ b/tasks/server-tests/fixtures/redwood-app/web/dist/404.html
@@ -14,7 +14,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"><!--$-->
+  <div id="cedar-app"><!--$-->
     <main>
       <style>
         html,

--- a/tasks/server-tests/fixtures/redwood-app/web/dist/about.html
+++ b/tasks/server-tests/fixtures/redwood-app/web/dist/about.html
@@ -14,7 +14,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app">
+  <div id="cedar-app">
     <header class="relative flex items-center justify-between bg-blue-700 px-8 py-4 text-white">
       <h1 class="text-3xl font-semibold tracking-tight"><a href="/"
           class="text-blue-400 transition duration-100 hover:text-blue-100">Cedar Blog</a></h1>

--- a/tasks/server-tests/fixtures/redwood-app/web/dist/contacts/new.html
+++ b/tasks/server-tests/fixtures/redwood-app/web/dist/contacts/new.html
@@ -14,7 +14,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app">
+  <div id="cedar-app">
     <div class="rw-scaffold">
       <div style="position:fixed;z-index:9999;top:16px;left:16px;right:16px;bottom:16px;pointer-events:none"></div>
       <header class="rw-header">

--- a/tasks/server-tests/fixtures/redwood-app/web/dist/index.html
+++ b/tasks/server-tests/fixtures/redwood-app/web/dist/index.html
@@ -13,7 +13,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app">
+  <div id="cedar-app">
     <header class="relative flex items-center justify-between bg-blue-700 px-8 py-4 text-white">
       <h1 class="text-3xl font-semibold tracking-tight"><a href="/"
           class="text-blue-400 transition duration-100 hover:text-blue-100">Cedar Blog</a></h1>

--- a/tasks/server-tests/fixtures/redwood-app/web/dist/nested/index.html
+++ b/tasks/server-tests/fixtures/redwood-app/web/dist/nested/index.html
@@ -11,7 +11,7 @@
 
 <body>
   <!-- Please keep this div empty -->
-  <div id="redwood-app"></div>
+  <div id="cedar-app"></div>
 </body>
 
 </html>

--- a/tasks/smoke-tests/rsa/tests/rsa.spec.ts
+++ b/tasks/smoke-tests/rsa/tests/rsa.spec.ts
@@ -6,13 +6,13 @@ test('Submitting the form should return a response', async ({ page }) => {
   const h1 = await page.locator('h1').innerText()
   expect(h1).toMatch(/Hello Anonymous!!/)
 
-  const pageText = await page.locator('#redwood-app > div').innerText()
+  const pageText = await page.locator('#cedar-app > div').innerText()
   expect(pageText).toMatch('The form has been submitted 0 times.')
 
   await page.getByRole('textbox').fill('Hello World')
   await page.getByRole('button').click()
 
-  const submittedPageText = page.locator('#redwood-app > div')
+  const submittedPageText = page.locator('#cedar-app > div')
   await expect(submittedPageText).toHaveText(
     /The form has been submitted 1 times./,
   )

--- a/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
+++ b/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
@@ -100,13 +100,13 @@ test('Submitting the form should return a response', async ({ page }) => {
   const h1 = await page.locator('h1').innerText()
   expect(h1).toMatch(/Hello Anonymous!!/)
 
-  const pageText = await page.locator('#redwood-app > div').innerText()
+  const pageText = await page.locator('#cedar-app > div').innerText()
   expect(pageText).toMatch('This form has been sent 0 times')
 
   await page.getByRole('textbox').fill('Hello World')
   await page.getByRole('button').getByText('Send').click()
 
-  const submittedPageText = page.locator('#redwood-app > div')
+  const submittedPageText = page.locator('#cedar-app > div')
   await expect(submittedPageText).toHaveText(/This form has been sent 1 times/)
 
   // Expect an echo of our message back from the server

--- a/tasks/smoke-tests/shared/common.ts
+++ b/tasks/smoke-tests/shared/common.ts
@@ -22,9 +22,9 @@ export async function smokeTest({ page }: PlaywrightTestArgs) {
   ).toBeVisible()
 
   // CSS checks. We saw this break when we switched bundlers, so while it's not comprehensive, it's at least something.
-  // While playwright recommends against using locators that are too-closely tied to the DOM, `#redwood-app` is a stable ID.
+  // While playwright recommends against using locators that are too-closely tied to the DOM, `#cedar-app` is a stable ID.
   const bgBlue700 = 'rgb(29, 78, 216)'
-  await expect(page.locator('#redwood-app > header')).toHaveCSS(
+  await expect(page.locator('#cedar-app > header')).toHaveCSS(
     'background-color',
     bgBlue700,
   )

--- a/tasks/ud-tests/fixtures/cedar-app/web/index.html
+++ b/tasks/ud-tests/fixtures/cedar-app/web/index.html
@@ -5,6 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
   <body>
-    <div id="redwood-app"></div>
+    <div id="cedar-app"></div>
   </body>
 </html>

--- a/tasks/ud-tests/fixtures/cedar-app/web/src/entry.client.tsx
+++ b/tasks/ud-tests/fixtures/cedar-app/web/src/entry.client.tsx
@@ -3,13 +3,13 @@ import { createRoot } from 'react-dom/client'
 import App from './App'
 import Routes from './Routes'
 
-const redwoodAppElement = document.getElementById('redwood-app')
+const cedarAppElement = document.getElementById('cedar-app')
 
-if (!redwoodAppElement) {
-  throw new Error("Could not find an element with ID 'redwood-app'")
+if (!cedarAppElement) {
+  throw new Error("Could not find an element with ID 'cedar-app'")
 }
 
-const root = createRoot(redwoodAppElement)
+const root = createRoot(cedarAppElement)
 root.render(
   <App>
     <Routes />

--- a/tasks/ud-tests/udDev.test.mts
+++ b/tasks/ud-tests/udDev.test.mts
@@ -49,7 +49,7 @@ describe('cedar dev --ud', () => {
     const webRes = await fetch(`${BASE_URL}/`)
     expect(webRes.status).toEqual(200)
     const webText = await webRes.text()
-    expect(webText).toContain('<div id="redwood-app">')
+    expect(webText).toContain('<div id="cedar-app">')
     expect(webText).toContain('<script type="module"')
 
     // 4. Native handleRequest function

--- a/tasks/ud-tests/udServe.test.mts
+++ b/tasks/ud-tests/udServe.test.mts
@@ -72,7 +72,7 @@ describe('cedar serve api --ud', () => {
     const webRes = await fetch(`http://localhost:${WEB_PORT}/`)
     expect(webRes.status).toEqual(200)
     const webText = await webRes.text()
-    expect(webText).toContain('<div id="redwood-app">')
+    expect(webText).toContain('<div id="cedar-app">')
     expect(webText).toContain('<script type="module"')
   }, 90_000)
 })


### PR DESCRIPTION
Default to using `"cedar-app"` as the main mount target for Cedar apps, while still supporting `"redwood-app"` for existing apps.