### PR TITLE
fix(cca): pnpm: Allow building needed packages

### DIFF
--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -112,7 +112,17 @@ export async function setUpTestProject({
     if (packageManager === 'npm') {
       pkg.overrides = { 'react-is': '19.2.3' }
     } else {
-      pkg.pnpm = { overrides: { 'react-is': '19.2.3' } }
+      pkg.pnpm = {
+        overrides: { 'react-is': '19.2.3' },
+        onlyBuiltDependencies: [
+          '@prisma/engines',
+          '@swc/core',
+          'esbuild',
+          'msw',
+          'prisma',
+          'protobufjs',
+        ],
+      }
     }
 
     if (packageManager === 'npm') {

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -12,6 +12,14 @@
   },
   "packageManager": "pnpm@10.34.3",
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "@prisma/engines",
+      "@swc/core",
+      "esbuild",
+      "msw",
+      "prisma",
+      "protobufjs"
+    ],
     "overrides": {
       "react-is": "19.2.3"
     }

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -12,6 +12,14 @@
   },
   "packageManager": "pnpm@10.34.3",
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "@prisma/engines",
+      "@swc/core",
+      "esbuild",
+      "msw",
+      "prisma",
+      "protobufjs"
+    ],
     "overrides": {
       "react-is": "19.2.3"
     }


### PR DESCRIPTION
Prevents this error in CI

```
Progress: resolved 1758, reused 0, downloaded 1642, added 0
Progress: resolved 1780, reused 0, downloaded 1668, added 0
[WARN] 16 deprecated subdependencies found: @babel/plugin-proposal-private-methods@7.18.6, @humanwhocodes/config-array@0.13.0, @humanwhocodes/object-schema@2.0.3, abab@2.0.6, domexception@4.0.0, eslint@8.57.1, glob@10.5.0, glob@11.1.0, glob@7.2.3, glob@9.3.5, inflight@1.0.6, node-domexception@1.0.0, react-server-dom-webpack@19.2.4, rimraf@3.0.2, whatwg-encoding@2.0.0, whatwg-encoding@3.1.1
Packages: +1673
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 1780, reused 0, downloaded 1668, added 1
Progress: resolved 1780, reused 0, downloaded 1668, added 1673, done
[WARN] Issues with peer dependencies found. Run "pnpm peers check" to list them.

devDependencies:
+ @cedarjs/core 4.2.0
+ @cedarjs/eslint-config 4.2.0
+ @cedarjs/project-config 4.2.0
+ @cedarjs/testing 4.2.0
+ prettier-plugin-tailwindcss 0.8.0

[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @prisma/engines@7.8.0, @swc/core@1.15.33, esbuild@0.27.7, msw@1.3.5, prisma@7.8.0, protobufjs@7.6.4

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
/home/runner/work/cedar/cedar/node_modules/@actions/exec/lib/toolrunner.js:600
                error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
                        ^

Error: The process '/usr/local/bin/pnpm' failed with exit code 1
    at ExecState._setResult (/home/runner/work/cedar/cedar/node_modules/@actions/exec/lib/toolrunner.js:600:25)
    at ExecState.CheckComplete (/home/runner/work/cedar/cedar/node_modules/@actions/exec/lib/toolrunner.js:583:18)
    at ChildProcess.<anonymous> (/home/runner/work/cedar/cedar/node_modules/@actions/exec/lib/toolrunner.js:478:27)
    at ChildProcess.emit (node:events:509:28)
    at maybeClose (node:internal/child_process:1124:16)
    at ChildProcess._handle.onexit (node:internal/child_process:306:5)

Node.js v24.16.0
```

And similar errors for users when they create pnpm based Cedar apps