### PR TITLE
fix(pm): peerDeps instead of deps for correct hoisting

### DIFF
--- a/docs/implementation-docs/2026-07-03-pnpm-package-hoisting.md
+++ b/docs/implementation-docs/2026-07-03-pnpm-package-hoisting.md
@@ -1,0 +1,109 @@
+# PNPM Package Hoisting Issue
+
+## Symptom
+
+CI failed on `main` — 🔄 Package Manager Smoke Tests → `Run cedar test web`.
+
+5 test files failing:
+
+```
+Error: You must register a useQuery hook via the `GraphQLHooksProvider`
+Error: You must register a useMutation hook via the `GraphQLHooksProvider`
+```
+
+**Failing tests:**
+
+- `WaterfallBlogPostCell.test.tsx`
+- `WaterfallPage.test.tsx`
+- `BlogPostPage.test.tsx`
+- `ContactUsPage.test.tsx`
+- `HomePage.test.tsx`
+
+## Root Cause
+
+`@cedarjs/testing` lists `@cedarjs/web` (and `@cedarjs/router`, `@cedarjs/auth`)
+as regular `dependencies` — not `peerDependencies`. With pnpm's strict module
+isolation, this means there are two separate instances of `@cedarjs/web` at
+runtime:
+
+1. **Inside `@cedarjs/testing`'s private scope** — where `MockProviders` sets up
+   `GraphQLHooksProvider`
+2. **In the web package** — where `BlogPostsCell` reads `GraphQLHooksContext`
+
+Since `React.createContext()` produces a unique object per module instance, the
+provider from instance 1 is invisible to instance 2. The context read by
+`BlogPostsCell` gets the default (throwing) value.
+
+With yarn/npm, hoisting puts both imports into the same file on disk, so they
+resolve to the same object. pnpm's isolation breaks that assumption.
+
+### Relevant code
+
+| File                                                                                                                                                                        | Role                                                            |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| [`packages/testing/package.json:121-128`](https://github.com/cedarjs/cedar/blob/main/packages/testing/package.json#L121-L128)                                               | `@cedarjs/web` in `dependencies` (should be `peerDependencies`) |
+| [`packages/web/src/components/GraphQLHooksProvider.tsx:71`](https://github.com/cedarjs/cedar/blob/main/packages/web/src/components/GraphQLHooksProvider.tsx#L71)            | `React.createContext()` with throwing defaults                  |
+| [`packages/web/src/components/GraphQLHooksProvider.tsx:74,79`](https://github.com/cedarjs/cedar/blob/main/packages/web/src/components/GraphQLHooksProvider.tsx#L74-L79)     | Throwing error messages seen in CI                              |
+| [`packages/testing/src/web/MockProviders.tsx:4-5`](https://github.com/cedarjs/cedar/blob/main/packages/testing/src/web/MockProviders.tsx#L4-L5)                             | `MockProviders` imports from `@cedarjs/web` (gets private copy) |
+| [`packages/web/src/components/GraphQLHooksProvider.tsx:156-167`](https://github.com/cedarjs/cedar/blob/main/packages/web/src/components/GraphQLHooksProvider.tsx#L156-L167) | `useQuery` reads `GraphQLHooksContext` (gets host-project copy) |
+
+## Fix
+
+In `packages/testing/package.json`, move these three from `dependencies` →
+`peerDependencies`:
+
+- `@cedarjs/web`
+- `@cedarjs/router`
+- `@cedarjs/auth`
+
+This tells pnpm to use the host project's single installed copy rather than a
+private one, ensuring `React.createContext()` returns the same object
+everywhere.
+
+These should be listed as `peerDependencies` only — not both `peerDependencies`
+and `dependencies`. The dual-listing pattern was a pre-npm-v7 workaround so
+consumers who forgot to install the peer dep would still get something, but it
+never guaranteed a singleton and pnpm's strict isolation explicitly breaks it.
+npm v7+ made this pattern obsolete by auto-installing peer deps. If the package
+needs these for its own test suite within the monorepo, add them to
+`devDependencies` instead.
+
+This is also relevant when choosing a **Yarn linker**. We currently use the
+`node-modules` linker, which hoists everything into a flat `node_modules` (just
+like npm) and masks incorrect dependency declarations. The default PnP linker
+and the `pnpm` linker both create strict package boundaries, meaning they would
+produce the exact same errors if this dependency type isn't fixed.
+
+## CI Runs
+
+The 🔄 Package Manager Smoke Tests workflow has been failing consistently on
+`main`:
+
+| #   | Date   | URL                                                       |
+| --- | ------ | --------------------------------------------------------- |
+| #19 | Jul 3  | https://github.com/cedarjs/cedar/actions/runs/28643802319 |
+| #18 | Jul 2  | https://github.com/cedarjs/cedar/actions/runs/28571527091 |
+| #17 | Jul 1  | https://github.com/cedarjs/cedar/actions/runs/28502683635 |
+| #16 | Jun 30 | https://github.com/cedarjs/cedar/actions/runs/28428346053 |
+| #15 | Jun 29 | https://github.com/cedarjs/cedar/actions/runs/28359808185 |
+| #14 | Jun 28 | https://github.com/cedarjs/cedar/actions/runs/28315429735 |
+| #13 | Jun 27 | https://github.com/cedarjs/cedar/actions/runs/28281560707 |
+| #12 | Jun 26 | https://github.com/cedarjs/cedar/actions/runs/28224363626 |
+| #11 | Jun 25 | https://github.com/cedarjs/cedar/actions/runs/28154253823 |
+| #10 | Jun 24 | https://github.com/cedarjs/cedar/actions/runs/28082572629 |
+| #9  | Jun 23 | https://github.com/cedarjs/cedar/actions/runs/28010126547 |
+| #8  | Jun 22 | https://github.com/cedarjs/cedar/actions/runs/27943394890 |
+| #7  | Jun 21 | https://github.com/cedarjs/cedar/actions/runs/27898433561 |
+| #6  | Jun 20 | https://github.com/cedarjs/cedar/actions/runs/27864529039 |
+
+Every run from #6 onward has been failing — broken on `main` for ~2 weeks.
+
+## References
+
+- [How peers are resolved — pnpm docs](https://pnpm.io/how-peers-are-resolved) —
+  explains that peer dependencies are resolved from the host project, ensuring
+  singleton behavior.
+- [pnpm#2443 — "pnpm install with workspaces causes duplicate modules"](https://github.com/pnpm/pnpm/issues/2443)
+  — same class of problem: shared singleton state broken by pnpm's isolation.
+- [Peer dependencies in (P)NPM — DEV article](https://dev.to/timoschinkel/peer-dependencies-in-pnpm-4mo6)
+  — broader explanation of the concept.

--- a/docs/implementation-docs/2026-07-03-pnpm-package-hoisting.md
+++ b/docs/implementation-docs/2026-07-03-pnpm-package-hoisting.md
@@ -21,14 +21,18 @@ Error: You must register a useMutation hook via the `GraphQLHooksProvider`
 
 ## Root Cause
 
-`@cedarjs/testing` lists `@cedarjs/web` (and `@cedarjs/router`, `@cedarjs/auth`)
-as regular `dependencies` — not `peerDependencies`. With pnpm's strict module
-isolation, this means there are two separate instances of `@cedarjs/web` at
-runtime:
+Several CedarJS packages list singleton framework packages (`@cedarjs/web`,
+`@cedarjs/router`, `@cedarjs/auth`) as regular `dependencies` instead of
+`peerDependencies`. With pnpm's strict module isolation, this means the
+consuming package gets its own private copy of these dependencies, creating
+multiple module instances at runtime.
+
+The smoke test failure surfaced through `@cedarjs/testing`:
 
 1. **Inside `@cedarjs/testing`'s private scope** — where `MockProviders` sets up
    `GraphQLHooksProvider`
-2. **In the web package** — where `BlogPostsCell` reads `GraphQLHooksContext`
+2. **In the host project's web package** — where `BlogPostsCell` reads
+   `GraphQLHooksContext`
 
 Since `React.createContext()` produces a unique object per module instance, the
 provider from instance 1 is invisible to instance 2. The context read by
@@ -49,12 +53,19 @@ resolve to the same object. pnpm's isolation breaks that assumption.
 
 ## Fix
 
-In `packages/testing/package.json`, move these three from `dependencies` →
-`peerDependencies`:
+For each affected package, move the singleton framework packages from
+`dependencies` → `peerDependencies`, and add them to `devDependencies` so they
+remain available for local development/testing in the monorepo:
 
-- `@cedarjs/web`
-- `@cedarjs/router`
-- `@cedarjs/auth`
+| Package                | Moved from `dependencies` to `peerDependencies`                       | Added to `devDependencies`                         |
+| ---------------------- | --------------------------------------------------------------------- | -------------------------------------------------- |
+| `@cedarjs/testing`     | `@cedarjs/web`, `@cedarjs/router`, `@cedarjs/auth`                    | `@cedarjs/web`, `@cedarjs/router`, `@cedarjs/auth` |
+| `@cedarjs/gqlorm`      | `@cedarjs/web`                                                        | `@cedarjs/web`                                     |
+| `@cedarjs/ogimage-gen` | `@cedarjs/router`                                                     | `@cedarjs/router`                                  |
+| `@cedarjs/prerender`   | `@cedarjs/web`, `@cedarjs/router`                                     | `@cedarjs/web`, `@cedarjs/router`                  |
+| `@cedarjs/router`      | `@cedarjs/auth`                                                       | `@cedarjs/auth`                                    |
+| `@cedarjs/web`         | `@cedarjs/auth`                                                       | `@cedarjs/auth`                                    |
+| `@cedarjs/vite`        | `@cedarjs/web`, `@cedarjs/auth` (and added missing `@cedarjs/router`) | `@cedarjs/web`, `@cedarjs/router`, `@cedarjs/auth` |
 
 This tells pnpm to use the host project's single installed copy rather than a
 private one, ensuring `React.createContext()` returns the same object
@@ -64,9 +75,7 @@ These should be listed as `peerDependencies` only — not both `peerDependencies
 and `dependencies`. The dual-listing pattern was a pre-npm-v7 workaround so
 consumers who forgot to install the peer dep would still get something, but it
 never guaranteed a singleton and pnpm's strict isolation explicitly breaks it.
-npm v7+ made this pattern obsolete by auto-installing peer deps. If the package
-needs these for its own test suite within the monorepo, add them to
-`devDependencies` instead.
+npm v7+ made this pattern obsolete by auto-installing peer deps.
 
 This is also relevant when choosing a **Yarn linker**. We currently use the
 `node-modules` linker, which hoists everything into a flat `node_modules` (just
@@ -97,6 +106,28 @@ The 🔄 Package Manager Smoke Tests workflow has been failing consistently on
 | #6  | Jun 20 | https://github.com/cedarjs/cedar/actions/runs/27864529039 |
 
 Every run from #6 onward has been failing — broken on `main` for ~2 weeks.
+
+## Potential follow-up
+
+The framework package fixes above make `@cedarjs/testing` (and others) declare
+`@cedarjs/web`, `@cedarjs/router`, and `@cedarjs/auth` as `peerDependencies`. In
+a Cedar app, those packages are normally installed in the `web` workspace, while
+`@cedarjs/testing` is installed at the project root.
+
+For pnpm, this means the root workspace now has **unmet peer dependencies**
+unless the package manager auto-installs them (`auto-install-peers=true` is the
+default in pnpm v7+, but not guaranteed). To make the dependency graph explicit
+and avoid relying on auto-install behavior, consider adding these three packages
+to the root `devDependencies` of:
+
+- `__fixtures__/test-project/package.json`
+- `__fixtures__/test-project-esm/package.json`
+- `__fixtures__/test-project-pnpm/package.json`
+- `packages/create-cedar-app/templates/ts/package.json`
+- `packages/create-cedar-app/templates/esm-ts/package.json`
+
+This ensures pnpm resolves the peer deps from the same copies the `web`
+workspace uses, keeping the singleton intact.
 
 ## References
 

--- a/packages/gqlorm/package.json
+++ b/packages/gqlorm/package.json
@@ -138,9 +138,7 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@cedarjs/auth": "workspace:*",
     "@cedarjs/server-store": "workspace:*",
-    "@cedarjs/web": "workspace:*",
     "graphql": "16.13.2"
   },
   "devDependencies": {
@@ -148,6 +146,7 @@
     "@babel/cli": "7.29.7",
     "@babel/core": "^7.26.10",
     "@cedarjs/framework-tools": "workspace:*",
+    "@cedarjs/web": "workspace:*",
     "@testing-library/jest-dom": "6.9.1",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
@@ -159,6 +158,7 @@
     "vitest": "3.2.6"
   },
   "peerDependencies": {
+    "@cedarjs/web": "workspace:*",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -42,8 +42,6 @@
   "dependencies": {
     "@cedarjs/internal": "workspace:*",
     "@cedarjs/project-config": "workspace:*",
-    "@cedarjs/router": "workspace:*",
-    "@cedarjs/web": "workspace:*",
     "fast-glob": "3.3.3",
     "lodash": "4.18.1",
     "react": "19.2.3",
@@ -51,12 +49,16 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
+    "@cedarjs/router": "workspace:*",
     "@playwright/test": "1.61.0",
     "ts-toolbelt": "9.6.0",
     "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vite": "7.3.5",
     "vitest": "3.2.6"
+  },
+  "peerDependencies": {
+    "@cedarjs/router": "workspace:*"
   },
   "engines": {
     "node": ">=24"

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -73,10 +73,8 @@
     "@babel/traverse": "7.29.7",
     "@cedarjs/babel-config": "workspace:*",
     "@cedarjs/project-config": "workspace:*",
-    "@cedarjs/router": "workspace:*",
     "@cedarjs/structure": "workspace:*",
     "@cedarjs/vite": "workspace:*",
-    "@cedarjs/web": "workspace:*",
     "@rollup/plugin-alias": "5.1.1",
     "@rollup/plugin-commonjs": "28.0.9",
     "@rollup/plugin-node-resolve": "16.0.3",
@@ -95,6 +93,8 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
+    "@cedarjs/router": "workspace:*",
+    "@cedarjs/web": "workspace:*",
     "@types/mime-types": "2.1.4",
     "@types/react": "^18.2.55",
     "babel-plugin-tester": "11.0.4",
@@ -105,6 +105,8 @@
     "vitest": "3.2.6"
   },
   "peerDependencies": {
+    "@cedarjs/router": "workspace:*",
+    "@cedarjs/web": "workspace:*",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -94,7 +94,6 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@cedarjs/auth": "workspace:*",
     "@cedarjs/server-store": "workspace:*",
     "react": "19.2.3",
     "react-dom": "19.2.3",
@@ -104,6 +103,7 @@
     "@arethetypeswrong/cli": "0.18.3",
     "@babel/cli": "7.29.7",
     "@babel/core": "^7.26.10",
+    "@cedarjs/auth": "workspace:*",
     "@cedarjs/framework-tools": "workspace:*",
     "@testing-library/jest-dom": "6.9.1",
     "@types/react": "^18.2.55",
@@ -116,6 +116,7 @@
     "vitest": "3.2.6"
   },
   "peerDependencies": {
+    "@cedarjs/auth": "workspace:*",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -119,13 +119,10 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@cedarjs/auth": "workspace:*",
     "@cedarjs/babel-config": "workspace:*",
     "@cedarjs/context": "workspace:*",
     "@cedarjs/graphql-server": "workspace:*",
     "@cedarjs/project-config": "workspace:*",
-    "@cedarjs/router": "workspace:*",
-    "@cedarjs/web": "workspace:*",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "14.3.1",
     "@testing-library/user-event": "14.6.1",
@@ -145,7 +142,10 @@
     "whatwg-fetch": "3.6.20"
   },
   "devDependencies": {
+    "@cedarjs/auth": "workspace:*",
     "@cedarjs/framework-tools": "workspace:*",
+    "@cedarjs/router": "workspace:*",
+    "@cedarjs/web": "workspace:*",
     "concurrently": "9.2.1",
     "jsdom": "27.4.0",
     "publint": "0.3.21",
@@ -154,6 +154,9 @@
     "vitest": "3.2.6"
   },
   "peerDependencies": {
+    "@cedarjs/auth": "workspace:*",
+    "@cedarjs/router": "workspace:*",
+    "@cedarjs/web": "workspace:*",
     "vitest": "3.2.6"
   },
   "peerDependenciesMeta": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -68,7 +68,6 @@
     "@babel/traverse": "7.29.7",
     "@babel/types": "7.29.7",
     "@cedarjs/api": "workspace:*",
-    "@cedarjs/auth": "workspace:*",
     "@cedarjs/babel-config": "workspace:*",
     "@cedarjs/context": "workspace:*",
     "@cedarjs/cookie-jar": "workspace:*",
@@ -77,7 +76,6 @@
     "@cedarjs/project-config": "workspace:*",
     "@cedarjs/server-store": "workspace:*",
     "@cedarjs/testing": "workspace:*",
-    "@cedarjs/web": "workspace:*",
     "@fastify/url-data": "6.0.3",
     "@swc/core": "1.15.41",
     "@universal-deploy/store": "^0.2.1",
@@ -111,6 +109,9 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.3",
+    "@cedarjs/auth": "workspace:*",
+    "@cedarjs/router": "workspace:*",
+    "@cedarjs/web": "workspace:*",
     "@hyrious/esbuild-plugin-commonjs": "0.2.6",
     "@jridgewell/trace-mapping": "0.3.31",
     "@types/aws-lambda": "8.10.162",
@@ -127,6 +128,11 @@
     "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
+  },
+  "peerDependencies": {
+    "@cedarjs/auth": "workspace:*",
+    "@cedarjs/router": "workspace:*",
+    "@cedarjs/web": "workspace:*"
   },
   "engines": {
     "node": ">=24"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -140,7 +140,6 @@
   },
   "dependencies": {
     "@apollo/client": "3.14.1",
-    "@cedarjs/auth": "workspace:*",
     "@cedarjs/server-store": "workspace:*",
     "@dr.pogodin/react-helmet": "2.0.4",
     "@whatwg-node/fetch": "0.10.13",
@@ -160,6 +159,7 @@
     "@babel/core": "^7.26.10",
     "@babel/plugin-transform-runtime": "7.29.7",
     "@babel/runtime": "7.29.7",
+    "@cedarjs/auth": "workspace:*",
     "@cedarjs/framework-tools": "workspace:*",
     "@cedarjs/internal": "workspace:*",
     "@rollup/plugin-babel": "6.1.0",
@@ -179,6 +179,7 @@
     "vitest": "3.2.6"
   },
   "peerDependencies": {
+    "@cedarjs/auth": "workspace:*",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3216,7 +3216,6 @@ __metadata:
     "@arethetypeswrong/cli": "npm:0.18.3"
     "@babel/cli": "npm:7.29.7"
     "@babel/core": "npm:^7.26.10"
-    "@cedarjs/auth": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/server-store": "workspace:*"
     "@cedarjs/web": "workspace:*"
@@ -3231,6 +3230,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
+    "@cedarjs/web": "workspace:*"
     react: 19.2.3
     react-dom: 19.2.3
   languageName: unknown
@@ -3463,7 +3463,6 @@ __metadata:
     "@cedarjs/internal": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
     "@cedarjs/router": "workspace:*"
-    "@cedarjs/web": "workspace:*"
     "@playwright/test": "npm:1.61.0"
     fast-glob: "npm:3.3.3"
     lodash: "npm:4.18.1"
@@ -3474,6 +3473,8 @@ __metadata:
     typescript: "npm:5.9.3"
     vite: "npm:7.3.5"
     vitest: "npm:3.2.6"
+  peerDependencies:
+    "@cedarjs/router": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -3516,6 +3517,8 @@ __metadata:
     vite: "npm:7.3.5"
     vitest: "npm:3.2.6"
   peerDependencies:
+    "@cedarjs/router": "workspace:*"
+    "@cedarjs/web": "workspace:*"
     react: 19.2.3
     react-dom: 19.2.3
   languageName: unknown
@@ -3614,6 +3617,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
+    "@cedarjs/auth": "workspace:*"
     react: 19.2.3
     react-dom: 19.2.3
   languageName: unknown
@@ -3738,6 +3742,9 @@ __metadata:
     vitest: "npm:3.2.6"
     whatwg-fetch: "npm:3.6.20"
   peerDependencies:
+    "@cedarjs/auth": "workspace:*"
+    "@cedarjs/router": "workspace:*"
+    "@cedarjs/web": "workspace:*"
     vitest: 3.2.6
   peerDependenciesMeta:
     vitest:
@@ -3796,6 +3803,7 @@ __metadata:
     "@cedarjs/graphql-server": "workspace:*"
     "@cedarjs/internal": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
+    "@cedarjs/router": "workspace:*"
     "@cedarjs/server-store": "workspace:*"
     "@cedarjs/testing": "workspace:*"
     "@cedarjs/web": "workspace:*"
@@ -3845,6 +3853,10 @@ __metadata:
     vitest: "npm:3.2.6"
     ws: "npm:8.20.0"
     yargs-parser: "npm:21.1.1"
+  peerDependencies:
+    "@cedarjs/auth": "workspace:*"
+    "@cedarjs/router": "workspace:*"
+    "@cedarjs/web": "workspace:*"
   bin:
     cedar-dev-fe: ./dist/devFeServer.js
     cedar-serve-fe: ./dist/runFeServer.js
@@ -3915,6 +3927,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
+    "@cedarjs/auth": "workspace:*"
     react: 19.2.3
     react-dom: 19.2.3
   bin:


### PR DESCRIPTION
Fix pnpm issue in Cedar apps with regards to dependency hoisting of Cedar packages

See `docs/implementation-docs/2026-07-03-pnpm-package-hoisting.md` for the full details