### PR TITLE
chore(test-project): Include shared packages in pnpm workspace

### DIFF
--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -135,6 +135,7 @@ export async function setUpTestProject({
         'packages:',
         '  - api',
         '  - web',
+        '  - packages/*',
         '',
         'allowBuilds:',
         "  '@prisma/engines': true",


### PR DESCRIPTION
Both the web and the api workspace include `@my-org/validator`, which lives in the packages workspace, so it needs to be included in the list