### PR TITLE
chore(workspaces): move workspace functions between packages

### DIFF
--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -78,6 +78,16 @@
         "types": "./dist/cjs/packageManager/display.d.ts",
         "default": "./dist/cjs/packageManager/display.js"
       }
+    },
+    "./packageManager/workspaces": {
+      "import": {
+        "types": "./dist/packageManager/workspaces.d.ts",
+        "default": "./dist/packageManager/workspaces.js"
+      },
+      "default": {
+        "types": "./dist/cjs/packageManager/workspaces.d.ts",
+        "default": "./dist/cjs/packageManager/workspaces.js"
+      }
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/cli-helpers/src/packageManager/workspaces.ts
+++ b/packages/cli-helpers/src/packageManager/workspaces.ts
@@ -33,7 +33,7 @@ function addPnpmWorkspaceDir(
     return 'exists'
   }
 
-  const match = content.match(/^(packages:[\s\S]*?)(?=^\w|\Z)/m)
+  const match = content.match(/^(packages:[\s\S]*?)(?=^\w|(?![\\s\\S]))/m)
   if (!match) {
     throw new Error('Invalid workspace config in ' + yamlPath)
   }

--- a/packages/cli-helpers/src/packageManager/workspaces.ts
+++ b/packages/cli-helpers/src/packageManager/workspaces.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import type { PackageManager } from '@cedarjs/project-config/packageManager'
+
+export type AddWorkspaceDirResult = 'exists' | 'added'
+
+export function addWorkspaceDir(
+  baseDir: string,
+  packagePath: string,
+  pm: PackageManager,
+): AddWorkspaceDirResult {
+  if (pm === 'pnpm') {
+    return addPnpmWorkspaceDir(baseDir, packagePath)
+  }
+
+  return addPackageJsonWorkspaceDir(baseDir, packagePath)
+}
+
+function addPnpmWorkspaceDir(
+  baseDir: string,
+  packagePath: string,
+): AddWorkspaceDirResult {
+  const yamlPath = path.join(baseDir, 'pnpm-workspace.yaml')
+  if (!fs.existsSync(yamlPath)) {
+    throw new Error('Invalid workspace config in ' + yamlPath)
+  }
+
+  const content = fs.readFileSync(yamlPath, 'utf8')
+  const packageEntry = `  - ${packagePath}`
+
+  if (content.includes(packageEntry)) {
+    return 'exists'
+  }
+
+  const match = content.match(/^(packages:[\s\S]*?)(?=^\w|\Z)/m)
+  if (!match) {
+    throw new Error('Invalid workspace config in ' + yamlPath)
+  }
+
+  const packagesSection = match[1]
+  const lines = packagesSection.split('\n')
+  const lastPackageLine = lines
+    .map((line, i) => ({ line, i }))
+    .filter(({ line }) => line.trimStart().startsWith('- '))
+    .pop()
+
+  if (!lastPackageLine) {
+    throw new Error('Invalid workspace config in ' + yamlPath)
+  }
+
+  const insertAfter = lastPackageLine.i
+  lines.splice(insertAfter + 1, 0, packageEntry)
+  const updatedContent = content.replace(packagesSection, lines.join('\n'))
+
+  fs.writeFileSync(yamlPath, updatedContent, 'utf8')
+  return 'added'
+}
+
+function addPackageJsonWorkspaceDir(
+  baseDir: string,
+  packagePath: string,
+): AddWorkspaceDirResult {
+  const pkgPath = path.join(baseDir, 'package.json')
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+
+  if (!Array.isArray(pkg.workspaces)) {
+    throw new Error('Invalid workspace config in ' + pkgPath)
+  }
+
+  const hasWildcardPackagesWorkspace = pkg.workspaces.includes('packages/*')
+  const hasNamedPackagesWorkspace = pkg.workspaces.includes(packagePath)
+  const hasOtherNamedPackages = pkg.workspaces.some(
+    (workspace: string) =>
+      workspace.startsWith('packages/') && workspace !== packagePath,
+  )
+
+  if (hasWildcardPackagesWorkspace || hasNamedPackagesWorkspace) {
+    return 'exists'
+  }
+
+  if (hasOtherNamedPackages) {
+    pkg.workspaces.push(packagePath)
+  } else {
+    pkg.workspaces.push('packages/*')
+  }
+
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2))
+  return 'added'
+}

--- a/packages/cli/src/commands/build/__tests__/build.test.ts
+++ b/packages/cli/src/commands/build/__tests__/build.test.ts
@@ -15,6 +15,10 @@ vi.mock('@cedarjs/telemetry', () => {
   }
 })
 
+vi.mock('@cedarjs/project-config/workspaces', () => ({
+  getNonApiWebWorkspaces: () => ['packages/*'],
+}))
+
 vi.mock('@cedarjs/project-config', () => {
   return {
     getPaths: () => {
@@ -196,6 +200,7 @@ test('Should run prerender for web (packagesWorkspace enabled)', async () => {
   const tasks = Array.isArray(firstCallArg) ? firstCallArg : [firstCallArg]
   expect(tasks.map((x: ListrTask) => x.title)).toMatchInlineSnapshot(`
     [
+      "Building Packages...",
       "Checking workspace packages...",
       "Building Web...",
     ]

--- a/packages/cli/src/commands/build/__tests__/build.test.ts
+++ b/packages/cli/src/commands/build/__tests__/build.test.ts
@@ -15,10 +15,6 @@ vi.mock('@cedarjs/telemetry', () => {
   }
 })
 
-vi.mock('@cedarjs/project-config/workspaces', () => ({
-  getNonApiWebWorkspaces: () => ['packages/*'],
-}))
-
 vi.mock('@cedarjs/project-config', () => {
   return {
     getPaths: () => {
@@ -200,7 +196,6 @@ test('Should run prerender for web (packagesWorkspace enabled)', async () => {
   const tasks = Array.isArray(firstCallArg) ? firstCallArg : [firstCallArg]
   expect(tasks.map((x: ListrTask) => x.title)).toMatchInlineSnapshot(`
     [
-      "Building Packages...",
       "Checking workspace packages...",
       "Building Web...",
     ]

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -22,7 +22,8 @@ import { generate } from '@cedarjs/internal/dist/generate/generate'
 import { generateGqlormArtifacts } from '@cedarjs/internal/dist/generate/gqlormSchema'
 import { loadAndValidateSdls } from '@cedarjs/internal/dist/validateSchema'
 import { detectPrerenderRoutes } from '@cedarjs/prerender/detection'
-import { type Paths } from '@cedarjs/project-config'
+import type { Paths } from '@cedarjs/project-config'
+import { getNonApiWebWorkspaces } from '@cedarjs/project-config/workspaces'
 import { timedTelemetry } from '@cedarjs/telemetry'
 import { buildCedarApp } from '@cedarjs/vite/build'
 import { buildUDApiServer } from '@cedarjs/vite/buildUDApiServer'
@@ -154,15 +155,7 @@ export const handler = async ({
     prismaSchemaExists &&
     (workspace.includes('api') || prerenderRoutes.length > 0)
 
-  const packageJsonPath = path.join(cedarPaths.base, 'package.json')
-  const packageJson: { workspaces?: unknown } = JSON.parse(
-    fs.readFileSync(packageJsonPath, 'utf8'),
-  )
-  const packageJsonWorkspaces = packageJson.workspaces
-  const nonApiWebWorkspaces =
-    Array.isArray(packageJsonWorkspaces) && packageJsonWorkspaces.length > 2
-      ? workspace.filter((w) => w !== 'api' && w !== 'web')
-      : []
+  const nonApiWebWorkspaces = getNonApiWebWorkspaces(cedarPaths.base)
 
   const gqlFeaturesTaskTitle = `Generating types needed for ${[
     useFragments && 'GraphQL Fragments',

--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -23,7 +23,6 @@ import { generateGqlormArtifacts } from '@cedarjs/internal/dist/generate/gqlormS
 import { loadAndValidateSdls } from '@cedarjs/internal/dist/validateSchema'
 import { detectPrerenderRoutes } from '@cedarjs/prerender/detection'
 import type { Paths } from '@cedarjs/project-config'
-import { getNonApiWebWorkspaces } from '@cedarjs/project-config/workspaces'
 import { timedTelemetry } from '@cedarjs/telemetry'
 import { buildCedarApp } from '@cedarjs/vite/build'
 import { buildUDApiServer } from '@cedarjs/vite/buildUDApiServer'
@@ -155,7 +154,9 @@ export const handler = async ({
     prismaSchemaExists &&
     (workspace.includes('api') || prerenderRoutes.length > 0)
 
-  const nonApiWebWorkspaces = getNonApiWebWorkspaces(cedarPaths.base)
+  const nonApiWebWorkspaces = workspace.filter(
+    (w) => w !== 'api' && w !== 'web',
+  )
 
   const gqlFeaturesTaskTitle = `Generating types needed for ${[
     useFragments && 'GraphQL Fragments',

--- a/packages/cli/src/commands/generate/package/packageHandler.js
+++ b/packages/cli/src/commands/generate/package/packageHandler.js
@@ -12,7 +12,9 @@ import { recordTelemetryAttributes, colors as c } from '@cedarjs/cli-helpers'
 import { workspacePackageSpecifier } from '@cedarjs/cli-helpers/packageManager'
 import { runScript, runBinSync } from '@cedarjs/cli-helpers/packageManager/exec'
 import { installPackages } from '@cedarjs/cli-helpers/packageManager/packages'
+import { addWorkspaceDir } from '@cedarjs/cli-helpers/packageManager/workspaces'
 import { getConfig } from '@cedarjs/project-config'
+import { getPackageManager } from '@cedarjs/project-config/packageManager'
 import { errorTelemetry } from '@cedarjs/telemetry'
 
 import { getPaths, writeFilesTask } from '../../../lib/index.js'
@@ -431,41 +433,14 @@ export const handler = async ({ name, force, ...rest }) => {
       },
       {
         title: 'Updating workspace config...',
-        task: async (ctx, task) => {
-          const rootPackageJsonPath = path.join(getPaths().base, 'package.json')
-          const packageJson = JSON.parse(
-            await fs.promises.readFile(rootPackageJsonPath, 'utf8'),
-          )
-
-          if (!Array.isArray(packageJson.workspaces)) {
-            throw new Error(
-              'Invalid workspace config in ' + rootPackageJsonPath,
-            )
-          }
-
+        task: (ctx, task) => {
+          const pm = getPackageManager()
           const packagePath = `packages/${ctx.nameVariants.folderName}`
-          const hasWildcardPackagesWorkspace =
-            packageJson.workspaces.includes('packages/*')
-          const hasNamedPackagesWorkspace =
-            packageJson.workspaces.includes(packagePath)
-          const hasOtherNamedPackages = packageJson.workspaces.some(
-            (workspace) =>
-              workspace.startsWith('packages/') && workspace !== packagePath,
-          )
 
-          if (hasWildcardPackagesWorkspace || hasNamedPackagesWorkspace) {
+          const result = addWorkspaceDir(getPaths().base, packagePath, pm)
+
+          if (result === 'exists') {
             task.skip('Workspaces already configured')
-          } else {
-            if (hasOtherNamedPackages) {
-              packageJson.workspaces.push(packagePath)
-            } else {
-              packageJson.workspaces.push('packages/*')
-            }
-
-            await fs.promises.writeFile(
-              rootPackageJsonPath,
-              JSON.stringify(packageJson, null, 2),
-            )
           }
         },
       },

--- a/packages/project-config/build.ts
+++ b/packages/project-config/build.ts
@@ -7,7 +7,11 @@ await build({
   buildOptions: {
     ...defaultBuildOptions,
     bundle: true,
-    entryPoints: ['./src/index.ts', './src/packageManager.ts'],
+    entryPoints: [
+      './src/index.ts',
+      './src/packageManager.ts',
+      './src/workspaces.ts',
+    ],
     format: 'esm',
     packages: 'external',
   },
@@ -18,7 +22,11 @@ await build({
   buildOptions: {
     ...defaultBuildOptions,
     bundle: true,
-    entryPoints: ['./src/index.ts', './src/packageManager.ts'],
+    entryPoints: [
+      './src/index.ts',
+      './src/packageManager.ts',
+      './src/workspaces.ts',
+    ],
     outdir: 'dist/cjs',
     packages: 'external',
   },

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -28,6 +28,16 @@
         "types": "./dist/cjs/packageManager.d.ts",
         "default": "./dist/cjs/packageManager.js"
       }
+    },
+    "./workspaces": {
+      "import": {
+        "types": "./dist/workspaces.d.ts",
+        "default": "./dist/workspaces.js"
+      },
+      "default": {
+        "types": "./dist/cjs/workspaces.d.ts",
+        "default": "./dist/cjs/workspaces.js"
+      }
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/project-config/src/workspaces.ts
+++ b/packages/project-config/src/workspaces.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { getPackageManager } from './packageManager.js'
+
+export function getNonApiWebWorkspaces(baseDir: string): string[] {
+  const pm = getPackageManager()
+  const workspaces =
+    pm === 'pnpm'
+      ? readPnpmWorkspaces(baseDir)
+      : readPackageJsonWorkspaces(baseDir)
+
+  return workspaces.filter((w) => w !== 'api' && w !== 'web')
+}
+
+function readPackageJsonWorkspaces(baseDir: string): string[] {
+  const pkgPath = path.join(baseDir, 'package.json')
+  if (!fs.existsSync(pkgPath)) {
+    return []
+  }
+
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+    return Array.isArray(pkg.workspaces) ? pkg.workspaces : []
+  } catch {
+    return []
+  }
+}
+
+function readPnpmWorkspaces(baseDir: string): string[] {
+  const yamlPath = path.join(baseDir, 'pnpm-workspace.yaml')
+  if (!fs.existsSync(yamlPath)) {
+    return []
+  }
+
+  try {
+    const content = fs.readFileSync(yamlPath, 'utf8')
+    const match = content.match(/^packages:\n([\s\S]*?)(?=^\w|\Z)/m)
+    if (!match) {
+      return []
+    }
+
+    return match[1]
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('- '))
+      .map((line) => line.slice(2).trim())
+      .filter(Boolean)
+  } catch {
+    return []
+  }
+}

--- a/packages/project-config/src/workspaces.ts
+++ b/packages/project-config/src/workspaces.ts
@@ -35,7 +35,7 @@ function readPnpmWorkspaces(baseDir: string): string[] {
 
   try {
     const content = fs.readFileSync(yamlPath, 'utf8')
-    const match = content.match(/^packages:\n([\s\S]*?)(?=^\w|\Z)/m)
+    const match = content.match(/^packages:\n([\s\S]*?)(?=^\w|(?![\\s\\S]))/m)
     if (!match) {
       return []
     }

--- a/packages/vite/src/lib/workspacePackageAliases.ts
+++ b/packages/vite/src/lib/workspacePackageAliases.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { normalizePath } from 'vite'
 
 import type { Config, Paths } from '@cedarjs/project-config'
+import { getNonApiWebWorkspaces } from '@cedarjs/project-config/workspaces'
 
 /**
  * Given a workspace package directory and its parsed package.json, attempts to
@@ -90,20 +91,7 @@ export function getWorkspacePackageAliases(
   }
 
   try {
-    const rootPkgPath = path.join(cedarPaths.base, 'package.json')
-    const rootPkg = JSON.parse(fs.readFileSync(rootPkgPath, 'utf-8')) as {
-      workspaces?: unknown
-    }
-
-    if (!Array.isArray(rootPkg.workspaces) || rootPkg.workspaces.length <= 2) {
-      return {}
-    }
-
-    // Find workspaces that are not 'api' or 'web' (i.e. packages/* entries),
-    // mirroring the nonApiWebWorkspaces check in buildHandler.ts
-    const nonApiWebWorkspaces = (rootPkg.workspaces as string[]).filter(
-      (w) => w !== 'api' && w !== 'web',
-    )
+    const nonApiWebWorkspaces = getNonApiWebWorkspaces(cedarPaths.base)
 
     if (nonApiWebWorkspaces.length === 0) {
       return {}


### PR DESCRIPTION
Move reading workspace functions (`readWorkspaces`, `getNonApiWebWorkspaces`) from `cli-helpers` to `project-config`, and keep mutating function (`addWorkspaceDir`) in `cli-helpers`. Update consumers accordingly.