### PR TITLE
chore(cli): Fix buildHandler types

### DIFF
--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -30,7 +30,6 @@ import { buildUDApiServer } from '@cedarjs/vite/buildUDApiServer'
 import { generatePrismaCommand } from '../../lib/generatePrismaClient.js'
 import { getPaths, getConfig } from '../../lib/index.js'
 
-// @ts-expect-error - Types not available for JS files
 import { buildPackagesTask } from './buildPackagesTask.js'
 
 interface PackageJson {
@@ -187,7 +186,7 @@ export const handler = async ({
     nonApiWebWorkspaces.length > 0 &&
       usePackagesWorkspace && {
         title: 'Building Packages...',
-        task: (_ctx: unknown, task: unknown) =>
+        task: (_ctx: unknown, task) =>
           buildPackagesTask(task, nonApiWebWorkspaces),
       },
     (workspace.includes('web') || workspace.includes('api')) &&

--- a/packages/cli/src/commands/build/buildPackagesTask.ts
+++ b/packages/cli/src/commands/build/buildPackagesTask.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import type { ListrRenderer, ListrTaskWrapper } from 'listr2'
+import type { ListrRendererFactory, ListrTaskWrapper } from 'listr2'
 
 import { runScript } from '@cedarjs/cli-helpers/packageManager/exec'
 import { importStatementPath } from '@cedarjs/project-config'
@@ -10,7 +10,7 @@ import { errorTelemetry } from '@cedarjs/telemetry'
 import { getPaths } from '../../lib/index.js'
 
 export async function buildPackagesTask(
-  task: ListrTaskWrapper<unknown, typeof ListrRenderer, typeof ListrRenderer>,
+  task: ListrTaskWrapper<unknown, ListrRendererFactory, ListrRendererFactory>,
   nonApiWebWorkspaces: string[],
 ) {
   const cedarPaths = getPaths()

--- a/packages/cli/src/commands/build/buildPackagesTask.ts
+++ b/packages/cli/src/commands/build/buildPackagesTask.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import type { ListrTaskWrapper } from 'listr2'
+import type { ListrRenderer, ListrTaskWrapper } from 'listr2'
 
 import { runScript } from '@cedarjs/cli-helpers/packageManager/exec'
 import { importStatementPath } from '@cedarjs/project-config'
@@ -10,7 +10,7 @@ import { errorTelemetry } from '@cedarjs/telemetry'
 import { getPaths } from '../../lib/index.js'
 
 export async function buildPackagesTask(
-  task: ListrTaskWrapper<any, any, any>,
+  task: ListrTaskWrapper<unknown, typeof ListrRenderer, typeof ListrRenderer>,
   nonApiWebWorkspaces: string[],
 ) {
   const cedarPaths = getPaths()

--- a/packages/cli/src/commands/build/buildPackagesTask.ts
+++ b/packages/cli/src/commands/build/buildPackagesTask.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+import type { ListrTaskWrapper } from 'listr2'
+
 import { runScript } from '@cedarjs/cli-helpers/packageManager/exec'
 import { importStatementPath } from '@cedarjs/project-config'
 import { errorTelemetry } from '@cedarjs/telemetry'
@@ -8,10 +10,7 @@ import { errorTelemetry } from '@cedarjs/telemetry'
 import { getPaths } from '../../lib/index.js'
 
 export async function buildPackagesTask(
-  task: {
-    skip: (msg: string) => void
-    newListr: (...args: unknown[]) => unknown
-  },
+  task: ListrTaskWrapper<any, any, any>,
   nonApiWebWorkspaces: string[],
 ) {
   const cedarPaths = getPaths()


### PR DESCRIPTION
Using the generic real `ListrTaskWrapper` type gives much better intellisense than what my custom types did