### PR TITLE
fix(ci): translate tarsync yarn resolutions to pnpm overrides

### DIFF
--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -138,7 +138,14 @@ export async function setUpTestProject({
         (pkg.resolutions as Record<string, string>) || {},
       )
         .filter(([, value]) => typeof value === 'string' && value.endsWith('.tgz'))
-        .map(([name, value]) => `  '${name}': 'file:${value}'`)
+        .map(([name, value]) => {
+          // In YAML single-quoted scalars, a literal single quote is escaped by
+          // doubling it. Package names like @cedarjs/foo never contain quotes,
+          // but the tarball path could on unusual runner configs.
+          const safeName = name.replace(/'/g, "''")
+          const safePath = value.replace(/'/g, "''")
+          return `  '${safeName}': 'file:${safePath}'`
+        })
         .join('\n')
 
       const yaml = [

--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -131,6 +131,16 @@ export async function setUpTestProject({
         },
       }
 
+      // Translate tarsync's yarn-style resolutions into pnpm overrides so
+      // pnpm install uses the local framework tarballs instead of fetching
+      // the published canary from the registry.
+      const tarsyncOverrideLines = Object.entries(
+        (pkg.resolutions as Record<string, string>) || {},
+      )
+        .filter(([, value]) => typeof value === 'string' && value.endsWith('.tgz'))
+        .map(([name, value]) => `  '${name}': 'file:${value}'`)
+        .join('\n')
+
       const yaml = [
         'packages:',
         '  - api',
@@ -154,6 +164,7 @@ export async function setUpTestProject({
         '',
         'overrides:',
         "  'react-is': '19.2.3'",
+        tarsyncOverrideLines,
         '',
       ].join('\n')
 

--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -27,6 +27,19 @@ function lockfileName(pm: PackageManager): string {
   return 'yarn.lock'
 }
 
+function isString(value: unknown): value is string {
+  return typeof value === 'string'
+}
+
+/**
+ * In YAML single-quoted scalars, a literal single quote is escaped by doubling
+ * it. Package names like @cedarjs/foo never contain quotes, but the tarball
+ * path could on unusual runner configs.
+ */
+function quotes(value: string) {
+  return value.replace(/'/g, "''")
+}
+
 interface Args {
   setOutput: (key: string, value: string) => void
   getInput: (key: string) => string
@@ -137,15 +150,8 @@ export async function setUpTestProject({
       const tarsyncOverrideLines = Object.entries(
         (pkg.resolutions as Record<string, string>) || {},
       )
-        .filter(([, value]) => typeof value === 'string' && value.endsWith('.tgz'))
-        .map(([name, value]) => {
-          // In YAML single-quoted scalars, a literal single quote is escaped by
-          // doubling it. Package names like @cedarjs/foo never contain quotes,
-          // but the tarball path could on unusual runner configs.
-          const safeName = name.replace(/'/g, "''")
-          const safePath = value.replace(/'/g, "''")
-          return `  '${safeName}': 'file:${safePath}'`
-        })
+        .filter(([, value]) => isString(value) && value.endsWith('.tgz'))
+        .map(([name, value]) => `  '${quotes(name)}': 'file:${quotes(value)}'`)
         .join('\n')
 
       const yaml = [


### PR DESCRIPTION
## Summary

• **Root cause**: pnpm ignores yarn's `resolutions` field. After `tarsync` runs and writes local tarball paths into `package.json`'s `resolutions`, `pnpm install` ignores those and fetches `@cedarjs/project-config@4.2.0` from the npm registry. The published canary predates PR #1799 (which moved `index.html` from `web/src/` to `web/`) and still resolves `paths.web.html` to `web/src/index.html`.

• **Symptom**: Every pnpm smoke test since 2026-06-26 fails with `Could not resolve entry module "src/index.html"` — 5 consecutive daily failures.

• **Fix**: After tarsync runs, read its yarn `resolutions` entries that point to local `.tgz` files and emit them as pnpm overrides (with `file:` prefix) in `pnpm-workspace.yaml`, so `pnpm install` uses the local tarballs instead of the stale registry canary.

## Test plan

- [ ] pnpm smoke tests CI passes after this change
- [ ] npm smoke tests are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)