### PR TITLE
chore(docs): add CLAUDE.md symlink and update type safety guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,12 @@
 - Every non-obvious cast must include a short comment describing why it is safe or necessary.
 - Avoid chained assertions unless required (e.g. `as unknown as X` at library typing boundaries); document why when used.
 - When filtering arrays, prefer typed predicates (e.g. `(v): v is T => Boolean(v)`) instead of broad casts like `as T[]`.
+- **Never use `e as Error` in try/catch clauses.** The caught value is `unknown` and may not be an `Error`. Always narrow the type properly, e.g.:
+  ```ts
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+  }
+  ```
 
 ## Testing Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
- Adds `CLAUDE.md` as a symlink to `AGENTS.md` so the Claude Code harness auto-loads the repo guidelines into context for every session
- Adds a rule to `AGENTS.md`: never use `e as Error` in try/catch clauses — the caught value is `unknown` and must be narrowed with `instanceof Error`