### PR TITLE
fix(cli): prettier-plugin-tailwindcss 0.8.0

### DIFF
--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcssHandler.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcssHandler.js
@@ -101,7 +101,7 @@ export const handler = async ({ force, install }) => {
   })
   const rwPaths = getPaths()
 
-  const projectPackages = ['prettier-plugin-tailwindcss@^0.7.0']
+  const projectPackages = ['prettier-plugin-tailwindcss@^0.8.0']
 
   const webWorkspacePackages = [
     'postcss',

--- a/tasks/test-project/tasks.mts
+++ b/tasks/test-project/tasks.mts
@@ -40,7 +40,7 @@ export async function webTasks(
         // @NOTE: use cfw, because calling the copy function doesn't seem to work here
         task: () =>
           execa(
-            'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss@^0.7.0',
+            'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss@^0.8.0',
             [],
             getExecaOptions(outputPath),
           ),


### PR DESCRIPTION
#1940 bumped the plugin to v0.8.0, but the setup commands were never updated along with that PR. 
This PR brings them in sync