### PR TITLE
chore(ci): delete projects after e2e runs + daily cleanup

### DIFF
--- a/.github/workflows/cleanup-vercel.yml
+++ b/.github/workflows/cleanup-vercel.yml
@@ -2,7 +2,7 @@ name: 🧹 Cleanup Vercel projects
 
 on:
   schedule:
-    - cron: '0 * * * *' # hourly
+    - cron: '0 3 * * *' # daily at 03:00 UTC
   workflow_dispatch:
 
 jobs:
@@ -18,17 +18,31 @@ jobs:
           # Delete any whose timestamp is more than 2 hours old so active
           # deployments are never removed mid-run.
           CUTOFF=$(( $(date +%s) - 7200 ))
+          NEXT_CURSOR=""
 
-          curl -s "https://api.vercel.com/v9/projects?search=cedar-e2e-&limit=100" \
-            -H "Authorization: Bearer $VERCEL_TOKEN" | \
-          jq -r --argjson cutoff "$CUTOFF" \
-            '.projects[]
-             | select(.name | test("^cedar-e2e-[0-9]+$"))
-             | select((.name | ltrimstr("cedar-e2e-") | tonumber) < $cutoff)
-             | .id' | \
-          while read -r id; do
-            echo "Deleting project $id"
-            curl -s -X DELETE "https://api.vercel.com/v9/projects/$id" \
-              -H "Authorization: Bearer $VERCEL_TOKEN"
-            echo
+          while true; do
+            URL="https://api.vercel.com/v9/projects?search=cedar-e2e-&limit=100"
+            if [ -n "$NEXT_CURSOR" ]; then
+              URL="$URL&until=$NEXT_CURSOR"
+            fi
+
+            RESPONSE=$(curl -sf "https://api.vercel.com/v9/projects?search=cedar-e2e-&limit=100${NEXT_CURSOR:+&until=$NEXT_CURSOR}" \
+              -H "Authorization: Bearer $VERCEL_TOKEN")
+
+            echo "$RESPONSE" | \
+            jq -r --argjson cutoff "$CUTOFF" \
+              '.projects[]
+               | select(.name | test("^cedar-e2e-[0-9]+$"))
+               | select((.name | ltrimstr("cedar-e2e-") | tonumber) < $cutoff)
+               | .id' | \
+            while read -r id; do
+              echo "Deleting project $id"
+              curl -sf -X DELETE "https://api.vercel.com/v9/projects/$id" \
+                -H "Authorization: Bearer $VERCEL_TOKEN"
+            done
+
+            NEXT_CURSOR=$(echo "$RESPONSE" | jq -r '.pagination.next // empty')
+            if [ -z "$NEXT_CURSOR" ]; then
+              break
+            fi
           done

--- a/.github/workflows/cleanup-vercel.yml
+++ b/.github/workflows/cleanup-vercel.yml
@@ -1,0 +1,34 @@
+name: 🧹 Cleanup Vercel projects
+
+on:
+  schedule:
+    - cron: '0 * * * *' # hourly
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete stale cedar-e2e-* projects
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          # cedar-e2e projects are named cedar-e2e-<epoch seconds>.
+          # Delete any whose timestamp is more than 2 hours old so active
+          # deployments are never removed mid-run.
+          CUTOFF=$(( $(date +%s) - 7200 ))
+
+          curl -s "https://api.vercel.com/v9/projects?search=cedar-e2e-&limit=100" \
+            -H "Authorization: Bearer $VERCEL_TOKEN" | \
+          jq -r --argjson cutoff "$CUTOFF" \
+            '.projects[]
+             | select(.name | test("^cedar-e2e-[0-9]+$"))
+             | select((.name | ltrimstr("cedar-e2e-") | tonumber) < $cutoff)
+             | .id' | \
+          while read -r id; do
+            echo "Deleting project $id"
+            curl -s -X DELETE "https://api.vercel.com/v9/projects/$id" \
+              -H "Authorization: Bearer $VERCEL_TOKEN"
+            echo
+          done

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -98,3 +98,7 @@ jobs:
         working-directory: tasks/vercel-tests
         env:
           VERCEL_DEPLOY_URL: ${{ steps.vercel-deploy.outputs.deploy-url }}
+
+      - name: 🧹 Delete Vercel project
+        if: always() && steps.create-project.outputs.project-name != ''
+        run: npx vercel projects rm "${{ steps.create-project.outputs.project-name }}" --token "$VERCEL_TOKEN" --yes


### PR DESCRIPTION
## Problem

The Vercel E2E workflow creates a new project (`cedar-e2e-<timestamp>`) for every run but never deletes it. This accumulates projects until the Hobby plan's 200-project limit is hit, breaking all subsequent runs with:

> The project cedar-e2e-1782388953 could not be created because this team has reached the 200 project Hobby limit.

## Solution

**1. Inline cleanup** (`e2e-vercel.yml`) — deletes the project at the end of every run, whether it passed or failed:

```yaml
- name: 🧹 Delete Vercel project
  if: always() && steps.create-project.outputs.project-name != ''
  run: npx vercel projects rm "${{ steps.create-project.outputs.project-name }}" --token "$VERCEL_TOKEN" --yes
```

**2. Scheduled cleanup** (`cleanup-vercel.yml`) — daily cron (3 am) that removes any `cedar-e2e-*` project older than 2 hours, catching orphans from cancelled or timed-out jobs. The 2-hour window ensures active deployments are never deleted mid-run.