### PR TITLE
fix(api): More robust version fetching

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -30,6 +30,7 @@ type PackageJson = {
 }
 
 let packageJson: PackageJson | undefined
+let importMetaError: Error | undefined
 
 // @ts-expect-error - import.meta is replaced with {} in CJS build, so .resolve
 // is undefined, but TS's typings declare it as always present
@@ -43,9 +44,10 @@ if (import.meta.resolve) {
     if (packageJson?.name !== '@cedarjs/api') {
       packageJson = cedarApiRequire(`${cedarApiDir}../package.json`)
     }
-  } catch {
-    // import.meta.resolve can fail when this code is bundled (e.g. by Rolldown)
-    // and the package is not installed separately at runtime.
+  } catch (error) {
+    // If the code above fails for whatever reason, I want to try the
+    // `createRequire` fallback below.
+    importMetaError = error instanceof Error ? error : new Error(String(error))
   }
 }
 
@@ -64,7 +66,7 @@ if (!packageJson) {
   } catch (error) {
     throw new Error(
       'Could not read package.json to determine package version',
-      { cause: error },
+      { cause: importMetaError ?? error },
     )
   }
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -61,8 +61,11 @@ if (!packageJson) {
     if (packageJson?.name !== '@cedarjs/api') {
       packageJson = cedarApiRequire(`${__dirname}/../../package.json`)
     }
-  } catch {
-    // Fallback if __dirname is not available or doesn't point to the package
+  } catch (error) {
+    throw new Error(
+      'Could not read package.json to determine package version',
+      { cause: error },
+    )
   }
 }
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -34,24 +34,35 @@ let packageJson: PackageJson | undefined
 // @ts-expect-error - import.meta is replaced with {} in CJS build, so .resolve
 // is undefined, but TS's typings declare it as always present
 if (import.meta.resolve) {
-  const cedarApiEntryUrl = import.meta.resolve('@cedarjs/api')
-  const cedarApiDir = fileURLToPath(new URL('.', cedarApiEntryUrl))
-  const cedarApiRequire = createRequire(cedarApiEntryUrl)
-  packageJson = cedarApiRequire(`${cedarApiDir}/package.json`)
+  try {
+    const cedarApiEntryUrl = import.meta.resolve('@cedarjs/api')
+    const cedarApiDir = fileURLToPath(new URL('.', cedarApiEntryUrl))
+    const cedarApiRequire = createRequire(cedarApiEntryUrl)
+    packageJson = cedarApiRequire(`${cedarApiDir}/package.json`)
 
-  if (packageJson?.name !== '@cedarjs/api') {
-    packageJson = cedarApiRequire(`${cedarApiDir}../package.json`)
+    if (packageJson?.name !== '@cedarjs/api') {
+      packageJson = cedarApiRequire(`${cedarApiDir}../package.json`)
+    }
+  } catch {
+    // import.meta.resolve can fail when this code is bundled (e.g. by Rolldown)
+    // and the package is not installed separately at runtime.
   }
-} else {
-  const cedarApiRequire = createRequire(__filename)
-  packageJson = cedarApiRequire(`${__dirname}/package.json`)
+}
 
-  if (packageJson?.name !== '@cedarjs/api') {
-    packageJson = cedarApiRequire(`${__dirname}/../package.json`)
-  }
+if (!packageJson) {
+  try {
+    const cedarApiRequire = createRequire(__filename)
+    packageJson = cedarApiRequire(`${__dirname}/package.json`)
 
-  if (packageJson?.name !== '@cedarjs/api') {
-    packageJson = cedarApiRequire(`${__dirname}/../../package.json`)
+    if (packageJson?.name !== '@cedarjs/api') {
+      packageJson = cedarApiRequire(`${__dirname}/../package.json`)
+    }
+
+    if (packageJson?.name !== '@cedarjs/api') {
+      packageJson = cedarApiRequire(`${__dirname}/../../package.json`)
+    }
+  } catch {
+    // Fallback if __dirname is not available or doesn't point to the package
   }
 }
 


### PR DESCRIPTION
Wrap in try/catch to fall through to `createRequire` backup code path. And then rethrow error if that also doesn't work