### PR TITLE
chore(api-server): Simplify routePath construction

### DIFF
--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -51,7 +51,7 @@ export const setLambdaFunctions = async (foundFunctions: string[]) => {
   const imports = foundFunctions.map(async (fnPath) => {
     const ts = Date.now()
     const routeName = path.basename(fnPath).replace('.js', '')
-    const routePath = routeName === 'graphql' ? '/graphql' : `/${routeName}`
+    const routePath = `/${routeName}`
 
     const fnImport = await import(pathToFileURL(fnPath).href)
     const handler: Handler | undefined = (() => {

--- a/packages/api/build.mts
+++ b/packages/api/build.mts
@@ -14,6 +14,7 @@ const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8')) as {
 if (!pkg.version) {
   throw new Error('build error: No version specified')
 }
+
 if (!pkg.dependencies['@prisma/client']) {
   throw new Error('build error: @prisma/client is not available')
 }


### PR DESCRIPTION
Removing unnecessary complex expression for building `routePath`