### PR TITLE
chore(lefthook): Run smart-format without tsx. Node supports ts

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,7 +31,7 @@ pre-commit:
         - '**/templates/**/*.tsx'
 
     - name: format staged files
-      run: yarn tsx tasks/smart-format.mts {staged_files}
+      run: node tasks/smart-format.mts {staged_files}
       glob:
         - '*.{js,mjs,cjs,ts,mts,jsx,tsx,json,yml,md,mdx,css,sh}'
         - Dockerfile|.gitignore|.gitattributes


### PR DESCRIPTION
No need for tsx here