### PR TITLE
feat(ud): Debugger support

### DIFF
--- a/docs/implementation-docs/2026-06-29-debug-port-inspector-ud-mode.md
+++ b/docs/implementation-docs/2026-06-29-debug-port-inspector-ud-mode.md
@@ -1,0 +1,307 @@
+# Node.js Debugger Integration in `--ud` Mode
+
+**Date:** 2026-06-29
+
+## Problem
+
+Attaching a Node.js debugger to a Cedar app running in Universal Deploy (`--ud`)
+mode does not work. The `--debug-port` flag passed to `cedar dev --ud` is
+silently ignored by `cedar-unified-dev`, and `NODE_OPTIONS="--inspect=<port>"`
+opens the inspector on the wrong process (the CLI parent, not the Vite server).
+
+A secondary issue surfaced while testing: even once the inspector is open on the
+correct process, **static breakpoints set on Vite SSR-loaded API functions never
+fire**. This doc covers both the fix and the breakpoint limitation.
+
+## Root Cause
+
+The `cedar-unified-dev.ts` entry point parses `--port`, `--apiPort`, and
+`--debug` via yargs-parser, but never parsed `--debug-port`. The flag fell
+through into the `...serverArgs` rest spread and was passed to Vite's server
+config, which ignored it.
+
+Additionally, `NODE_OPTIONS="--inspect=<port>"` cannot work because Cedar's
+architecture has two Node.js processes in the tree:
+
+1. The cedar CLI process (parent)
+2. The `cedar-unified-dev` process (child, where API functions execute)
+
+`NODE_OPTIONS` applies to **every** Node.js process spawned from that
+environment. The parent CLI binds to the inspector port first, and the child
+process fails with a port conflict.
+
+## Fix
+
+In `packages/vite/src/cedar-unified-dev.ts`:
+
+- Added `'debug-port'` to the yargs-parser `number` config
+- Extracted argument parsing into an exported `parseCliArgs()` helper
+- Extracted inspector activation into an exported `openDebugger(port)` helper
+  that dynamically imports `node:inspector` (keeping it out of the bundle when
+  unused)
+- Destructured `debugPort` from parsed args and called `openDebugger(debugPort)`
+  before starting the Vite server
+
+This opens the inspector on the one process where API functions actually
+execute.
+
+## Vite SSR Module Loading and the V8 Inspector
+
+### The issue
+
+When writing an integration test for this feature, we discovered that
+`viteServer.ssrLoadModule()` (used by `apiDevMiddleware.ts` to load API
+functions) does **not** expose individual source files as V8 scripts.
+
+The call chain is:
+
+1. `startApiDevMiddleware()` calls `loadApiFunctions(viteServer)`
+2. `loadApiFunctions()` calls
+   `viteServer.ssrLoadModule(pathToFileURL(fnPath).href)`
+3. `ssrLoadModule()` compiles the TypeScript via Vite's transform pipeline and
+   evaluates it within Vite's module graph
+
+The result: individual source files like `hello.ts` never appear in
+`Debugger.scriptParsed` events. They are compiled and evaluated as part of
+Vite's internal module graph, not as standalone V8 scripts.
+
+### Why `Debugger.setBreakpointByUrl` doesn't work
+
+`Debugger.setBreakpointByUrl` matches against V8 script URLs. Since the API
+function source files never appear as scripts, the URL regex can never match
+them. The CDP command returns a `breakpointId` (it doesn't error), but the
+breakpoint is never actually resolved to any script.
+
+We confirmed this by collecting all `Debugger.scriptParsed` URLs — they are
+exclusively `file://` URLs from `node_modules/` and Cedar's own `dist/`
+directories. No function source files appear.
+
+### Source map line number mismatch
+
+There is a second, independent reason breakpoints miss. Vite's SSR transform
+pipeline wraps user module code (e.g. `hello.ts`, 6 lines) into a generated
+JavaScript module (~18 lines) with a Vite SSR runtime wrapper. The wrapper
+occupies the first 3 generated lines (0, 1, 2), which have **no** source-map
+mappings back to the original TypeScript source.
+
+Using `Debugger.setBreakpoint` with `lineNumber: 1` (targeting
+`return new Response(...)` in the original TS) resolves to **generated line 2**
+— inside the Vite SSR wrapper, not inside `handleRequest`. V8 adjusts the
+breakpoint from line 1 → 2 because line 1 has no executable bytecode.
+
+The source map for `hello.ts` decodes (VLQ segments) as:
+
+```
+;;; => generated lines 0, 1, 2: NO MAPPINGS (Vite SSR wrapper)
+AAAA,... => generated line 3: maps to original line 0 (function signature)
+AACrD,... => generated line 4: maps to original line 1 (return statement)
+...       => generated lines 5-8: map to rest of original source
+```
+
+Key findings from the source map:
+
+- `lineNumber: 3` (generated) → function declaration line
+- `lineNumber: 4` (generated) → first statement inside function body
+  (`return new Response(...)`)
+- The breakpoint must be on **generated** line 4+ to land inside
+  `handleRequest`, not on **original** source line 1
+
+### V8 script lifecycle for SSR modules
+
+The deeper issue: even if set at the correct generated line, the breakpoint may
+never fire because the V8 `Script` object for the SSR module is
+garbage-collected before the CDP session connects.
+
+Timeline:
+
+1. Dev server starts → `loadApiFunctions()` calls
+   `viteServer.ssrLoadModule(pathToFileURL(fnPath).href)` → V8 parses the
+   SSR-transformed code → `Debugger.scriptParsed` fires (but no CDP client is
+   connected yet)
+2. Script is fully executed, `handleRequest` is extracted into
+   `LAMBDA_FUNCTIONS`, and the `Script` object becomes eligible for V8 GC
+3. CDP client connects and calls `Debugger.enable` → V8 re-emits `scriptParsed`
+   for all known, uncollected scripts
+4. If the `Script` was GC'd (very likely between steps 2 and 3 on a busy
+   startup), `hello.ts` is NOT re-emitted
+5. `Debugger.setBreakpointByUrl` with `urlRegex: "hello\\.ts"` or
+   `Debugger.setBreakpoint` with its old `scriptId` cannot resolve against the
+   now-invalid `Script`
+6. The breakpoint is stored but never maps to any function; it never fires
+
+This matches the observed test output: only one script (empty URL) collected
+after `Debugger.enable` — `hello.ts` is absent. Force-loading via
+`Runtime.evaluate` with `import('file://...hello.ts')` creates a **new** V8
+`Script` from Node.js's ESM loader (separate from Vite's SSR module runner),
+which is a different script object — breakpoints on it wouldn't fire when Vite's
+handler calls the original function.
+
+### Vite SSR module runner internals
+
+Vite 7 uses a custom SSR module runner (not `import()` or `require()`) that
+evaluates transformed code via `new Function()` or similar. This creates a V8
+`Script`, but the script's lifecycle is tied to the module runner's internal
+cache, not Node.js's module system.
+
+Key characteristics:
+
+- Script URL is the original file path (e.g. `/Users/.../hello.ts`), set via
+  `//# sourceURL` comments added by Vite's transform pipeline
+- The script is fully synchronous — the module is parsed, executed, and its
+  exports cached in one shot
+- After execution, the function reference is held in `LAMBDA_FUNCTIONS`, but the
+  V8 `Script` can be GC'd because no active closure references the script's
+  source
+
+### Why this differs from VS Code / Chrome DevTools
+
+Real debuggers (VS Code, Chrome DevTools) connect to the inspector **before**
+user code runs. Two common setups:
+
+1. **`--inspect-brk`:** Node.js pauses on the first line of execution, giving
+   the debugger time to set breakpoints on all scripts before any module loading
+2. **`--inspect` at spawn time:** The debugger is connected by the time the
+   first `import()` or `require()` runs, so `scriptParsed` events are captured
+   before scripts are GC'd
+
+In Cedar's case, `inspector.open(debugPort, '127.0.0.1')` is called **during**
+server startup, after Vite is initialized but before `loadApiFunctions()`
+completes. However, by the time a test or external tool connects via WebSocket,
+the SSR module scripts have already been loaded and potentially GC'd.
+
+### The solution: `Debugger.pause()`
+
+`Debugger.pause()` tells V8 to pause at the **next JavaScript statement
+execution**, regardless of how the code was loaded. This works with Vite's SSR
+pipeline because:
+
+1. `Debugger.pause()` is sent (armed)
+2. An HTTP request triggers the API function handler (or any JS executes)
+3. V8 pauses when the next statement begins executing
+4. The test asserts the pause event, then calls `Debugger.resume()`
+5. The HTTP response completes
+
+This approach is robust against Vite's module caching, TypeScript transforms,
+the source-map line mismatch, and any future changes to how `ssrLoadModule`
+works.
+
+### Comparison of CDP approaches
+
+| Approach                               | Works with Vite SSR? | Notes                                        |
+| -------------------------------------- | -------------------- | -------------------------------------------- |
+| `Debugger.setBreakpointByUrl`          | No                   | Source files don't appear as V8 scripts      |
+| `Debugger.setBreakpoint` (by scriptId) | No                   | Same reason — no scriptId for function files |
+| `Debugger.pause()`                     | Yes                  | Pauses at next statement execution           |
+| `Debugger.breakOnExceptions`           | Partially            | Only pauses on thrown exceptions             |
+
+### Practical debugging approaches that work
+
+For actual debugging of SSR-transformed API functions, connect the inspector
+**before** the dev server loads SSR modules:
+
+```
+yarn node --inspect=127.0.0.1:38911 packages/vite/dist/cedar-unified-dev.js ...
+```
+
+Or use a deferred-loading mechanism where the CDP client must be connected
+before `loadApiFunctions()` proceeds. This is how VS Code's `launch.json` works.
+
+For ad-hoc inspection without breakpoints, the current `--debug-port`
+implementation is sufficient for:
+
+- Profiling (CPU/memory via Chrome DevTools' Profiler tab)
+- `Runtime.evaluate` for live inspection
+- `Debugger.pause()` / `Debugger.resume` for halting execution on demand
+- Console.log debugging (which appears in the stderr output, not through the
+  inspector)
+
+## Why `NODE_OPTIONS` doesn't work for targeted inspection
+
+When running `NODE_OPTIONS="--inspect=<port>" yarn cedar dev --ud`:
+
+1. Node.js reads `NODE_OPTIONS` and opens the inspector on the cedar CLI process
+   (port bound)
+2. The CLI spawns `cedar-unified-dev` as a child process
+3. The child inherits `NODE_OPTIONS` from the environment
+4. The child tries to open its own inspector on the same port
+5. **Port conflict** — the child's inspector fails to bind
+
+The parent CLI process has the inspector, but it's useless for debugging API
+functions because functions execute in the child `cedar-unified-dev` process.
+
+`cedar-unified-dev.ts` preserves `process.env.NODE_OPTIONS` (via
+`getDevNodeOptions()` in `devHandler.ts`), which appends `--enable-source-maps`.
+If the user passes `NODE_OPTIONS="--inspect"`, both processes get it.
+
+## Implications for testing
+
+The `--debug-port` integration test (`cedar dev --ud --debug-port`) verifies the
+inspector is functional via three complementary checks:
+
+| Step                 | Assertion                         | Method                                             |
+| -------------------- | --------------------------------- | -------------------------------------------------- |
+| Inspector opens      | Port matches `--debug-port` value | stderr regex parse                                 |
+| CDP messaging        | `1 + 1` evaluates to `2`          | `Runtime.evaluate`                                 |
+| Debugger halts       | `debugger;` pauses execution      | `Runtime.evaluate` + `Debugger.paused` event       |
+| Execution resumes    | Expression returns `42`           | `Debugger.resume` + await evaluate promise         |
+| Request interruption | API call completes after pause    | `Debugger.pause()` armed before fetch + verify 200 |
+
+The request-interruption check arms `Debugger.pause()` **before** issuing the
+fetch, rather than sleeping and then pausing. This is deterministic: a trivial
+handler (e.g. `hello.ts` returning a static response) can complete in well under
+a fixed delay, which would leave the pause pending forever and time out the
+test. Arming the pause first guarantees V8 halts on the next statement the dev
+server executes.
+
+The test distinguishes between "the inspector/debugger works" (proven) and
+"breakpoints on SSR modules fire" (currently not provable via a post-startup CDP
+session, for the reasons above).
+
+### Process management and stdin lifecycle
+
+The dev server is spawned with zx's `$` template and tracked via
+`testContext.processes`, which is cleaned up in `afterEach` (see
+`vitest.setup.mts`). The inspector URL is read from the spawned process's stderr
+stream (`devProcess.stderr.on('data', ...)`, which zx exposes as a `Readable`).
+
+A pitfall to avoid if spawning manually: `stdio: ['ignore', 'pipe', 'pipe']`
+causes the dev server to exit immediately. When stdin is connected to
+`/dev/null` (the `'ignore'` option), the stream ends instantly and Vite's event
+loop drains because there are no active handles keeping it alive. Use
+`stdio: ['pipe', 'pipe', 'pipe']` (or rely on zx, which handles this) to keep
+stdin open and the event loop alive.
+
+### V8 Inspector WebSocket URL
+
+The V8 inspector's WebSocket URL includes a UUID path:
+
+```
+Debugger listening on ws://127.0.0.1:38911/5d3f0a7f-0e71-454c-bbc3-be145c3d7b4b
+```
+
+The `ws` WebSocket library (and the CDP handshake) requires the full URL
+including the UUID. Connecting to `ws://127.0.0.1:38911` without the UUID
+returns HTTP 400. The test parses the full URL from stderr using a regex that
+captures the UUID.
+
+The test uses distinct ports (18920/18921/38911) to avoid conflicts with the
+existing test block, though tests run serially (`singleThread: true`).
+
+## Files Changed
+
+| File                                                    | Change                                                             |
+| ------------------------------------------------------- | ------------------------------------------------------------------ |
+| `packages/vite/src/cedar-unified-dev.ts`                | Parse `--debug-port`, call `inspector.open()` via `openDebugger()` |
+| `packages/vite/src/__tests__/cedar-unified-dev.test.ts` | Unit tests for `parseCliArgs` and `openDebugger`                   |
+| `package.json` (root)                                   | Add `ws` as devDependency                                          |
+| `yarn.lock` (root)                                      | Reference `ws` from the root workspace                             |
+| `tasks/ud-tests/udDev.test.mts`                         | Add `createCdpSession` helper and `--debug-port` integration test  |
+
+## Related
+
+- `apiDevMiddleware.ts` — `loadApiFunctions()` uses `ssrLoadModule()` to load
+  API functions into Vite's module graph
+- `serverManager.ts` — Non-UD mode properly handles `--debug-port` via
+  `fork()` + `execArgv`
+- `apiDebugFlag.ts` — CLI translates `--apiDebugPort` to `--debug-port` for
+  `cedar-unified-dev`

--- a/docs/implementation-plans/ud-debug-proxy-attach-breakpoints-plan.md
+++ b/docs/implementation-plans/ud-debug-proxy-attach-breakpoints-plan.md
@@ -1,0 +1,499 @@
+# Plan: Debug Proxy for Attach-Workflow Breakpoints in UD Mode
+
+## Summary
+
+When a user attaches a debugger to `yarn cedar dev --ud`, breakpoints on API
+functions don't fire. The modules have already been loaded via Vite's
+`ssrLoadModule()` at startup, and the V8 `Script` objects are eligible for
+garbage collection by the time the debugger connects — so pending URL
+breakpoints never attach.
+
+This plan introduces a **WebSocket proxy** on the debug port. When a debugger
+connects, the proxy transparently forwards CDP traffic to the real inspector
+**and** simultaneously invalidates Vite's SSR module cache + reloads API
+functions. The next request re-evaluates the modules with the debugger
+connected, so `scriptParsed` fires fresh and pending breakpoints attach.
+
+This solves the **attach workflow** (the common case: user starts dev server,
+sees something wrong, attaches debugger, sets breakpoints, reloads) without
+requiring the user to manually save files or use `--inspect-brk`.
+
+## Goals
+
+- Breakpoints set in an editor **fire on the next request** after attaching a
+  debugger to a running `yarn cedar dev --ud` server
+- No change to the user's workflow — they attach as they normally would
+  (`Debugger: Attach to Node Process` in VS Code, `chrome://inspect` in Chrome)
+- The proxy is transparent — editors see a standard CDP WebSocket endpoint, no
+  editor-specific configuration needed
+- Source maps continue to work — the editor translates original TS lines to
+  generated JS lines as before
+- Non-blocking when no debugger is connected — the dev server runs normally
+- The existing `--debug-port` flag and `inspector.open()` behavior are preserved
+  as the underlying mechanism
+
+## Non-Goals
+
+- Replacing `inspector.open()` with `--inspect` via `execArgv` — the UD spawn
+  path uses `concurrently` (shell-based `spawn`, not `fork`), so `execArgv`
+  can't reach the child. `inspector.open()` is the right approach for UD mode.
+- Supporting `--inspect-brk` (break before any code runs). This is a separate
+  feature that would use `inspector.waitForDebugger()`. It helps the **launch**
+  workflow (editor starts the process) but not the **attach** workflow (user
+  attaches to a running process). See "Future Work" below.
+- Fixing breakpoint persistence across HMR reloads. Vite's HMR already
+  re-evaluates modules on file change, which causes pending breakpoints to
+  attach. This plan covers the gap between "server started" and "user edits a
+  file."
+- Non-UD mode. Attach already works there because Node's native `import()`
+  caches modules in a way that prevents V8 from GC'ing the `Script` objects.
+  Vite's `ssrLoadModule()` has no equivalent persistence.
+
+## Current State
+
+### How `--debug-port` works today
+
+1. User runs `yarn cedar dev --ud --apiDebugPort 18911`
+2. CLI builds a shell command string:
+   `cross-env NODE_ENV=development cedar-unified-dev --port 8910 --apiPort 8911 --debug-port 18911`
+3. `concurrently` spawns it via `child_process.spawn('/bin/sh', ['-c', cmd])` —
+   **not** `fork()`, so no `execArgv`
+4. `cedar-unified-dev.ts` calls `inspector.open(18911, '127.0.0.1')` at
+   `packages/vite/src/cedar-unified-dev.ts:72-74`
+5. `startApiDevMiddleware()` runs immediately after, calling
+   `loadApiFunctions(viteServer)` at `packages/vite/src/apiDevMiddleware.ts:436`
+6. `loadApiFunctions()` calls `viteServer.ssrLoadModule()` for each API function
+   at `packages/vite/src/apiDevMiddleware.ts:88`
+7. Server is up. Modules are loaded and cached in `LAMBDA_FUNCTIONS`.
+
+### Why breakpoints don't fire after attach
+
+- `ssrLoadModule()` evaluates transformed code via `new Function()` inside
+  Vite's SSR module runner, creating a V8 `Script`
+- Only the exported function references are retained in `LAMBDA_FUNCTIONS`
+- The V8 `Script` objects themselves have no lingering references and are
+  eligible for GC
+- When the debugger connects later and calls `Debugger.enable`, V8 re-emits
+  `scriptParsed` only for uncollected scripts — the API function scripts are
+  gone
+- `Debugger.setBreakpointsByUrl` registers the breakpoint as **pending** (URL
+  pattern match), but it only attaches when a matching script is loaded
+- The only thing that triggers a fresh `ssrLoadModule()` is HMR — a file change
+  on disk. See `setupHmrHandlers()` at
+  `packages/vite/src/apiDevMiddleware.ts:258-331`
+
+### How HMR invalidation works today
+
+`setupHmrHandlers()` in `apiDevMiddleware.ts` listens for file changes:
+
+1. `viteServer.watcher.on('change')` fires
+2. `viteServer.moduleGraph.invalidateModule(mod)` is called for the changed
+   module and all its importers (lines 280-293)
+3. `loadApiFunctions(viteServer)` is called to re-evaluate all functions
+   (line 296)
+
+There is also a standalone helper `invalidateApiModules()` at line 234 that
+invalidates **all** modules under `api.src` — used by the `add` and `unlink`
+handlers (lines 312-313, 329-330).
+
+### Existing invalidation API
+
+The key functions we can reuse:
+
+- `invalidateApiModules(viteServer, normalizedApiSrc)` — invalidates all modules
+  under `api.src` in Vite's module graph (`apiDevMiddleware.ts:234-256`)
+- `loadApiFunctions(viteServer)` — re-imports all API functions via
+  `ssrLoadModule()` (`apiDevMiddleware.ts:35-50`)
+
+### Non-UD mode: why attach works there
+
+Non-UD uses Node's native `import()` to load functions
+(`packages/api-server/src/plugins/lambdaLoader.ts:56`):
+
+```ts
+const fnImport = await import(pathToFileURL(fnPath).href)
+```
+
+Node's module cache holds a reference to the module's `Script`, preventing GC.
+When the debugger attaches and calls `Debugger.enable`, all cached scripts are
+re-emitted via `scriptParsed`, and breakpoints attach to existing scripts.
+
+## Architecture
+
+### The WebSocket proxy
+
+```
+Editor (VS Code / Chrome DevTools)
+  │
+  │  WebSocket: ws://127.0.0.1:18911/<uuid>
+  │
+  ▼
+┌─────────────────────────────────┐
+│  Debug Proxy (ws proxy)         │
+│  - listens on debugPort         │
+│  - on connection:               │
+│    1. invalidate SSR modules    │
+│    2. reload API functions      │
+│    3. forward CDP bidirectionally│
+└─────────────────────────────────┘
+  │
+  │  WebSocket: ws://127.0.0.1:<random>/<uuid>
+  │
+  ▼
+┌─────────────────────────────────┐
+│  V8 Inspector (node:inspector)  │
+│  - opened on random port        │
+│  - inspector.open(0, ...)       │
+└─────────────────────────────────┘
+```
+
+The proxy sits between the editor and the real V8 inspector. CDP is just JSON
+over WebSocket, so forwarding is trivial — parse nothing, just pipe bytes
+through. The proxy's only intelligence is the `connection` event handler, which
+triggers module invalidation before forwarding begins.
+
+### Why a proxy instead of a CDP event listener
+
+We need to know **when** a debugger connects. Options:
+
+1. **CDP `Runtime.executionContextCreated` / `Debugger.enable`** — requires
+   parsing CDP messages, maintaining protocol state, and the inspector doesn't
+   emit a "client connected" event natively.
+2. **WebSocket connection event** — the proxy owns the WebSocket server, so it
+   gets a `connection` event for free. No CDP parsing needed. The proxy is
+   protocol-agnostic — it forwards raw bytes.
+
+Option 2 is simpler, more robust, and doesn't couple to CDP protocol versions.
+
+### Why `inspector.open(0)` instead of `inspector.open(debugPort)`
+
+The proxy needs to listen on `debugPort` (the user-facing port). The inspector
+can't share that port — it's a WebSocket server itself. So the inspector opens
+on a random port (`0`), and the proxy forwards to it. `inspector.url()` returns
+the full `ws://127.0.0.1:<random>/<uuid>` URL for forwarding.
+
+## Implementation Steps
+
+### Step 1: Export invalidation + reload from `apiDevMiddleware.ts`
+
+Currently `invalidateApiModules()` is a private function and
+`loadApiFunctions()` is exported. Export a combined helper:
+
+```ts
+// packages/vite/src/apiDevMiddleware.ts
+
+export async function invalidateAndReloadApiFunctions(
+  viteServer: ViteDevServer
+): Promise<void> {
+  const normalizedApiSrc = normalizePath(getPaths().api.src)
+  invalidateApiModules(viteServer, normalizedApiSrc)
+  await loadApiFunctions(viteServer)
+}
+```
+
+This is the same sequence the HMR `add`/`unlink` handlers already call (lines
+312-313, 329-330), just extracted into a reusable function.
+
+### Step 2: Rewrite `openDebugger()` as a proxy in `cedar-unified-dev.ts`
+
+Replace the current `openDebugger()`:
+
+```ts
+// Current (packages/vite/src/cedar-unified-dev.ts:50-53)
+export async function openDebugger(port: number) {
+  const inspector = await import('node:inspector')
+  inspector.open(port, '127.0.0.1')
+}
+```
+
+With a proxy-based version:
+
+```ts
+import { createServer } from 'node:http'
+import { WebSocketServer } from 'ws'
+import WebSocket from 'ws'
+
+export function openDebugger(
+  debugPort: number,
+  onConnect?: () => void | Promise<void>
+): { close: () => void } {
+  const inspector = require('node:inspector')
+
+  // Open the real inspector on a random internal port
+  inspector.open(0, '127.0.0.1')
+  const inspectorUrl = inspector.url()
+
+  if (!inspectorUrl) {
+    throw new Error('Failed to open V8 inspector')
+  }
+
+  // Create a WebSocket proxy on the user-facing debug port
+  const server = createServer()
+  const wss = new WebSocketServer({ server })
+
+  wss.on('connection', async (clientWs) => {
+    // Debugger attached — invalidate SSR modules so the next request
+    // re-evaluates them with the debugger connected and breakpoints armed
+    if (onConnect) {
+      try {
+        await onConnect()
+      } catch (err) {
+        // Log but don't block the debugger connection
+        const message = err instanceof Error ? err.message : String(err)
+        console.error(`[debug-proxy] invalidation failed: ${message}`)
+      }
+    }
+
+    // Forward CDP traffic bidirectionally
+    const inspectorWs = new WebSocket(inspectorUrl)
+
+    inspectorWs.on('message', (data) => clientWs.send(data))
+    clientWs.on('message', (data) => inspectorWs.send(data))
+
+    inspectorWs.on('close', () => clientWs.close())
+    clientWs.on('close', () => inspectorWs.close())
+
+    inspectorWs.on('error', () => clientWs.close())
+    clientWs.on('error', () => inspectorWs.close())
+  })
+
+  server.listen(debugPort, '127.0.0.1')
+
+  return {
+    close: () => {
+      wss.close()
+      server.close()
+      inspector.close()
+    },
+  }
+}
+```
+
+The `onConnect` callback is what triggers module invalidation — it's passed in
+by `startUnifiedDevServer()` so `openDebugger` stays decoupled from the Vite
+server.
+
+### Step 3: Wire up the `onConnect` callback in `startUnifiedDevServer()`
+
+Currently `openDebugger(debugPort)` is called **before**
+`startApiDevMiddleware()` (line 73 vs line 82), so the Vite server doesn't exist
+yet. The proxy needs the Vite server to invalidate modules.
+
+Two options:
+
+**Option A: Defer proxy start until after Vite server exists**
+
+```ts
+const startUnifiedDevServer = async () => {
+  // ... parse args ...
+
+  const {
+    close: closeApi,
+    handler: apiHandler,
+    viteServer,
+  } = await startApiDevMiddleware()
+
+  // Now the Vite server exists — start the debug proxy with invalidation
+  let debugProxy: { close: () => void } | undefined
+  if (debugPort) {
+    debugProxy = openDebugger(debugPort, async () => {
+      const { invalidateAndReloadApiFunctions } =
+        await import('./apiDevMiddleware.js')
+      await invalidateAndReloadApiFunctions(viteServer)
+    })
+  }
+
+  // ... rest of server setup ...
+}
+```
+
+**Option B: Start proxy immediately, defer invalidation via a stored ref**
+
+Start the proxy (which starts listening but doesn't invalidate) before the Vite
+server exists. Store the Vite server reference once it's created. The
+`onConnect` callback checks if the ref is populated.
+
+Option A is cleaner — the inspector opens a few milliseconds later (after
+`startApiDevMiddleware()` instead of before), but that's negligible. The only
+risk is if `startApiDevMiddleware()` takes a long time and the user tries to
+attach during that window — but the server isn't ready then anyway.
+
+**Recommendation: Option A.**
+
+### Step 4: Return `viteServer` from `startApiDevMiddleware()`
+
+Currently `startApiDevMiddleware()` returns `{ viteServer, close, handler }` at
+`apiDevMiddleware.ts:428-446` — **it already returns the Vite server**. No
+change needed here.
+
+### Step 5: Clean up the proxy on server shutdown
+
+Add the proxy's `close()` to the existing shutdown path:
+
+```ts
+// In startUnifiedDevServer(), in the shutdown/cleanup section:
+if (debugProxy) {
+  debugProxy.close()
+}
+```
+
+## Edge Cases
+
+### Debugger connects before server is ready
+
+If the user attaches during `startApiDevMiddleware()` (before
+`loadApiFunctions()` completes), the `onConnect` invalidation runs but
+`loadApiFunctions()` is already in flight. `loadApiFunctions()` has a guard for
+this at `apiDevMiddleware.ts:36-49`:
+
+```ts
+if (loadApiFunctionsInFlight) {
+  needsReloadAfterInFlight = true
+  return
+}
+```
+
+So the invalidation's `loadApiFunctions()` call will queue up and run after the
+initial load completes. The `needsReloadAfterInFlight` flag ensures the reload
+happens. This is already handled.
+
+### Multiple debugger connections
+
+If the user disconnects and reconnects, the `connection` event fires again,
+invalidating modules again. This is correct — each reconnection should get fresh
+scripts with breakpoints armed.
+
+Chrome DevTools opens multiple WebSocket connections (one for the page target,
+sometimes one for the service worker). Each connection triggers invalidation.
+This is wasteful but harmless — `invalidateApiModules()` is idempotent, and
+`loadApiFunctions()` has the in-flight guard.
+
+If this becomes a performance concern, we can debounce: only invalidate on the
+**first** connection after a disconnect, or throttle to one invalidation per N
+seconds.
+
+### `inspector.url()` returns `undefined`
+
+`inspector.url()` returns `undefined` if the inspector isn't open. The proxy
+code checks for this and throws. This should never happen since we call
+`inspector.open(0)` immediately before, but the guard prevents a silent crash.
+
+### No debugger ever connects
+
+The proxy listens on the debug port but never blocks. If no debugger connects,
+the server runs normally. `inspector.open(0)` starts the inspector in the
+background — it's non-blocking. The only overhead is the HTTP server listening
+on the debug port, which is negligible.
+
+### Existing `NODE_OPTIONS="--inspect=..."` usage
+
+If the user passes `NODE_OPTIONS="--inspect=<port>"`, both the CLI parent and
+the `cedar-unified-dev` child will try to open the inspector. The child's
+`inspector.open(0)` (random port) won't conflict with the `NODE_OPTIONS` port,
+but the parent's inspector is useless for debugging API functions. This is the
+existing behavior — the proxy doesn't change it. The `--debug-port` flag is the
+correct mechanism.
+
+## Testing
+
+### Unit tests (`cedar-unified-dev.test.ts`)
+
+Update the existing `openDebugger` test to account for the proxy:
+
+- Mock `node:inspector`, `node:http`, and `ws`
+- Verify `inspector.open(0, '127.0.0.1')` is called (not the user-facing port)
+- Verify the HTTP server listens on the user-facing `debugPort`
+- Verify `onConnect` is called when a WebSocket connection is made
+- Verify CDP messages are forwarded bidirectionally
+- Verify `close()` cleans up all resources
+
+### Integration test (`udDev.test.mts`)
+
+Add a new test block: `cedar dev --ud --debug-port (attach workflow)`:
+
+1. Start dev server with `--debug-port 38911` (existing setup)
+2. Wait for server to be ready (`pollForReady`)
+3. Make an initial request to `/.api/functions/hello` — confirms the server
+   works and the module is loaded + cached
+4. Connect CDP session to `ws://127.0.0.1:38911` (through the proxy)
+5. Enable the debugger (`Debugger.enable`)
+6. Set a breakpoint by URL on `hello.ts`:
+
+   ```ts
+   await cdp.send('Debugger.setBreakpointsByUrl', {
+     lineNumber: 0, // function declaration line
+     url: 'file://' + helloTsPath,
+     columnNumber: 0,
+     condition: '',
+   })
+   ```
+
+7. Make a request to `/.api/functions/hello`
+8. Wait for `Debugger.paused` event — **this is the assertion that was
+   previously impossible**
+9. Verify call frames include `handleRequest`
+10. Resume and verify the HTTP response
+
+This test proves the proxy + invalidation works end-to-end: the breakpoint fires
+on a module that was loaded **before** the debugger connected, without any file
+edits.
+
+### Existing integration test
+
+The existing `cedar dev --ud --debug-port` test (Runtime.evaluate, debugger;
+statement, Debugger.pause during request) should continue to pass unchanged —
+the proxy is transparent to CDP messaging.
+
+## Dependencies
+
+- `ws` (WebSocket) — **already added** as a devDependency in the impl-3 branch.
+  Used for both the CDP test client and the proxy server.
+- `node:http` — built-in, no new dependency
+- `node:inspector` — built-in, already used
+
+## Files to Change
+
+| File                                                    | Change                                                                                                            |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `packages/vite/src/apiDevMiddleware.ts`                 | Export `invalidateAndReloadApiFunctions()`                                                                        |
+| `packages/vite/src/cedar-unified-dev.ts`                | Rewrite `openDebugger()` as WebSocket proxy; move call after `startApiDevMiddleware()`; pass `onConnect` callback |
+| `packages/vite/src/__tests__/cedar-unified-dev.test.ts` | Update `openDebugger` tests for proxy behavior                                                                    |
+| `tasks/ud-tests/udDev.test.mts`                         | Add attach-workflow integration test with `setBreakpointsByUrl`                                                   |
+
+## Future Work
+
+### `--debug-brk` for the launch workflow
+
+Add a `--debug-brk` flag that calls `inspector.waitForDebugger()` after
+`inspector.open()`. This blocks until a debugger attaches, then proceeds. Useful
+for VS Code `launch.json` configurations where the editor starts the process and
+connects automatically. This is orthogonal to the proxy — it helps a different
+workflow (launch, not attach) and can be added independently.
+
+### Lazy function loading
+
+Don't call `loadApiFunctions()` at startup. Load each function on its first
+request. This would make the proxy's invalidation unnecessary for the **first**
+request to each function — the module loads fresh with the debugger already
+connected. However, it doesn't help for subsequent requests (the function is
+cached after the first load). The proxy is still needed for the "reload after
+seeing broken output" workflow.
+
+### Streaming SSR mode
+
+Streaming SSR has its own dev server setup (`devFeServer.ts`) that bypasses
+`cedar-unified-dev`. The proxy would need to be wired into that path separately
+if debugger support is needed there.
+
+## Related
+
+- `packages/vite/src/apiDevMiddleware.ts` — `loadApiFunctions()`,
+  `invalidateApiModules()`, `setupHmrHandlers()`
+- `packages/vite/src/cedar-unified-dev.ts` — `openDebugger()`,
+  `startUnifiedDevServer()`
+- `packages/cli/src/commands/dev/apiDebugFlag.ts` — `--debug-port` flag
+  generation
+- `packages/api-server/src/serverManager.ts` — non-UD mode uses `fork()` +
+  `execArgv` with `--inspect=<port>`
+- `docs/implementation-docs/2026-06-29-debug-port-inspector-ud-mode.md` —
+  background on why breakpoints don't fire with `ssrLoadModule()`

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.60.1",
     "vitest": "3.2.6",
+    "ws": "8.20.0",
     "yargs": "17.7.2",
     "zx": "8.8.5"
   },

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -44,6 +44,12 @@ export const builder = (yargs: Argv) => {
         'with no value it defaults to 1 prepended to the api port (e.g. api ' +
         'port 8913 -> debug port 18913).',
     })
+    .option('debugBrk', {
+      type: 'boolean',
+      description:
+        'Wait for a debugger to connect before starting the API dev server, ' +
+        'similar to Node.js --inspect-brk. Only works in --ud mode.',
+    })
     .option('ud', {
       type: 'boolean',
       default: false,

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -27,6 +27,7 @@ interface DevHandlerOptions {
   forward?: string
   generate?: boolean
   apiDebugPort?: number
+  debugBrk?: boolean
   ud?: boolean
 }
 
@@ -35,6 +36,7 @@ export const handler = async ({
   forward = '',
   generate = true,
   apiDebugPort,
+  debugBrk,
   ud = false,
 }: DevHandlerOptions) => {
   recordTelemetryAttributes({
@@ -257,6 +259,7 @@ export const handler = async ({
       `  --port ${webAvailablePort}`,
       `  --apiPort ${apiAvailablePort}`,
       getApiDebugFlag(apiDebugPort, apiAvailablePort),
+      debugBrk ? '--debug-brk' : '',
       forward,
     ]
       .join(' ')

--- a/packages/vite/src/__tests__/cedar-unified-dev.test.ts
+++ b/packages/vite/src/__tests__/cedar-unified-dev.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockOpen = vi.fn()
+
+vi.mock('node:inspector', () => ({
+  default: { open: mockOpen },
+  open: mockOpen,
+}))
+
+vi.mock('@cedarjs/project-config', () => ({
+  getPaths: () => ({
+    web: { viteConfig: '/fake/vite.config.ts' },
+  }),
+  getConfig: () => ({}),
+}))
+
+// Suppress the module-level startUnifiedDevServer() auto-execution side effects
+vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+vi.spyOn(console, 'error').mockImplementation(() => {})
+
+const { parseCliArgs, openDebugger } = await import('../cedar-unified-dev.js')
+
+describe('parseCliArgs', () => {
+  it('extracts debugPort from --debug-port flag', () => {
+    const result = parseCliArgs([
+      'node',
+      'cedar-unified-dev',
+      '--debug-port',
+      '18911',
+    ])
+
+    expect(result.debugPort).toBe(18911)
+  })
+
+  it('returns undefined debugPort when --debug-port is absent', () => {
+    const result = parseCliArgs(['node', 'cedar-unified-dev', '--port', '8910'])
+
+    expect(result.debugPort).toBeUndefined()
+  })
+
+  it('parses --debug-port alongside other flags', () => {
+    const result = parseCliArgs([
+      'node',
+      'cedar-unified-dev',
+      '--port',
+      '8911',
+      '--apiPort',
+      '8912',
+      '--debug-port',
+      '18912',
+      '--https',
+    ])
+
+    expect(result.debugPort).toBe(18912)
+    expect(result.portArg).toBe(8911)
+  })
+
+  it('defaults to process.argv when no argv is provided', () => {
+    const originalArgv = process.argv
+    process.argv = ['node', 'cedar-unified-dev', '--debug-port', '9229']
+
+    const result = parseCliArgs()
+
+    expect(result.debugPort).toBe(9229)
+    process.argv = originalArgv
+  })
+
+  it('returns undefined debugPort when --debug-port has no value', () => {
+    const result = parseCliArgs(['node', 'cedar-unified-dev', '--debug-port'])
+
+    expect(result.debugPort).toBeUndefined()
+  })
+})
+
+describe('openDebugger', () => {
+  beforeEach(() => {
+    mockOpen.mockClear()
+  })
+
+  it('opens the inspector on the given port and 127.0.0.1', async () => {
+    await openDebugger(18911)
+
+    expect(mockOpen).toHaveBeenCalledExactlyOnceWith(18911, '127.0.0.1')
+  })
+})

--- a/packages/vite/src/__tests__/cedar-unified-dev.test.ts
+++ b/packages/vite/src/__tests__/cedar-unified-dev.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockOpen = vi.fn()
+const mockWaitForDebugger = vi.fn()
 
 vi.mock('node:inspector', () => ({
-  default: { open: mockOpen },
+  default: { open: mockOpen, waitForDebugger: mockWaitForDebugger },
   open: mockOpen,
+  waitForDebugger: mockWaitForDebugger,
 }))
 
 vi.mock('@cedarjs/project-config', () => ({
@@ -70,16 +72,44 @@ describe('parseCliArgs', () => {
 
     expect(result.debugPort).toBeUndefined()
   })
+
+  it('extracts debugBrk from --debug-brk flag', () => {
+    const result = parseCliArgs(['node', 'cedar-unified-dev', '--debug-brk'])
+
+    expect(result.debugBrk).toBe(true)
+  })
+
+  it('returns undefined debugBrk when --debug-brk is absent', () => {
+    const result = parseCliArgs(['node', 'cedar-unified-dev', '--port', '8910'])
+
+    expect(result.debugBrk).toBeUndefined()
+  })
 })
 
 describe('openDebugger', () => {
   beforeEach(() => {
     mockOpen.mockClear()
+    mockWaitForDebugger.mockClear()
   })
 
   it('opens the inspector on the given port and 127.0.0.1', async () => {
     await openDebugger(18911)
 
     expect(mockOpen).toHaveBeenCalledExactlyOnceWith(18911, '127.0.0.1')
+    expect(mockWaitForDebugger).not.toHaveBeenCalled()
+  })
+
+  it('calls waitForDebugger when the second argument is true', async () => {
+    await openDebugger(18911, true)
+
+    expect(mockOpen).toHaveBeenCalledExactlyOnceWith(18911, '127.0.0.1')
+    expect(mockWaitForDebugger).toHaveBeenCalledOnce()
+  })
+
+  it('does not call waitForDebugger when the second argument is false', async () => {
+    await openDebugger(18911, false)
+
+    expect(mockOpen).toHaveBeenCalledExactlyOnceWith(18911, '127.0.0.1')
+    expect(mockWaitForDebugger).not.toHaveBeenCalled()
   })
 })

--- a/packages/vite/src/cedar-unified-dev.ts
+++ b/packages/vite/src/cedar-unified-dev.ts
@@ -81,7 +81,7 @@ const startUnifiedDevServer = async () => {
   const { forceOptimize, debug, portArg, debugPort, debugBrk, serverArgs } =
     parseCliArgs()
 
-  if (debugPort) {
+  if (debugPort !== undefined) {
     await openDebugger(debugPort, debugBrk)
   }
 

--- a/packages/vite/src/cedar-unified-dev.ts
+++ b/packages/vite/src/cedar-unified-dev.ts
@@ -30,6 +30,28 @@ function isApiRequest(url: string, apiUrl: string, apiGqlUrl: string): boolean {
   )
 }
 
+export function parseCliArgs(argv = process.argv) {
+  const {
+    force: forceOptimize,
+    debug,
+    port: portArg,
+    apiPort: _apiPortArg,
+    'debug-port': debugPort,
+    _: _positional,
+    ...serverArgs
+  } = yargsParser(argv.slice(2), {
+    boolean: ['https', 'open', 'strictPort', 'force', 'cors', 'debug'],
+    number: ['port', 'apiPort', 'debug-port'],
+  })
+
+  return { forceOptimize, debug, portArg, debugPort, serverArgs }
+}
+
+export async function openDebugger(port: number) {
+  const inspector = await import('node:inspector')
+  inspector.open(port, '127.0.0.1')
+}
+
 const startUnifiedDevServer = async () => {
   // Signal to Cedar plugins (e.g. cedarWaitForApiServer) that we're running
   // in unified-dev mode so they can skip behaviours that assume a separate
@@ -44,17 +66,12 @@ const startUnifiedDevServer = async () => {
     throw new Error('Could not locate your web/vite.config.{js,ts} file')
   }
 
-  const {
-    force: forceOptimize,
-    debug,
-    port: portArg,
-    apiPort: _apiPortArg,
-    _: _positional,
-    ...serverArgs
-  } = yargsParser(process.argv.slice(2), {
-    boolean: ['https', 'open', 'strictPort', 'force', 'cors', 'debug'],
-    number: ['port', 'apiPort'],
-  })
+  const { forceOptimize, debug, portArg, debugPort, serverArgs } =
+    parseCliArgs()
+
+  if (debugPort) {
+    await openDebugger(debugPort)
+  }
 
   const webPort =
     (portArg as number | undefined) ?? cedarConfig.web.port ?? 8910

--- a/packages/vite/src/cedar-unified-dev.ts
+++ b/packages/vite/src/cedar-unified-dev.ts
@@ -37,19 +37,31 @@ export function parseCliArgs(argv = process.argv) {
     port: portArg,
     apiPort: _apiPortArg,
     'debug-port': debugPort,
+    'debug-brk': debugBrk,
     _: _positional,
     ...serverArgs
   } = yargsParser(argv.slice(2), {
-    boolean: ['https', 'open', 'strictPort', 'force', 'cors', 'debug'],
+    boolean: [
+      'https',
+      'open',
+      'strictPort',
+      'force',
+      'cors',
+      'debug',
+      'debug-brk',
+    ],
     number: ['port', 'apiPort', 'debug-port'],
   })
 
-  return { forceOptimize, debug, portArg, debugPort, serverArgs }
+  return { forceOptimize, debug, portArg, debugPort, debugBrk, serverArgs }
 }
 
-export async function openDebugger(port: number) {
+export async function openDebugger(port: number, waitForDebugger = false) {
   const inspector = await import('node:inspector')
   inspector.open(port, '127.0.0.1')
+  if (waitForDebugger) {
+    inspector.waitForDebugger()
+  }
 }
 
 const startUnifiedDevServer = async () => {
@@ -66,11 +78,11 @@ const startUnifiedDevServer = async () => {
     throw new Error('Could not locate your web/vite.config.{js,ts} file')
   }
 
-  const { forceOptimize, debug, portArg, debugPort, serverArgs } =
+  const { forceOptimize, debug, portArg, debugPort, debugBrk, serverArgs } =
     parseCliArgs()
 
   if (debugPort) {
-    await openDebugger(debugPort)
+    await openDebugger(debugPort, debugBrk)
   }
 
   const webPort =

--- a/tasks/ud-tests/udDev.test.mts
+++ b/tasks/ud-tests/udDev.test.mts
@@ -368,3 +368,88 @@ describe('cedar dev --ud --debug-port', () => {
     }
   }, 60_000)
 })
+
+// ---------------------------------------------------------------------------
+// debug-brk integration test — early-connect flow
+// ---------------------------------------------------------------------------
+
+describe('cedar dev --ud --debug-brk', () => {
+  it('blocks the server until a debugger connects, then serves requests normally', async () => {
+    // Use distinct ports — no overlap with the other two test blocks
+    const WEB_PORT = 18930
+    const API_PORT = 18931
+    const DEBUG_PORT = 38912
+    const BASE_URL = `http://localhost:${WEB_PORT}`
+
+    // 1. Start the unified dev server with --debug-brk.
+    //    inspector.open() runs first (logged to stderr), then
+    //    inspector.waitForDebugger() blocks.
+    const unifiedDevBin = resolveUnifiedDevBin()
+
+    let stderrBuffer = ''
+    const devProcess = $`yarn node ${unifiedDevBin} --port ${WEB_PORT} --apiPort ${API_PORT} --debug-port ${DEBUG_PORT} --debug-brk --no-open`
+    devProcess.stderr.on('data', (data: Buffer) => {
+      stderrBuffer += data.toString()
+    })
+    testContext.processes.push(devProcess)
+
+    // 2. Wait for the inspector message on stderr.
+    const inspectorUrl = await new Promise<string>((resolve, reject) => {
+      const inspectorTimeout = 15_000
+      const start = Date.now()
+      const poll = setInterval(() => {
+        const match = stderrBuffer.match(
+          /Debugger listening on (ws:\/\/127\.0\.0\.1:\d+\/[a-f0-9-]+)/,
+        )
+        if (match) {
+          clearInterval(poll)
+          resolve(match[1])
+        } else if (Date.now() - start > inspectorTimeout) {
+          clearInterval(poll)
+          reject(
+            new Error(
+              `Inspector did not start within ${inspectorTimeout}ms. stderr so far:\n${stderrBuffer}`,
+            ),
+          )
+        }
+      }, 100)
+    })
+
+    expect(inspectorUrl).toContain(`:${DEBUG_PORT}/`)
+
+    // 3. Verify the web server is NOT ready — waitForDebugger is blocking.
+    //    pollForReady with a short timeout should throw.
+    await expect(
+      pollForReady(`${BASE_URL}/`, { timeout: 3_000, interval: 300 }),
+    ).rejects.toThrow()
+
+    // 4. Connect to the inspector.  The process is still blocked at
+    //    waitForDebugger, so the connection establishes quickly.
+    const cdp = await createCdpSession(inspectorUrl, { timeout: 10_000 })
+
+    try {
+      // 5. Enable the debugger and unblock waitForDebugger().
+      //    Runtime.runIfWaitingForDebugger is what the inspector waits for —
+      //    it tells V8 to continue execution.  This must be sent after
+      //    Debugger.enable so the client can receive events immediately.
+      await cdp.send('Debugger.enable')
+      await cdp.send('Runtime.runIfWaitingForDebugger')
+
+      // 6. The server should now become available.
+      await pollForReady(`${BASE_URL}/`)
+
+      // 7. Verify basic CDP messaging works.
+      const evalResult = (await cdp.send('Runtime.evaluate', {
+        expression: '1 + 1',
+      })) as { result?: { value?: unknown } }
+      expect(evalResult.result?.value).toBe(2)
+
+      // 8. Verify the API function works.
+      const helloRes = await fetchJson(`${BASE_URL}/.api/functions/hello`)
+      expect(helloRes.status).toEqual(200)
+      expect(helloRes.body).toEqual({ data: 'hello from cedar' })
+    } finally {
+      cdp.close()
+    }
+  }, 60_000)
+})

--- a/tasks/ud-tests/udDev.test.mts
+++ b/tasks/ud-tests/udDev.test.mts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import WebSocket from 'ws'
 import { fs, path, $ } from 'zx'
 
 import {
@@ -107,6 +108,263 @@ describe('cedar dev --ud', () => {
     } finally {
       // Always restore the original source
       fs.writeFileSync(helloSrcPath, originalSrc)
+    }
+  }, 60_000)
+})
+
+// ---------------------------------------------------------------------------
+// CDP (Chrome DevTools Protocol) helper
+// ---------------------------------------------------------------------------
+
+interface CdpSession {
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>
+  on(
+    event: string,
+    callback: (params: Record<string, unknown>) => void,
+  ): () => void
+  close(): void
+}
+
+function createCdpSession(
+  wsUrl: string,
+  opts: { timeout?: number } = {},
+): Promise<CdpSession> {
+  const { timeout = 5_000 } = opts
+
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl)
+    const pending = new Map<
+      number,
+      { resolve: (v: unknown) => void; reject: (e: Error) => void }
+    >()
+    const listeners = new Map<
+      string,
+      ((params: Record<string, unknown>) => void)[]
+    >()
+    let nextId = 1
+    let settled = false
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true
+        ws.close()
+        reject(
+          new Error(`CDP connection to ${wsUrl} timed out after ${timeout}ms`),
+        )
+      }
+    }, timeout)
+
+    ws.on('open', () => {
+      settled = true
+      clearTimeout(timer)
+      resolve({
+        send(method: string, params?: Record<string, unknown>) {
+          return new Promise((res, rej) => {
+            const id = nextId++
+            pending.set(id, { resolve: res, reject: rej })
+
+            // Safety timeout per-message so a single hung CDP command
+            // can't stall the test forever.
+            setTimeout(() => {
+              if (pending.has(id)) {
+                pending.delete(id)
+                rej(
+                  new Error(
+                    `CDP ${method} (id=${id}) timed out after ${timeout}ms`,
+                  ),
+                )
+              }
+            }, timeout)
+
+            ws.send(JSON.stringify({ id, method, params }))
+          })
+        },
+        on(event: string, callback: (params: Record<string, unknown>) => void) {
+          if (!listeners.has(event)) {
+            listeners.set(event, [])
+          }
+          listeners.get(event)!.push(callback)
+          return () => {
+            const cbs = listeners.get(event)
+            if (cbs) {
+              const idx = cbs.indexOf(callback)
+              if (idx !== -1) {
+                cbs.splice(idx, 1)
+              }
+            }
+          }
+        },
+        close() {
+          ws.close()
+        },
+      })
+    })
+
+    ws.on('message', (data) => {
+      const msg = JSON.parse(data.toString())
+
+      if (msg.id !== undefined && pending.has(msg.id)) {
+        const p = pending.get(msg.id)!
+        pending.delete(msg.id)
+        if (msg.error) {
+          p.reject(new Error(`CDP error: ${msg.error.message}`))
+        } else {
+          p.resolve(msg.result)
+        }
+      } else if (msg.method) {
+        const cbs = listeners.get(msg.method)
+        if (cbs) {
+          for (const cb of cbs) {
+            cb(msg.params)
+          }
+        }
+      }
+    })
+
+    ws.on('error', (err) => {
+      if (!settled) {
+        settled = true
+        clearTimeout(timer)
+        reject(err)
+      }
+    })
+
+    ws.on('close', () => {
+      clearTimeout(timer)
+      for (const [, p] of pending) {
+        p.reject(new Error('CDP WebSocket closed unexpectedly'))
+      }
+      pending.clear()
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// debug-port integration test
+// ---------------------------------------------------------------------------
+
+describe('cedar dev --ud --debug-port', () => {
+  it('opens the inspector on the given port, allows CDP interaction, and can pause/resume execution', async () => {
+    // Use distinct ports to avoid accidental overlap if tests ever parallelise
+    const WEB_PORT = 18920
+    const API_PORT = 18921
+    const DEBUG_PORT = 38911
+    const BASE_URL = `http://localhost:${WEB_PORT}`
+
+    // 1. Start the unified dev server with --debug-port. We pass the flag
+    //    directly to cedar-unified-dev (bypassing the CLI) because the fixture
+    //    has an empty yarn.lock and no node_modules — see
+    //    resolveUnifiedDevBin() above. CEDAR_CWD is set globally by beforeAll
+    //    in vitest.setup.mts.
+    const unifiedDevBin = resolveUnifiedDevBin()
+
+    let stderrBuffer = ''
+    const devProcess = $`yarn node ${unifiedDevBin} --port ${WEB_PORT} --apiPort ${API_PORT} --debug-port ${DEBUG_PORT} --no-open`
+    devProcess.stderr.on('data', (data: Buffer) => {
+      stderrBuffer += data.toString()
+    })
+    testContext.processes.push(devProcess)
+
+    // 2. Wait for the inspector message on stderr and verify the port.
+    //    inspector.open() logs:  Debugger listening on ws://127.0.0.1:<port>/<uuid>
+    const inspectorUrl = await new Promise<string>((resolve, reject) => {
+      const inspectorTimeout = 15_000
+      const start = Date.now()
+      const poll = setInterval(() => {
+        const match = stderrBuffer.match(
+          /Debugger listening on (ws:\/\/127\.0\.0\.1:\d+\/[a-f0-9-]+)/,
+        )
+        if (match) {
+          clearInterval(poll)
+          resolve(match[1])
+        } else if (Date.now() - start > inspectorTimeout) {
+          clearInterval(poll)
+          reject(
+            new Error(
+              `Inspector did not start within ${inspectorTimeout}ms. stderr so far:\n${stderrBuffer}`,
+            ),
+          )
+        }
+      }, 100)
+    })
+
+    const inspectorPort = parseInt(inspectorUrl.match(/:(\d+)\//)![1], 10)
+    expect(inspectorPort).toBe(DEBUG_PORT)
+
+    // 3. Wait for the web server to be ready
+    await pollForReady(`${BASE_URL}/`)
+
+    // 4. Connect to the inspector via CDP using the full WebSocket URL
+    //    (including the UUID path, which the inspector requires — connecting
+    //    to ws://host:port without the UUID returns HTTP 400).
+    const cdp = await createCdpSession(inspectorUrl, { timeout: 10_000 })
+
+    try {
+      // 5. Verify basic CDP messaging works by evaluating a simple expression
+      const evalResult = (await cdp.send('Runtime.evaluate', {
+        expression: '1 + 1',
+      })) as { result?: { value?: unknown } }
+      expect(evalResult.result?.value).toBe(2)
+
+      // 6. Enable the debugger so we can pause execution
+      await cdp.send('Debugger.enable')
+
+      // 7. Test that the debugger halts on a `debugger;` statement and can
+      //    resume. The evaluate response only arrives after we resume.
+      let pausedResolve!: (params: Record<string, unknown>) => void
+      const pausedOnce = new Promise<Record<string, unknown>>((resolve) => {
+        pausedResolve = resolve
+      })
+      const unsubPause = cdp.on('Debugger.paused', (params) => {
+        unsubPause()
+        pausedResolve(params)
+      })
+
+      const evalPromise = cdp.send('Runtime.evaluate', {
+        expression: '(() => { debugger; return 42; })()',
+      })
+
+      const paused = await pausedOnce
+      expect(paused.reason).toBe('other')
+      expect((paused.callFrames as unknown[]).length).toBeGreaterThan(0)
+
+      await cdp.send('Debugger.resume')
+      const pausedEvalResult = (await evalPromise) as {
+        result?: { value?: unknown }
+      }
+      expect(pausedEvalResult.result?.value).toBe(42)
+
+      // 8. Test that Debugger.pause() can interrupt a real API request.
+      //    Arm the pause BEFORE issuing the request so V8 halts on the next
+      //    statement the dev server executes. This is deterministic — it
+      //    avoids the race where a trivial handler (hello.ts returns a static
+      //    response) completes before the pause is armed, which would leave
+      //    the pause pending forever and time out the test.
+      let requestPausedResolve!: (params: Record<string, unknown>) => void
+      const requestPausedOnce = new Promise<Record<string, unknown>>(
+        (resolve) => {
+          requestPausedResolve = resolve
+        },
+      )
+      const unsubRequestPause = cdp.on('Debugger.paused', (params) => {
+        unsubRequestPause()
+        requestPausedResolve(params)
+      })
+
+      await cdp.send('Debugger.pause')
+      const fetchPromise = fetchJson(`${BASE_URL}/.api/functions/hello`)
+
+      const requestPaused = await requestPausedOnce
+      expect(requestPaused.reason).toBeDefined()
+      expect((requestPaused.callFrames as unknown[]).length).toBeGreaterThan(0)
+
+      // 9. Resume and verify the HTTP response completes successfully
+      await cdp.send('Debugger.resume')
+      const helloRes = await fetchPromise
+      expect(helloRes.status).toEqual(200)
+      expect(helloRes.body).toEqual({ data: 'hello from cedar' })
+    } finally {
+      cdp.close()
     }
   }, 60_000)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -25828,6 +25828,7 @@ __metadata:
     typescript: "npm:5.9.3"
     typescript-eslint: "npm:8.60.1"
     vitest: "npm:3.2.6"
+    ws: "npm:8.20.0"
     yargs: "npm:17.7.2"
     zx: "npm:8.8.5"
   dependenciesMeta:


### PR DESCRIPTION
Pass through `--debug-port` to `cedar-unified-dev`'s `startUnifiedDevServer()` and attach the node inspector to vite's node process. Also adds `--debug-brk` which probably is what you want to use most of the time when debugging in an IDE. Launch with that flag from your debug configurations.

For attaching to an already-running server, you'll have to trigger HMR in the file you want to debug for Vite to invalidate its cache and load the module again, which lets the debugger properly discover the breakpoint and break on it