### PR TITLE
chore(test-project): Use GQL error in contacts resolver

### DIFF
--- a/__fixtures__/test-project-esm/api/src/services/contacts/contacts.ts
+++ b/__fixtures__/test-project-esm/api/src/services/contacts/contacts.ts
@@ -1,6 +1,8 @@
 import { validateEmail } from '@my-org/validators'
 import type { QueryResolvers, MutationResolvers } from 'types/graphql'
 
+import { ServiceValidationError } from '@cedarjs/api'
+
 // Testing aliased imports with extensions
 import { db } from 'src/lib/db.js'
 
@@ -18,7 +20,7 @@ export const createContact: MutationResolvers['createContact'] = ({
   input,
 }) => {
   if (!validateEmail(input.email)) {
-    throw new Error('Invalid email >' + input.email + '<')
+    throw new ServiceValidationError('Invalid email >' + input.email + '<')
   } else {
     console.log('Creating contact with email:', input.email)
   }

--- a/__fixtures__/test-project-live/api/src/services/contacts/contacts.ts
+++ b/__fixtures__/test-project-live/api/src/services/contacts/contacts.ts
@@ -1,6 +1,8 @@
 import { validateEmail } from '@my-org/validators'
 import type { QueryResolvers, MutationResolvers } from 'types/graphql'
 
+import { ServiceValidationError } from '@cedarjs/api'
+
 // Testing aliased imports with extensions
 import { db } from 'src/lib/db.js'
 
@@ -18,7 +20,7 @@ export const createContact: MutationResolvers['createContact'] = ({
   input,
 }) => {
   if (!validateEmail(input.email)) {
-    throw new Error('Invalid email >' + input.email + '<')
+    throw new ServiceValidationError('Invalid email >' + input.email + '<')
   } else {
     console.log('Creating contact with email:', input.email)
   }

--- a/__fixtures__/test-project/api/src/services/contacts/contacts.ts
+++ b/__fixtures__/test-project/api/src/services/contacts/contacts.ts
@@ -1,6 +1,8 @@
 import { validateEmail } from '@my-org/validators'
 import type { QueryResolvers, MutationResolvers } from 'types/graphql'
 
+import { ServiceValidationError } from '@cedarjs/api'
+
 // Testing aliased imports with extensions
 import { db } from 'src/lib/db.js'
 
@@ -18,7 +20,7 @@ export const createContact: MutationResolvers['createContact'] = ({
   input,
 }) => {
   if (!validateEmail(input.email)) {
-    throw new Error('Invalid email >' + input.email + '<')
+    throw new ServiceValidationError('Invalid email >' + input.email + '<')
   } else {
     console.log('Creating contact with email:', input.email)
   }

--- a/tasks/test-project/codemods/contacts.mts
+++ b/tasks/test-project/codemods/contacts.mts
@@ -36,7 +36,7 @@ export default (file: FileInfo, api: API) => {
 
   // Insert this if-statment at the top of the `createContact` service function
   // if (!validateEmail(input.email)) {
-  //   throw new Error('Invalid email')
+  //   throw new ServiceValidationError('Invalid email')
   // } else {
   //   console.log('Creating contact with email:', input.email)
   // }

--- a/tasks/test-project/codemods/contacts.mts
+++ b/tasks/test-project/codemods/contacts.mts
@@ -14,9 +14,25 @@ export default (file: FileInfo, api: API) => {
     j.stringLiteral('@my-org/validators'),
   )
 
+  const serviceValidationErrorImport = j.importDeclaration(
+    [
+      j.importSpecifier(
+        j.identifier('ServiceValidationError'),
+        j.identifier('ServiceValidationError'),
+      ),
+    ],
+    j.stringLiteral('@cedarjs/api'),
+  )
+
   // Add `import { validateEmail } from '@my-org/validators'` to the top of the
   // file
   root.get().node.program.body.unshift(validateImport)
+
+  // Add `import { ServiceValidationError } from '@cedarjs/api'` after the
+  // types/graphql import
+  root
+    .find(j.ImportDeclaration, { source: { value: 'types/graphql' } })
+    .insertAfter(serviceValidationErrorImport)
 
   // Insert this if-statment at the top of the `createContact` service function
   // if (!validateEmail(input.email)) {
@@ -45,7 +61,7 @@ export default (file: FileInfo, api: API) => {
 
         const ifBody = j.blockStatement([
           j.throwStatement(
-            j.newExpression(j.identifier('Error'), [
+            j.newExpression(j.identifier('ServiceValidationError'), [
               j.binaryExpression(
                 '+',
                 j.binaryExpression(


### PR DESCRIPTION
Use a proper gql error that doesn't get masked in the GraphQL response. With a plain Error, GraphQL Yoga swallows the message in production (returns just "Unexpected error"). ServiceValidationError is a Cedar framework error that GraphQL Yoga recognizes and passes through to the client, so the email validation message actually shows up in the API response.