### PR TITLE
fix(vercel-tests): rename DEPLOY_URL to VERCEL_DEPLOY_URL

### DIFF
--- a/tasks/vercel-tests/vercel.test.mts
+++ b/tasks/vercel-tests/vercel.test.mts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 function deployUrl() {
-  const url = process.env.DEPLOY_URL
+  const url = process.env.VERCEL_DEPLOY_URL
   if (!url) {
     throw new Error(
-      'DEPLOY_URL environment variable not set. ' +
-        'Run with VERCEL_DEPLOY_URL set.',
+      'VERCEL_DEPLOY_URL environment variable not set. ' +
+        'Example: VERCEL_DEPLOY_URL=https://your-site.vercel.app yarn vitest run',
     )
   }
   return url

--- a/tasks/vercel-tests/vitest.setup.mts
+++ b/tasks/vercel-tests/vitest.setup.mts
@@ -17,5 +17,5 @@ beforeAll(() => {
     )
   }
 
-  process.env.DEPLOY_URL = VERCEL_DEPLOY_URL.replace(/\/+$/, '')
+  process.env.VERCEL_DEPLOY_URL = VERCEL_DEPLOY_URL.replace(/\/+$/, '')
 })


### PR DESCRIPTION
Part of #1832.

`vercel.test.mts` was reading `process.env.DEPLOY_URL` but the error message told users to set `VERCEL_DEPLOY_URL`. This renames the internal env var to `VERCEL_DEPLOY_URL` throughout:

- `vercel.test.mts`: reads `process.env.VERCEL_DEPLOY_URL` instead of `DEPLOY_URL`
- `vitest.setup.mts`: writes the trailing-slash-stripped value back to `process.env.VERCEL_DEPLOY_URL` instead of `DEPLOY_URL`

The CI workflow already passes `VERCEL_DEPLOY_URL`, so no workflow changes needed.