### PR TITLE
fix(ud): Wrap gql response in Response

### DIFF
--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -379,7 +379,15 @@ async function generateGraphQLModule(distPath: string): Promise<string> {
           authDecoder: graphqlOptions ? graphqlOptions.authDecoder : undefined,
         });
         const event = await requestToLegacyEvent(request, cedarContext);
-        return yoga.handle(request, { request, cedarContext, event, requestContext: undefined });
+        const response = await yoga.handle(request, { request, cedarContext, event, requestContext: undefined });
+        // GraphQL Yoga returns a PonyfillResponse from @whatwg-node/fetch
+        // which is not an instanceof the native Response class. Netlify's
+        // bootstrap checks instanceof Response, so we wrap it.
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        });
       }
     };
   `


### PR DESCRIPTION
Construct a proper web standards `Response` from the `PonyfillResponse` yoga gives us. Netliy requires this.