### PR TITLE
chore(testing): remove debug ls -la from build scripts

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -107,8 +107,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types && ls -la",
-    "build:pack": "ls -la && yarn pack -o cedarjs-testing.tgz",
+    "build": "tsx ./build.mts && yarn build:types",
+    "build:pack": "yarn pack -o cedarjs-testing.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext 'js,jsx,ts,tsx' --ignore dist --exec 'yarn build'",


### PR DESCRIPTION
Left over from debugging a yarn pack issue (commit `2f79713cb3`). The `ls` command doesn't exist on Windows, causing `build:pack` to fail with exit code 127 whenever the NX remote cache is cold for `@cedarjs/testing` — which is why it was intermittent (Linux runners populate the cache, Windows runners usually get a cache hit and never execute the script).

Removes `ls -la` from both affected scripts in `packages/testing/package.json`:
- `"build"`: `tsx ./build.mts && yarn build:types && ls -la` → `tsx ./build.mts && yarn build:types`
- `"build:pack"`: `ls -la && yarn pack -o cedarjs-testing.tgz` → `yarn pack -o cedarjs-testing.tgz`