### PR TITLE
fix(dev): make native git hooks work on Windows

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -48,3 +48,7 @@ packages/testing/config
 
 /.nx/cache
 /.nx/workspace-data
+
+# Ignore agent instruction symlinks that are checked out as placeholder files on Windows
+/CLAUDE.md
+/GEMINI.md

--- a/tasks/git-hooks/pre-push.mts
+++ b/tasks/git-hooks/pre-push.mts
@@ -16,8 +16,13 @@ if (currentBranch === 'next' || currentBranch.startsWith('release/')) {
   process.exit(0)
 }
 
+const buildResult = await execAsync('yarn', ['build'], { NX_TUI: 'false' })
+
+if (buildResult !== 0) {
+  process.exit(buildResult)
+}
+
 const results = await Promise.allSettled([
-  execAsync('yarn', ['build'], { NX_TUI: 'false' }),
   execAsync('yarn', ['lint']),
   execAsync('yarn', ['prettier', '--check', '.']),
   execAsync('yarn', ['check']),

--- a/tasks/git-hooks/shared.mts
+++ b/tasks/git-hooks/shared.mts
@@ -6,7 +6,13 @@ export function execAsync(
   extraEnv: Record<string, string> = {},
 ) {
   return new Promise<number>((resolve, reject) => {
-    const child = spawn(command, args, {
+    const isWindowsYarn = process.platform === 'win32' && command === 'yarn'
+    const commandForPlatform = isWindowsYarn ? 'cmd.exe' : command
+    const argsForPlatform = isWindowsYarn
+      ? ['/d', '/s', '/c', 'yarn.cmd', ...args]
+      : args
+
+    const child = spawn(commandForPlatform, argsForPlatform, {
       stdio: 'inherit',
       env: { ...process.env, ...extraEnv },
     })

--- a/tasks/smart-format.mts
+++ b/tasks/smart-format.mts
@@ -61,5 +61,10 @@ if (existingFiles.length > 0) {
 }
 
 function quoteAll(files: string[]): string {
+  if (process.platform === 'win32') {
+    return files.join(' ')
+  }
+
   return files.map((f) => `'${f.replaceAll("'", "'\\''")}'`).join(' ')
 }
+

--- a/tasks/smart-format.mts
+++ b/tasks/smart-format.mts
@@ -67,4 +67,3 @@ function quoteAll(files: string[]): string {
 
   return files.map((f) => `'${f.replaceAll("'", "'\\''")}'`).join(' ')
 }
-


### PR DESCRIPTION
## Summary

Fixes a few Windows issues in the new native git hooks.

The hooks now:
- run Yarn correctly on Windows
- format staged files without Unix-only quoting
- skip agent doc symlinks that Prettier sees incorrectly on Windows
- build before linting in pre-push, so lint does not read missing `dist` files

## Testing

Tested on Windows:

- `node tasks/git-hooks/pre-commit.mts`
- `node tasks/git-hooks/pre-push.mts`
- `git push origin HEAD`

All hooks passed.