### PR TITLE
fix(pm): Fix regex syntax for workspace parsing

### DIFF
--- a/packages/cli-helpers/src/packageManager/__tests__/workspaces.test.ts
+++ b/packages/cli-helpers/src/packageManager/__tests__/workspaces.test.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { vol } from 'memfs'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+import { addWorkspaceDir } from '../workspaces.js'
+
+vi.mock('node:fs', async () => {
+  const memfs = await import('memfs')
+  return { ...memfs, default: memfs.fs }
+})
+
+beforeEach(() => {
+  vol.reset()
+})
+
+describe('addWorkspaceDir with pnpm', () => {
+  it('adds a workspace entry into a multi-key pnpm-workspace.yaml', () => {
+    vol.fromJSON(
+      {
+        'pnpm-workspace.yaml': [
+          'packages:',
+          '  - api',
+          '  - web',
+          '',
+          'allowBuilds:',
+          '  esbuild: true',
+          '',
+          'overrides:',
+          "  'react-is': '19.2.3'",
+        ].join('\n'),
+      },
+      '/test-project',
+    )
+
+    const result = addWorkspaceDir(
+      '/test-project',
+      'packages/validators',
+      'pnpm',
+    )
+
+    expect(result).toBe('added')
+
+    const updated = fs.readFileSync(
+      path.join('/test-project', 'pnpm-workspace.yaml'),
+      'utf8',
+    )
+    expect(updated).toMatchInlineSnapshot(`
+      "packages:
+        - api
+        - web
+        - packages/validators
+
+      allowBuilds:
+        esbuild: true
+
+      overrides:
+        'react-is': '19.2.3'"
+    `)
+  })
+})

--- a/packages/cli-helpers/src/packageManager/workspaces.ts
+++ b/packages/cli-helpers/src/packageManager/workspaces.ts
@@ -33,7 +33,7 @@ function addPnpmWorkspaceDir(
     return 'exists'
   }
 
-  const match = content.match(/^(packages:[\s\S]*?)(?=^\w|(?![\\s\\S]))/m)
+  const match = content.match(/^(packages:[\s\S]*?)(?=^\w|(?![\s\S]))/m)
   if (!match) {
     throw new Error('Invalid workspace config in ' + yamlPath)
   }

--- a/packages/project-config/src/__tests__/workspaces.test.ts
+++ b/packages/project-config/src/__tests__/workspaces.test.ts
@@ -1,0 +1,51 @@
+import { vol } from 'memfs'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+
+import { getNonApiWebWorkspaces } from '../workspaces.js'
+
+vi.mock('node:fs', async () => {
+  const memfs = await import('memfs')
+  return { ...memfs, default: memfs.fs }
+})
+
+vi.mock('../packageManager', () => ({
+  getPackageManager: vi.fn(() => 'pnpm'),
+}))
+
+const origCedarCwd = process.env.CEDAR_CWD
+
+beforeEach(() => {
+  vol.reset()
+  process.env.CEDAR_CWD = '/test-project'
+})
+
+afterEach(() => {
+  process.env.CEDAR_CWD = origCedarCwd
+})
+
+describe('getNonApiWebWorkspaces with pnpm', () => {
+  it('parses workspace dirs from a multi-key pnpm-workspace.yaml', () => {
+    vol.fromJSON(
+      {
+        'pnpm-workspace.yaml': [
+          'packages:',
+          '  - api',
+          '  - web',
+          '  - packages/validators',
+          '',
+          'allowBuilds:',
+          '  esbuild: true',
+          '',
+          'overrides:',
+          "  'react-is': '19.2.3'",
+        ].join('\n'),
+      },
+      '/test-project',
+    )
+
+    const result = getNonApiWebWorkspaces('/test-project')
+
+    // api and web are filtered out by getNonApiWebWorkspaces
+    expect(result).toEqual(['packages/validators'])
+  })
+})

--- a/packages/project-config/src/workspaces.ts
+++ b/packages/project-config/src/workspaces.ts
@@ -35,7 +35,7 @@ function readPnpmWorkspaces(baseDir: string): string[] {
 
   try {
     const content = fs.readFileSync(yamlPath, 'utf8')
-    const match = content.match(/^packages:\n([\s\S]*?)(?=^\w|(?![\\s\\S]))/m)
+    const match = content.match(/^packages:\n([\s\S]*?)(?=^\w|(?![\s\S]))/m)
     if (!match) {
       return []
     }


### PR DESCRIPTION
Found a bug in the implementation from #1996 
This is what I get for not adding unit tests from the get-go!