### PR TITLE
chore(babel): replace babel-plugin-remove-dev-fatal-error-page

### DIFF
--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -126,7 +126,8 @@ export const getWebSideBabelPlugins = (
       'rwjs-web-auto-import',
     ],
     ['babel-plugin-graphql-tag', undefined, 'rwjs-babel-graphql-tag'],
-    process.env.NODE_ENV !== 'development' && [
+    // Vite uses vite-plugin-cedar-remove-dev-fatal-error-page instead
+    !forVite && process.env.NODE_ENV !== 'development' && [
       require('./plugins/babel-plugin-redwood-remove-dev-fatal-error-page')
         .default,
       undefined,

--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -127,12 +127,13 @@ export const getWebSideBabelPlugins = (
     ],
     ['babel-plugin-graphql-tag', undefined, 'rwjs-babel-graphql-tag'],
     // Vite uses vite-plugin-cedar-remove-dev-fatal-error-page instead
-    !forVite && process.env.NODE_ENV !== 'development' && [
-      require('./plugins/babel-plugin-redwood-remove-dev-fatal-error-page')
-        .default,
-      undefined,
-      'rwjs-remove-dev-fatal-error-page',
-    ],
+    !forVite &&
+      process.env.NODE_ENV !== 'development' && [
+        require('./plugins/babel-plugin-redwood-remove-dev-fatal-error-page')
+          .default,
+        undefined,
+        'rwjs-remove-dev-fatal-error-page',
+      ],
   ].filter(Boolean) as TransformOptions[]
 
   return plugins

--- a/packages/prerender/src/build-and-import/buildAndImport.ts
+++ b/packages/prerender/src/build-and-import/buildAndImport.ts
@@ -20,6 +20,7 @@ import { cellTransformPlugin } from './rollupPlugins/rollup-plugin-cedarjs-cell.
 import { cedarjsDirectoryNamedImportPlugin } from './rollupPlugins/rollup-plugin-cedarjs-directory-named-imports.js'
 import { externalPlugin } from './rollupPlugins/rollup-plugin-cedarjs-external.js'
 import { ignoreHtmlAndCssImportsPlugin } from './rollupPlugins/rollup-plugin-cedarjs-ignore-html-and-css-imports.js'
+import { cedarRemoveDevFatalErrorPagePlugin } from './rollupPlugins/rollup-plugin-cedar-remove-dev-fatal-error-page.js'
 import { injectFileGlobalsPlugin } from './rollupPlugins/rollup-plugin-cedarjs-inject-file-globals.js'
 import { cedarjsPrerenderMediaImportsPlugin } from './rollupPlugins/rollup-plugin-cedarjs-prerender-media-imports.js'
 import { cedarjsRoutesAutoLoaderPlugin } from './rollupPlugins/rollup-plugin-cedarjs-routes-auto-loader.js'
@@ -128,6 +129,7 @@ export async function buildAndImport(
           }
         },
       },
+      cedarRemoveDevFatalErrorPagePlugin(),
       ignoreHtmlAndCssImportsPlugin(),
       cellTransformPlugin(),
       cedarjsRoutesAutoLoaderPlugin(),

--- a/packages/prerender/src/build-and-import/buildAndImport.ts
+++ b/packages/prerender/src/build-and-import/buildAndImport.ts
@@ -16,11 +16,11 @@ import {
   parseTypeScriptConfigFiles,
 } from '../internal.js'
 
+import { cedarRemoveDevFatalErrorPagePlugin } from './rollupPlugins/rollup-plugin-cedar-remove-dev-fatal-error-page.js'
 import { cellTransformPlugin } from './rollupPlugins/rollup-plugin-cedarjs-cell.js'
 import { cedarjsDirectoryNamedImportPlugin } from './rollupPlugins/rollup-plugin-cedarjs-directory-named-imports.js'
 import { externalPlugin } from './rollupPlugins/rollup-plugin-cedarjs-external.js'
 import { ignoreHtmlAndCssImportsPlugin } from './rollupPlugins/rollup-plugin-cedarjs-ignore-html-and-css-imports.js'
-import { cedarRemoveDevFatalErrorPagePlugin } from './rollupPlugins/rollup-plugin-cedar-remove-dev-fatal-error-page.js'
 import { injectFileGlobalsPlugin } from './rollupPlugins/rollup-plugin-cedarjs-inject-file-globals.js'
 import { cedarjsPrerenderMediaImportsPlugin } from './rollupPlugins/rollup-plugin-cedarjs-prerender-media-imports.js'
 import { cedarjsRoutesAutoLoaderPlugin } from './rollupPlugins/rollup-plugin-cedarjs-routes-auto-loader.js'

--- a/packages/prerender/src/build-and-import/rollupPlugins/rollup-plugin-cedar-remove-dev-fatal-error-page.ts
+++ b/packages/prerender/src/build-and-import/rollupPlugins/rollup-plugin-cedar-remove-dev-fatal-error-page.ts
@@ -3,8 +3,13 @@ import type { Plugin as RollupPlugin } from 'rollup'
 const DEV_FATAL_ERROR_PAGE_MODULE =
   '@cedarjs/web/dist/components/DevFatalErrorPage'
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const ESCAPED_MODULE = escapeRegExp(DEV_FATAL_ERROR_PAGE_MODULE)
 const IMPORT_PATTERN = new RegExp(
-  `import\\s*\\{[^}]*\\bDevFatalErrorPage\\b[^}]*\\}\\s*from\\s*['"]${DEV_FATAL_ERROR_PAGE_MODULE.replace(/\//g, '\\/')}['"]`,
+  `import\\s*\\{[^}]*\\bDevFatalErrorPage\\b[^}]*\\}\\s*from\\s*['"]${ESCAPED_MODULE}['"]`,
 )
 
 /**
@@ -30,6 +35,11 @@ export const cedarRemoveDevFatalErrorPagePlugin = (): RollupPlugin => {
         IMPORT_PATTERN,
         'const DevFatalErrorPage = undefined',
       )
+
+      // Only return a result if the code actually changed
+      if (newCode === code) {
+        return null
+      }
 
       return { code: newCode, map: null }
     },

--- a/packages/prerender/src/build-and-import/rollupPlugins/rollup-plugin-cedar-remove-dev-fatal-error-page.ts
+++ b/packages/prerender/src/build-and-import/rollupPlugins/rollup-plugin-cedar-remove-dev-fatal-error-page.ts
@@ -1,0 +1,37 @@
+import type { Plugin as RollupPlugin } from 'rollup'
+
+const DEV_FATAL_ERROR_PAGE_MODULE =
+  '@cedarjs/web/dist/components/DevFatalErrorPage'
+
+const IMPORT_PATTERN = new RegExp(
+  `import\\s*\\{[^}]*\\bDevFatalErrorPage\\b[^}]*\\}\\s*from\\s*['"]${DEV_FATAL_ERROR_PAGE_MODULE.replace(/\//g, '\\/')}['"]`,
+)
+
+/**
+ * Rollup plugin to remove the DevFatalErrorPage import during prerendering.
+ *
+ * Replaces:
+ *   import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
+ * with:
+ *   const DevFatalErrorPage = undefined
+ *
+ * Prerendering runs in a production context and should not include the
+ * dev-only error page component in the bundle.
+ */
+export const cedarRemoveDevFatalErrorPagePlugin = (): RollupPlugin => {
+  return {
+    name: 'cedar-remove-dev-fatal-error-page',
+    transform(code) {
+      if (!code.includes(DEV_FATAL_ERROR_PAGE_MODULE)) {
+        return null
+      }
+
+      const newCode = code.replace(
+        IMPORT_PATTERN,
+        'const DevFatalErrorPage = undefined',
+      )
+
+      return { code: newCode, map: null }
+    },
+  }
+}

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -13,6 +13,7 @@ import { cedarCellTransform } from './plugins/vite-plugin-cedar-cell.js'
 import { cedarEntryInjectionPlugin } from './plugins/vite-plugin-cedar-entry-injection.js'
 import { cedarHtmlEnvPlugin } from './plugins/vite-plugin-cedar-html-env.js'
 import { cedarNodePolyfills } from './plugins/vite-plugin-cedar-node-polyfills.js'
+import { cedarRemoveDevFatalErrorPage } from './plugins/vite-plugin-cedar-remove-dev-fatal-error-page.js'
 import { cedarRemoveFromBundle } from './plugins/vite-plugin-cedar-remove-from-bundle.js'
 import { cedarWaitForApiServer } from './plugins/vite-plugin-cedar-wait-for-api-server.js'
 import { cedarjsResolveCedarStyleImportsPlugin } from './plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.js'
@@ -27,6 +28,7 @@ export { cedarEntryInjectionPlugin } from './plugins/vite-plugin-cedar-entry-inj
 export { cedarHtmlEnvPlugin } from './plugins/vite-plugin-cedar-html-env.js'
 export { cedarImportDirPlugin } from './plugins/vite-plugin-cedar-import-dir.js'
 export { cedarNodePolyfills } from './plugins/vite-plugin-cedar-node-polyfills.js'
+export { cedarRemoveDevFatalErrorPage } from './plugins/vite-plugin-cedar-remove-dev-fatal-error-page.js'
 export { cedarRemoveFromBundle } from './plugins/vite-plugin-cedar-remove-from-bundle.js'
 export { cedarjsResolveCedarStyleImportsPlugin } from './plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.js'
 export { cedarjsJobPathInjectorPlugin } from './plugins/vite-plugin-cedarjs-job-path-injector.js'
@@ -82,6 +84,7 @@ export function cedar({ mode }: PluginOptions = {}): PluginOption[] {
     cedarCellTransform(),
     cedarTransformJsAsJsx(),
     cedarRemoveFromBundle(),
+    cedarRemoveDevFatalErrorPage(),
     react({ babel: babelConfig }),
   ]
 }

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
@@ -1,9 +1,22 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import type { ResolvedConfig } from 'vite'
 
 import { cedarRemoveDevFatalErrorPage } from '../vite-plugin-cedar-remove-dev-fatal-error-page.js'
 
-function transform(code: string) {
+function transform(code: string, mode: string = 'production') {
   const plugin = cedarRemoveDevFatalErrorPage()
+
+  if (typeof plugin.configResolved !== 'function') {
+    throw new Error('Expected plugin to have configResolved hook')
+  }
+
+  // Mock ResolvedConfig with minimal required fields
+  const config = {
+    command: 'build',
+    mode,
+  } as ResolvedConfig
+
+  plugin.configResolved(config)
 
   if (typeof plugin.transform !== 'function') {
     throw new Error('Expected plugin to have a transform function')
@@ -62,14 +75,12 @@ export default () => <div>Hello</div>`
     expect(result.code).toBe('const DevFatalErrorPage = undefined')
   })
 
-  it('returns null when NODE_ENV is development', () => {
-    process.env.NODE_ENV = 'development'
-
+  it('returns null when mode is development', () => {
     const code = `import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
 
 export default DevFatalErrorPage || (() => <div>Error</div>)`
 
-    const result = transform(code)
+    const result = transform(code, 'development')
 
     expect(result).toBeNull()
   })

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 
 import { cedarRemoveDevFatalErrorPage } from '../vite-plugin-cedar-remove-dev-fatal-error-page.js'
 
@@ -19,6 +19,9 @@ function transform(code: string) {
 }
 
 describe('cedarRemoveDevFatalErrorPage', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'production'
+  })
   it('replaces the DevFatalErrorPage import with undefined', () => {
     const code = `import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
 
@@ -57,5 +60,17 @@ export default () => <div>Hello</div>`
     const result = transform(code) as { code: string }
 
     expect(result.code).toBe('const DevFatalErrorPage = undefined')
+  })
+
+  it('returns null when NODE_ENV is development', () => {
+    process.env.NODE_ENV = 'development'
+
+    const code = `import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
+
+export default DevFatalErrorPage || (() => <div>Error</div>)`
+
+    const result = transform(code)
+
+    expect(result).toBeNull()
   })
 })

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+
+import { cedarRemoveDevFatalErrorPage } from '../vite-plugin-cedar-remove-dev-fatal-error-page.js'
+
+function transform(code: string) {
+  const plugin = cedarRemoveDevFatalErrorPage()
+
+  if (typeof plugin.transform !== 'function') {
+    throw new Error('Expected plugin to have a transform function')
+  }
+
+  // Cast to bypass the overloaded signature — we only care about the string return
+  const result = (plugin.transform as (code: string, id: string) => unknown)(
+    code,
+    'FatalErrorPage.tsx',
+  )
+
+  return result
+}
+
+describe('cedarRemoveDevFatalErrorPage', () => {
+  it('replaces the DevFatalErrorPage import with undefined', () => {
+    const code = `import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
+
+export default DevFatalErrorPage || (() => <div>Error</div>)`
+
+    const result = transform(code)
+
+    expect(result).toEqual({
+      code: `const DevFatalErrorPage = undefined
+
+export default DevFatalErrorPage || (() => <div>Error</div>)`,
+    })
+  })
+
+  it('returns null when the import is not present', () => {
+    const code = `import React from 'react'
+
+export default () => <div>Hello</div>`
+
+    const result = transform(code)
+
+    expect(result).toBeNull()
+  })
+
+  it('handles extra whitespace in the import braces', () => {
+    const code = `import {  DevFatalErrorPage  } from '@cedarjs/web/dist/components/DevFatalErrorPage'`
+
+    const result = transform(code) as { code: string }
+
+    expect(result.code).toBe('const DevFatalErrorPage = undefined')
+  })
+
+  it('handles double quotes in the import', () => {
+    const code = `import { DevFatalErrorPage } from "@cedarjs/web/dist/components/DevFatalErrorPage"`
+
+    const result = transform(code) as { code: string }
+
+    expect(result.code).toBe('const DevFatalErrorPage = undefined')
+  })
+})

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
@@ -46,6 +46,7 @@ export default DevFatalErrorPage || (() => <div>Error</div>)`
       code: `const DevFatalErrorPage = undefined
 
 export default DevFatalErrorPage || (() => <div>Error</div>)`,
+      map: null,
     })
   })
 
@@ -62,17 +63,23 @@ export default () => <div>Hello</div>`
   it('handles extra whitespace in the import braces', () => {
     const code = `import {  DevFatalErrorPage  } from '@cedarjs/web/dist/components/DevFatalErrorPage'`
 
-    const result = transform(code) as { code: string }
+    const result = transform(code) as { code: string; map: null }
 
-    expect(result.code).toBe('const DevFatalErrorPage = undefined')
+    expect(result).toEqual({
+      code: 'const DevFatalErrorPage = undefined',
+      map: null,
+    })
   })
 
   it('handles double quotes in the import', () => {
     const code = `import { DevFatalErrorPage } from "@cedarjs/web/dist/components/DevFatalErrorPage"`
 
-    const result = transform(code) as { code: string }
+    const result = transform(code) as { code: string; map: null }
 
-    expect(result.code).toBe('const DevFatalErrorPage = undefined')
+    expect(result).toEqual({
+      code: 'const DevFatalErrorPage = undefined',
+      map: null,
+    })
   })
 
   it('returns null when mode is development', () => {

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach } from 'vitest'
 import type { ResolvedConfig } from 'vite'
+import { describe, it, expect, beforeEach } from 'vitest'
 
 import { cedarRemoveDevFatalErrorPage } from '../vite-plugin-cedar-remove-dev-fatal-error-page.js'
 
-function transform(code: string, mode: string = 'production') {
+function transform(code: string, mode = 'production') {
   const plugin = cedarRemoveDevFatalErrorPage()
 
   if (typeof plugin.configResolved !== 'function') {

--- a/packages/vite/src/plugins/vite-plugin-cedar-remove-dev-fatal-error-page.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-remove-dev-fatal-error-page.ts
@@ -3,8 +3,13 @@ import type { Plugin } from 'vite'
 const DEV_FATAL_ERROR_PAGE_MODULE =
   '@cedarjs/web/dist/components/DevFatalErrorPage'
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const ESCAPED_MODULE = escapeRegExp(DEV_FATAL_ERROR_PAGE_MODULE)
 const IMPORT_PATTERN = new RegExp(
-  `import\\s*\\{[^}]*\\bDevFatalErrorPage\\b[^}]*\\}\\s*from\\s*['"]${DEV_FATAL_ERROR_PAGE_MODULE.replace(/\//g, '\\/')}['"]`,
+  `import\\s*\\{[^}]*\\bDevFatalErrorPage\\b[^}]*\\}\\s*from\\s*['"]${ESCAPED_MODULE}['"]`,
 )
 
 /**
@@ -24,6 +29,11 @@ export function cedarRemoveDevFatalErrorPage(): Plugin {
     name: 'cedar-remove-dev-fatal-error-page',
     apply: 'build',
     transform(code) {
+      // Skip transformation if not in production
+      if (process.env.NODE_ENV === 'development') {
+        return null
+      }
+
       if (!code.includes(DEV_FATAL_ERROR_PAGE_MODULE)) {
         return null
       }
@@ -32,6 +42,11 @@ export function cedarRemoveDevFatalErrorPage(): Plugin {
         IMPORT_PATTERN,
         'const DevFatalErrorPage = undefined',
       )
+
+      // Only return a result if the code actually changed
+      if (newCode === code) {
+        return null
+      }
 
       return { code: newCode }
     },

--- a/packages/vite/src/plugins/vite-plugin-cedar-remove-dev-fatal-error-page.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-remove-dev-fatal-error-page.ts
@@ -1,0 +1,39 @@
+import type { Plugin } from 'vite'
+
+const DEV_FATAL_ERROR_PAGE_MODULE =
+  '@cedarjs/web/dist/components/DevFatalErrorPage'
+
+const IMPORT_PATTERN = new RegExp(
+  `import\\s*\\{[^}]*\\bDevFatalErrorPage\\b[^}]*\\}\\s*from\\s*['"]${DEV_FATAL_ERROR_PAGE_MODULE.replace(/\//g, '\\/')}['"]`,
+)
+
+/**
+ * Vite plugin to remove the DevFatalErrorPage import in production builds.
+ *
+ * Replaces:
+ *   import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
+ * with:
+ *   const DevFatalErrorPage = undefined
+ *
+ * This ensures the DevFatalErrorPage component is not shipped in the
+ * production bundle. In development, the import is kept so the page
+ * renders when an unhandled error bubbles to the top of the app.
+ */
+export function cedarRemoveDevFatalErrorPage(): Plugin {
+  return {
+    name: 'cedar-remove-dev-fatal-error-page',
+    apply: 'build',
+    transform(code) {
+      if (!code.includes(DEV_FATAL_ERROR_PAGE_MODULE)) {
+        return null
+      }
+
+      const newCode = code.replace(
+        IMPORT_PATTERN,
+        'const DevFatalErrorPage = undefined',
+      )
+
+      return { code: newCode }
+    },
+  }
+}

--- a/packages/vite/src/plugins/vite-plugin-cedar-remove-dev-fatal-error-page.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-remove-dev-fatal-error-page.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from 'vite'
+import type { Plugin, ResolvedConfig } from 'vite'
 
 const DEV_FATAL_ERROR_PAGE_MODULE =
   '@cedarjs/web/dist/components/DevFatalErrorPage'
@@ -25,12 +25,17 @@ const IMPORT_PATTERN = new RegExp(
  * renders when an unhandled error bubbles to the top of the app.
  */
 export function cedarRemoveDevFatalErrorPage(): Plugin {
+  let config: ResolvedConfig
+
   return {
     name: 'cedar-remove-dev-fatal-error-page',
     apply: 'build',
+    configResolved(resolvedConfig) {
+      config = resolvedConfig
+    },
     transform(code) {
       // Skip transformation if not in production
-      if (process.env.NODE_ENV === 'development') {
+      if (config.command === 'build' && config.mode === 'development') {
         return null
       }
 
@@ -48,7 +53,7 @@ export function cedarRemoveDevFatalErrorPage(): Plugin {
         return null
       }
 
-      return { code: newCode }
+      return { code: newCode, map: null }
     },
   }
 }


### PR DESCRIPTION
## Summary

Migrates `babel-plugin-redwood-remove-dev-fatal-error-page` out of Babel entirely, replacing it with native plugins for each build pipeline. The Babel plugin is kept only for Jest.

### What the plugin does

In production builds, replaces:
```ts
import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
```
with:
```ts
const DevFatalErrorPage = undefined
```

This strips the `DevFatalErrorPage` component from production bundles. In development, the import stays so the page renders when an unhandled error bubbles to the top of the app.

### Changes

**Vite pipeline:**
- `packages/vite/src/plugins/vite-plugin-cedar-remove-dev-fatal-error-page.ts` — new Vite plugin using `transform` hook with `apply: 'build'`
- `packages/vite/src/index.ts` — registers and exports the new plugin; adds it to the `cedar()` plugin list

**Prerender pipeline** (uses Rollup, not Babel):
- `packages/prerender/src/build-and-import/rollupPlugins/rollup-plugin-cedar-remove-dev-fatal-error-page.ts` — new Rollup plugin with the same transform
- `packages/prerender/src/build-and-import/buildAndImport.ts` — wires the plugin into the rollup build

**Babel** (kept for Jest, skipped everywhere else):
- `packages/babel-config/src/web.ts` — adds `!forVite &&` guard so the babel plugin is skipped for Vite builds

**Tests:**
- `packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts`