### PR TITLE
chore(knip): ignore framework-specific entries

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -14,6 +14,29 @@
     "packages/create-cedar-app/templates/**"
   ],
   "exclude": ["files", "exports", "types", "enumMembers", "duplicates"],
+  "ignoreBinaries": [
+    "attw",
+    "build",
+    "cedar",
+    "code",
+    "create-cedar-app",
+    "cygpath",
+    "init",
+    "install",
+    "k6",
+    "powershell",
+    "redwood",
+    "run",
+    "rw",
+    "rw-fwtools-attw",
+    "serve"
+  ],
+  "ignoreUnresolved": [
+    "/@react-refresh",
+    "jest-environment-jsdom",
+    "jest.setup.ts",
+    "~__CEDAR__USER_ROUTES_FOR_MOCK"
+  ],
   "ignoreExportsUsedInFile": {
     "interface": true,
     "type": true

--- a/knip.json
+++ b/knip.json
@@ -15,28 +15,16 @@
   ],
   "exclude": ["files", "exports", "types", "enumMembers", "duplicates"],
   "ignoreBinaries": [
-    "attw",
-    "build",
     "cedar",
     "code",
     "create-cedar-app",
     "cygpath",
-    "init",
-    "install",
     "k6",
     "powershell",
     "redwood",
-    "run",
-    "rw",
-    "rw-fwtools-attw",
-    "serve"
+    "rw"
   ],
-  "ignoreUnresolved": [
-    "/@react-refresh",
-    "jest-environment-jsdom",
-    "jest.setup.ts",
-    "~__CEDAR__USER_ROUTES_FOR_MOCK"
-  ],
+  "ignoreUnresolved": ["/@react-refresh", "~__CEDAR__USER_ROUTES_FOR_MOCK"],
   "ignoreExportsUsedInFile": {
     "interface": true,
     "type": true


### PR DESCRIPTION
Adds Knip ignores for Cedar-specific binaries and virtual imports that cannot be resolved statically.

This keeps the initial Knip output focused on dependency findings instead of known framework/tooling entry points.

my approach:

- [x] Setup PR: add Knip config and dependency.
- [x] Tuning PR: reduce obvious framework false positives.
- [ ] Cleanup PRs: remove or fix real findings in small groups.