### PR TITLE
feat(testing): Make testing work with prisma for yarn, npm and pnpm

### DIFF
--- a/packages/testing/src/api/vitest/CedarApiVitestEnv.ts
+++ b/packages/testing/src/api/vitest/CedarApiVitestEnv.ts
@@ -5,6 +5,7 @@ import execa from 'execa'
 import type { Environment } from 'vitest/environments'
 
 import { getPaths } from '@cedarjs/project-config'
+import { getPackageManager } from '@cedarjs/project-config/packageManager'
 
 const CedarApiVitestEnvironment: Environment = {
   name: 'cedar-api',
@@ -28,7 +29,13 @@ const CedarApiVitestEnvironment: Environment = {
         ? ['prisma', 'migrate', 'reset', '--force']
         : ['prisma', 'db', 'push', '--force-reset', '--accept-data-loss']
 
-    execa.sync('yarn', ['cedar', ...command], {
+    const pm = getPackageManager()
+    // This kind of logic should not live here. We have it in cli-helpers, but
+    // it also doesn't make sense to have the testing package depend on
+    // cli-helpers I don't think. So I duplicate the logic here.
+    // see `runTransitiveBinSync` in packages/cli-helpers/src/packageManager/exec.ts
+    const pmExec = pm === 'pnpm' ? pm : 'npx'
+    execa.sync(pmExec, ['cedar', ...command], {
       cwd: cedarPaths.api.base,
       stdio: 'inherit',
       env: process.env,

--- a/packages/testing/src/config/jest/api/globalSetup.ts
+++ b/packages/testing/src/config/jest/api/globalSetup.ts
@@ -4,6 +4,7 @@ import 'dotenv-defaults/config'
 import execa from 'execa'
 
 import { getPaths } from '@cedarjs/project-config'
+import { getPackageManager } from '@cedarjs/project-config/packageManager'
 
 export default async function () {
   if (process.env.SKIP_DB_PUSH === '1') {
@@ -21,7 +22,13 @@ export default async function () {
       ? ['prisma', 'migrate', 'reset', '--force']
       : ['prisma', 'db', 'push', '--force-reset', '--accept-data-loss']
 
-  execa.sync('yarn', ['cedar', ...command], {
+  const pm = getPackageManager()
+  // This kind of logic should not live here. We have it in cli-helpers, but it
+  // also doesn't make sense to have the testing package depend on cli-helpers
+  // I don't think. So I duplicate the logic here.
+  // see `runTransitiveBinSync` in packages/cli-helpers/src/packageManager/exec.ts
+  const pmExec = pm === 'pnpm' ? pm : 'npx'
+  execa.sync(pmExec, ['cedar', ...command], {
     cwd: cedarPaths.api.base,
     stdio: 'inherit',
     env: process.env,


### PR DESCRIPTION
Since Prisma isn't a direct dependency of Cedar Apps we have to do some shenanigans here