### PR TITLE
chore(vite): use ts-dedent in remove-dev-fatal-error-page plugin tests

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -121,6 +121,7 @@
     "memfs": "4.57.7",
     "publint": "0.3.21",
     "rollup": "4.60.4",
+    "ts-dedent": "2.3.0",
     "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
@@ -1,69 +1,85 @@
+import dedent from 'ts-dedent'
 import type { ResolvedConfig } from 'vite'
 import { describe, it, expect, beforeEach } from 'vitest'
 
 import { cedarRemoveDevFatalErrorPage } from '../vite-plugin-cedar-remove-dev-fatal-error-page.js'
 
-function transform(code: string, mode = 'production') {
+function getPluginTransform(mode?: string) {
   const plugin = cedarRemoveDevFatalErrorPage()
 
   if (typeof plugin.configResolved !== 'function') {
-    throw new Error('Expected plugin to have configResolved hook')
+    expect.fail('Expected plugin to have a configResolved function')
   }
 
-  // Mock ResolvedConfig with minimal required fields
+  if (typeof plugin.transform !== 'function') {
+    expect.fail('Expected plugin to have a transform function')
+  }
+
+  // Mock ResolvedConfig with minimal required fields (so we don't have to
+  // provide ~35 fields with dummy values)
   const config = {
     command: 'build',
     mode,
   } as ResolvedConfig
 
-  plugin.configResolved(config)
+  // Calling `bind` to please TS
+  // See https://stackoverflow.com/a/70463512/88106
+  // Typecasting because we're only going to call transform, and we don't need
+  // anything provided by the context.
+  // This used to be `{} as TransformPluginContext`, but that requires transient
+  // dependencies to match versions. Using `ThisParameterType` is more resilient
+  plugin.configResolved.bind(
+    {} as ThisParameterType<typeof plugin.configResolved>,
+  )(config)
 
-  if (typeof plugin.transform !== 'function') {
-    throw new Error('Expected plugin to have a transform function')
-  }
-
-  // Cast to bypass the overloaded signature — we only care about the string return
-  const result = (plugin.transform as (code: string, id: string) => unknown)(
-    code,
-    'FatalErrorPage.tsx',
-  )
-
-  return result
+  return plugin.transform.bind({} as ThisParameterType<typeof plugin.transform>)
 }
 
 describe('cedarRemoveDevFatalErrorPage', () => {
   beforeEach(() => {
     process.env.NODE_ENV = 'production'
   })
+
   it('replaces the DevFatalErrorPage import with undefined', () => {
-    const code = `import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
+    const code = dedent`
+      import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
 
-export default DevFatalErrorPage || (() => <div>Error</div>)`
+      export default DevFatalErrorPage || (() => <div>Error</div>)
+    `
 
-    const result = transform(code)
+    const transform = getPluginTransform()
+    const result = transform(code, 'FatalErrorPage.tsx')
 
     expect(result).toEqual({
-      code: `const DevFatalErrorPage = undefined
+      code: dedent`
+        const DevFatalErrorPage = undefined
 
-export default DevFatalErrorPage || (() => <div>Error</div>)`,
+        export default DevFatalErrorPage || (() => <div>Error</div>)
+      `,
       map: null,
     })
   })
 
   it('returns null when the import is not present', () => {
-    const code = `import React from 'react'
+    const code = dedent`
+      import React from 'react'
 
-export default () => <div>Hello</div>`
+      export default () => <div>Hello</div>
+    `
 
-    const result = transform(code)
+    const transform = getPluginTransform()
+    const result = transform(code, 'FatalErrorPage.tsx')
 
     expect(result).toBeNull()
   })
 
   it('handles extra whitespace in the import braces', () => {
-    const code = `import {  DevFatalErrorPage  } from '@cedarjs/web/dist/components/DevFatalErrorPage'`
+    const code = dedent`
+      import {  DevFatalErrorPage  } from '@cedarjs/web/dist/components/DevFatalErrorPage'
+    `
 
-    const result = transform(code) as { code: string; map: null }
+    const transform = getPluginTransform()
+    const result = transform(code, 'FatalErrorPage.tsx')
 
     expect(result).toEqual({
       code: 'const DevFatalErrorPage = undefined',
@@ -72,9 +88,12 @@ export default () => <div>Hello</div>`
   })
 
   it('handles double quotes in the import', () => {
-    const code = `import { DevFatalErrorPage } from "@cedarjs/web/dist/components/DevFatalErrorPage"`
+    const code = dedent`
+      import { DevFatalErrorPage } from "@cedarjs/web/dist/components/DevFatalErrorPage"
+    `
 
-    const result = transform(code) as { code: string; map: null }
+    const transform = getPluginTransform()
+    const result = transform(code, 'FatalErrorPage.tsx')
 
     expect(result).toEqual({
       code: 'const DevFatalErrorPage = undefined',
@@ -83,11 +102,14 @@ export default () => <div>Hello</div>`
   })
 
   it('returns null when mode is development', () => {
-    const code = `import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
+    const code = dedent`
+      import { DevFatalErrorPage } from '@cedarjs/web/dist/components/DevFatalErrorPage'
 
-export default DevFatalErrorPage || (() => <div>Error</div>)`
+      export default DevFatalErrorPage || (() => <div>Error</div>)
+    `
 
-    const result = transform(code, 'development')
+    const transform = getPluginTransform('development')
+    const result = transform(code, 'FatalErrorPage.tsx')
 
     expect(result).toBeNull()
   })

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-remove-dev-fatal-error-page.test.ts
@@ -1,4 +1,4 @@
-import dedent from 'ts-dedent'
+import { dedent } from 'ts-dedent'
 import type { ResolvedConfig } from 'vite'
 import { describe, it, expect, beforeEach } from 'vitest'
 

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedarjs-job-path-injector.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedarjs-job-path-injector.test.ts
@@ -28,10 +28,9 @@ function getPluginTransform() {
   }
 
   // Calling `bind` to please TS
-  // See https://stackoverflow.com/a/70463512/88106
   // Typecasting because we're only going to call transform, and we don't need
   // anything provided by the context.
-  // This used to be `{} as TransformPluginContext`, but that requires transient
+  // This used to be `{} as any`, but that requires transient
   // dependencies to match versions. Using `ThisParameterType` is more resilient
   return plugin.transform.bind({} as ThisParameterType<typeof plugin.transform>)
 }

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedarjs-job-path-injector.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedarjs-job-path-injector.test.ts
@@ -28,9 +28,10 @@ function getPluginTransform() {
   }
 
   // Calling `bind` to please TS
+  // See https://stackoverflow.com/a/70463512/88106
   // Typecasting because we're only going to call transform, and we don't need
   // anything provided by the context.
-  // This used to be `{} as any`, but that requires transient
+  // This used to be `{} as TransformPluginContext`, but that requires transient
   // dependencies to match versions. Using `ThisParameterType` is more resilient
   return plugin.transform.bind({} as ThisParameterType<typeof plugin.transform>)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3851,6 +3851,7 @@ __metadata:
     rimraf: "npm:6.1.3"
     rollup: "npm:4.60.4"
     rou3: "npm:^0.8.1"
+    ts-dedent: "npm:2.3.0"
     tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vite: "npm:7.3.5"


### PR DESCRIPTION
- Replace raw template literals with `ts-dedent` in the plugin test file added in #2042
- Improves code formatting and enables proper code folding in Zed