### PR TITLE
chore(vite): use prettyPrintCedarCommand to remove cli-helpers dep

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -73,7 +73,6 @@
     "@cedarjs/api": "workspace:*",
     "@cedarjs/auth": "workspace:*",
     "@cedarjs/babel-config": "workspace:*",
-    "@cedarjs/cli-helpers": "workspace:*",
     "@cedarjs/context": "workspace:*",
     "@cedarjs/cookie-jar": "workspace:*",
     "@cedarjs/graphql-server": "workspace:*",

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -3,8 +3,8 @@ import { pathToFileURL } from 'node:url'
 import type { Request as ExpressRequest } from 'express'
 import type { ViteDevServer } from 'vite'
 
-import { formatCedarCommand } from '@cedarjs/cli-helpers/packageManager/display'
 import { getPaths } from '@cedarjs/project-config'
+import { prettyPrintCedarCommand } from '@cedarjs/project-config/packageManager'
 
 import type { EntryServer } from './types.js'
 
@@ -19,7 +19,7 @@ export function ensureProcessDirWeb(webDir: string = getPaths().web.base) {
     console.error('⚠️  Warning: CWD is ', process.cwd())
     console.warn('~'.repeat(50))
     console.warn(
-      `The cwd must be web/. Please use \`${formatCedarCommand(['<command>'])}\` or run the command from the web/ directory.`,
+      `The cwd must be web/. Please use \`${prettyPrintCedarCommand(['<command>'])}\` or run the command from the web/ directory.`,
     )
     console.log(`Changing cwd to ${webDir}....`)
     console.log()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3782,7 +3782,6 @@ __metadata:
     "@cedarjs/api": "workspace:*"
     "@cedarjs/auth": "workspace:*"
     "@cedarjs/babel-config": "workspace:*"
-    "@cedarjs/cli-helpers": "workspace:*"
     "@cedarjs/context": "workspace:*"
     "@cedarjs/cookie-jar": "workspace:*"
     "@cedarjs/graphql-server": "workspace:*"


### PR DESCRIPTION
Replace `formatCedarCommand` with `prettyPrintCedarCommand` from `project-config` and remove the now-unused `@cedarjs/cli-helpers` dependency.