### PR TITLE
chore(deps): Drop dependency human-id

### DIFF
--- a/__fixtures__/test-project-esm/package.json
+++ b/__fixtures__/test-project-esm/package.json
@@ -12,7 +12,7 @@
     "@cedarjs/project-config": "4.2.0",
     "@cedarjs/testing": "4.2.0",
     "vitest": "3.2.6",
-    "prettier-plugin-tailwindcss": "^0.8.0"
+    "prettier-plugin-tailwindcss": "^0.7.0"
   },
   "engines": {
     "node": "=24.x"

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -11,7 +11,7 @@
     "@cedarjs/eslint-config": "4.2.0",
     "@cedarjs/project-config": "4.2.0",
     "@cedarjs/testing": "4.2.0",
-    "prettier-plugin-tailwindcss": "^0.8.0"
+    "prettier-plugin-tailwindcss": "^0.7.0"
   },
   "engines": {
     "node": "=24.x"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "execa": "5.1.1",
     "fast-glob": "3.3.3",
     "globals": "16.5.0",
-    "human-id": "^4.1.1",
     "jest": "29.7.0",
     "jscodeshift": "17.3.0",
     "lefthook": "2.1.9",

--- a/tasks/changesets/changesetsHelpers.mts
+++ b/tasks/changesets/changesetsHelpers.mts
@@ -1,6 +1,5 @@
 import { fileURLToPath } from 'node:url'
 
-import { humanId } from 'human-id'
 import type { ProcessPromise } from 'zx'
 import { $, argv, path, fs } from 'zx'
 
@@ -27,10 +26,7 @@ export function getChangesetFilePath(prNumber?: number) {
   if (prNumber) {
     changesetId = prNumber
   } else {
-    changesetId = humanId({
-      separator: '-',
-      capitalize: false,
-    })
+    changesetId = new Date().toISOString().replace(/[:.]/g, '-')
   }
 
   return path.join(CHANGESETS_DIR, `${changesetId}.md`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -18494,15 +18494,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"human-id@npm:^4.1.1":
-  version: 4.2.0
-  resolution: "human-id@npm:4.2.0"
-  bin:
-    human-id: dist/cli.js
-  checksum: 10c0/80071f3b785b2e91080b5f9aa2d079c2e9a464e009ea12c035255b61d1b70beefe7eda42209dff9c1bb9a9fa58e50ada38c1b314ba3a23266a72cd5e9a453e1f
-  languageName: node
-  linkType: hard
-
 "human-signals@npm:^1.1.1":
   version: 1.1.1
   resolution: "human-signals@npm:1.1.1"
@@ -25653,7 +25644,6 @@ __metadata:
     execa: "npm:5.1.1"
     fast-glob: "npm:3.3.3"
     globals: "npm:16.5.0"
-    human-id: "npm:^4.1.1"
     jest: "npm:29.7.0"
     jscodeshift: "npm:17.3.0"
     lefthook: "npm:2.1.9"


### PR DESCRIPTION
Just use a simple timestamp as the id instead.  It's not as nice, but it's good enough for how seldom this is used