### PR TITLE
chore(test-project): Skip project:copy since we're doing tarsync

### DIFF
--- a/tasks/test-project/rebuild-test-project-fixture.mts
+++ b/tasks/test-project/rebuild-test-project-fixture.mts
@@ -465,18 +465,6 @@ async function rebuildTestProject() {
 
   await tuiTask({
     step: 4,
-    title: '[link] Copying framework packages to project',
-    task: () => {
-      return copyFrameworkPackages(
-        CEDAR_FRAMEWORK_PATH,
-        OUTPUT_PROJECT_PATH,
-        'pipe',
-      )
-    },
-  })
-
-  await tuiTask({
-    step: 5,
     title: 'Prep for env var tests',
     task: () => {
       // Prisma's `env()` helper will throw an error if it cannot find the
@@ -519,7 +507,7 @@ async function rebuildTestProject() {
   })
 
   await tuiTask({
-    step: 6,
+    step: 5,
     title: 'Apply web codemods',
     task: () => {
       return webTasks(OUTPUT_PROJECT_PATH, live)
@@ -527,7 +515,7 @@ async function rebuildTestProject() {
   })
 
   await tuiTask({
-    step: 7,
+    step: 6,
     title: 'Apply api codemods',
     task: async () => {
       setOutputPath(OUTPUT_PROJECT_PATH)
@@ -537,7 +525,7 @@ async function rebuildTestProject() {
   })
 
   await tuiTask({
-    step: 8,
+    step: 7,
     title: 'Add workspace packages',
     task: async () => {
       const cedarTomlPath = path.join(OUTPUT_PROJECT_PATH, 'cedar.toml')
@@ -691,7 +679,7 @@ async function rebuildTestProject() {
   })
 
   await tuiTask({
-    step: 9,
+    step: 8,
     title: 'Add scripts',
     task: async () => {
       const nestedPath = path.join(OUTPUT_PROJECT_PATH, 'scripts', 'one', 'two')
@@ -761,7 +749,7 @@ async function rebuildTestProject() {
   })
 
   await tuiTask({
-    step: 10,
+    step: 9,
     title: 'Add test functions',
     task: async () => {
       const functionsDir = path.join(
@@ -820,7 +808,7 @@ async function rebuildTestProject() {
   })
 
   await tuiTask({
-    step: 11,
+    step: 10,
     title: 'Running prisma migrate reset',
     task: () => {
       return exec(
@@ -832,7 +820,7 @@ async function rebuildTestProject() {
   })
 
   await tuiTask({
-    step: 12,
+    step: 11,
     title: 'Lint --fix all the things',
     task: async () => {
       try {
@@ -863,7 +851,7 @@ async function rebuildTestProject() {
   })
 
   await tuiTask({
-    step: 13,
+    step: 12,
     title: 'Replace and Cleanup Fixture',
     task: async () => {
       // @TODO: This only works on UNIX, we should use path.join everywhere
@@ -947,7 +935,7 @@ async function rebuildTestProject() {
   })
 
   await tuiTask({
-    step: 14,
+    step: 13,
     title: 'All done!',
     task: () => {
       console.log('-'.repeat(30))


### PR DESCRIPTION
`project:copy` deletes and re-copies framework packages from the build output. Since `project:tarsync` (step 2) already installs framework packages from freshly-built tarballs, the copy is redundant.