### PR TITLE
feat(pm): bump pnpm to v11.8.0

### DIFF
--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -120,13 +120,13 @@ export async function setUpTestProject({
 
       pkg.engines = {
         ...pkg.engines,
-        pnpm: '=11.x',
+        pnpm: '>=11.8.0 <12.0.0',
       }
 
       pkg.devEngines = {
         packageManager: {
           name: 'pnpm',
-          version: '=11.x',
+          version: '11.8.0',
           onFail: 'download',
         },
       }

--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -112,17 +112,30 @@ export async function setUpTestProject({
     if (packageManager === 'npm') {
       pkg.overrides = { 'react-is': '19.2.3' }
     } else {
-      pkg.pnpm = {
-        overrides: { 'react-is': '19.2.3' },
-        onlyBuiltDependencies: [
-          '@prisma/engines',
-          '@swc/core',
-          'esbuild',
-          'msw',
-          'prisma',
-          'protobufjs',
-        ],
-      }
+      // pnpm 11 no longer reads the `pnpm` field from package.json. Settings
+      // must go in pnpm-workspace.yaml. The `overrides` for react-is is set
+      // at root-level package.json too (where both npm and pnpm can read it).
+      pkg.overrides = { 'react-is': '19.2.3' }
+
+      const yaml = [
+        'packages:',
+        '  - api',
+        '  - web',
+        '',
+        'allowBuilds:',
+        "  '@prisma/engines': true",
+        "  '@swc/core': true",
+        '  esbuild: true',
+        '  msw: true',
+        '  prisma: true',
+        '  protobufjs: true',
+        '',
+        'overrides:',
+        "  'react-is': '19.2.3'",
+        '',
+      ].join('\n')
+
+      fs.writeFileSync(path.join(testProjectPath, 'pnpm-workspace.yaml'), yaml)
     }
 
     if (packageManager === 'npm') {

--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -105,17 +105,18 @@ export async function setUpTestProject({
     // delete packageManager to let the `<pm> install` command set it
     delete pkg.packageManager
 
-    // The fixture pins react-is via yarn's `resolutions`, but npm and pnpm uses
+    // The fixture pins react-is via yarn's `resolutions`, but npm uses
     // `overrides` instead. Without this override, react-is resolves to 17.x
     // (from pretty-format's dep range), which doesn't properly recognize React
     // 19 elements. This breaks snapshot serialization.
-    if (packageManager === 'npm' || packageManager === 'pnpm') {
+    if (packageManager === 'npm') {
       pkg.overrides = { 'react-is': '19.2.3' }
     }
 
     if (packageManager === 'pnpm') {
-      // Tell pnpm what workspaces we have, and what 3rd-party packages are
-      // allowed to run build scripts.
+      // Tell pnpm what workspaces we have, what 3rd-party packages are allowed
+      // to run build scripts, and what versions of react-is to use (see also
+      // npm comment above)
 
       const yaml = [
         'packages:',
@@ -129,6 +130,9 @@ export async function setUpTestProject({
         '  msw: true',
         '  prisma: true',
         '  protobufjs: true',
+        '',
+        'overrides:',
+        "  'react-is': '19.2.3'",
         '',
       ].join('\n')
 

--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -118,6 +118,19 @@ export async function setUpTestProject({
       // to run build scripts, and what versions of react-is to use (see also
       // npm comment above)
 
+      pkg.engines = {
+        ...pkg.engines,
+        pnpm: '>=11.8.0 <12.0.0',
+      }
+
+      pkg.devEngines = {
+        packageManager: {
+          name: 'pnpm',
+          version: '>=11.8.0 <12.0.0',
+          onFail: 'download',
+        },
+      }
+
       const yaml = [
         'packages:',
         '  - api',
@@ -126,6 +139,7 @@ export async function setUpTestProject({
         'allowBuilds:',
         "  '@prisma/engines': true",
         "  '@swc/core': true",
+        '  better-sqlite3: true',
         '  esbuild: true',
         '  msw: true',
         '  prisma: true',

--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -105,17 +105,17 @@ export async function setUpTestProject({
     // delete packageManager to let the `<pm> install` command set it
     delete pkg.packageManager
 
-    // The fixture pins react-is via yarn's `resolutions`, but npm uses
-    // `overrides` instead. Without this override, npm resolves react-is to
-    // 17.x (from pretty-format's dep range), which doesn't properly
-    // recognize React 19 elements — breaking snapshot serialization.
-    if (packageManager === 'npm') {
+    // The fixture pins react-is via yarn's `resolutions`, but npm and pnpm uses
+    // `overrides` instead. Without this override, react-is resolves to 17.x
+    // (from pretty-format's dep range), which doesn't properly recognize React
+    // 19 elements. This breaks snapshot serialization.
+    if (packageManager === 'npm' || packageManager === 'pnpm') {
       pkg.overrides = { 'react-is': '19.2.3' }
-    } else {
-      // pnpm 11 no longer reads the `pnpm` field from package.json. Settings
-      // must go in pnpm-workspace.yaml. The `overrides` for react-is is set
-      // at root-level package.json too (where both npm and pnpm can read it).
-      pkg.overrides = { 'react-is': '19.2.3' }
+    }
+
+    if (packageManager === 'pnpm') {
+      // Tell pnpm what workspaces we have, and what 3rd-party packages are
+      // allowed to run build scripts.
 
       const yaml = [
         'packages:',
@@ -129,9 +129,6 @@ export async function setUpTestProject({
         '  msw: true',
         '  prisma: true',
         '  protobufjs: true',
-        '',
-        'overrides:',
-        "  'react-is': '19.2.3'",
         '',
       ].join('\n')
 

--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -120,13 +120,13 @@ export async function setUpTestProject({
 
       pkg.engines = {
         ...pkg.engines,
-        pnpm: '>=11.8.0 <12.0.0',
+        pnpm: '=11.x',
       }
 
       pkg.devEngines = {
         packageManager: {
           name: 'pnpm',
-          version: '>=11.8.0 <12.0.0',
+          version: '=11.x',
           onFail: 'download',
         },
       }

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -9,12 +9,12 @@
   },
   "engines": {
     "node": "=24.x",
-    "pnpm": ">=11.8.0 <12.0.0"
+    "pnpm": "=11.x"
   },
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11.8.0 <12.0.0",
+      "version": "=11.x",
       "onFail": "download"
     }
   }

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -9,12 +9,12 @@
   },
   "engines": {
     "node": "=24.x",
-    "pnpm": "=11.x"
+    "pnpm": ">=11.8.0 <12.0.0"
   },
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "=11.x",
+      "version": "11.8.0",
       "onFail": "download"
     }
   }

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -10,18 +10,8 @@
   "engines": {
     "node": "=24.x"
   },
-  "packageManager": "pnpm@10.34.3",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@prisma/engines",
-      "@swc/core",
-      "esbuild",
-      "msw",
-      "prisma",
-      "protobufjs"
-    ],
-    "overrides": {
-      "react-is": "19.2.3"
-    }
-  }
+  "overrides": {
+    "react-is": "19.2.3"
+  },
+  "packageManager": "pnpm@11.6.0"
 }

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -8,10 +8,7 @@
     "@cedarjs/testing": "3.1.0"
   },
   "engines": {
-    "node": "=24.x"
-  },
-  "overrides": {
-    "react-is": "19.2.3"
-  },
-  "packageManager": "pnpm@11.8.0"
+    "node": "=24.x",
+    "pnpm": "=11.x"
+  }
 }

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -9,6 +9,13 @@
   },
   "engines": {
     "node": "=24.x",
-    "pnpm": "=11.x"
+    "pnpm": ">=11.8.0 <12.0.0"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": ">=11.8.0 <12.0.0",
+      "onFail": "download"
+    }
   }
 }

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -13,5 +13,5 @@
   "overrides": {
     "react-is": "19.2.3"
   },
-  "packageManager": "pnpm@11.6.0"
+  "packageManager": "pnpm@11.8.0"
 }

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/pnpm-workspace.yaml
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 allowBuilds:
   '@prisma/engines': true
   '@swc/core': true
+  better-sqlite3: true
   esbuild: true
   msw: true
   prisma: true

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/pnpm-workspace.yaml
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/pnpm-workspace.yaml
@@ -1,3 +1,14 @@
 packages:
   - api
   - web
+
+allowBuilds:
+  '@prisma/engines': true
+  '@swc/core': true
+  esbuild: true
+  msw: true
+  prisma: true
+  protobufjs: true
+
+overrides:
+  'react-is': '19.2.3'

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/pnpm-workspace.yaml
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/pnpm-workspace.yaml
@@ -9,3 +9,6 @@ allowBuilds:
   msw: true
   prisma: true
   protobufjs: true
+
+overrides:
+  'react-is': '19.2.3'

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/pnpm-workspace.yaml
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/pnpm-workspace.yaml
@@ -9,6 +9,3 @@ allowBuilds:
   msw: true
   prisma: true
   protobufjs: true
-
-overrides:
-  'react-is': '19.2.3'

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -9,12 +9,12 @@
   },
   "engines": {
     "node": "=24.x",
-    "pnpm": ">=11.8.0 <12.0.0"
+    "pnpm": "=11.x"
   },
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11.8.0 <12.0.0",
+      "version": "=11.x",
       "onFail": "download"
     }
   }

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -9,12 +9,12 @@
   },
   "engines": {
     "node": "=24.x",
-    "pnpm": "=11.x"
+    "pnpm": ">=11.8.0 <12.0.0"
   },
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "=11.x",
+      "version": "11.8.0",
       "onFail": "download"
     }
   }

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -10,18 +10,8 @@
   "engines": {
     "node": "=24.x"
   },
-  "packageManager": "pnpm@10.34.3",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@prisma/engines",
-      "@swc/core",
-      "esbuild",
-      "msw",
-      "prisma",
-      "protobufjs"
-    ],
-    "overrides": {
-      "react-is": "19.2.3"
-    }
-  }
+  "overrides": {
+    "react-is": "19.2.3"
+  },
+  "packageManager": "pnpm@11.6.0"
 }

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -8,10 +8,7 @@
     "@cedarjs/testing": "3.1.0"
   },
   "engines": {
-    "node": "=24.x"
-  },
-  "overrides": {
-    "react-is": "19.2.3"
-  },
-  "packageManager": "pnpm@11.8.0"
+    "node": "=24.x",
+    "pnpm": "=11.x"
+  }
 }

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -9,6 +9,13 @@
   },
   "engines": {
     "node": "=24.x",
-    "pnpm": "=11.x"
+    "pnpm": ">=11.8.0 <12.0.0"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": ">=11.8.0 <12.0.0",
+      "onFail": "download"
+    }
   }
 }

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -13,5 +13,5 @@
   "overrides": {
     "react-is": "19.2.3"
   },
-  "packageManager": "pnpm@11.6.0"
+  "packageManager": "pnpm@11.8.0"
 }

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/pnpm-workspace.yaml
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 allowBuilds:
   '@prisma/engines': true
   '@swc/core': true
+  better-sqlite3: true
   esbuild: true
   msw: true
   prisma: true

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/pnpm-workspace.yaml
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/pnpm-workspace.yaml
@@ -1,3 +1,14 @@
 packages:
   - api
   - web
+
+allowBuilds:
+  '@prisma/engines': true
+  '@swc/core': true
+  esbuild: true
+  msw: true
+  prisma: true
+  protobufjs: true
+
+overrides:
+  'react-is': '19.2.3'

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/pnpm-workspace.yaml
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/pnpm-workspace.yaml
@@ -9,3 +9,6 @@ allowBuilds:
   msw: true
   prisma: true
   protobufjs: true
+
+overrides:
+  'react-is': '19.2.3'

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/pnpm-workspace.yaml
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/pnpm-workspace.yaml
@@ -9,6 +9,3 @@ allowBuilds:
   msw: true
   prisma: true
   protobufjs: true
-
-overrides:
-  'react-is': '19.2.3'


### PR DESCRIPTION
pnpm v11 uses pnpm-workspace.yaml for more of its config

Have to use an exact pnpm version: https://github.com/pnpm/pnpm/issues/11388