### PR TITLE
fix(cca): placeholder glob patterns

### DIFF
--- a/packages/create-cedar-app/src/placeholders.ts
+++ b/packages/create-cedar-app/src/placeholders.ts
@@ -31,8 +31,8 @@ export async function replacePlaceholders(
   }
 
   const patterns = [
-    '**/*.{cjs,json,md,mjs,js,ts,yml,yaml}',
-    '**/.*/**/*.{json,md,js,ts,yml,yaml}',
+    '**/*.{json,md,js,ts,mjs,cjs,yml,yaml}',
+    '**/.*/**/*.{json,md,js,ts,mjs,cjs,yml,yaml}',
     '**/.env*',
   ]
 


### PR DESCRIPTION
Should have been part of #1981 but got lost in a diff shuffle

The files we look for when doing placeholder replacements now include *.cjs and *.mjs files at all levels