### PR TITLE
fix(api-server): use consistent apiRootPath default

### DIFF
--- a/packages/api-server/src/cliHelpers.ts
+++ b/packages/api-server/src/cliHelpers.ts
@@ -13,6 +13,10 @@ export function getAPIPort() {
     : getConfig().api.port
 }
 
+export function getAPIRootPath() {
+  return process.env.CEDAR_API_ROOT_PATH ?? '/'
+}
+
 export function getWebHost() {
   let host = process.env.REDWOOD_WEB_HOST
   host ??= getConfig().web.host

--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -8,7 +8,7 @@ import type {
 
 import { coerceRootPath } from '@cedarjs/fastify-web/dist/helpers.js'
 
-import { getAPIHost, getAPIPort } from './cliHelpers.js'
+import { getAPIHost, getAPIPort, getAPIRootPath } from './cliHelpers.js'
 
 export type StartOptions = Omit<FastifyListenOptions, 'port' | 'host'>
 
@@ -61,7 +61,7 @@ type DefaultCreateServerOptions = Required<
 // getAPIHost and getAPIPort just by importing this file.
 export const getDefaultCreateServerOptions: () => DefaultCreateServerOptions =
   () => ({
-    apiRootPath: '/',
+    apiRootPath: getAPIRootPath(),
     logger: {
       level:
         process.env.LOG_LEVEL ??

--- a/packages/cli/src/commands/serveBothHandler.ts
+++ b/packages/cli/src/commands/serveBothHandler.ts
@@ -14,7 +14,6 @@ import {
 import { getConfig, getPaths } from '@cedarjs/project-config'
 import { errorTelemetry } from '@cedarjs/telemetry'
 
-// @ts-expect-error - Types not available for JS files
 import { exitWithError } from '../lib/exit.js'
 
 type ServeBothArgv = {

--- a/packages/cli/src/commands/serveBothHandler.ts
+++ b/packages/cli/src/commands/serveBothHandler.ts
@@ -7,6 +7,7 @@ import { handler as apiServerHandler } from '@cedarjs/api-server/cjs/apiCliConfi
 import {
   getAPIHost,
   getAPIPort,
+  getAPIRootPath,
   getWebHost,
   getWebPort,
 } from '@cedarjs/api-server/cjs/cliHelpers'
@@ -55,12 +56,14 @@ export const bothServerFileHandler = async (argv: ServeBothArgv) => {
     argv.webPort ??= getWebPort()
     argv.webHost ??= getWebHost()
 
+    const apiRootPath = argv.apiRootPath ?? getAPIRootPath()
+
     const apiProxyTarget = [
       'http://',
       argv.apiHost.includes(':') ? `[${argv.apiHost}]` : argv.apiHost,
       ':',
       argv.apiPort,
-      argv.apiRootPath,
+      apiRootPath,
     ].join('')
 
     const { result } = concurrently(
@@ -69,7 +72,7 @@ export const bothServerFileHandler = async (argv: ServeBothArgv) => {
           name: 'api',
           command: `yarn node ${path.join('dist', 'server.js')} --apiPort ${
             argv.apiPort
-          } --apiHost ${argv.apiHost} --apiRootPath ${argv.apiRootPath}`,
+          } --apiHost ${argv.apiHost} --apiRootPath ${apiRootPath}`,
           cwd: getPaths().api.base,
           prefixColor: 'cyan',
         },

--- a/packages/cli/src/commands/serveBothHandler.ts
+++ b/packages/cli/src/commands/serveBothHandler.ts
@@ -110,7 +110,7 @@ export const bothSsrRscServerHandler = async (
   rscEnabled?: boolean,
 ) => {
   const apiPromise = apiServerHandler({
-    apiRootPath: argv.apiRootPath,
+    apiRootPath: argv.apiRootPath ?? getAPIRootPath(),
     host: argv.apiHost,
     port: argv.apiPort,
   })


### PR DESCRIPTION
- Add `getAPIRootPath()` helper that reads `CEDAR_API_ROOT_PATH` env var
- Default to `'/'` to match other code paths (`bothCLIConfigHandler`, api plugin, graphql plugin)
- Fix `serveBothHandler.ts` not having a default, instead potentially expanding into `'undefined'`
- Both `serveBothHandler` and `createServerHelpers` now use the same source for defaults

Previously `serveBothHandler` defaulted to `undefined` while `createServerHelpers` defaulted to `'/'`,
which could cause subtle inconsistencies. Now both respect the existing `CEDAR_API_ROOT_PATH`
env var and default to `'/'` when not set.