### PR TITLE
fix(ud): Use 200.html

### DIFF
--- a/.commandcode/taste/taste.md
+++ b/.commandcode/taste/taste.md
@@ -9,7 +9,7 @@ See [typescript/taste.md](typescript/taste.md)
 # Architecture
 
 - CedarJS only supports Apollo Client for GraphQL. Remove abstractions/wrappers that suggest alternative GraphQL clients are supported. Confidence: 0.75
-- CedarJS owns zero deployment adapters. The framework's only UD responsibility is calling `addEntry()` from `@universal-deploy/store` with WinterTC-compatible handler paths. All provider-specific adapter logic (Node, Netlify, Vercel, Cloudflare) belongs to Universal Deploy adapters, not Cedar. Confidence: 0.85
+- CedarJS owns zero deployment adapters. The framework's only UD responsibility is calling `addEntry()` from `@universal-deploy/store` with WinterTC-compatible handler paths. Cloudless server-side serving uses `srvx` in the Cedar CLI directly (no Cedar-owned adapter package for Node, and no UD adapter needed for that path). Provider-specific adapter logic for Netlify/Vercel/Cloudflare belongs to Universal Deploy adapters, not Cedar. Confidence: 0.90
 - Cedar apps default to CJS + Jest (not vitest). Only ESM-template apps use vitest. Confidence: 0.85
 
 # Workflow
@@ -52,6 +52,7 @@ See [code-style/taste.md](code-style/taste.md)
 # Debugging
 
 - When reproducing bugs, validate against realistic production code paths (e.g., curl against a running server) rather than synthetic/unit-level demonstrations that load modules in isolation. The repro should prove the bug happens in real usage. Confidence: 0.75
+- When designing E2E tests for deployment paths, exercise the same boot path users actually run in production (e.g., `cedar serve api --ud` matching the systemd `ExecStart`), not a synthetic test-only entrypoint. Tests should validate the documented production recipe directly. Confidence: 0.80
 - When testing detection logic that checks generated files for specific strings (e.g., checking if a Prisma client has been generated), the test should verify that the expected strings still appear in real generated output. The goal is a regression canary that catches upstream changes to the generated output format. Confidence: 0.75
 - Prefer `fs.globSync`/`fsPromises.glob` (Node 22+ built-in) over hand-rolled `readdirSync({ recursive: true })` for file pattern matching — it's simpler, more declarative, and already handles extension filtering and exclusion. Confidence: 0.65
 - When warning about packages found outside expected locations, don't label them as "stray" — users may have legitimate non-Prisma uses for those packages, which means they shouldn't be removed. Confidence: 0.65
@@ -59,3 +60,8 @@ See [code-style/taste.md](code-style/taste.md)
 # node
 
 - Cedar requires Node 24+. --experimental-strip-types is unflagged and not needed. Confidence: 0.90
+- When forwarding a request body via `fetch()` in Cedar server code (e.g., API proxy middleware), include `duplex: 'half'` in the `RequestInit` with a `@ts-expect-error` and explanatory comment. Node 18+ fetch requires this option when streaming a body; without it, POST requests silently fail with `TypeError: RequestInit: duplex option is required when sending a body.` The DOM lib types don't yet include it. Confidence: 0.90
+
+# Web Serve
+
+- For SPA fallback in `cedar serve` (both Fastify and `--ud` srvx paths), use `web/dist/200.html` (unprerendered shell) when it exists, otherwise fall back to `web/dist/index.html`. Returning the prerendered `index.html` for non-prerendered routes makes the client think the page was prerendered and crashes on `prerenderLoader(name).default` when the page module isn't in `__REDWOOD__PRERENDER_PAGES`. Mirror the Fastify web adapter's logic at `packages/adapters/fastify/web/src/web.ts`. Confidence: 0.85

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,7 @@ jobs:
 
   e2e-node:
     needs: check
-    if: github.repository == 'cedarjs/cedar' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
-    name: 🟢 E2E Node self-host
+    name: 🖥️ E2E Node self-host
     uses: ./.github/workflows/e2e-node.yml
 
   ci-status-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,12 @@ jobs:
     uses: ./.github/workflows/e2e-vercel.yml
     secrets: inherit
 
+  e2e-node:
+    needs: check
+    if: github.repository == 'cedarjs/cedar' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+    name: 🟢 E2E Node self-host
+    uses: ./.github/workflows/e2e-node.yml
+
   ci-status-check:
     needs:
       - check
@@ -276,6 +282,7 @@ jobs:
       - background-jobs-e2e
       - e2e-netlify
       - e2e-vercel
+      - e2e-node
     if: always()
 
     name: ✅ CI Status Check

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -1,4 +1,4 @@
-name: 🟢 E2E - Node Self-host
+name: 🖥️ E2E - Node Self-host
 
 on:
   workflow_call:
@@ -57,6 +57,6 @@ jobs:
         working-directory: ./tasks/smoke-tests/serve
         run: npx playwright test
         env:
-          CEDAR_TEST_PROJECT_PATH: ../cedar-test-app
+          CEDAR_TEST_PROJECT_PATH: ${{ github.workspace }}/../cedar-test-app
           CEDAR_SERVE_UD: '1'
           REDWOOD_DISABLE_TELEMETRY: 1

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -1,0 +1,62 @@
+name: 🟢 E2E - Node Self-host
+
+on:
+  workflow_call:
+
+jobs:
+  e2e-node:
+    runs-on: ubuntu-latest
+
+    env:
+      CEDAR_CI: 1
+      CEDAR_VERBOSE_TELEMETRY: 1
+      YARN_ENABLE_HARDENED_MODE: 0
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
+    steps:
+      - name: Checkout the framework code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
+
+      - name: 📋 Set up test project
+        run: cp -r __fixtures__/test-project-esm ../cedar-test-app
+
+      - name: 🔗 Link local packages via tarsync
+        run: yarn project:tarsync ../cedar-test-app
+
+      - name: 🔧 Set up Universal Deploy
+        working-directory: ../cedar-test-app
+        run: yarn cedar setup deploy universal-deploy
+
+      - name: 🔑 Generate dbAuth secret
+        working-directory: ../cedar-test-app
+        run: |
+          SECRET=$(yarn cedar g secret --raw)
+          echo "SESSION_SECRET='$SECRET'" >> .env
+
+      - name: 🗄️ Set up SQLite database (migrate + seed)
+        working-directory: ../cedar-test-app
+        run: |
+          yarn cedar prisma migrate reset --force
+          yarn cedar prisma db seed
+
+      - name: 🏗️ Build with --ud
+        working-directory: ../cedar-test-app
+        run: yarn cedar build --ud
+
+      - name: 🎭 Install Playwright OS dependencies
+        if: runner.os == 'Linux'
+        run: npx playwright install-deps chromium
+
+      - name: 🎭 Install Playwright dependencies
+        run: npx playwright install chromium
+
+      - name: 🧪 Run Node self-host e2e tests
+        working-directory: ./tasks/smoke-tests/serve
+        run: npx playwright test
+        env:
+          CEDAR_TEST_PROJECT_PATH: ../cedar-test-app
+          CEDAR_SERVE_UD: '1'
+          REDWOOD_DISABLE_TELEMETRY: 1

--- a/__fixtures__/test-project-esm/package.json
+++ b/__fixtures__/test-project-esm/package.json
@@ -12,7 +12,7 @@
     "@cedarjs/project-config": "4.2.0",
     "@cedarjs/testing": "4.2.0",
     "vitest": "3.2.6",
-    "prettier-plugin-tailwindcss": "^0.8.0"
+    "prettier-plugin-tailwindcss": "^0.7.0"
   },
   "engines": {
     "node": "=24.x"

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -11,7 +11,7 @@
     "@cedarjs/eslint-config": "4.2.0",
     "@cedarjs/project-config": "4.2.0",
     "@cedarjs/testing": "4.2.0",
-    "prettier-plugin-tailwindcss": "^0.8.0"
+    "prettier-plugin-tailwindcss": "^0.7.0"
   },
   "engines": {
     "node": "=24.x"

--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -39,7 +39,8 @@
 │  Browser ──GET──▶ static files/prerender           │                         │
 │                    │                                ▼                        │
 │               SPA fallback                      GraphQL Yoga                  │
-│               (index.html)                   (services use @cedarjs/context)  │
+│               (200.html if present,           (services use @cedarjs/context)  │
+│                else index.html)                                               │
 │                    │                                                          │
 │                    ▼                                                         │
 │               React (client)                                                  │

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -177,15 +177,21 @@ export const builder = async (yargs: Argv) => {
           // 1. serveStatic: serve files from web/dist/ (SPA assets)
           // 2. apiProxy: forward API-prefixed requests to UD Fetchable on API
           //    port
-          // 3. spaFallback: serve index.html for client-side routing
+          // 3. spaFallback: serve the unprerendered SPA shell for client-side
+          //    routing
           const { serveStatic } = await import('srvx/static')
           const apiUrl = getConfig().web.apiUrl
           const webDist = getPaths().web.dist
 
-          const indexHtml = fs.readFileSync(
-            path.join(webDist, 'index.html'),
-            'utf-8',
-          )
+          // SPA fallback: use `200.html` (unprerendered shell) if it exists,
+          // otherwise `index.html`. This matches the Fastify web adapter
+          // behaviour and prevents client-side prerender detection from
+          // triggering on routes that weren't actually prerendered.
+          const prerenderIndexPath = path.join(webDist, '200.html')
+          const fallbackIndexPath = fs.existsSync(prerenderIndexPath)
+            ? prerenderIndexPath
+            : path.join(webDist, 'index.html')
+          const spaHtml = fs.readFileSync(fallbackIndexPath, 'utf-8')
 
           const webServer = serveSrvx({
             // Dummy fetch handler. All requests are handled by middleware
@@ -210,11 +216,14 @@ export const builder = async (yargs: Argv) => {
                   method: req.method,
                   headers: req.headers,
                   body: req.body,
+                  // @ts-expect-error - `duplex` is required when forwarding a
+                  // request body via fetch (Node 18+).
+                  duplex: 'half',
                 })
               },
               () => {
                 const headers = { 'Content-Type': 'text/html' }
-                return new Response(indexHtml, { headers })
+                return new Response(spaHtml, { headers })
               },
             ],
             port: webPort,

--- a/tasks/smoke-tests/serve/playwright.config.ts
+++ b/tasks/smoke-tests/serve/playwright.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
 
   // Run your local dev server before starting the tests
   webServer: {
-    command: 'yarn cedar serve',
+    command: process.env.CEDAR_SERVE_UD
+      ? 'yarn cedar serve --ud'
+      : 'yarn cedar serve',
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
     url: 'http://127.0.0.1:8910',
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
1. SPA fallback was returning the prerendered `index.html` instead of the bare unprerendered shell. Routes like /contact (not prerendered) were getting the prerendered home page's HTML, which made the client think it was prerendered and crash on missing page modules. Fixed by reading web/dist/200.html first (the unprerendered shell that the prerender step copies from index.html), falling back to index.html if 200.html doesn't exist. Mirrors the Fastify web adapter exactly.
2. fetch to the API proxy crashed on POST bodies with TypeError: RequestInit: duplex option is required when sending a body. Added `duplex: 'half'` with `@ts-expect-error` and a comment explaining why (Node 18+ fetch requirement, not yet in `lib.dom` types).