### PR TITLE
fix(internal): recompute source map paths

### DIFF
--- a/packages/internal/src/__tests__/fixSourceMaps.test.ts
+++ b/packages/internal/src/__tests__/fixSourceMaps.test.ts
@@ -1,0 +1,132 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { fixSourceMaps } from '../build/api.js'
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cedar-sourcemaps-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function writeMap(relPath: string, sources: string[]) {
+  const absPath = path.join(tmpDir, relPath)
+  fs.mkdirSync(path.dirname(absPath), { recursive: true })
+  fs.writeFileSync(absPath, JSON.stringify({ version: 3, sources, mappings: '' }))
+}
+
+function readMapSources(relPath: string): string[] {
+  const absPath = path.join(tmpDir, relPath)
+  return JSON.parse(fs.readFileSync(absPath, 'utf8')).sources
+}
+
+function touchFile(relPath: string) {
+  const absPath = path.join(tmpDir, relPath)
+  fs.mkdirSync(path.dirname(absPath), { recursive: true })
+  fs.writeFileSync(absPath, '')
+}
+
+describe('fixSourceMaps', () => {
+  it('rewrites wrong sources path to correct relative path', async () => {
+    const distDir = path.join(tmpDir, 'dist')
+    const srcDir = path.join(tmpDir, 'src')
+
+    writeMap('dist/functions/graphql.js.map', ['/absolute/wrong/path.ts'])
+    touchFile('src/functions/graphql.ts')
+
+    await fixSourceMaps(distDir, srcDir)
+
+    expect(readMapSources('dist/functions/graphql.js.map')).toEqual([
+      '../../src/functions/graphql.ts',
+    ])
+  })
+
+  it('leaves an already-correct path untouched', async () => {
+    const distDir = path.join(tmpDir, 'dist')
+    const srcDir = path.join(tmpDir, 'src')
+
+    writeMap('dist/functions/graphql.js.map', [
+      '../../src/functions/graphql.ts',
+    ])
+    touchFile('src/functions/graphql.ts')
+
+    const before = fs.statSync(
+      path.join(tmpDir, 'dist/functions/graphql.js.map'),
+    ).mtimeMs
+
+    await fixSourceMaps(distDir, srcDir)
+
+    const after = fs.statSync(
+      path.join(tmpDir, 'dist/functions/graphql.js.map'),
+    ).mtimeMs
+
+    expect(before).toBe(after) // file was not rewritten
+  })
+
+  it('handles nested paths correctly', async () => {
+    const distDir = path.join(tmpDir, 'dist')
+    const srcDir = path.join(tmpDir, 'src')
+
+    writeMap('dist/services/posts/posts.js.map', ['wrong'])
+    touchFile('src/services/posts/posts.ts')
+
+    await fixSourceMaps(distDir, srcDir)
+
+    expect(readMapSources('dist/services/posts/posts.js.map')).toEqual([
+      '../../../src/services/posts/posts.ts',
+    ])
+  })
+
+  it('handles .tsx source files', async () => {
+    const distDir = path.join(tmpDir, 'dist')
+    const srcDir = path.join(tmpDir, 'src')
+
+    writeMap('dist/functions/widget.js.map', ['wrong'])
+    touchFile('src/functions/widget.tsx')
+
+    await fixSourceMaps(distDir, srcDir)
+
+    expect(readMapSources('dist/functions/widget.js.map')).toEqual([
+      '../../src/functions/widget.tsx',
+    ])
+  })
+
+  it('skips map files with no corresponding source file', async () => {
+    const distDir = path.join(tmpDir, 'dist')
+    const srcDir = path.join(tmpDir, 'src')
+
+    writeMap('dist/functions/generated.js.map', ['wrong'])
+    // no source file created
+
+    await fixSourceMaps(distDir, srcDir)
+
+    // sources left unchanged
+    expect(readMapSources('dist/functions/generated.js.map')).toEqual(['wrong'])
+  })
+
+  it('skips maps with empty sources array', async () => {
+    const distDir = path.join(tmpDir, 'dist')
+    const srcDir = path.join(tmpDir, 'src')
+
+    writeMap('dist/functions/empty.js.map', [])
+    touchFile('src/functions/empty.ts')
+
+    await fixSourceMaps(distDir, srcDir)
+
+    expect(readMapSources('dist/functions/empty.js.map')).toEqual([])
+  })
+
+  it('returns early without throwing when distDir does not exist', async () => {
+    const distDir = path.join(tmpDir, 'nonexistent-dist')
+    const srcDir = path.join(tmpDir, 'src')
+
+    await expect(fixSourceMaps(distDir, srcDir)).resolves.toBeUndefined()
+  })
+})

--- a/packages/internal/src/__tests__/fixSourceMaps.test.ts
+++ b/packages/internal/src/__tests__/fixSourceMaps.test.ts
@@ -19,7 +19,10 @@ afterEach(() => {
 function writeMap(relPath: string, sources: string[]) {
   const absPath = path.join(tmpDir, relPath)
   fs.mkdirSync(path.dirname(absPath), { recursive: true })
-  fs.writeFileSync(absPath, JSON.stringify({ version: 3, sources, mappings: '' }))
+  fs.writeFileSync(
+    absPath,
+    JSON.stringify({ version: 3, sources, mappings: '' }),
+  )
 }
 
 function readMapSources(relPath: string): string[] {

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -212,7 +212,10 @@ export async function fixSourceMaps(
           return
         }
 
-        const correctRelPath = path.relative(path.dirname(mapFile), srcFile)
+        // Source map `sources` must always use forward slashes, even on Windows
+        const correctRelPath = path
+          .relative(path.dirname(mapFile), srcFile)
+          .replaceAll('\\', '/')
 
         if (map.sources[0] === correctRelPath) {
           return // already correct

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -27,7 +27,10 @@ export const rebuildApi = async () => {
   if (!BUILD_CTX) {
     BUILD_CTX = await context(getEsbuildOptions(apiFiles))
   }
-  return BUILD_CTX.rebuild()
+  const result = await BUILD_CTX.rebuild()
+  const cedarPaths = getPaths()
+  await fixSourceMaps(cedarPaths.api.dist, cedarPaths.api.src)
+  return result
 }
 
 export const cleanApiBuild = async () => {
@@ -158,7 +161,67 @@ export const buildApiWithVite = async () => {
 }
 
 const transpileApi = async (files: string[]) => {
-  return build(getEsbuildOptions(files))
+  const result = await build(getEsbuildOptions(files))
+  const cedarPaths = getPaths()
+  await fixSourceMaps(cedarPaths.api.dist, cedarPaths.api.src)
+  return result
+}
+
+// esbuild combines Babel's inline source maps with its own, but the resulting
+// `sources` paths are often wrong (absolute or relative to the wrong base),
+// which breaks debugger breakpoints. This mirrors the known workaround from
+// issue #24: recompute the correct relative path from each .js.map file to its
+// corresponding .ts source file and overwrite the sources entry.
+async function fixSourceMaps(distDir: string, srcDir: string): Promise<void> {
+  let entries: fs.Dirent[]
+  try {
+    entries = await fs.promises.readdir(distDir, {
+      recursive: true,
+      withFileTypes: true,
+    })
+  } catch {
+    return
+  }
+
+  const mapFiles = entries
+    .filter((e) => e.isFile() && e.name.endsWith('.js.map'))
+    .map((e) => path.join((e as any).parentPath ?? (e as any).path, e.name))
+
+  await Promise.all(
+    mapFiles.map(async (mapFile) => {
+      try {
+        const raw = await fs.promises.readFile(mapFile, 'utf8')
+        const map = JSON.parse(raw)
+
+        if (!Array.isArray(map.sources) || map.sources.length === 0) {
+          return
+        }
+
+        // Derive the source file path: dist/functions/graphql.js.map → src/functions/graphql.ts
+        const jsFile = mapFile.slice(0, -4) // strip '.map'
+        const baseName = path.relative(distDir, jsFile).replace(/\.js$/, '')
+
+        const srcFile = ['.ts', '.tsx', '.jsx', '.js']
+          .map((ext) => path.join(srcDir, baseName + ext))
+          .find((f) => fs.existsSync(f))
+
+        if (!srcFile) {
+          return
+        }
+
+        const correctRelPath = path.relative(path.dirname(mapFile), srcFile)
+
+        if (map.sources[0] === correctRelPath) {
+          return // already correct
+        }
+
+        map.sources = [correctRelPath]
+        await fs.promises.writeFile(mapFile, JSON.stringify(map), 'utf8')
+      } catch {
+        // skip files that can't be read/parsed
+      }
+    }),
+  )
 }
 
 function getEsbuildOptions(files: string[]): BuildOptions {

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -172,7 +172,10 @@ const transpileApi = async (files: string[]) => {
 // which breaks debugger breakpoints. This mirrors the known workaround from
 // issue #24: recompute the correct relative path from each .js.map file to its
 // corresponding .ts source file and overwrite the sources entry.
-async function fixSourceMaps(distDir: string, srcDir: string): Promise<void> {
+export async function fixSourceMaps(
+  distDir: string,
+  srcDir: string,
+): Promise<void> {
   let entries: fs.Dirent[]
   try {
     entries = await fs.promises.readdir(distDir, {

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -212,10 +212,9 @@ export async function fixSourceMaps(
           return
         }
 
-        // Source map `sources` must always use forward slashes, even on Windows
-        const correctRelPath = path
-          .relative(path.dirname(mapFile), srcFile)
-          .replaceAll('\\', '/')
+        const correctRelPath = normalizePath(
+          path.relative(path.dirname(mapFile), srcFile),
+        )
 
         if (map.sources[0] === correctRelPath) {
           return // already correct


### PR DESCRIPTION
## Problem

When debugging a Cedar API, VS Code (and other debuggers) can't resolve breakpoints because the `sources` entries in the generated `.js.map` files point to wrong paths — either absolute or relative to the wrong base. This was reported in #24 by a user who had to run a separate chokidar watcher script to fix the maps at runtime.

## Root cause

`transformWithBabel` runs Babel with `sourceMaps: 'inline'`, embedding a source map comment into the transformed JS. esbuild is then supposed to chain this with its own map to produce a combined `.js.map`. The chaining works, but esbuild doesn't correctly re-express the `sources` paths relative to the output `.js.map` file — so the debugger can't find the original `.ts` file.

## Fix

Add a `fixSourceMaps()` post-processing step that runs after both `transpileApi` (full build) and `rebuildApi` (incremental). It:

1. Walks all `*.js.map` files in `api/dist/`
2. Derives the corresponding source path: `dist/functions/graphql.js.map` → `src/functions/graphql.ts`
3. Rewrites `sources[0]` to the correct relative path from the map file to the source file (e.g. `../../src/functions/graphql.ts`)

This is the same logic as the workaround script Tobbe shared in #24, baked directly into the build pipeline so no external tooling is needed.

## Testing

1. Create a Cedar app and run `cedar dev`
2. Attach the VS Code debugger (using the generated `.vscode/launch.json`)
3. Set a breakpoint in `api/src/functions/graphql.ts`
4. Make an API request — the breakpoint should be hit and show the correct source line
5. Check `api/dist/functions/graphql.js.map` — `sources[0]` should now be a valid relative path back to the `.ts` file

Closes #24