### PR TITLE
chore(ci): use `vercel rm --yes` to delete project

### DIFF
--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -101,4 +101,4 @@ jobs:
 
       - name: 🧹 Delete Vercel project
         if: always() && steps.create-project.outputs.project-name != ''
-        run: npx vercel projects rm "${{ steps.create-project.outputs.project-name }}" --token "$VERCEL_TOKEN" --yes
+        run: npx vercel rm "${{ steps.create-project.outputs.project-name }}" --token "$VERCEL_TOKEN" --yes


### PR DESCRIPTION
`vercel projects rm` doesn't support `--yes` (or `--non-interactive` — even `CI=true` doesn't suppress the prompt). The top-level `vercel rm` command does support `--yes`.

Fixes CI failure introduced in #1997:
```
Error: unknown or unexpected option: --yes
Error: Process completed with exit code 1.
```

You can verify locally with just \`vercel rm <project-name> --yes\` (no token needed if you're already logged in to the CLI).