### PR TITLE
chore(ud): Update early return checks in Cedar UD plugin

### DIFF
--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -205,9 +205,9 @@ export function cedarUniversalDeployPlugin(
     },
 
     buildStart() {
-      // Skip during client builds — the emitted chunks reference Node.js
-      // builtins and paths that only exist during SSR builds.
-      if (this.environment?.name !== 'ssr') {
+      // Skip during client builds. The emitted chunks reference Node.js
+      // builtins and paths that are only relevant for server builds.
+      if (this.environment.config.consumer === 'client') {
         return
       }
 
@@ -230,9 +230,9 @@ export function cedarUniversalDeployPlugin(
     },
 
     resolveId(id) {
-      // Skip during client builds — the virtual modules reference Node.js
-      // APIs and paths that only work in an SSR context.
-      if (this.environment?.name !== 'ssr') {
+      // Skip during client builds. The virtual modules reference Node.js
+      // APIs and paths that only make sense for server builds.
+      if (this.environment.config.consumer === 'client') {
         return undefined
       }
 
@@ -251,7 +251,7 @@ export function cedarUniversalDeployPlugin(
 
     async load(id) {
       // Skip during client builds.
-      if (this.environment?.name !== 'ssr') {
+      if (this.environment.config.consumer === 'client') {
         return undefined
       }
 

--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -205,9 +205,13 @@ export function cedarUniversalDeployPlugin(
     },
 
     buildStart() {
-      // Skip during client builds. The emitted chunks reference Node.js
-      // builtins and paths that are only relevant for server builds.
-      if (this.environment.config.consumer === 'client') {
+      // Only run during the default 'ssr' build.
+      // The emitted chunks reference Node.js builtins and paths that are only
+      // relevant for server builds, so we can't run this for client builds.
+      // We also skip custom environments (they'd have other names) because
+      // those custom environments all currently get their inputs from the UD
+      // store via configEnvironment hooks instead
+      if (this.environment.name !== 'ssr') {
         return
       }
 
@@ -230,9 +234,13 @@ export function cedarUniversalDeployPlugin(
     },
 
     resolveId(id) {
+      const viteEnv = this.environment
+
       // Skip during client builds. The virtual modules reference Node.js
       // APIs and paths that only make sense for server builds.
-      if (this.environment.config.consumer === 'client') {
+      // Also skip for the 'api' environment, because raw 'api' builds should
+      // not see the virtual modules
+      if (viteEnv.config.consumer === 'client' || viteEnv.name === 'api') {
         return undefined
       }
 
@@ -250,8 +258,10 @@ export function cedarUniversalDeployPlugin(
     },
 
     async load(id) {
-      // Skip during client builds.
-      if (this.environment.config.consumer === 'client') {
+      const viteEnv = this.environment
+
+      // Only load virtual modules for environments that consume UD entries.
+      if (viteEnv.config.consumer !== 'server' || viteEnv.name === 'api') {
         return undefined
       }
 

--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -261,7 +261,7 @@ export function cedarUniversalDeployPlugin(
       const viteEnv = this.environment
 
       // Only load virtual modules for environments that consume UD entries.
-      if (viteEnv.config.consumer !== 'server' || viteEnv.name === 'api') {
+      if (viteEnv.config.consumer === 'client' || viteEnv.name === 'api') {
         return undefined
       }
 


### PR DESCRIPTION
Check consumer type + own known env name instead of just the standard 'ssr' env name. This makes us more compatible with other plugins who might add custom environments of their own