### PR TITLE
chore(vite): use ts-dedent in remove-dev-fatal-error-page plugin tests

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -108,7 +108,7 @@
     "yargs-parser": "21.1.1"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "0.18.4",
+    "@arethetypeswrong/cli": "0.18.3",
     "@cedarjs/auth": "workspace:*",
     "@cedarjs/router": "workspace:*",
     "@cedarjs/web": "workspace:*",
@@ -125,6 +125,7 @@
     "memfs": "4.57.7",
     "publint": "0.3.21",
     "rollup": "4.60.4",
+    "ts-dedent": "2.3.0",
     "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
@@ -1,3 +1,4 @@
+import dedent from 'ts-dedent'
 import type { ResolvedConfig } from 'vite'
 import { describe, it, expect, beforeEach } from 'vitest'
 
@@ -35,25 +36,32 @@ describe('cedarRemoveDevFatalErrorPage', () => {
   beforeEach(() => {
     process.env.NODE_ENV = 'production'
   })
-  it('replaces the DevFatalErrorPage import with undefined', () => {
-    const code = `import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
 
-export default DevFatalErrorPage || (() => <div>Error</div>)`
+  it('replaces the DevFatalErrorPage import with undefined', () => {
+    const code = dedent`
+      import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
+
+      export default DevFatalErrorPage || (() => <div>Error</div>)
+    `
 
     const result = transform(code)
 
     expect(result).toEqual({
-      code: `const DevFatalErrorPage = undefined
+      code: dedent`
+        const DevFatalErrorPage = undefined
 
-export default DevFatalErrorPage || (() => <div>Error</div>)`,
+        export default DevFatalErrorPage || (() => <div>Error</div>)
+      `,
       map: null,
     })
   })
 
   it('returns null when the import is not present', () => {
-    const code = `import React from 'react'
+    const code = dedent`
+      import React from 'react'
 
-export default () => <div>Hello</div>`
+      export default () => <div>Hello</div>
+    `
 
     const result = transform(code)
 
@@ -61,7 +69,9 @@ export default () => <div>Hello</div>`
   })
 
   it('handles extra whitespace in the import braces', () => {
-    const code = `import {  DevFatalErrorPage  } from '@cedarjs/web/dist/components/DevFatalErrorPage'`
+    const code = dedent`
+      import {  DevFatalErrorPage  } from '@cedarjs/web/dist/components/DevFatalErrorPage'
+    `
 
     const result = transform(code) as { code: string; map: null }
 
@@ -72,7 +82,9 @@ export default () => <div>Hello</div>`
   })
 
   it('handles double quotes in the import', () => {
-    const code = `import { DevFatalErrorPage } from "@cedarjs/web/dist/components/DevFatalErrorPage"`
+    const code = dedent`
+      import { DevFatalErrorPage } from "@cedarjs/web/dist/components/DevFatalErrorPage"
+    `
 
     const result = transform(code) as { code: string; map: null }
 
@@ -83,9 +95,11 @@ export default () => <div>Hello</div>`
   })
 
   it('returns null when mode is development', () => {
-    const code = `import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
+    const code = dedent`
+      import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
 
-export default DevFatalErrorPage || (() => <div>Error</div>)`
+      export default DevFatalErrorPage || (() => <div>Error</div>)
+    `
 
     const result = transform(code, 'development')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,11 +218,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@arethetypeswrong/cli@npm:0.18.4":
-  version: 0.18.4
-  resolution: "@arethetypeswrong/cli@npm:0.18.4"
+"@arethetypeswrong/cli@npm:0.18.3":
+  version: 0.18.3
+  resolution: "@arethetypeswrong/cli@npm:0.18.3"
   dependencies:
-    "@arethetypeswrong/core": "npm:0.18.4"
+    "@arethetypeswrong/core": "npm:0.18.3"
     chalk: "npm:^4.1.2"
     cli-table3: "npm:^0.6.3"
     commander: "npm:^10.0.1"
@@ -231,13 +231,13 @@ __metadata:
     semver: "npm:^7.5.4"
   bin:
     attw: ./dist/index.js
-  checksum: 10c0/33fda6943521762f873fc3c508ac5544e4578de018abaed195b30d5db54b7e43a88e7725d70196da6cb67522a19cc1e636189784af53041dad8f68ee34476033
+  checksum: 10c0/ce4e5b3e33bca5928561ed94286a7f3d35da13905ddcb358940ed41237e59767398dfb8c42a0dc00275b66147ea78f8958e209afe99010d75b05243f974444b1
   languageName: node
   linkType: hard
 
-"@arethetypeswrong/core@npm:0.18.4":
-  version: 0.18.4
-  resolution: "@arethetypeswrong/core@npm:0.18.4"
+"@arethetypeswrong/core@npm:0.18.3":
+  version: 0.18.3
+  resolution: "@arethetypeswrong/core@npm:0.18.3"
   dependencies:
     "@andrewbranch/untar.js": "npm:^1.0.3"
     "@loaderkit/resolve": "npm:^1.0.2"
@@ -247,7 +247,7 @@ __metadata:
     semver: "npm:^7.5.4"
     typescript: "npm:5.6.1-rc"
     validate-npm-package-name: "npm:^5.0.0"
-  checksum: 10c0/988eb93c3eaa42216b19cda2cc2c3076bf36b7ba29bff7ce447931b2224eeb117cd37139ae6e3c18bbc5ebae22c9d7ca4a82af49420b64eec95c49585ba086dd
+  checksum: 10c0/e4d7aefd03e4e1a622561a972379b27defa9a9dd484b23581b76c93c5f6740e43a4fec6e96d84d6cacc1d526c5c6cb6db2061e4ab809a713cae88128407be079
   languageName: node
   linkType: hard
 
@@ -2270,7 +2270,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-auth0-api@workspace:packages/auth-providers/auth0/api"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/api": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/jsonwebtoken": "npm:9.0.10"
@@ -2288,7 +2288,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-auth0-setup@workspace:packages/auth-providers/auth0/setup"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/cli-helpers": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/yargs": "npm:17.0.35"
@@ -2323,7 +2323,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-azure-active-directory-api@workspace:packages/auth-providers/azureActiveDirectory/api"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/api": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/aws-lambda": "npm:8.10.162"
@@ -2342,7 +2342,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-azure-active-directory-setup@workspace:packages/auth-providers/azureActiveDirectory/setup"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/cli-helpers": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/yargs": "npm:17.0.35"
@@ -2378,7 +2378,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-clerk-api@workspace:packages/auth-providers/clerk/api"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/api": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@clerk/backend": "npm:1.34.0"
@@ -2395,7 +2395,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-clerk-setup@workspace:packages/auth-providers/clerk/setup"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/cli-helpers": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/yargs": "npm:17.0.35"
@@ -2430,7 +2430,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-custom-setup@workspace:packages/auth-providers/custom/setup"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/cli-helpers": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/yargs": "npm:17.0.35"
@@ -2446,7 +2446,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-dbauth-api@workspace:packages/auth-providers/dbAuth/api"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/api": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
@@ -2466,7 +2466,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-dbauth-middleware@workspace:packages/auth-providers/dbAuth/middleware"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/api": "workspace:*"
     "@cedarjs/auth-dbauth-api": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
@@ -2505,7 +2505,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-dbauth-web@workspace:packages/auth-providers/dbAuth/web"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/auth": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@simplewebauthn/browser": "npm:10.0.0"
@@ -2524,7 +2524,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-firebase-api@workspace:packages/auth-providers/firebase/api"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/api": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/aws-lambda": "npm:8.10.162"
@@ -2541,7 +2541,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-firebase-setup@workspace:packages/auth-providers/firebase/setup"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/cli-helpers": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/yargs": "npm:17.0.35"
@@ -2576,7 +2576,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-netlify-api@workspace:packages/auth-providers/netlify/api"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/api": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/aws-lambda": "npm:8.10.162"
@@ -2594,7 +2594,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-netlify-setup@workspace:packages/auth-providers/netlify/setup"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/cli-helpers": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/yargs": "npm:17.0.35"
@@ -2629,7 +2629,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-supabase-api@workspace:packages/auth-providers/supabase/api"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/api": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@supabase/ssr": "npm:0.12.0"
@@ -2648,7 +2648,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-supabase-middleware@workspace:packages/auth-providers/supabase/middleware"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/api": "workspace:*"
     "@cedarjs/auth": "workspace:*"
     "@cedarjs/auth-supabase-api": "workspace:*"
@@ -2670,7 +2670,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-supabase-setup@workspace:packages/auth-providers/supabase/setup"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/cli-helpers": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/yargs": "npm:17.0.35"
@@ -2705,7 +2705,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-supertokens-api@workspace:packages/auth-providers/supertokens/api"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/api": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/jsonwebtoken": "npm:9.0.10"
@@ -2725,7 +2725,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth-supertokens-setup@workspace:packages/auth-providers/supertokens/setup"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/cli-helpers": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@types/yargs": "npm:17.0.35"
@@ -2761,7 +2761,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/auth@workspace:packages/auth"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/framework-tools": "workspace:*"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:14.3.1"
@@ -3020,7 +3020,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/context@workspace:packages/context"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/framework-tools": "workspace:*"
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
@@ -3190,7 +3190,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/framework-tools@workspace:packages/framework-tools"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     esbuild: "npm:0.27.7"
     execa: "npm:5.1.1"
     fast-glob: "npm:3.3.3"
@@ -3214,7 +3214,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/gqlorm@workspace:packages/gqlorm"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@babel/cli": "npm:7.29.7"
     "@babel/core": "npm:^7.26.10"
     "@cedarjs/framework-tools": "workspace:*"
@@ -3285,7 +3285,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/internal@workspace:packages/internal"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@babel/core": "npm:^7.26.10"
     "@babel/parser": "npm:7.29.7"
     "@babel/plugin-transform-react-jsx": "npm:7.29.7"
@@ -3529,7 +3529,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/project-config@workspace:packages/project-config"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/framework-tools": "workspace:*"
     "@prisma/internals": "npm:7.8.0"
     concurrently: "npm:9.2.1"
@@ -3599,7 +3599,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/router@workspace:packages/router"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@babel/cli": "npm:7.29.7"
     "@babel/core": "npm:^7.26.10"
     "@cedarjs/auth": "workspace:*"
@@ -3642,7 +3642,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/storage@workspace:packages/storage"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
     "@prisma/adapter-better-sqlite3": "npm:7.8.0"
@@ -3790,7 +3790,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/vite@workspace:packages/vite"
   dependencies:
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@ast-grep/napi": "npm:0.43.0"
     "@babel/generator": "npm:7.29.7"
     "@babel/parser": "npm:7.29.7"
@@ -3846,6 +3846,7 @@ __metadata:
     rimraf: "npm:6.1.3"
     rollup: "npm:4.60.4"
     rou3: "npm:^0.8.1"
+    ts-dedent: "npm:2.3.0"
     tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vite: "npm:7.3.5"
@@ -3893,7 +3894,7 @@ __metadata:
   dependencies:
     "@apollo/client": "npm:3.14.1"
     "@apollo/client-react-streaming": "npm:0.12.3"
-    "@arethetypeswrong/cli": "npm:0.18.4"
+    "@arethetypeswrong/cli": "npm:0.18.3"
     "@babel/cli": "npm:7.29.7"
     "@babel/core": "npm:^7.26.10"
     "@babel/plugin-transform-runtime": "npm:7.29.7"


### PR DESCRIPTION
## Summary

- Replace raw template literals with `ts-dedent` in the plugin test file added in #2042
- Improves code formatting and enables proper code folding in editors

`ts-dedent` is already a root-level dependency.

## Test plan

- [ ] CI passes — no behavior changes, tests are functionally identical