### PR TITLE
chore(cli): migrate 10 test files from JS to TS (batch 4)

### DIFF
--- a/packages/cli/src/commands/deploy/__tests__/nftPack.test.ts
+++ b/packages/cli/src/commands/deploy/__tests__/nftPack.test.ts
@@ -34,7 +34,7 @@ vi.mock('@cedarjs/project-config', () => {
         },
       }
     },
-    ensurePosixPath: (path) => {
+    ensurePosixPath: (path: string): string => {
       return path.replace(/\\/g, '/')
     },
   }
@@ -43,7 +43,7 @@ vi.mock('@cedarjs/project-config', () => {
 test('Check packager detects all functions', () => {
   const packageFileMock = vi
     .spyOn(nftPacker, 'packageSingleFunction')
-    .mockResolvedValue(true)
+    .mockResolvedValue(undefined)
 
   nftPacker.nftPack()
 
@@ -54,6 +54,9 @@ test('Creates entry file for nested functions correctly', () => {
   const nestedFunction = findApiDistFunctions().find((fPath) =>
     fPath.includes('nested'),
   )
+  if (!nestedFunction) {
+    throw new Error('Expected to find nested function in test fixtures')
+  }
 
   const [outputPath, content] = nftPacker.generateEntryFile(
     nestedFunction,
@@ -70,6 +73,9 @@ test('Creates entry file for top level functions correctly', () => {
   const graphqlFunction = findApiDistFunctions().find((fPath) =>
     fPath.includes('graphql'),
   )
+  if (!graphqlFunction) {
+    throw new Error('Expected to find graphql function in test fixtures')
+  }
 
   const [outputPath, content] = nftPacker.generateEntryFile(
     graphqlFunction,

--- a/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.mockListr.test.ts
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.mockListr.test.ts
@@ -1,4 +1,4 @@
-global.__dirname = __dirname
+globalThis.__dirname = __dirname
 
 vi.mock('node:fs')
 
@@ -7,7 +7,7 @@ import path from 'path'
 // Load mocks
 import '../../../../lib/test'
 
-const actualFs = await vi.importActual('node:fs')
+const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs')
 import Enquirer from 'enquirer'
 import { vol } from 'memfs'
 import {
@@ -20,10 +20,7 @@ import {
   afterAll,
 } from 'vitest'
 
-// Can't use .js when importing TS files from JS files in Vitest
-// TODO: Add .js when we've upgraded to Vite 6.1.0
-// https://github.com/vitest-dev/vitest/issues/5999
-import { Listr2Mock } from '../../../../__tests__/Listr2Mock'
+import { Listr2Mock } from '../../../../__tests__/Listr2Mock.js'
 import { getPaths } from '../../../../lib/index.js'
 import * as dbAuth from '../dbAuthHandler.js'
 
@@ -32,7 +29,7 @@ vi.mock('listr2', () => ({
 }))
 
 // Mock files needed for each test
-const mockFiles = {}
+const mockFiles: Record<string, string> = {}
 
 const dbAuthTemplateFiles = [
   'forgotPassword.tsx.template',

--- a/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.postInstallMessage.test.ts
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.postInstallMessage.test.ts
@@ -1,4 +1,4 @@
-global.__dirname = __dirname
+globalThis.__dirname = __dirname
 
 vi.mock('node:fs')
 
@@ -7,7 +7,7 @@ import path from 'path'
 // Load mocks
 import '../../../../lib/test'
 
-const actualFs = await vi.importActual('node:fs')
+const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs')
 import { vol } from 'memfs'
 import { afterEach, beforeEach, vi, describe, it, expect } from 'vitest'
 
@@ -50,10 +50,10 @@ export const { AuthProvider, useAuth } = createAuth(dbAuthClient)
         webauthn: false,
       })
 
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).toMatch(
         /Look in LoginPage, Sign/,
       )
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).not.toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).not.toMatch(
         /yarn cedar setup auth dbAuth/,
       )
     })
@@ -74,10 +74,10 @@ export const { AuthProvider, useAuth } = createAuth(dbAuthClient)
         webauthn: false,
       })
 
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).toMatch(
         /Look in LoginPage, Sign/,
       )
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).not.toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).not.toMatch(
         /yarn cedar setup auth dbAuth/,
       )
     })
@@ -109,10 +109,10 @@ export { useAuth }
         webauthn: false,
       })
 
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).toMatch(
         /Look in LoginPage, Sign/,
       )
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).not.toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).not.toMatch(
         /yarn cedar setup auth dbAuth/,
       )
     })
@@ -161,10 +161,10 @@ export const AuthProvider = ({ children }: Props) => {
         webauthn: false,
       })
 
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).toMatch(
         /Look in LoginPage, Sign/,
       )
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).toMatch(
         /yarn cedar setup auth dbAuth/,
       )
     })
@@ -185,10 +185,10 @@ export const AuthProvider = ({ children }: Props) => {
         webauthn: false,
       })
 
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).toMatch(
         /Look in LoginPage, Sign/,
       )
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).not.toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).not.toMatch(
         /yarn cedar setup auth dbAuth/,
       )
     })
@@ -209,10 +209,10 @@ export const { AuthProvider, useAuth } = createAuth(dbAuthClient)
         webauthn: true,
       })
 
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).toMatch(
         /look for the `REDIRECT`/,
       )
-      expect(vi.mocked(console).log.mock.calls.at(-1)[0]).not.toMatch(
+      expect(vi.mocked(console).log.mock.calls.at(-1)?.[0]).not.toMatch(
         /yarn cedar setup auth dbAuth/,
       )
     })

--- a/packages/cli/src/commands/generate/ogImage/__tests__/ogImage.test.ts
+++ b/packages/cli/src/commands/generate/ogImage/__tests__/ogImage.test.ts
@@ -1,4 +1,6 @@
 /* eslint-disable camelcase */
+import type * as NodeFS from 'node:fs'
+
 globalThis.__dirname = __dirname
 
 import { vol, fs as memfs } from 'memfs'
@@ -13,12 +15,12 @@ vi.mock('node:fs', async (importOriginal) => {
   const { wrapFsForUnionfs, wrapMemfsForUnionfs } =
     await import('../../../../__tests__/ufsFsProxy.js')
   ufs
-    .use(wrapFsForUnionfs(await importOriginal()))
+    .use(wrapFsForUnionfs(await importOriginal<typeof NodeFS>()))
     .use(wrapMemfsForUnionfs(memfs))
   return { ...ufs, default: { ...ufs } }
 })
 vi.mock('@cedarjs/project-config', async (importOriginal) => {
-  const actual = await importOriginal()
+  const actual = await importOriginal<typeof import('@cedarjs/project-config')>()
 
   return {
     ...actual,
@@ -35,7 +37,8 @@ vi.mock('@cedarjs/project-config', async (importOriginal) => {
     }),
   }
 })
-let original_CEDAR_CWD
+
+let original_CEDAR_CWD: string | undefined
 
 describe('ogImage generator', () => {
   beforeEach(() => {

--- a/packages/cli/src/commands/generate/service/__tests__/scenario.test.ts
+++ b/packages/cli/src/commands/generate/service/__tests__/scenario.test.ts
@@ -6,6 +6,24 @@ import { describe, test, expect } from 'vitest'
 
 import * as serviceHandler from '../serviceHandler.js'
 
+// Helper to build a minimal field object compatible with PrismaField.
+// The required structural fields (name, kind, isList, isRequired, isId) are
+// set to safe defaults so each test can focus on the property under test.
+const makeField = (overrides: {
+  type: string
+  kind?: string
+  isUnique?: boolean
+  name?: string
+  enumValues?: Array<{ name: string; dbName?: string }>
+}) => ({
+  name: 'testField',
+  kind: 'scalar',
+  isList: false,
+  isRequired: true,
+  isId: false,
+  ...overrides,
+})
+
 describe('the scenario generator', () => {
   test('parseSchema returns an object with required scalar fields', async () => {
     const { scalarFields } = await serviceHandler.parseSchema('UserProfile')
@@ -98,7 +116,7 @@ describe('the scenario generator', () => {
   })
 
   test('scenarioFieldValue returns a plain string for non-unique String types', () => {
-    const field = { type: 'String', isUnique: false }
+    const field = makeField({ type: 'String', isUnique: false })
     const value = serviceHandler.scenarioFieldValue(field)
 
     expect(value).toEqual(expect.any(String))
@@ -106,7 +124,7 @@ describe('the scenario generator', () => {
   })
 
   test('scenarioFieldValue returns a valid email for non-unique String types with a field name that includes "email"', () => {
-    const field = { type: 'String', isUnique: false, name: 'email' }
+    const field = makeField({ type: 'String', isUnique: false, name: 'email' })
     const value = serviceHandler.scenarioFieldValue(field)
 
     expect(typeof value).toBe('string')
@@ -114,7 +132,7 @@ describe('the scenario generator', () => {
   })
 
   test('scenarioFieldValue returns a unique string for unique String types', () => {
-    const field = { type: 'String', isUnique: true }
+    const field = makeField({ type: 'String', isUnique: true })
     const value = serviceHandler.scenarioFieldValue(field)
 
     expect(value).toEqual(expect.any(String))
@@ -124,7 +142,11 @@ describe('the scenario generator', () => {
   })
 
   test('scenarioFieldValue returns a valid unique email for unique String types with a field name that includes "email"', () => {
-    const field = { type: 'String', isUnique: true, name: 'authorEmail' }
+    const field = makeField({
+      type: 'String',
+      isUnique: true,
+      name: 'authorEmail',
+    })
     const value = serviceHandler.scenarioFieldValue(field)
 
     expect(value).toMatch(/foo\d+@bar\.com/)
@@ -132,7 +154,7 @@ describe('the scenario generator', () => {
   })
 
   test('scenarioFieldValue returns a true for BigInt types', () => {
-    const field = { type: 'BigInt' }
+    const field = makeField({ type: 'BigInt' })
     const value = serviceHandler.scenarioFieldValue(field)
 
     expect(value).toMatch(/^\d+n$/)
@@ -140,7 +162,7 @@ describe('the scenario generator', () => {
   })
 
   test('scenarioFieldValue returns a true for Boolean types', () => {
-    const field = { type: 'Boolean' }
+    const field = makeField({ type: 'Boolean' })
     const value = serviceHandler.scenarioFieldValue(field)
 
     expect(value).toEqual(true)
@@ -148,65 +170,63 @@ describe('the scenario generator', () => {
   })
 
   test('scenarioFieldValue returns a float for Decimal types', () => {
-    const field = { type: 'Decimal' }
+    const field = makeField({ type: 'Decimal' })
     const value = serviceHandler.scenarioFieldValue(field)
 
-    expect(value).toEqual(parseFloat(value))
+    expect(value).toEqual(parseFloat(String(value)))
     expect(typeof value).toBe('number')
   })
 
   test('scenarioFieldValue returns a float for Float types', () => {
-    const field = { type: 'Float' }
+    const field = makeField({ type: 'Float' })
     const value = serviceHandler.scenarioFieldValue(field)
 
-    expect(value).toEqual(parseFloat(value))
+    expect(value).toEqual(parseFloat(String(value)))
     expect(typeof value).toBe('number')
   })
 
   test('scenarioFieldValue returns a number for Int types', () => {
-    const field = { type: 'Int' }
+    const field = makeField({ type: 'Int' })
     const value = serviceHandler.scenarioFieldValue(field)
 
-    expect(value).toEqual(parseInt(value))
+    expect(value).toEqual(parseInt(String(value)))
     expect(typeof value).toBe('number')
   })
 
   test('scenarioFieldValue returns a valid Date for DateTime types', () => {
-    const field = { type: 'DateTime' }
+    const field = makeField({ type: 'DateTime' })
     const value = serviceHandler.scenarioFieldValue(field)
 
     expect(value instanceof Date).toBe(true)
-    expect(!isNaN(value)).toBe(true)
+    expect(!isNaN(Number(value))).toBe(true)
   })
 
   test('scenarioFieldValue returns JSON for Json types', () => {
-    const field = { type: 'Json' }
+    const field = makeField({ type: 'Json' })
 
     expect(serviceHandler.scenarioFieldValue(field)).toEqual({ foo: 'bar' })
   })
 
   test('scenarioFieldValue returns the first enum option for enum kinds', () => {
-    const field = {
+    const field = makeField({
       type: 'Color',
       kind: 'enum',
-      enumValues: [
-        { name: 'Red', dbValue: null },
-        { name: 'Blue', dbValue: null },
-      ],
-    }
+      // No dbName — function falls back to .name
+      enumValues: [{ name: 'Red' }, { name: 'Blue' }],
+    })
 
     expect(serviceHandler.scenarioFieldValue(field)).toEqual('Red')
   })
 
   test('scenarioFieldValue returns the dbName for enum types if present', () => {
-    const field = {
+    const field = makeField({
       type: 'Color',
       kind: 'enum',
       enumValues: [
         { name: 'Red', dbName: 'color-red' },
         { name: 'Blue', dbName: 'color-blue' },
       ],
-    }
+    })
 
     expect(serviceHandler.scenarioFieldValue(field)).toEqual('color-red')
   })
@@ -216,11 +236,19 @@ describe('the scenario generator', () => {
       {
         name: 'firstName',
         type: 'String',
+        kind: 'scalar',
+        isList: false,
+        isRequired: true,
+        isId: false,
         isUnique: false,
       },
       {
         name: 'lastName',
         type: 'String',
+        kind: 'scalar',
+        isList: false,
+        isRequired: true,
+        isId: false,
         isUnique: true,
       },
     ]

--- a/packages/cli/src/commands/setup/deploy/__tests__/netlify.test.ts
+++ b/packages/cli/src/commands/setup/deploy/__tests__/netlify.test.ts
@@ -9,7 +9,8 @@ vi.mock('node:fs', async () => {
 })
 
 vi.mock('@cedarjs/project-config', async (importOriginal) => {
-  const actual = await importOriginal()
+  const actual =
+    await importOriginal<typeof import('@cedarjs/project-config')>()
   return {
     ...actual,
     getConfigPath: vi.fn(() => '/cedar-app/cedar.toml'),
@@ -17,9 +18,9 @@ vi.mock('@cedarjs/project-config', async (importOriginal) => {
 })
 
 vi.mock('listr2', async (importOriginal) => {
-  const mod = await importOriginal()
+  const mod = await importOriginal<typeof import('listr2')>()
 
-  const Listr = vi.fn((tasks, options) => {
+  const Listr = vi.fn((tasks: unknown[], options: Record<string, unknown>) => {
     return new mod.Listr(tasks, { ...options, renderer: 'silent' })
   })
 
@@ -37,10 +38,11 @@ import '../../../../lib/test'
 
 import { getPaths } from '../../../../lib/index.js'
 import { updateApiURLTask } from '../helpers/index.js'
-import { handler } from '../providers/netlifyHandler'
+import { handler } from '../providers/netlifyHandler.js'
 
 vi.mock('../../../../lib', async (importOriginal) => {
-  const { printSetupNotes } = await importOriginal()
+  const { printSetupNotes } =
+    await importOriginal<typeof import('../../../../lib/index.js')>()
 
   return {
     printSetupNotes,
@@ -54,7 +56,7 @@ vi.mock('../../../../lib', async (importOriginal) => {
         port: 8910,
       },
     }),
-    writeFilesTask: (fileNameToContentMap) => {
+    writeFilesTask: (fileNameToContentMap: Record<string, string>) => {
       const keys = Object.keys(fileNameToContentMap)
       expect(keys.length).toBe(1)
       // Need to escape path.sep on Windows, otherwise the backslash (that
@@ -78,10 +80,8 @@ const mockConfigPath = '/cedar-app/cedar.toml'
 beforeEach(() => {
   process.env.CEDAR_CWD = '/cedar-app'
 
-  vi.mocked(getPaths).mockReturnValue({
-    base: '/cedar-app',
-    web: { base: '/cedar-app/web' },
-  })
+  // @ts-expect-error - providing a minimal stub; only base and web.base are used in these tests
+  vi.mocked(getPaths).mockReturnValue({ base: '/cedar-app', web: { base: '/cedar-app/web' } })
 
   vol.fromJSON({
     [mockConfigPath]: `[web]
@@ -102,19 +102,19 @@ beforeEach(() => {
 
 describe('netlify', () => {
   it('should call the handler without error', async () => {
-    let error = undefined
+    let error: unknown = undefined
     try {
-      await handler({ force: true })
+      await handler({ force: true, ud: false })
     } catch (err) {
       error = err
     }
     expect(error).toBeUndefined()
     const filesystem = vol.toJSON()
-    const netlifyTomlPath = Object.keys(filesystem).find((path) =>
-      path.endsWith('netlify.toml'),
+    const netlifyTomlPath = Object.keys(filesystem).find((p) =>
+      p.endsWith('netlify.toml'),
     )
     expect(netlifyTomlPath).toBeDefined()
-    expect(filesystem[netlifyTomlPath]).toMatchSnapshot()
+    expect(filesystem[netlifyTomlPath!]).toMatchSnapshot()
   })
 
   it('Should update cedar.toml apiUrl', () => {
@@ -126,15 +126,15 @@ describe('netlify', () => {
   })
 
   it('should add netlify.toml', async () => {
-    const netlify = await import('../providers/netlify')
-    await netlify.handler({ force: true })
+    const netlify = await import('../providers/netlify.js')
+    await netlify.handler({ force: true, ud: false })
 
     const filesystem = vol.toJSON()
-    const netlifyTomlPath = Object.keys(filesystem).find((path) =>
-      path.endsWith('netlify.toml'),
+    const netlifyTomlPath = Object.keys(filesystem).find((p) =>
+      p.endsWith('netlify.toml'),
     )
     expect(netlifyTomlPath).toBeDefined()
-    expect(filesystem[netlifyTomlPath]).toMatchSnapshot()
+    expect(filesystem[netlifyTomlPath!]).toMatchSnapshot()
   })
 })
 
@@ -183,8 +183,8 @@ describe('netlify with --ud', () => {
       p.endsWith('netlify.toml'),
     )
     expect(netlifyToml).toBeDefined()
-    expect(filesystem[netlifyToml]).toContain('api/dist/ud')
-    expect(filesystem[netlifyToml]).toContain('build --ud')
+    expect(filesystem[netlifyToml!]).toContain('api/dist/ud')
+    expect(filesystem[netlifyToml!]).toContain('build --ud')
 
     // Verify vite config has the Netlify plugin imports
     expect(filesystem['/cedar-app/web/vite.config.ts']).toMatchInlineSnapshot(`

--- a/packages/cli/src/commands/setup/package/__tests__/packageHandler.test.ts
+++ b/packages/cli/src/commands/setup/package/__tests__/packageHandler.test.ts
@@ -1,9 +1,9 @@
-vi.mock('@cedarjs/project-config', () => {
+vi.mock('@cedarjs/project-config', async () => {
+  const { join } = await import('path')
   return {
     getPaths: () => {
-      const path = require('path')
       return {
-        base: path.join('mocked', 'project'),
+        base: join('mocked', 'project'),
       }
     },
   }
@@ -24,7 +24,7 @@ vi.mock('@cedarjs/cli-helpers', () => {
         'important',
         'caution',
         'link',
-      ].map((k) => [k, (s) => s]),
+      ].map((k) => [k, (s: string) => s]),
     ),
     getCompatibilityData: vi.fn(() => {
       throw new Error('Mock Not Implemented')
@@ -33,9 +33,9 @@ vi.mock('@cedarjs/cli-helpers', () => {
 })
 vi.mock('node:fs')
 vi.mock('@cedarjs/cli-helpers/packageManager/exec', async () => {
-  const actual = await vi.importActual(
-    '@cedarjs/cli-helpers/packageManager/exec',
-  )
+  const actual = await vi.importActual<
+    typeof import('@cedarjs/cli-helpers/packageManager/exec')
+  >('@cedarjs/cli-helpers/packageManager/exec')
   return {
     ...actual,
     dlx: vi.fn(),
@@ -66,6 +66,11 @@ import { getCompatibilityData } from '@cedarjs/cli-helpers'
 import { dlx } from '@cedarjs/cli-helpers/packageManager/exec'
 
 import { handler } from '../packageHandler.js'
+
+// Helper: configure what enq.Select.run() returns for the next call.
+// @ts-expect-error - returning a minimal { run } mock instead of a full Enquirer Select instance
+const mockSelectRun = (value: string) =>
+  vi.mocked(enq.Select).mockImplementation(() => ({ run: vi.fn(() => value) }))
 
 describe('packageHandler', () => {
   beforeEach(() => {
@@ -125,15 +130,11 @@ describe('packageHandler', () => {
   })
 
   test('compatiblity check error prompts to continue', async () => {
-    getCompatibilityData.mockImplementation(() => {
+    vi.mocked(getCompatibilityData).mockImplementation(() => {
       throw new Error('No compatible version found')
     })
 
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'cancel'),
-      }
-    })
+    mockSelectRun('cancel')
     await handler({
       npmPackage: 'some-package',
       force: false,
@@ -142,11 +143,7 @@ describe('packageHandler', () => {
     expect(enq.Select).toHaveBeenCalledTimes(1)
     expect(dlx).not.toHaveBeenCalled()
 
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'continue'),
-      }
-    })
+    mockSelectRun('continue')
     await handler({
       npmPackage: 'some-package',
       force: false,
@@ -160,16 +157,10 @@ describe('packageHandler', () => {
   })
 
   test('default of latest is compatible', async () => {
-    getCompatibilityData.mockImplementation(() => {
+    vi.mocked(getCompatibilityData).mockImplementation(() => {
       return {
-        preferred: {
-          version: '1.0.0',
-          tag: 'latest',
-        },
-        compatible: {
-          version: '1.0.0',
-          tag: 'latest',
-        },
+        preferred: { version: '1.0.0', tag: 'latest' },
+        compatible: { version: '1.0.0', tag: 'latest' },
       }
     })
 
@@ -186,24 +177,14 @@ describe('packageHandler', () => {
   })
 
   test('default of latest is not compatible', async () => {
-    getCompatibilityData.mockImplementation(() => {
+    vi.mocked(getCompatibilityData).mockImplementation(() => {
       return {
-        preferred: {
-          version: '2.0.0',
-          tag: 'latest',
-        },
-        compatible: {
-          version: '1.0.0',
-          tag: undefined,
-        },
+        preferred: { version: '2.0.0', tag: 'latest' },
+        compatible: { version: '1.0.0', tag: undefined },
       }
     })
 
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'useLatestCompatibleVersion'),
-      }
-    })
+    mockSelectRun('useLatestCompatibleVersion')
     await handler({
       npmPackage: 'some-package',
       force: false,
@@ -220,11 +201,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'usePreferredVersion'),
-      }
-    })
+    mockSelectRun('usePreferredVersion')
     await handler({
       npmPackage: 'some-package',
       force: false,
@@ -241,11 +218,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'cancel'),
-      }
-    })
+    mockSelectRun('cancel')
     await handler({
       npmPackage: 'some-package',
       force: false,
@@ -261,16 +234,10 @@ describe('packageHandler', () => {
   })
 
   test('tag is compatible', async () => {
-    getCompatibilityData.mockImplementation(() => {
+    vi.mocked(getCompatibilityData).mockImplementation(() => {
       return {
-        preferred: {
-          version: '1.0.0',
-          tag: 'stable',
-        },
-        compatible: {
-          version: '1.0.0',
-          tag: 'stable',
-        },
+        preferred: { version: '1.0.0', tag: 'stable' },
+        compatible: { version: '1.0.0', tag: 'stable' },
       }
     })
 
@@ -288,24 +255,14 @@ describe('packageHandler', () => {
   })
 
   test('tag is not compatible', async () => {
-    getCompatibilityData.mockImplementation(() => {
+    vi.mocked(getCompatibilityData).mockImplementation(() => {
       return {
-        preferred: {
-          version: '2.0.0',
-          tag: 'stable',
-        },
-        compatible: {
-          version: '1.0.0',
-          tag: undefined,
-        },
+        preferred: { version: '2.0.0', tag: 'stable' },
+        compatible: { version: '1.0.0', tag: undefined },
       }
     })
 
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'useLatestCompatibleVersion'),
-      }
-    })
+    mockSelectRun('useLatestCompatibleVersion')
     await handler({
       npmPackage: 'some-package@stable',
       force: false,
@@ -322,11 +279,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'usePreferredVersion'),
-      }
-    })
+    mockSelectRun('usePreferredVersion')
     await handler({
       npmPackage: 'some-package@stable',
       force: false,
@@ -343,11 +296,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'cancel'),
-      }
-    })
+    mockSelectRun('cancel')
     await handler({
       npmPackage: 'some-package@stable',
       force: false,
@@ -363,16 +312,10 @@ describe('packageHandler', () => {
   })
 
   test('specific version is compatible', async () => {
-    getCompatibilityData.mockImplementation(() => {
+    vi.mocked(getCompatibilityData).mockImplementation(() => {
       return {
-        preferred: {
-          version: '1.0.0',
-          tag: 'latest',
-        },
-        compatible: {
-          version: '1.0.0',
-          tag: 'latest',
-        },
+        preferred: { version: '1.0.0', tag: 'latest' },
+        compatible: { version: '1.0.0', tag: 'latest' },
       }
     })
 
@@ -389,24 +332,14 @@ describe('packageHandler', () => {
   })
 
   test('specific version is not compatible', async () => {
-    getCompatibilityData.mockImplementation(() => {
+    vi.mocked(getCompatibilityData).mockImplementation(() => {
       return {
-        preferred: {
-          version: '2.0.0',
-          tag: 'latest',
-        },
-        compatible: {
-          version: '1.0.0',
-          tag: undefined,
-        },
+        preferred: { version: '2.0.0', tag: 'latest' },
+        compatible: { version: '1.0.0', tag: undefined },
       }
     })
 
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'useLatestCompatibleVersion'),
-      }
-    })
+    mockSelectRun('useLatestCompatibleVersion')
     await handler({
       npmPackage: 'some-package@1.0.0',
       force: false,
@@ -423,11 +356,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'usePreferredVersion'),
-      }
-    })
+    mockSelectRun('usePreferredVersion')
     await handler({
       npmPackage: 'some-package@1.0.0',
       force: false,
@@ -444,11 +373,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'cancel'),
-      }
-    })
+    mockSelectRun('cancel')
     await handler({
       npmPackage: 'some-package@1.0.0',
       force: false,
@@ -464,16 +389,10 @@ describe('packageHandler', () => {
   })
 
   test('specific version is experimental', async () => {
-    getCompatibilityData.mockImplementation(() => {
+    vi.mocked(getCompatibilityData).mockImplementation(() => {
       return {
-        preferred: {
-          version: '0.0.1',
-          tag: 'latest',
-        },
-        compatible: {
-          version: '0.0.1',
-          tag: 'latest',
-        },
+        preferred: { version: '0.0.1', tag: 'latest' },
+        compatible: { version: '0.0.1', tag: 'latest' },
       }
     })
 
@@ -488,11 +407,7 @@ describe('packageHandler', () => {
     )
 
     // No force should prompt
-    enq.Select.mockImplementation(() => {
-      return {
-        run: vi.fn(() => 'useLatestCompatibleVersion'),
-      }
-    })
+    mockSelectRun('useLatestCompatibleVersion')
     await handler({
       npmPackage: 'some-package@0.0.1',
       force: false,

--- a/packages/cli/src/commands/setup/realtime/__tests__/addRealtimeToGraphql.test.ts
+++ b/packages/cli/src/commands/setup/realtime/__tests__/addRealtimeToGraphql.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-let functionsDir = null
+let functionsDir: string | null = null
 
 const fixtures = vi.hoisted(() => [
   'aliased-import',
@@ -16,29 +16,29 @@ const fixtures = vi.hoisted(() => [
 ])
 
 vi.mock('node:fs', async (importOriginal) => {
-  const originalFs = await importOriginal()
-  const path = await import('node:path')
+  const originalFs = await importOriginal<typeof import('node:fs')>()
+  const pathModule = await import('node:path')
 
-  const inMemoryFiles = {}
+  const inMemoryFiles: Record<string, string> = {}
 
   for (const fixture of fixtures) {
-    const fixturePath = path.join(import.meta.dirname, fixture, 'graphql.js')
+    const fixturePath = pathModule.join(
+      import.meta.dirname,
+      fixture,
+      'graphql.js',
+    )
     const source = originalFs.readFileSync(fixturePath, 'utf8')
     inMemoryFiles[fixturePath] = source
   }
 
   const mockFs = {
-    existsSync: vi.fn((path) => {
-      return !!inMemoryFiles[path]
+    existsSync: vi.fn((p: string) => {
+      return !!inMemoryFiles[p]
     }),
-    readFileSync: (p) => {
-      const inMemoryFile = inMemoryFiles[p]
-
-      if (inMemoryFile) {
-        return inMemoryFile
-      }
+    readFileSync: (p: string) => {
+      return inMemoryFiles[p]
     },
-    writeFileSync: vi.fn((p, content) => {
+    writeFileSync: vi.fn((p: string, content: string) => {
       inMemoryFiles[p] = content
     }),
   }
@@ -70,7 +70,7 @@ vi.mock('@cedarjs/cli-helpers', () => {
         'important',
         'caution',
         'link',
-      ].map((k) => [k, (s) => s]),
+      ].map((k) => [k, (s: string) => s]),
     ),
     isTypeScriptProject: () => {
       return false
@@ -94,10 +94,10 @@ describe('addRealtimeToGraphqlHandler (filesystem)', () => {
     functionsDir = path.join(import.meta.dirname, 'default-graphql-function')
     const graphqlPath = path.join(functionsDir, 'graphql.js')
 
-    const ctx = {}
+    const ctx: { realtimeHandlerSkipped?: boolean } = {}
     const task = { skip: vi.fn() }
 
-    addRealtimeToGraphqlHandler(ctx, task)
+    addRealtimeToGraphqlHandler(ctx, task, false)
 
     const modified = fs.readFileSync(graphqlPath, 'utf8')
 
@@ -108,7 +108,7 @@ describe('addRealtimeToGraphqlHandler (filesystem)', () => {
     expect(task.skip).not.toHaveBeenCalled()
 
     // Running again should be idempotent and cause a skip
-    addRealtimeToGraphqlHandler(ctx, task)
+    addRealtimeToGraphqlHandler(ctx, task, false)
     expect(ctx.realtimeHandlerSkipped).toBe(true)
     expect(task.skip).toHaveBeenCalledWith('Realtime import already exists')
   })
@@ -121,10 +121,10 @@ describe('addRealtimeToGraphqlHandler (filesystem)', () => {
     it(`skips for fixture "${fixture}" (handler not found)`, () => {
       functionsDir = path.join(import.meta.dirname, fixture)
 
-      const ctx = {}
+      const ctx: { realtimeHandlerSkipped?: boolean } = {}
       const task = { skip: vi.fn() }
 
-      addRealtimeToGraphqlHandler(ctx, task)
+      addRealtimeToGraphqlHandler(ctx, task, false)
 
       expect(ctx.realtimeHandlerSkipped).toBe(true)
       expect(task.skip).toHaveBeenCalledWith(
@@ -137,10 +137,10 @@ describe('addRealtimeToGraphqlHandler (filesystem)', () => {
   it('skips when GraphQL handler file is missing', () => {
     functionsDir = path.join(import.meta.dirname, 'does-not-exist')
 
-    const ctx = {}
+    const ctx: { realtimeHandlerSkipped?: boolean } = {}
     const task = { skip: vi.fn() }
 
-    addRealtimeToGraphqlHandler(ctx, task)
+    addRealtimeToGraphqlHandler(ctx, task, false)
 
     expect(ctx.realtimeHandlerSkipped).toBe(true)
     expect(task.skip).toHaveBeenCalledWith('GraphQL handler not found')

--- a/packages/cli/src/lib/__tests__/index.test.ts
+++ b/packages/cli/src/lib/__tests__/index.test.ts
@@ -1,11 +1,15 @@
-global.__dirname = __dirname
+globalThis.__dirname = __dirname
+
+import type * as ProjectConfig from '@cedarjs/project-config'
+
 vi.mock('@cedarjs/project-config', async (importOriginal) => {
-  const originalProjectConfig = await importOriginal()
-  const path = require('path')
+  const originalProjectConfig =
+    await importOriginal<typeof ProjectConfig>()
+  const { join } = await import('node:path')
   return {
     ...originalProjectConfig,
     getPaths: () => {
-      const BASE_PATH = path.join(globalThis.__dirname, 'fixtures')
+      const BASE_PATH = join(globalThis.__dirname, 'fixtures')
       return {
         base: BASE_PATH,
         api: {

--- a/packages/cli/src/lib/__tests__/rollback.test.ts
+++ b/packages/cli/src/lib/__tests__/rollback.test.ts
@@ -9,6 +9,13 @@ import { vi, it, expect, beforeEach } from 'vitest'
 
 import * as rollback from '../rollback.js'
 
+// executeRollback is typed as a ListrTaskFn that requires (ctx, task) arguments,
+// but in these unit tests we exercise the rollback logic directly without a
+// Listr2 context. Wrapping with a no-arg helper avoids repeating the suppression
+// on every call.
+// @ts-expect-error - executeRollback is a ListrTaskFn; calling without ctx/task is safe here
+const runRollback: () => Promise<void> = rollback.executeRollback
+
 beforeEach(() => {
   vol.reset()
 })
@@ -22,7 +29,7 @@ it('resets file contents', async () => {
 
   fs.writeFileSync('fake-file-1', 'fake-content-changed')
 
-  await rollback.executeRollback()
+  await runRollback()
   expect(fs.readFileSync('fake-file-1', 'utf-8')).toBe('fake-content-1')
   expect(fs.readFileSync('fake-file-2', 'utf-8')).toBe('fake-content-2')
 })
@@ -36,7 +43,7 @@ it('removes new files', async () => {
 
   fs.writeFileSync('fake-file-2', 'fake-content-new')
 
-  await rollback.executeRollback()
+  await runRollback()
   expect(fs.readFileSync('fake-file-1', 'utf-8')).toBe('fake-content-1')
   expect(fs.existsSync('fake-file-2')).toBe(false)
 })
@@ -53,7 +60,7 @@ it('removes empty folders after removing files', async () => {
     'fake-content',
   )
 
-  await rollback.executeRollback()
+  await runRollback()
   expect(
     fs.existsSync(path.join('fake_dir', 'mock_dir', 'test_dir', 'fake-file')),
   ).toBe(false)
@@ -65,7 +72,7 @@ it('executes sync functions', async () => {
   rollback.addFunctionToRollback(() => {
     fs.writeFileSync('/fake-file', 'fake-content')
   })
-  await rollback.executeRollback()
+  await runRollback()
   expect(fs.readFileSync('/fake-file', 'utf-8')).toBe('fake-content')
 })
 
@@ -73,12 +80,12 @@ it('executes async functions', async () => {
   vol.fromJSON({})
   rollback.addFunctionToRollback(async () => {
     // make up some async process
-    await new Promise((resolve, _) => {
+    await new Promise<void>((resolve) => {
       fs.writeFileSync('/fake-file', 'fake-content')
       resolve()
     })
   })
-  await rollback.executeRollback()
+  await runRollback()
   expect(fs.readFileSync('/fake-file', 'utf-8')).toBe('fake-content')
 })
 
@@ -96,7 +103,7 @@ it('executes rollback in order', async () => {
   rollback.addFunctionToRollback(() => {
     fs.writeFileSync('fake-file', '3')
   })
-  await rollback.executeRollback()
+  await runRollback()
   expect(fs.readFileSync('fake-file', 'utf-8')).toBe('1')
 
   // handles the atEnd flag
@@ -112,7 +119,7 @@ it('executes rollback in order', async () => {
   rollback.addFunctionToRollback(() => {
     fs.writeFileSync('fake-file', '3')
   })
-  await rollback.executeRollback()
+  await runRollback()
   expect(fs.readFileSync('fake-file', 'utf-8')).toBe('2')
 
   // using files rather than functions
@@ -125,7 +132,7 @@ it('executes rollback in order', async () => {
   fs.writeFileSync('fake-file', '2')
   rollback.addFileToRollback('fake-file')
   fs.writeFileSync('fake-file', '3')
-  await rollback.executeRollback()
+  await runRollback()
   expect(fs.readFileSync('fake-file', 'utf-8')).toBe('0')
 
   // using files rather than functions and the atEnd flag
@@ -138,7 +145,7 @@ it('executes rollback in order', async () => {
   fs.writeFileSync('fake-file', '2')
   rollback.addFileToRollback('fake-file', true)
   fs.writeFileSync('fake-file', '3')
-  await rollback.executeRollback()
+  await runRollback()
   expect(fs.readFileSync('fake-file', 'utf-8')).toBe('2')
 })
 
@@ -148,7 +155,7 @@ it('reset clears the stack', async () => {
     fs.writeFileSync('fake-file', 'fake-content')
   })
   rollback.resetRollback()
-  await rollback.executeRollback()
+  await runRollback()
   expect(fs.existsSync('fake-file')).toBe(false)
 })
 
@@ -157,8 +164,9 @@ it('prepare clears the stack', async () => {
   rollback.addFunctionToRollback(() => {
     fs.writeFileSync('fake-file', 'fake-content')
   })
+  // @ts-expect-error - empty object tests the resetRollback() path; tasks.tasks is optional-chained so no Listr instance is needed
   rollback.prepareForRollback({})
-  await rollback.executeRollback()
+  await runRollback()
   expect(fs.existsSync('fake-file')).toBe(false)
 })
 


### PR DESCRIPTION
## Summary

Continues the JS→TS migration in `packages/cli/src`, converting 10 test files:

- `commands/deploy/__tests__/nftPack.test`
- `commands/generate/service/__tests__/scenario.test`
- `commands/setup/realtime/__tests__/addRealtimeToGraphql.test`
- `lib/__tests__/index.test`
- `lib/__tests__/rollback.test`
- `commands/generate/ogImage/__tests__/ogImage.test`
- `commands/setup/deploy/__tests__/netlify.test`
- `commands/setup/package/__tests__/packageHandler.test`
- `commands/generate/dbAuth/__tests__/dbAuth.postInstallMessage.test`
- `commands/generate/dbAuth/__tests__/dbAuth.mockListr.test`

## Changes

### Type safety patterns used throughout:
- `globalThis.__dirname` instead of `global.__dirname`
- `vi.importActual<typeof import('...')>()` for typed actual module imports
- Async `vi.mock()` factories using `await import()` instead of `require()` (required for `"module": "node20"`)
- `@ts-expect-error` with explanation comments instead of `as` casts
- Proper `ListrTaskFn` callback signatures with `(ctx, task)` args

### File-specific highlights:

**nftPack.test.ts** — Type guards for `.find()` results; `mockResolvedValue(undefined)` for `Promise<void>` return type

**scenario.test.ts** — `makeField()` helper that provides all required `PrismaField` properties with safe defaults; removed `dbValue: null` (not in `PrismaField` type)

**addRealtimeToGraphql.test.ts** — Added required `force: boolean` third argument; typed `ctx` as `{ realtimeHandlerSkipped?: boolean }`

**rollback.test.ts** — `runRollback` wrapper with single `@ts-expect-error` for `ListrTaskFn` calling convention

**packageHandler.test.ts** — `mockSelectRun` helper with single `@ts-expect-error` for partial Enquirer Select mock

**dbAuth.mockListr.test.ts** — `mockFiles: Record<string, string>`; added `.js` extension to `Listr2Mock.js` import (TS→TS import)

## Test plan

- [ ] `yarn vitest packages/cli/src/commands/deploy/__tests__/nftPack.test.ts`
- [ ] `yarn vitest packages/cli/src/commands/generate/service/__tests__/scenario.test.ts`
- [ ] `yarn vitest packages/cli/src/commands/setup/realtime/__tests__/addRealtimeToGraphql.test.ts`
- [ ] `yarn vitest packages/cli/src/lib/__tests__/index.test.ts`
- [ ] `yarn vitest packages/cli/src/lib/__tests__/rollback.test.ts`
- [ ] `yarn vitest packages/cli/src/commands/generate/ogImage/__tests__/ogImage.test.ts`
- [ ] `yarn vitest packages/cli/src/commands/setup/deploy/__tests__/netlify.test.ts`
- [ ] `yarn vitest packages/cli/src/commands/setup/package/__tests__/packageHandler.test.ts`
- [ ] `yarn vitest packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.postInstallMessage.test.ts`
- [ ] `yarn vitest packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.mockListr.test.ts`
- [ ] `yarn tsc --noEmit` in `packages/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)