### PR TITLE
fix(ud): Server guard for externalized optional peer deps

### DIFF
--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -169,7 +169,8 @@ export async function buildCedarApp({
           typeof specifier === 'string' &&
           !specifier.startsWith('.') &&
           !specifier.startsWith('/') &&
-          importer?.includes('node_modules')
+          importer?.includes('node_modules') &&
+          this.environment.config.consumer === 'server'
         ) {
           return { id: specifier, external: true }
         }


### PR DESCRIPTION
Greptile left this review on #1876 

---

<h3>Greptile Summary</h3>

This PR generalises Rollup warning suppression (Prisma `EVAL` and graphql-scalars `INVALID_ANNOTATION`) from the `api` environment only to all Vite environments, by replacing the inline `rollupOptions.onwarn` with a `configResolved` plugin that correctly composes with any pre-existing handler. It also adds a new `cedar-optional-peer-deps` plugin that resolves bare-specifier dynamic imports from `node_modules` as external to avoid `UNRESOLVED_IMPORT` warnings for optional peer dependencies.

- The `onwarn` composition now correctly chains existing handlers (`existingOnwarn ? wrapper : onwarn`), addressing the concerns from previous review threads.
- The new `cedar-optional-peer-deps` plugin's `resolveDynamicImport` hook has no environment guard and fires for the browser `client` environment too; returning `{ external: true }` for bare specifiers in a browser bundle produces native `import('pkg')` calls at runtime, which fail in all standard browsers, silently trading a build-time warning for an opaque runtime error.

<h3>Confidence Score: 4/5</h3>

The `onwarn` changes are safe; the new `cedar-optional-peer-deps` plugin can cause silent browser runtime import failures for any web-side dependency that uses bare-specifier dynamic imports, because it applies to the `client` environment without a guard.

The `onwarn` refactor is correct and the warning-suppression composition is well-implemented. The new `cedar-optional-peer-deps` plugin lacks an environment check, which means it marks bare-specifier dynamic imports as external in the browser bundle too — in practice this converts build-time unresolved-import warnings into opaque runtime failures in any browser that encounters such an import.

packages/vite/src/buildApp.ts — specifically the `cedar-optional-peer-deps` plugin's `resolveDynamicImport` hook and its effect on the `client` environment.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/vite/src/buildApp.ts | Moves `onwarn` suppression from the hard-coded `api` rollupOptions into a `configResolved` plugin that iterates all environments, correctly composing with any pre-existing handler. Adds a new `cedar-optional-peer-deps` plugin that marks bare-specifier dynamic imports from node_modules as external — but applies to the `client` (browser) environment as well, which can cause silent runtime import failures for web bundles. |

</details>



<!-- greptile_other_comments_section -->

<sub>Reviews (4): Last reviewed commit: ["fix existing onwarn handling"](https://github.com/cedarjs/cedar/commit/4d31ec3afd3b858ce1855edbf58b1477b9589705) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36378512)</sub>

---

I hope the changes in this PR addresses the browser environment concern