### PR TITLE
chore(babel): Rename extracted gql server options to __cedar_...

### DIFF
--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -140,14 +140,14 @@ export async function createServer(options: CreateServerOptions = {}) {
     const { redwoodFastifyGraphQLServer } = await import('./plugins/graphql.js')
     // This comes from a babel plugin that's applied to
     // api/dist/functions/graphql.{ts,js} in user projects
-    const { __rw_graphqlOptions } = await import(
+    const { __cedar_graphqlOptions } = await import(
       pathToFileURL(graphqlFunctionPath).href
     )
 
     await server.register(redwoodFastifyGraphQLServer, {
       redwood: {
         apiRootPath,
-        graphql: __rw_graphqlOptions,
+        graphql: __cedar_graphqlOptions,
       },
     })
   }

--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -53,16 +53,16 @@ export async function redwoodFastifyGraphQLServer(
 
       // This comes from a babel plugin that's applied to
       // api/dist/functions/graphql.{ts,js} in user projects
-      const { __rw_graphqlOptions } = await import(filePath)
+      const { __cedar_graphqlOptions } = await import(filePath)
 
-      if (!__rw_graphqlOptions) {
+      if (!__cedar_graphqlOptions) {
         // Our babel plugin couldn't find any grapqhql config options, so we
         // assume the user is doing their own thing.
         // Return here and skip creating a Cedar specific server
         return
       }
 
-      redwoodOptions.graphql = __rw_graphqlOptions as GraphQLYogaOptions
+      redwoodOptions.graphql = __cedar_graphqlOptions as GraphQLYogaOptions
     }
 
     const graphqlOptions = redwoodOptions.graphql

--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -15,9 +15,9 @@ import {
   registerBabel,
 } from './common.js'
 import pluginCedarGqlormInject from './plugins/babel-plugin-cedar-gqlorm-inject.js'
+import pluginCedarGraphqlOptionsExtract from './plugins/babel-plugin-cedar-graphql-options-extract.js'
 import pluginRedwoodContextWrapping from './plugins/babel-plugin-redwood-context-wrapping.js'
 import pluginRedwoodDirectoryNamedImport from './plugins/babel-plugin-redwood-directory-named-import.js'
-import pluginRedwoodGraphqlOptionsExtract from './plugins/babel-plugin-redwood-graphql-options-extract.js'
 import pluginRedwoodImportDir from './plugins/babel-plugin-redwood-import-dir.js'
 import pluginRedwoodJobPathInjector from './plugins/babel-plugin-redwood-job-path-injector.js'
 import pluginRedwoodOTelWrapping from './plugins/babel-plugin-redwood-otel-wrapping.js'
@@ -175,7 +175,7 @@ export const getApiSideBabelOverrides = ({ projectIsEsm = false } = {}) => {
     {
       // match */api/src/functions/graphql.js|ts
       test: /.+api(?:[\\|/])src(?:[\\|/])functions(?:[\\|/])graphql\.(?:js|ts)$/,
-      plugins: [pluginRedwoodGraphqlOptionsExtract, pluginCedarGqlormInject],
+      plugins: [pluginCedarGraphqlOptionsExtract, pluginCedarGqlormInject],
     },
     // Apply context wrapping to all functions
     {

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/aliased-import/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/aliased-import/output.js
@@ -6,7 +6,7 @@ import services from 'src/services/**/*.{js,ts}'
 import { db } from 'src/lib/db'
 import { executionContext } from 'src/lib/executionContext'
 import { logger } from 'src/lib/logger'
-export const __rw_graphqlOptions = {
+export const __cedar_graphqlOptions = {
   loggerConfig: {
     logger,
     options: {},
@@ -19,7 +19,7 @@ export const __rw_graphqlOptions = {
     db.$disconnect()
   },
 }
-const graphQLHandler = someOtherFunctionName(__rw_graphqlOptions)
+const graphQLHandler = someOtherFunctionName(__cedar_graphqlOptions)
 export const handler = async (event, context) => {
   const requestIdHeader = 'x-request-id'
   const requestId = event.headers[requestIdHeader] ?? scuid()

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/default-graphql-function/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/default-graphql-function/output.js
@@ -4,7 +4,7 @@ import sdls from 'src/graphql/**/*.sdl.{js,ts}'
 import services from 'src/services/**/*.{js,ts}'
 import { db } from 'src/lib/db'
 import { logger } from 'src/lib/logger'
-export const __rw_graphqlOptions = {
+export const __cedar_graphqlOptions = {
   loggerConfig: {
     logger,
     options: {},
@@ -17,4 +17,4 @@ export const __rw_graphqlOptions = {
     db.$disconnect()
   },
 }
-export const handler = createGraphQLHandler(__rw_graphqlOptions)
+export const handler = createGraphQLHandler(__cedar_graphqlOptions)

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/evil-graphql-function/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/evil-graphql-function/output.js
@@ -34,9 +34,9 @@ const config = {
 /**
  * Comments...
  */
-export const __rw_graphqlOptions = process.env.EVIL
+export const __cedar_graphqlOptions = process.env.EVIL
   ? config
   : {
       sadness: true,
     }
-export const handler = createGraphQLHandler(__rw_graphqlOptions)
+export const handler = createGraphQLHandler(__cedar_graphqlOptions)

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/function-graphql-function/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/function-graphql-function/output.js
@@ -17,5 +17,5 @@ const config = () => ({
     db.$disconnect()
   },
 })
-export const __rw_graphqlOptions = config()
-export const handler = createGraphQLHandler(__rw_graphqlOptions)
+export const __cedar_graphqlOptions = config()
+export const handler = createGraphQLHandler(__cedar_graphqlOptions)

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/modified-graphql-function/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/modified-graphql-function/output.js
@@ -34,5 +34,5 @@ const config = {
 /**
  * Comments...
  */
-export const __rw_graphqlOptions = config
-export const handler = createGraphQLHandler(__rw_graphqlOptions)
+export const __cedar_graphqlOptions = config
+export const handler = createGraphQLHandler(__cedar_graphqlOptions)

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/wrapper-function/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/wrapper-function/output.js
@@ -6,7 +6,7 @@ import services from 'src/services/**/*.{js,ts}'
 import { db } from 'src/lib/db'
 import { executionContext } from 'src/lib/executionContext'
 import { logger } from 'src/lib/logger'
-export const __rw_graphqlOptions = {
+export const __cedar_graphqlOptions = {
   loggerConfig: {
     logger,
     options: {},
@@ -19,7 +19,7 @@ export const __rw_graphqlOptions = {
     db.$disconnect()
   },
 }
-const graphQLHandler = createGraphQLHandler(__rw_graphqlOptions)
+const graphQLHandler = createGraphQLHandler(__cedar_graphqlOptions)
 export const handler = async (event, context) => {
   const requestIdHeader = 'x-request-id'
   const requestId = event.headers[requestIdHeader] ?? scuid()

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-cedar-graphql-options-extract.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-cedar-graphql-options-extract.test.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import pluginTester from 'babel-plugin-tester'
 import { vi } from 'vitest'
 
-import redwoodGraphqlOptionsExtract from '../babel-plugin-redwood-graphql-options-extract.js'
+import cedarGraphqlOptionsExtract from '../babel-plugin-cedar-graphql-options-extract.js'
 
 vi.mock('@cedarjs/project-config', () => {
   return {
@@ -14,7 +14,7 @@ vi.mock('@cedarjs/project-config', () => {
 })
 
 pluginTester({
-  plugin: redwoodGraphqlOptionsExtract,
-  pluginName: 'babel-plugin-redwood-graphql-options-extract',
+  plugin: cedarGraphqlOptionsExtract,
+  pluginName: 'babel-plugin-cedar-graphql-options-extract',
   fixtures: path.join(__dirname, '__fixtures__/graphql-options-extract'),
 })

--- a/packages/babel-config/src/plugins/babel-plugin-cedar-gqlorm-inject.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-cedar-gqlorm-inject.ts
@@ -161,10 +161,10 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
         //
         // We use Object.assign (mutate in-place) rather than
         //   sdls = { ...sdls, __gqlorm__: ... }
-        // because pluginRedwoodGraphqlOptionsExtract has already run and
-        // captured `sdls` by reference inside __rw_graphqlOptions:
-        //   const __rw_graphqlOptions = { ..., sdls, ... }
-        // Both __rw_graphqlOptions.sdls and the `sdls` variable point at the
+        // because pluginCedarGraphqlOptionsExtract has already run and captured
+        // `sdls` by reference inside __cedar_graphqlOptions:
+        //   const __cedar_graphqlOptions = { ..., sdls, ... }
+        // Both __cedar_graphqlOptions.sdls and the `sdls` variable point at the
         // same object, so mutating it in-place ensures createGraphQLHandler
         // sees the __gqlorm__ addition.
         const sdlsMutation = t.expressionStatement(

--- a/packages/babel-config/src/plugins/babel-plugin-cedar-graphql-options-extract.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-cedar-graphql-options-extract.ts
@@ -3,7 +3,7 @@ import type { NodePath, PluginObj, PluginPass, types } from '@babel/core'
 // This extracts the options passed to the graphql function and stores them in
 // an exported variable so they can be imported elsewhere.
 
-const exportVariableName = '__rw_graphqlOptions'
+const exportVariableName = '__cedar_graphqlOptions'
 
 function optionsConstNode(
   t: typeof types,
@@ -34,7 +34,7 @@ function optionsConstNode(
 
 export default function ({ types: t }: { types: typeof types }): PluginObj {
   return {
-    name: 'babel-plugin-redwood-graphql-options-extract',
+    name: 'babel-plugin-cedar-graphql-options-extract',
     visitor: {
       Program(path, state) {
         // Find all imports of the 'createGraphQLHandler' function from '@cedarjs/graphql-server'

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -129,8 +129,9 @@ async function internalLoadApiFunctions(viteServer: ViteDevServer) {
         )
       }
 
-      if (routeName === 'graphql' && '__rw_graphqlOptions' in mod) {
-        extractedGraphqlOptions = mod.__rw_graphqlOptions as GraphQLYogaOptions
+      if (routeName === 'graphql' && '__cedar_graphqlOptions' in mod) {
+        extractedGraphqlOptions =
+          mod.__cedar_graphqlOptions as GraphQLYogaOptions
       }
     } catch (err) {
       viteServer.ssrFixStacktrace(err as Error)

--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -372,7 +372,7 @@ async function generateGraphQLModule(distPath: string): Promise<string> {
   //   - No dynamic import() strings that nft can't trace
   //   - No build-time Rollup resolution of files that don't exist yet
   //
-  // The __rw_graphqlOptions export from the bundled code is used directly
+  // The __cedar_graphqlOptions export from the bundled code is used directly
   // by createGraphQLYoga, so we can initialise yoga synchronously from the
   // inline bundle rather than going through a separate file import.
   const bundledCode = await bundleDistFile(distPath)
@@ -400,8 +400,8 @@ async function generateGraphQLModule(distPath: string): Promise<string> {
 
     function getYoga() {
       if (!yogaInitPromise) {
-        yogaInitPromise = createGraphQLYoga(__rw_graphqlOptions).then(
-          ({ yoga }) => ({ yoga, graphqlOptions: __rw_graphqlOptions })
+        yogaInitPromise = createGraphQLYoga(__cedar_graphqlOptions).then(
+          ({ yoga }) => ({ yoga, graphqlOptions: __cedar_graphqlOptions })
         );
       }
       return yogaInitPromise;


### PR DESCRIPTION
Use `__cedar_graphqlOptions` to continue moving away from old naming.

This is only used internally, so safe to merge this as a "chore" commit