### PR TITLE
feat(gql): CedarGraphQLError

### DIFF
--- a/.changesets/release_notes_minor.md
+++ b/.changesets/release_notes_minor.md
@@ -53,3 +53,10 @@ export const handle = async (request, ctx) => {
   // query.page       → '1'          for ?page=1
 }
 ```
+
+## Deprecations
+
+- **`RedwoodGraphQLError` has been renamed to `CedarGraphQLError`.** The old
+  name `RedwoodGraphQLError` is still exported as a deprecated alias for
+  backwards compatibility. Please migrate to importing `CedarGraphQLError` from
+  `@cedarjs/graphql-server` instead.

--- a/docs/implementation-plans/golden-path-error-handling.md
+++ b/docs/implementation-plans/golden-path-error-handling.md
@@ -77,7 +77,7 @@ each carrying a stable `extensions.code`:
 | `UserInputError`      | `BAD_USER_INPUT`            |
 | `ValidationError`     | `GRAPHQL_VALIDATION_FAILED` |
 | `SyntaxError`         | `GRAPHQL_PARSE_FAILED`      |
-| `CedarGraphQLError` | `REDWOODJS_ERROR` (default) |
+| `CedarGraphQLError`   | `REDWOODJS_ERROR` (default) |
 
 This gives clients a consistent, parseable `extensions.code` field to branch on.
 

--- a/docs/implementation-plans/golden-path-error-handling.md
+++ b/docs/implementation-plans/golden-path-error-handling.md
@@ -77,7 +77,7 @@ each carrying a stable `extensions.code`:
 | `UserInputError`      | `BAD_USER_INPUT`            |
 | `ValidationError`     | `GRAPHQL_VALIDATION_FAILED` |
 | `SyntaxError`         | `GRAPHQL_PARSE_FAILED`      |
-| `RedwoodGraphQLError` | `REDWOODJS_ERROR` (default) |
+| `CedarGraphQLError` | `REDWOODJS_ERROR` (default) |
 
 This gives clients a consistent, parseable `extensions.code` field to branch on.
 
@@ -185,10 +185,10 @@ exposedErrorCodes?: string[]
 
 **Scope clarification:** this allowlist only applies to errors that already carry
 an `extensions.code` — that is, `GraphQLError` instances and subclasses
-(including `RedwoodGraphQLError`). Plain `Error` throws have no `extensions`
+(including `CedarGraphQLError`). Plain `Error` throws have no `extensions`
 property and will never match a code in this list; they will continue to be
 masked regardless. The allowlist is therefore an ergonomic alternative to
-subclassing `RedwoodGraphQLError` for teams that already throw `GraphQLError`
+subclassing `CedarGraphQLError` for teams that already throw `GraphQLError`
 instances with a known code (e.g. from a third-party library), not a general
 mechanism for exposing arbitrary thrown errors.
 
@@ -211,7 +211,7 @@ The `useRedwoodError` plugin would consult this list alongside the
 ### 3. Standardised error envelope (low effort, high consistency value)
 
 Define a canonical `extensions` shape for all Cedar GraphQL errors and enforce
-it in `RedwoodGraphQLError`:
+it in `CedarGraphQLError`:
 
 ```ts
 interface CedarErrorExtensions {

--- a/packages/graphql-server/src/errors.ts
+++ b/packages/graphql-server/src/errors.ts
@@ -1,7 +1,7 @@
 // based on ApolloError https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-errors/src/index.ts
 import { GraphQLError } from 'graphql'
 
-export class RedwoodGraphQLError extends GraphQLError {
+export class CedarGraphQLError extends GraphQLError {
   constructor(
     message: string,
     extensions?: Record<string, any>,
@@ -21,7 +21,10 @@ export class RedwoodGraphQLError extends GraphQLError {
   }
 }
 
-export class SyntaxError extends RedwoodGraphQLError {
+// @deprecated Use `CedarGraphQLError` instead
+export const RedwoodGraphQLError = CedarGraphQLError
+
+export class SyntaxError extends CedarGraphQLError {
   constructor(message: string) {
     super(message, { code: 'GRAPHQL_PARSE_FAILED' })
 
@@ -29,7 +32,7 @@ export class SyntaxError extends RedwoodGraphQLError {
   }
 }
 
-export class ValidationError extends RedwoodGraphQLError {
+export class ValidationError extends CedarGraphQLError {
   constructor(message: string) {
     super(message, { code: 'GRAPHQL_VALIDATION_FAILED' })
 
@@ -37,7 +40,7 @@ export class ValidationError extends RedwoodGraphQLError {
   }
 }
 
-export class AuthenticationError extends RedwoodGraphQLError {
+export class AuthenticationError extends CedarGraphQLError {
   constructor(message: string) {
     super(message, { code: 'UNAUTHENTICATED' })
 
@@ -45,7 +48,7 @@ export class AuthenticationError extends RedwoodGraphQLError {
   }
 }
 
-export class ForbiddenError extends RedwoodGraphQLError {
+export class ForbiddenError extends CedarGraphQLError {
   constructor(message: string) {
     super(message, { code: 'FORBIDDEN' })
 
@@ -53,7 +56,7 @@ export class ForbiddenError extends RedwoodGraphQLError {
   }
 }
 
-export class PersistedQueryNotFoundError extends RedwoodGraphQLError {
+export class PersistedQueryNotFoundError extends CedarGraphQLError {
   constructor() {
     super('PersistedQueryNotFound', { code: 'PERSISTED_QUERY_NOT_FOUND' })
 
@@ -61,7 +64,7 @@ export class PersistedQueryNotFoundError extends RedwoodGraphQLError {
   }
 }
 
-export class PersistedQueryNotSupportedError extends RedwoodGraphQLError {
+export class PersistedQueryNotSupportedError extends CedarGraphQLError {
   constructor() {
     super('PersistedQueryNotSupported', {
       code: 'PERSISTED_QUERY_NOT_SUPPORTED',
@@ -71,7 +74,7 @@ export class PersistedQueryNotSupportedError extends RedwoodGraphQLError {
   }
 }
 
-export class UserInputError extends RedwoodGraphQLError {
+export class UserInputError extends CedarGraphQLError {
   constructor(message: string, properties?: Record<string, any>) {
     super(message, { code: 'BAD_USER_INPUT', properties })
 

--- a/packages/graphql-server/src/errors.ts
+++ b/packages/graphql-server/src/errors.ts
@@ -21,8 +21,18 @@ export class CedarGraphQLError extends GraphQLError {
   }
 }
 
-// @deprecated Use `CedarGraphQLError` instead
+/** @deprecated Use `CedarGraphQLError` instead */
 export const RedwoodGraphQLError = CedarGraphQLError
+
+// Exporting as const (like we do above) puts RedwoodGraphQLError only in
+// TypeScript's value namespace, not the type namespace. Any caller who used the
+// old class as a type annotation (e.g., function handle(error:
+// RedwoodGraphQLError)) will now get a compile error: 'RedwoodGraphQLError'
+// refers to a value, but is being used as a type here. An instanceof guard and
+// new still work, but the type annotation form is a real backward-compat break.
+// A parallel type export makes both namespaces available.
+/** @deprecated Use `CedarGraphQLError` instead */
+export type RedwoodGraphQLError = CedarGraphQLError
 
 export class SyntaxError extends CedarGraphQLError {
   constructor(message: string) {

--- a/packages/graphql-server/src/plugins/__tests__/useRedwoodError.test.ts
+++ b/packages/graphql-server/src/plugins/__tests__/useRedwoodError.test.ts
@@ -13,8 +13,7 @@ import { createGraphQLHandler } from '../../functions/graphql.js'
 vi.mock('../../makeMergedSchema', async () => {
   const { createGraphQLError } = await import('graphql-yoga')
   const { makeExecutableSchema } = await import('@graphql-tools/schema')
-  const { ForbiddenError, RedwoodGraphQLError } =
-    await import('../../errors.js')
+  const { ForbiddenError, CedarGraphQLError } = await import('../../errors.js')
   const { CurrencyResolver } = await import('graphql-scalars')
   const { RedwoodError, EmailValidationError } =
     (await import('@cedarjs/api')) as {
@@ -85,8 +84,8 @@ vi.mock('../../makeMergedSchema', async () => {
               throw createGraphQLError('You are forbidden by a GraphQLError')
             },
             redwoodGraphQLErrorUser: () => {
-              throw new RedwoodGraphQLError(
-                'You are forbidden by a RedwoodGraphQLError',
+              throw new CedarGraphQLError(
+                'You are forbidden by a CedarGraphQLError',
               )
             },
             invalidUser: () => {
@@ -291,7 +290,7 @@ describe('useRedwoodError', () => {
       })
     })
 
-    describe('with a RedwoodGraphQLError', () => {
+    describe('with a CedarGraphQLError', () => {
       it('does not mask error message', async () => {
         const handler = createGraphQLHandler({
           loggerConfig: { logger: createLogger({}), options: {} },
@@ -317,7 +316,7 @@ describe('useRedwoodError', () => {
         expect(response.statusCode).toBe(200)
         expect(data).toBeNull()
         expect(errors[0].message).toContain(
-          'You are forbidden by a RedwoodGraphQLError',
+          'You are forbidden by a CedarGraphQLError',
         )
       })
     })

--- a/upgrade-scripts/4.3.x.ts
+++ b/upgrade-scripts/4.3.x.ts
@@ -1,0 +1,42 @@
+import { glob, readFile } from 'node:fs/promises'
+import * as path from 'node:path'
+import { styleText } from 'node:util'
+
+import { getPaths } from '@cedarjs/project-config'
+
+const projectRoot = getPaths().base
+
+const patterns = ['**/*.{js,cjs,mjs,ts,cts,mts}']
+
+const exclude = ['**/node_modules/**', '**/dist/**']
+
+async function main() {
+  const filesWithOldName: string[] = []
+
+  for await (const file of glob(patterns, { cwd: projectRoot, exclude })) {
+    const content = await readFile(path.join(projectRoot, file), 'utf8')
+
+    if (content.includes('RedwoodGraphQLError')) {
+      filesWithOldName.push(file)
+    }
+  }
+
+  if (filesWithOldName.length > 0) {
+    console.log(
+      styleText('yellow', 'Deprecated API detected: RedwoodGraphQLError') +
+        '\n',
+    )
+    console.log(
+      'Found RedwoodGraphQLError in: ' + filesWithOldName.join(', ') + '\n',
+    )
+    console.log(
+      'RedwoodGraphQLError has been renamed to CedarGraphQLError and will\n' +
+        'be removed in the next major release of CedarJS.\n',
+    )
+    console.log(
+      'Please rename it in the files listed above before the next major upgrade.\n',
+    )
+  }
+}
+
+main()

--- a/upgrade-scripts/5.x.ts
+++ b/upgrade-scripts/5.x.ts
@@ -30,6 +30,7 @@ async function main() {
   const filesWithOldRedirectTelemetryVar: string[] = []
   const filesWithOldDisableTelemetryVar: string[] = []
   const filesWithOldVerboseTelemetryVar: string[] = []
+  const filesWithOldGraphQLErrorName: string[] = []
 
   for await (const file of glob(patterns, { cwd: projectRoot, exclude })) {
     const content = await readFile(path.join(projectRoot, file), 'utf8')
@@ -48,6 +49,10 @@ async function main() {
 
     if (content.includes('REDWOOD_VERBOSE_TELEMETRY')) {
       filesWithOldVerboseTelemetryVar.push(file)
+    }
+
+    if (content.includes('RedwoodGraphQLError')) {
+      filesWithOldGraphQLErrorName.push(file)
     }
   }
 
@@ -126,6 +131,25 @@ async function main() {
     )
     console.log(
       'REDWOOD_VERBOSE_TELEMETRY has been renamed to CEDAR_VERBOSE_TELEMETRY and will\n' +
+        'be removed in the next major release of CedarJS.\n',
+    )
+    console.log(
+      'Please rename it in the files listed above before the next major upgrade.\n',
+    )
+  }
+
+  if (filesWithOldGraphQLErrorName.length > 0) {
+    console.log(
+      styleText('yellow', 'Deprecated API detected: RedwoodGraphQLError') +
+        '\n',
+    )
+    console.log(
+      'Found RedwoodGraphQLError in: ' +
+        filesWithOldGraphQLErrorName.join(', ') +
+        '\n',
+    )
+    console.log(
+      'RedwoodGraphQLError has been renamed to CedarGraphQLError and will\n' +
         'be removed in the next major release of CedarJS.\n',
     )
     console.log(

--- a/upgrade-scripts/manifest.json
+++ b/upgrade-scripts/manifest.json
@@ -1,1 +1,10 @@
-["canary.ts", "2.3.x.ts", "2.7.x.ts", "2.8.x.ts", "3.x.ts", "4.x.ts", "5.x.ts"]
+[
+  "canary.ts",
+  "2.3.x.ts",
+  "2.7.x.ts",
+  "2.8.x.ts",
+  "3.x.ts",
+  "4.x.ts",
+  "4.3.x.ts",
+  "5.x.ts"
+]


### PR DESCRIPTION
Continue rebranding to Cedar.

Old `RedwoodGraphQLError` is still exported, but is now deprecated