### PR TITLE
feat(baremetal)!: warn on unpushed commits before deploying

### DIFF
--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -93,9 +93,9 @@ export const builder = (yargs) => {
     type: 'boolean',
   })
 
-  yargs.option('skip-git-check', {
-    describe: 'Skip check for unpushed commits before deploying',
-    default: false,
+  yargs.option('git-check', {
+    describe: 'Check for unpushed commits before deploying',
+    default: true,
     type: 'boolean',
   })
 
@@ -123,7 +123,7 @@ export async function handler(yargs) {
     maintenance: yargs.maintenance,
     rollback: yargs.rollback,
     verbose: yargs.verbose,
-    skipGitCheck: yargs.skipGitCheck,
+    gitCheck: yargs.gitCheck,
   })
 
   const { handler: baremetalHandler } =

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -93,6 +93,12 @@ export const builder = (yargs) => {
     type: 'boolean',
   })
 
+  yargs.option('skip-git-check', {
+    describe: 'Skip check for unpushed commits before deploying',
+    default: false,
+    type: 'boolean',
+  })
+
   // TODO: Allow option to pass --sides and only deploy select sides instead of all, always
 
   yargs.epilogue(
@@ -117,6 +123,7 @@ export async function handler(yargs) {
     maintenance: yargs.maintenance,
     rollback: yargs.rollback,
     verbose: yargs.verbose,
+    skipGitCheck: yargs.skipGitCheck,
   })
 
   const { handler: baremetalHandler } =

--- a/packages/cli/src/commands/deploy/baremetal/baremetalHandler.js
+++ b/packages/cli/src/commands/deploy/baremetal/baremetalHandler.js
@@ -651,10 +651,16 @@ export const warnIfUnpushedCommits = async () => {
 
     if (!confirmed) {
       console.log('Aborting deploy. Push your commits and try again.')
-      process.exit(0)
+      process.exit(1)
     }
-  } catch {
-    // No upstream tracking branch set, or git is unavailable — skip the check
+  } catch (e) {
+    // No upstream tracking branch set (exit code 128) — skip the check silently
+    if (e?.exitCode === 128) {
+      return
+    }
+    // Unexpected error — surface it rather than silently swallowing it
+    console.error(c.warning('Warning: Could not check for unpushed commits.'))
+    throw e
   }
 }
 
@@ -673,7 +679,7 @@ export const handler = async (yargs) => {
     process.exit(1)
   }
 
-  if (!yargs.skipGitCheck) {
+  if (yargs.gitCheck) {
     await warnIfUnpushedCommits()
   }
 

--- a/packages/cli/src/commands/deploy/baremetal/baremetalHandler.js
+++ b/packages/cli/src/commands/deploy/baremetal/baremetalHandler.js
@@ -616,41 +616,48 @@ export const commands = (yargs, ssh) => {
 }
 
 export const warnIfUnpushedCommits = async () => {
-  const { stdout } = await execa('git', ['log', '@{u}..', '--oneline'], {
-    cwd: getPaths().base,
-  })
-  const unpushedCommits = stdout.trim()
+  try {
+    const { stdout } = await execa('git', ['log', '@{u}..', '--oneline'], {
+      cwd: getPaths().base,
+    })
+    const unpushedCommits = stdout.trim()
 
-  if (!unpushedCommits) {
-    return
-  }
+    if (!unpushedCommits) {
+      return
+    }
 
-  console.warn(
-    c.warning('\nWarning: You have local commits that have not been pushed:'),
-  )
-  console.warn(
-    unpushedCommits
-      .split('\n')
-      .map((line) => `  ${line}`)
-      .join('\n'),
-  )
-  console.warn(
-    c.warning(
-      'The server will pull from the remote, so these commits will not be deployed.\n',
-    ),
-  )
+    console.warn(
+      c.warning('\nWarning: You have local commits that have not been pushed:'),
+    )
+    console.warn(
+      unpushedCommits
+        .split('\n')
+        .map((line) => `  ${line}`)
+        .join('\n'),
+    )
+    console.warn(
+      c.warning(
+        'The server will pull from the remote, so these commits will not be deployed.\n',
+      ),
+    )
 
-  const { default: prompts } = await import('prompts')
-  const { confirmed } = await prompts({
-    type: 'confirm',
-    name: 'confirmed',
-    message: 'Deploy anyway?',
-    initial: false,
-  })
+    const { default: prompts } = await import('prompts')
+    const { confirmed } = await prompts({
+      type: 'confirm',
+      name: 'confirmed',
+      message: 'Deploy anyway?',
+      initial: false,
+    })
 
-  if (!confirmed) {
-    console.log('Aborting deploy. Push your commits and try again.')
-    process.exit(1)
+    if (!confirmed) {
+      console.log('Aborting deploy. Push your commits and try again.')
+      process.exit(1)
+    }
+  } catch (e) {
+    console.error(
+      c.error('\nCould not check for unpushed commits before deploying.'),
+    )
+    throw e
   }
 }
 

--- a/packages/cli/src/commands/deploy/baremetal/baremetalHandler.js
+++ b/packages/cli/src/commands/deploy/baremetal/baremetalHandler.js
@@ -616,51 +616,41 @@ export const commands = (yargs, ssh) => {
 }
 
 export const warnIfUnpushedCommits = async () => {
-  try {
-    const { stdout } = await execa('git', ['log', '@{u}..', '--oneline'], {
-      cwd: getPaths().base,
-    })
-    const unpushedCommits = stdout.trim()
+  const { stdout } = await execa('git', ['log', '@{u}..', '--oneline'], {
+    cwd: getPaths().base,
+  })
+  const unpushedCommits = stdout.trim()
 
-    if (!unpushedCommits) {
-      return
-    }
+  if (!unpushedCommits) {
+    return
+  }
 
-    console.warn(
-      c.warning('\nWarning: You have local commits that have not been pushed:'),
-    )
-    console.warn(
-      unpushedCommits
-        .split('\n')
-        .map((line) => `  ${line}`)
-        .join('\n'),
-    )
-    console.warn(
-      c.warning(
-        'The server will pull from the remote, so these commits will not be deployed.\n',
-      ),
-    )
+  console.warn(
+    c.warning('\nWarning: You have local commits that have not been pushed:'),
+  )
+  console.warn(
+    unpushedCommits
+      .split('\n')
+      .map((line) => `  ${line}`)
+      .join('\n'),
+  )
+  console.warn(
+    c.warning(
+      'The server will pull from the remote, so these commits will not be deployed.\n',
+    ),
+  )
 
-    const { default: prompts } = await import('prompts')
-    const { confirmed } = await prompts({
-      type: 'confirm',
-      name: 'confirmed',
-      message: 'Deploy anyway?',
-      initial: false,
-    })
+  const { default: prompts } = await import('prompts')
+  const { confirmed } = await prompts({
+    type: 'confirm',
+    name: 'confirmed',
+    message: 'Deploy anyway?',
+    initial: false,
+  })
 
-    if (!confirmed) {
-      console.log('Aborting deploy. Push your commits and try again.')
-      process.exit(1)
-    }
-  } catch (e) {
-    // No upstream tracking branch set (exit code 128) — skip the check silently
-    if (e?.exitCode === 128) {
-      return
-    }
-    // Unexpected error — surface it rather than silently swallowing it
-    console.error(c.warning('Warning: Could not check for unpushed commits.'))
-    throw e
+  if (!confirmed) {
+    console.log('Aborting deploy. Push your commits and try again.')
+    process.exit(1)
   }
 }
 

--- a/packages/cli/src/commands/deploy/baremetal/baremetalHandler.js
+++ b/packages/cli/src/commands/deploy/baremetal/baremetalHandler.js
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import boxen from 'boxen'
+import execa from 'execa'
 import { Listr } from 'listr2'
 import * as toml from 'smol-toml'
 import { env as envInterpolation } from 'string-env-interpolation'
@@ -614,6 +615,49 @@ export const commands = (yargs, ssh) => {
   return servers
 }
 
+export const warnIfUnpushedCommits = async () => {
+  try {
+    const { stdout } = await execa('git', ['log', '@{u}..', '--oneline'], {
+      cwd: getPaths().base,
+    })
+    const unpushedCommits = stdout.trim()
+
+    if (!unpushedCommits) {
+      return
+    }
+
+    console.warn(
+      c.warning('\nWarning: You have local commits that have not been pushed:'),
+    )
+    console.warn(
+      unpushedCommits
+        .split('\n')
+        .map((line) => `  ${line}`)
+        .join('\n'),
+    )
+    console.warn(
+      c.warning(
+        'The server will pull from the remote, so these commits will not be deployed.\n',
+      ),
+    )
+
+    const { default: prompts } = await import('prompts')
+    const { confirmed } = await prompts({
+      type: 'confirm',
+      name: 'confirmed',
+      message: 'Deploy anyway?',
+      initial: false,
+    })
+
+    if (!confirmed) {
+      console.log('Aborting deploy. Push your commits and try again.')
+      process.exit(0)
+    }
+  } catch {
+    // No upstream tracking branch set, or git is unavailable — skip the check
+  }
+}
+
 export const handler = async (yargs) => {
   const { SshExecutor } = await import('./SshExecutor.js')
 
@@ -627,6 +671,10 @@ export const handler = async (yargs) => {
         'Please run `yarn cedar setup deploy baremetal` before deploying',
     )
     process.exit(1)
+  }
+
+  if (!yargs.skipGitCheck) {
+    await warnIfUnpushedCommits()
   }
 
   const ssh = new SshExecutor(yargs.verbose)


### PR DESCRIPTION
Closes #1142

Before starting a baremetal deploy, check whether the local branch has commits that haven't been pushed to the remote. Since the server does a `git pull` (not a local copy), unpushed commits won't be included in the deploy — which is easy to miss.

## What this does

- Runs `git log @{u}.. --oneline` locally before connecting to any server
- If unpushed commits are found, prints a warning listing them and prompts "Deploy anyway? (y/N)"
- If the user declines (or hits Ctrl-C), aborts with a message to push first
- Pass `--no-git-check` to bypass entirely