### PR TITLE
fix(ud): Set CEDAR_API_ROOT_PATH earlier

### DIFF
--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -173,14 +173,6 @@ export const handler = async ({
     .filter(Boolean)
     .join(' and ')} support...`
 
-  // When --apiRootPath is passed via CLI, propagate it to
-  // cedarUniversalDeployPlugin via an env var so the plugin can use the cli
-  // argument value instead of the value from the user's Vite config (if they
-  // have set it there)
-  if (apiRootPath !== undefined) {
-    process.env.CEDAR_API_ROOT_PATH = apiRootPath
-  }
-
   const tasks = [
     shouldGeneratePrismaClient && {
       title: 'Generating Prisma Client...',
@@ -406,8 +398,8 @@ export const handler = async ({
     ud &&
       workspace.includes('api') && {
         title: 'Bundling API server entry (Universal Deploy)...',
-        task: async () => {
-          await buildUDApiServer({ verbose, apiRootPath })
+        task: () => {
+          return buildUDApiServer({ verbose })
         },
       },
   ].filter((t): t is ListrTask => Boolean(t))
@@ -437,12 +429,25 @@ export const handler = async ({
     renderer: verbose ? 'verbose' : undefined,
   })
 
-  await timedTelemetry(process.argv, { type: 'build' }, async () => {
-    await jobs.run()
+  // When --apiRootPath is passed via CLI, propagate it to
+  // cedarUniversalDeployPlugin via an env var so the plugin can use the cli
+  // argument value instead of the value from the user's Vite config (if they
+  // have set it there)
+  if (apiRootPath !== undefined) {
+    process.env.CEDAR_API_ROOT_PATH = apiRootPath
+  }
 
-    if (workspace.includes('web') && prerender && prismaSchemaExists) {
-      // This step is outside Listr so that it prints clearer, complete messages
-      await triggerPrerender()
-    }
-  })
+  try {
+    await timedTelemetry(process.argv, { type: 'build' }, async () => {
+      await jobs.run()
+
+      if (workspace.includes('web') && prerender && prismaSchemaExists) {
+        // This step is outside Listr so that it prints clearer, complete
+        // messages
+        await triggerPrerender()
+      }
+    })
+  } finally {
+    delete process.env.CEDAR_API_ROOT_PATH
+  }
 }

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -173,9 +173,9 @@ export const handler = async ({
     .filter(Boolean)
     .join(' and ')} support...`
 
-  // When --apiRootPath is passed via CLI, propagate it via env var to
-  // cedarUniversalDeployPlugin so it can use it instead of the value from the
-  // user's Vite config (if they have set it there)
+  // When --apiRootPath is passed via CLI, propagate it to
+  // cedarUniversalDeployPlugin via env var so it can use it instead of the
+  // value from the user's Vite config (if they have set it there)
   if (apiRootPath !== undefined) {
     process.env.CEDAR_API_ROOT_PATH = apiRootPath
   }

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -173,6 +173,13 @@ export const handler = async ({
     .filter(Boolean)
     .join(' and ')} support...`
 
+  // When --apiRootPath is passed via CLI, propagate it via env var to
+  // cedarUniversalDeployPlugin so it can use it instead of the value from the
+  // user's Vite config (if they have set it there)
+  if (apiRootPath !== undefined) {
+    process.env.CEDAR_API_ROOT_PATH = apiRootPath
+  }
+
   const tasks = [
     shouldGeneratePrismaClient && {
       title: 'Generating Prisma Client...',

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -174,8 +174,9 @@ export const handler = async ({
     .join(' and ')} support...`
 
   // When --apiRootPath is passed via CLI, propagate it to
-  // cedarUniversalDeployPlugin via env var so it can use it instead of the
-  // value from the user's Vite config (if they have set it there)
+  // cedarUniversalDeployPlugin via an env var so the plugin can use the cli
+  // argument value instead of the value from the user's Vite config (if they
+  // have set it there)
   if (apiRootPath !== undefined) {
     process.env.CEDAR_API_ROOT_PATH = apiRootPath
   }

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -404,32 +404,7 @@ export const handler = async ({
       },
   ].filter((t): t is ListrTask => Boolean(t))
 
-  const triggerPrerender = async () => {
-    console.log('Starting prerendering...')
-    if (prerenderRoutes.length === 0) {
-      console.log(
-        `You have not marked any routes to "prerender" in your ${terminalLink(
-          'Routes',
-          'file://' + cedarPaths.web.routes,
-        )}.`,
-      )
-
-      return
-    }
-
-    // Running a separate process here, otherwise it wouldn't pick up the
-    // generated Prisma Client due to require module caching
-    await runBin('cedar', ['prerender'], {
-      stdio: 'inherit',
-      cwd: cedarPaths.web.base,
-    })
-  }
-
-  const jobs = new Listr(tasks, {
-    renderer: verbose ? 'verbose' : undefined,
-  })
-
-  // When --apiRootPath is passed via CLI, propagate it to
+  // When --apiRootPath is passed via CLI we propagate it to
   // cedarUniversalDeployPlugin via an env var so the plugin can use the cli
   // argument value instead of the value from the user's Vite config (if they
   // have set it there)
@@ -439,15 +414,43 @@ export const handler = async ({
 
   try {
     await timedTelemetry(process.argv, { type: 'build' }, async () => {
+      const jobs = new Listr(tasks, {
+        renderer: verbose ? 'verbose' : undefined,
+      })
+
       await jobs.run()
 
       if (workspace.includes('web') && prerender && prismaSchemaExists) {
         // This step is outside Listr so that it prints clearer, complete
         // messages
-        await triggerPrerender()
+        await triggerPrerender(prerenderRoutes)
       }
     })
   } finally {
     delete process.env.CEDAR_API_ROOT_PATH
   }
+}
+
+type Routes = ReturnType<typeof detectPrerenderRoutes>
+async function triggerPrerender(prerenderRoutes: Routes) {
+  const cedarPaths = getPaths()
+
+  console.log('Starting prerendering...')
+  if (prerenderRoutes.length === 0) {
+    console.log(
+      `You have not marked any routes to "prerender" in your ${terminalLink(
+        'Routes',
+        'file://' + cedarPaths.web.routes,
+      )}.`,
+    )
+
+    return
+  }
+
+  // Running a separate process here, otherwise it wouldn't pick up the
+  // generated Prisma Client due to require module caching
+  await runBin('cedar', ['prerender'], {
+    stdio: 'inherit',
+    cwd: cedarPaths.web.base,
+  })
 }

--- a/packages/vite/src/buildUDApiServer.ts
+++ b/packages/vite/src/buildUDApiServer.ts
@@ -47,14 +47,6 @@ export async function buildUDApiServer({
   // collide with the existing esbuild output under api/dist/.
   const outDir = path.join(cedarPaths.api.dist, 'ud')
 
-  // When --apiRootPath is passed via CLI, propagate it to the plugin via
-  // an env var so the plugin can override whatever value was set in the
-  // user's vite config. This avoids modifying the opaque plugin instance
-  // after vite loads the user's configFile.
-  if (apiRootPath !== undefined) {
-    process.env.CEDAR_API_ROOT_PATH = apiRootPath
-  }
-
   try {
     await build({
       // Load the user's Vite config so all plugins (Cedar's UD plugin,

--- a/packages/vite/src/buildUDApiServer.ts
+++ b/packages/vite/src/buildUDApiServer.ts
@@ -5,7 +5,6 @@ import { getPaths } from '@cedarjs/project-config'
 
 export interface BuildUDApiServerOptions {
   verbose?: boolean
-  apiRootPath?: string
 }
 
 /**
@@ -34,7 +33,6 @@ export interface BuildUDApiServerOptions {
  */
 export async function buildUDApiServer({
   verbose = false,
-  apiRootPath,
 }: BuildUDApiServerOptions = {}) {
   const { build } = await import('vite')
   const { catchAll, devServer } = await import('@universal-deploy/vite')
@@ -47,75 +45,69 @@ export async function buildUDApiServer({
   // collide with the existing esbuild output under api/dist/.
   const outDir = path.join(cedarPaths.api.dist, 'ud')
 
-  try {
-    await build({
-      // Load the user's Vite config so all plugins (Cedar's UD plugin,
-      // provider plugins, etc.) run during the build.
-      configFile: cedarPaths.web.viteConfig,
-      logLevel: verbose ? 'info' : 'warn',
+  await build({
+    // Load the user's Vite config so all plugins (Cedar's UD plugin,
+    // provider plugins, etc.) run during the build.
+    configFile: cedarPaths.web.viteConfig,
+    logLevel: verbose ? 'info' : 'warn',
 
-      plugins: [
-        // catchAll() generates the rou3-based route dispatcher
-        // (virtual:ud:catch-all). devServer() provides Vite dev support for
-        // cedar dev --ud.
-        //
-        // NOTE: We intentionally do NOT use universalDeploy() here — that
-        // plugin auto-detects deployment targets and would embed the Node
-        // HTTP server startup code into the output. Our plugin list is
-        // adapter-free: the output is a pure Fetchable export, and cedar
-        // serve wraps it in srvx at runtime.
-        catchAll(),
-        devServer(),
+    plugins: [
+      // catchAll() generates the rou3-based route dispatcher
+      // (virtual:ud:catch-all). devServer() provides Vite dev support for
+      // cedar dev --ud.
+      //
+      // NOTE: We intentionally do NOT use universalDeploy() here — that
+      // plugin auto-detects deployment targets and would embed the Node
+      // HTTP server startup code into the output. Our plugin list is
+      // adapter-free: the output is a pure Fetchable export, and cedar
+      // serve wraps it in srvx at runtime.
+      catchAll(),
+      devServer(),
 
-        // Warn if no Cedar API routes were registered — likely means the
-        // user's vite config is missing cedarUniversalDeployPlugin or there
-        // are no API functions to serve.
-        {
-          name: 'cedar-ud-verify-routes',
-          configResolved() {
-            const entries = getAllEntries()
-            if (entries.length === 0) {
-              console.warn(
-                '\n  Warning: No Universal Deploy API routes were registered.',
-                '\n  The built server entry will be an empty router (404 for all',
-                '\n  requests). Check that you have API functions under',
-                '\n  `api/src/functions/` and that your vite config includes',
-                '\n  `cedarUniversalDeployPlugin()`.\n',
-              )
-            }
-          },
-        },
-      ],
-
-      // Legacy ssr flag approach. The explicit rollupOptions.input prevents the
-      // "index.html as SSR entry" error. Vite will also build a 'client'
-      // environment from the user's config file (wasteful but harmless), and
-      // the 'ssr' environment produces our canonical Fetchable artifact at
-      // api/dist/ud/index.js.
-      build: {
-        ssr: true,
-        outDir,
-        rollupOptions: {
-          input: catchAllEntry,
-          output: {
-            entryFileNames: 'index.js',
-          },
+      // Warn if no Cedar API routes were registered — likely means the
+      // user's vite config is missing cedarUniversalDeployPlugin or there
+      // are no API functions to serve.
+      {
+        name: 'cedar-ud-verify-routes',
+        configResolved() {
+          const entries = getAllEntries()
+          if (entries.length === 0) {
+            console.warn(
+              '\n  Warning: No Universal Deploy API routes were registered.',
+              '\n  The built server entry will be an empty router (404 for all',
+              '\n  requests). Check that you have API functions under',
+              '\n  `api/src/functions/` and that your vite config includes',
+              '\n  `cedarUniversalDeployPlugin()`.\n',
+            )
+          }
         },
       },
-    })
+    ],
 
-    // Write a package.json to mark the UD output directory as ESM. This
-    // ensures Node.js treats .js files (index.js, handler chunks) as ES
-    // modules regardless of the parent package.json type setting.
-    // TODO: Probably remove this - It's here to support CJS apps, but I'm not
-    // sure we'll ever be able to fully support that with UD
-    fs.writeFileSync(
-      path.join(outDir, 'package.json'),
-      JSON.stringify({ type: 'module' }, null, 2),
-    )
-  } finally {
-    if (apiRootPath !== undefined) {
-      delete process.env.CEDAR_API_ROOT_PATH
-    }
-  }
+    // Legacy ssr flag approach. The explicit rollupOptions.input prevents the
+    // "index.html as SSR entry" error. Vite will also build a 'client'
+    // environment from the user's config file (wasteful but harmless), and
+    // the 'ssr' environment produces our canonical Fetchable artifact at
+    // api/dist/ud/index.js.
+    build: {
+      ssr: true,
+      outDir,
+      rollupOptions: {
+        input: catchAllEntry,
+        output: {
+          entryFileNames: 'index.js',
+        },
+      },
+    },
+  })
+
+  // Write a package.json to mark the UD output directory as ESM. This
+  // ensures Node.js treats .js files (index.js, handler chunks) as ES
+  // modules regardless of the parent package.json type setting.
+  // TODO: Probably remove this - It's here to support CJS apps, but I'm not
+  // sure we'll ever be able to fully support that with UD
+  fs.writeFileSync(
+    path.join(outDir, 'package.json'),
+    JSON.stringify({ type: 'module' }, null, 2),
+  )
 }

--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -163,9 +163,9 @@ function clearCedarEntries(): void {
 export function cedarUniversalDeployPlugin(
   options: CedarUniversalDeployPluginOptions = {},
 ): Plugin {
-  // CEDAR_API_ROOT_PATH is set by buildUDApiServer when the --apiRootPath CLI
-  // flag is passed. It takes precedence over the option value in the user's
-  // vite config so CI/deploy can override without editing tracked files.
+  // CEDAR_API_ROOT_PATH is set by buildHandler when the --apiRootPath CLI flag
+  // is passed. It takes precedence over the option value in the user's Vite
+  // config so CI/deploy can override without editing tracked files
   const effectiveApiRootPath =
     process.env.CEDAR_API_ROOT_PATH ?? options.apiRootPath
   const routes = discoverCedarRoutes(effectiveApiRootPath ?? '/')


### PR DESCRIPTION
Make the env var available to `cedarUniversalDeployPlugin`'s `config` hook for all invocations, including during `buildCedarApp`