### PR TITLE
chore(vite): Explain lazy loaded esbuild

### DIFF
--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -305,6 +305,10 @@ interface Opts {
 }
 
 async function bundleDistFile(distPath: string, options: Opts = {}) {
+  // esbuild is lazily imported because it is only needed during server function
+  // bundling. Keeping it dynamic avoids loading esbuild's native binaries in
+  // Vite contexts where this plugin is loaded but bundleDistFile is unused
+  // (e.g. web dev server, client builds).
   const { build } = await import('esbuild')
 
   const buildOptions: BuildOptions = {


### PR DESCRIPTION
AI explanation:

`esbuild` is lazy-loaded for performance. `esbuild` has native binaries and is relatively heavy to require. The plugin is loaded in many Vite contexts (dev server, client builds, config resolution) where `bundleDistFile` is never called. With the dynamic import, esbuild is only pulled in when we actually need to bundle a function for the UD server build.

It’s also worth noting that `esbuild` isn’t a direct dependency of `@cedarjs/vite`; it comes transitively through Vite. The dynamic import makes that “use it only when needed” relationship explicit.

Node’s module cache means the first await import('esbuild') pays the load cost and subsequent calls are cheap, so there’s no downside for bundling multiple functions.

It could be changed to a static import, but then every Vite process that loads this plugin would pay the esbuild startup cost even when it’s unused.