### PR TITLE
chore(test): Fix locator in dev auth smoke tests

### DIFF
--- a/tasks/smoke-tests/dev/tests/authChecks.spec.ts
+++ b/tasks/smoke-tests/dev/tests/authChecks.spec.ts
@@ -58,11 +58,11 @@ test('requireAuth graphql checks', async ({ page }) => {
   // Try to create a post as an anonymous user.
   await createNewPost({ page })
 
-  expect(
+  await expect(
     page
       .locator('.rw-form-error-title')
       .locator("text=You don't have permission to do that"),
-  ).toBeTruthy()
+  ).toBeVisible()
 
   await page.goto('/')
 

--- a/tasks/smoke-tests/dev/tests/rbacChecks.spec.ts
+++ b/tasks/smoke-tests/dev/tests/rbacChecks.spec.ts
@@ -63,11 +63,11 @@ test('RBAC: Should not be able to delete contact as non-admin user', async ({
 
   await page.locator('text=Delete').first().click()
 
-  expect(
+  await expect(
     page
       .locator('.rw-scaffold')
       .locator("text=You don't have permission to do that"),
-  ).toBeTruthy()
+  ).toBeVisible()
 
   // @NOTE we do this because the scaffold content is actually on the page,
   // This is the only way we validate if its actually showing visually

--- a/tasks/smoke-tests/dev/tests/rbacChecks.spec.ts
+++ b/tasks/smoke-tests/dev/tests/rbacChecks.spec.ts
@@ -66,7 +66,7 @@ test('RBAC: Should not be able to delete contact as non-admin user', async ({
   await expect(
     page
       .locator('.rw-scaffold')
-      .locator("text=You don't have permission to do that"),
+      .locator("text=You don't have access to do that"),
   ).toBeVisible()
 
   // @NOTE we do this because the scaffold content is actually on the page,


### PR DESCRIPTION
**`.toBeTruthy()` on a Locator always passes**

`page.locator(...)` returns a `Locator` object, which is always a non-null JavaScript object and is therefore always truthy. Checking `toBeTruthy()` will never fail regardless of whether the error text that we're looking for is actually visible on the page, making the anonymous-user guard completely untested. The same pattern appears in both `authChecks.spec.ts` and `rbacChecks.spec.ts` on the non-admin delete test.