### PR TITLE
chore(babel): replace babel-plugin-redwood-routes-auto-loader

### DIFF
--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -144,7 +144,7 @@ cedar build:
 
 Vite plugins: cell transform | entry injection | html env | node polyfills |
   auto-imports | import-dir | js-as-jsx | merged config | api-babel-transform |
-  cedar-universal-deploy | cedar-wait-for-api-server
+  cedar-routes-auto-loader | cedar-universal-deploy | cedar-wait-for-api-server
   *SSR/RSC: adds RSC transforms
 ```
 
@@ -262,7 +262,7 @@ Routes.tsx ← 4 routes added inside <Set wrap={ScaffoldLayout} title="Posts" ..
 - Config: `cedar.toml` (fallback `redwood.toml`)
 - User project is a monorepo workspace: `["api", "web"]` (+ optional `packages/*`); framework monorepo: `["packages/*"]`
 - Auto-imports (Vite plugin): `gql` from graphql-tag, `context` from @cedarjs/context, `React` from react
-- Page auto-loading: Babel plugin scans `src/pages/` and auto-imports page components in `Routes.tsx`
+- Page auto-loading: `cedar-routes-auto-loader` (Vite plugin for dev/build; Babel plugin for Jest/prerender) scans `src/pages/` and auto-imports page components in `Routes.tsx`
 - Components/services: manual imports
 - `*Cell.tsx` → Vite plugin wraps in createCell() (exports QUERY+Loading+Success+Failure+Empty)
 - `*.sdl.ts` → GraphQL schema ONLY (types, queries, mutations, inputs). Resolvers live in services/.
@@ -270,7 +270,7 @@ Routes.tsx ← 4 routes added inside <Set wrap={ScaffoldLayout} title="Posts" ..
 - `*.routeHooks.ts` → exports `routeParameters()` (prerendering: expands params for dynamic routes)
   and `meta()` (SSR/RSC only: per-request meta tag injection)
 - Entry: `entry.client.tsx` (always). \*SSR/RSC: also `entry.server.tsx`
-- Routes in `Routes.tsx` as JSX (virtual, never rendered — Babel auto-loads pages)
+- Routes in `Routes.tsx` as JSX (virtual, never rendered — auto-loaded by `cedar-routes-auto-loader` Vite/Babel plugin)
 - Build: default = esbuild (api) + Vite (web); `--ud` = unified Vite (`client` + `api` + `ssr` environments, `preserveModules: true`, Babel plugin)
 - Server: API (Fastify by default; opt-in srvx via `cedar serve api --ud` or `cedar serve --ud`, which host the UD Fetchable from `api/dist/ud/index.js`). Web: Fastify (SPA). \*SSR/RSC: Web uses Express
 - Package mgr: Yarn 4 (+ experimental support for npm and pnpm); Framework: Yarn 4 + Nx (build orchestration).

--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -140,14 +140,15 @@ export const getWebSideBabelPlugins = (
 }
 
 export const getWebSideOverrides = (
-  { forPrerender }: Flags = { forPrerender: false },
+  { forPrerender, forVite }: Flags = { forPrerender: false },
 ): TransformOptions[] => {
   // Have to use a readonly array here because of a limitation in TS
   // See https://stackoverflow.com/a/70763406/88106
   const overrides: readonly (false | TransformOptions)[] = [
     // Automatically import files in `./web/src/pages/*` in to
     // the `./web/src/Routes.[ts|jsx]` file.
-    {
+    // Vite uses vite-plugin-cedar-routes-auto-loader instead
+    !forVite && {
       test: /src[\/\\]Routes.(js|tsx|jsx)$/,
       plugins: [
         [

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -15,6 +15,7 @@ import { cedarHtmlEnvPlugin } from './plugins/vite-plugin-cedar-html-env.js'
 import { cedarNodePolyfills } from './plugins/vite-plugin-cedar-node-polyfills.js'
 import { cedarRemoveDevFatalErrorPage } from './plugins/vite-plugin-cedar-remove-dev-fatal-error-page.js'
 import { cedarRemoveFromBundle } from './plugins/vite-plugin-cedar-remove-from-bundle.js'
+import { cedarRoutesAutoLoaderPlugin } from './plugins/vite-plugin-cedar-routes-auto-loader.js'
 import { cedarWaitForApiServer } from './plugins/vite-plugin-cedar-wait-for-api-server.js'
 import { cedarjsResolveCedarStyleImportsPlugin } from './plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.js'
 import { cedarTransformJsAsJsx } from './plugins/vite-plugin-jsx-loader.js'
@@ -29,6 +30,7 @@ export { cedarHtmlEnvPlugin } from './plugins/vite-plugin-cedar-html-env.js'
 export { cedarImportDirPlugin } from './plugins/vite-plugin-cedar-import-dir.js'
 export { cedarNodePolyfills } from './plugins/vite-plugin-cedar-node-polyfills.js'
 export { cedarRemoveDevFatalErrorPage } from './plugins/vite-plugin-cedar-remove-dev-fatal-error-page.js'
+export { cedarRoutesAutoLoaderPlugin } from './plugins/vite-plugin-cedar-routes-auto-loader.js'
 export { cedarRemoveFromBundle } from './plugins/vite-plugin-cedar-remove-from-bundle.js'
 export { cedarjsResolveCedarStyleImportsPlugin } from './plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.js'
 export { cedarjsJobPathInjectorPlugin } from './plugins/vite-plugin-cedarjs-job-path-injector.js'
@@ -56,18 +58,6 @@ export function cedar({ mode }: PluginOptions = {}): PluginOption[] {
 
   const babelConfig = {
     ...webSideDefaultBabelConfig,
-    // For RSC we don't want to include the routes auto-loader plugin as we
-    // handle that differently in each specific RSC build stage
-    overrides: rscEnabled
-      ? webSideDefaultBabelConfig.overrides.filter((override) => {
-          return !override.plugins?.some((plugin) => {
-            return (
-              Array.isArray(plugin) &&
-              plugin[2] === 'babel-plugin-redwood-routes-auto-loader'
-            )
-          })
-        })
-      : webSideDefaultBabelConfig.overrides,
   }
 
   return [
@@ -85,6 +75,8 @@ export function cedar({ mode }: PluginOptions = {}): PluginOption[] {
     cedarTransformJsAsJsx(),
     cedarRemoveFromBundle(),
     cedarRemoveDevFatalErrorPage(),
+    // RSC handles route auto-loading differently in each build stage
+    !rscEnabled && cedarRoutesAutoLoaderPlugin(),
     react({ babel: babelConfig }),
   ]
 }

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-routes-auto-loader.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-routes-auto-loader.test.ts
@@ -66,14 +66,16 @@ vi.mock('@cedarjs/project-config', async (importOriginal) => {
     // file pattern). Bare directory paths like /…/pages/HomePage should return
     // null so that the plugin tries the next candidate (PageName/PageName).
     resolveFile: vi.fn((filePath: string) => {
-      if (filePath.endsWith('/App')) {
+      // Normalize to forward slashes so the mock works on both Linux and Windows
+      const normalized = originalProjectConfig.ensurePosixPath(filePath)
+      if (normalized.endsWith('/App')) {
         return null
       }
-      const parts = filePath.split('/')
+      const parts = normalized.split('/')
       const last = parts[parts.length - 1]
       const secondToLast = parts[parts.length - 2]
       // Match the PageName/PageName pattern (e.g. HomePage/HomePage)
-      if (last === secondToLast && filePath.includes('/pages/')) {
+      if (last === secondToLast && normalized.includes('/pages/')) {
         return filePath + '.tsx'
       }
       return null
@@ -260,87 +262,6 @@ describe('cedarRoutesAutoLoaderPlugin', () => {
 
     expect(result).not.toBeNull()
     // HomePage should not get a lazy declaration despite the .tsx extension
-    expect(result?.code).not.toContain('const HomePage =')
-    // AboutPage should still get a declaration
-    expect(result?.code).toContain('const AboutPage =')
-  })
-
-  it('filters out composite imports (import Foo, { ... } from)', () => {
-    const routesCode = dedent`
-      import { Router, Route } from '@cedarjs/router'
-      import HomePage, { useHomePage } from 'src/pages/HomePage'
-
-      const Routes = () => {
-        return (
-          <Router>
-            <Route path="/" page={HomePage} name="home" />
-            <Route path="/about" page={AboutPage} name="about" />
-          </Router>
-        )
-      }
-
-      export default Routes
-    `
-
-    const transform = getPluginTransform()
-    const result = transform(routesCode, ROUTES_FILE)
-
-    expect(result).not.toBeNull()
-    // HomePage should not get a lazy declaration despite composite import
-    expect(result?.code).not.toContain('const HomePage =')
-    // AboutPage should still get a declaration
-    expect(result?.code).toContain('const AboutPage =')
-  })
-
-  it('filters out named imports (import { Foo } from)', () => {
-    const routesCode = dedent`
-      import { Router, Route } from '@cedarjs/router'
-      import { HomePage } from 'src/pages/HomePage'
-
-      const Routes = () => {
-        return (
-          <Router>
-            <Route path="/" page={HomePage} name="home" />
-            <Route path="/about" page={AboutPage} name="about" />
-          </Router>
-        )
-      }
-
-      export default Routes
-    `
-
-    const transform = getPluginTransform()
-    const result = transform(routesCode, ROUTES_FILE)
-
-    expect(result).not.toBeNull()
-    // HomePage should not get a lazy declaration despite named import
-    expect(result?.code).not.toContain('const HomePage =')
-    // AboutPage should still get a declaration
-    expect(result?.code).toContain('const AboutPage =')
-  })
-
-  it('filters out namespace imports (import * as Foo from)', () => {
-    const routesCode = dedent`
-      import { Router, Route } from '@cedarjs/router'
-      import * as HomePage from 'src/pages/HomePage'
-
-      const Routes = () => {
-        return (
-          <Router>
-            <Route path="/" page={HomePage} name="home" />
-            <Route path="/about" page={AboutPage} name="about" />
-          </Router>
-        )
-      }
-
-      export default Routes
-    `
-
-    const transform = getPluginTransform()
-    const result = transform(routesCode, ROUTES_FILE)
-
-    expect(result).not.toBeNull()
-    // HomePage should not get a lazy declaration despite namespace import
     expect(result?.code).not.toContain('const HomePage =')
     // AboutPage should still get a declaration
     expect(result?.code).toContain('const AboutPage =')

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-routes-auto-loader.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-routes-auto-loader.test.ts
@@ -237,6 +237,60 @@ describe('cedarRoutesAutoLoaderPlugin', () => {
 
     expect(result?.map).toBeNull()
   })
+
+  it('filters out explicitly imported pages with file extensions', () => {
+    const routesCode = dedent`
+      import { Router, Route } from '@cedarjs/router'
+      import HomePage from './pages/HomePage/HomePage.tsx'
+
+      const Routes = () => {
+        return (
+          <Router>
+            <Route path="/" page={HomePage} name="home" />
+            <Route path="/about" page={AboutPage} name="about" />
+          </Router>
+        )
+      }
+
+      export default Routes
+    `
+
+    const transform = getPluginTransform()
+    const result = transform(routesCode, ROUTES_FILE)
+
+    expect(result).not.toBeNull()
+    // HomePage should not get a lazy declaration despite the .tsx extension
+    expect(result?.code).not.toContain('const HomePage =')
+    // AboutPage should still get a declaration
+    expect(result?.code).toContain('const AboutPage =')
+  })
+
+  it('filters out composite imports (import Foo, { ... } from)', () => {
+    const routesCode = dedent`
+      import { Router, Route } from '@cedarjs/router'
+      import HomePage, { useHomePage } from 'src/pages/HomePage'
+
+      const Routes = () => {
+        return (
+          <Router>
+            <Route path="/" page={HomePage} name="home" />
+            <Route path="/about" page={AboutPage} name="about" />
+          </Router>
+        )
+      }
+
+      export default Routes
+    `
+
+    const transform = getPluginTransform()
+    const result = transform(routesCode, ROUTES_FILE)
+
+    expect(result).not.toBeNull()
+    // HomePage should not get a lazy declaration despite composite import
+    expect(result?.code).not.toContain('const HomePage =')
+    // AboutPage should still get a declaration
+    expect(result?.code).toContain('const AboutPage =')
+  })
 })
 
 describe('cedarRoutesAutoLoaderPlugin — duplicate pages', () => {

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-routes-auto-loader.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-routes-auto-loader.test.ts
@@ -291,6 +291,60 @@ describe('cedarRoutesAutoLoaderPlugin', () => {
     // AboutPage should still get a declaration
     expect(result?.code).toContain('const AboutPage =')
   })
+
+  it('filters out named imports (import { Foo } from)', () => {
+    const routesCode = dedent`
+      import { Router, Route } from '@cedarjs/router'
+      import { HomePage } from 'src/pages/HomePage'
+
+      const Routes = () => {
+        return (
+          <Router>
+            <Route path="/" page={HomePage} name="home" />
+            <Route path="/about" page={AboutPage} name="about" />
+          </Router>
+        )
+      }
+
+      export default Routes
+    `
+
+    const transform = getPluginTransform()
+    const result = transform(routesCode, ROUTES_FILE)
+
+    expect(result).not.toBeNull()
+    // HomePage should not get a lazy declaration despite named import
+    expect(result?.code).not.toContain('const HomePage =')
+    // AboutPage should still get a declaration
+    expect(result?.code).toContain('const AboutPage =')
+  })
+
+  it('filters out namespace imports (import * as Foo from)', () => {
+    const routesCode = dedent`
+      import { Router, Route } from '@cedarjs/router'
+      import * as HomePage from 'src/pages/HomePage'
+
+      const Routes = () => {
+        return (
+          <Router>
+            <Route path="/" page={HomePage} name="home" />
+            <Route path="/about" page={AboutPage} name="about" />
+          </Router>
+        )
+      }
+
+      export default Routes
+    `
+
+    const transform = getPluginTransform()
+    const result = transform(routesCode, ROUTES_FILE)
+
+    expect(result).not.toBeNull()
+    // HomePage should not get a lazy declaration despite namespace import
+    expect(result?.code).not.toContain('const HomePage =')
+    // AboutPage should still get a declaration
+    expect(result?.code).toContain('const AboutPage =')
+  })
 })
 
 describe('cedarRoutesAutoLoaderPlugin — duplicate pages', () => {

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-routes-auto-loader.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-routes-auto-loader.test.ts
@@ -1,0 +1,266 @@
+import path from 'node:path'
+
+import { vol } from 'memfs'
+import dedent from 'ts-dedent'
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+
+import type * as ProjectConfig from '@cedarjs/project-config'
+import { processPagesDir } from '@cedarjs/project-config'
+
+import { cedarRoutesAutoLoaderPlugin } from '../vite-plugin-cedar-routes-auto-loader.js'
+
+vi.mock('node:fs', async () => ({ default: (await import('memfs')).fs }))
+
+const TEST_CEDAR_CWD = '/Users/tobbe/test-app/'
+const CEDAR_CWD = process.env.CEDAR_CWD
+process.env.CEDAR_CWD = TEST_CEDAR_CWD
+
+const ROUTES_FILE = path.join(TEST_CEDAR_CWD, 'web/src/Routes.tsx')
+
+const mockPages = [
+  {
+    importName: 'HomePage',
+    constName: 'HomePage',
+    importPath: path.join(TEST_CEDAR_CWD, 'web/src/pages/HomePage/HomePage'),
+    path: path.join(TEST_CEDAR_CWD, 'web/src/pages/HomePage/HomePage.tsx'),
+    importStatement: '',
+  },
+  {
+    importName: 'AboutPage',
+    constName: 'AboutPage',
+    importPath: path.join(TEST_CEDAR_CWD, 'web/src/pages/AboutPage/AboutPage'),
+    path: path.join(TEST_CEDAR_CWD, 'web/src/pages/AboutPage/AboutPage.tsx'),
+    importStatement: '',
+  },
+  {
+    importName: 'NotFoundPage',
+    constName: 'NotFoundPage',
+    importPath: path.join(
+      TEST_CEDAR_CWD,
+      'web/src/pages/NotFoundPage/NotFoundPage',
+    ),
+    path: path.join(
+      TEST_CEDAR_CWD,
+      'web/src/pages/NotFoundPage/NotFoundPage.tsx',
+    ),
+    importStatement: '',
+  },
+]
+
+vi.mock('@cedarjs/project-config', async (importOriginal) => {
+  const originalProjectConfig = await importOriginal<typeof ProjectConfig>()
+  return {
+    ...originalProjectConfig,
+    getPaths: () => ({
+      ...originalProjectConfig.getPaths(),
+      web: {
+        ...originalProjectConfig.getPaths().web,
+        src: path.join(TEST_CEDAR_CWD, 'web/src'),
+        base: path.join(TEST_CEDAR_CWD, 'web'),
+        routes: ROUTES_FILE,
+      },
+    }),
+    processPagesDir: vi.fn(() => mockPages),
+    // resolveFile is used for src/-prefixed imports and App.tsx detection.
+    // Only resolve paths of the form /…/PageName/PageName (the canonical page
+    // file pattern). Bare directory paths like /…/pages/HomePage should return
+    // null so that the plugin tries the next candidate (PageName/PageName).
+    resolveFile: vi.fn((filePath: string) => {
+      if (filePath.endsWith('/App')) {
+        return null
+      }
+      const parts = filePath.split('/')
+      const last = parts[parts.length - 1]
+      const secondToLast = parts[parts.length - 2]
+      // Match the PageName/PageName pattern (e.g. HomePage/HomePage)
+      if (last === secondToLast && filePath.includes('/pages/')) {
+        return filePath + '.tsx'
+      }
+      return null
+    }),
+    importStatementPath: originalProjectConfig.importStatementPath,
+    ensurePosixPath: originalProjectConfig.ensurePosixPath,
+  }
+})
+
+function getPluginTransform() {
+  const plugin = cedarRoutesAutoLoaderPlugin()
+
+  if (typeof plugin.transform !== 'function') {
+    expect.fail('Expected plugin to have a transform function')
+  }
+
+  return plugin.transform.bind({} as ThisParameterType<typeof plugin.transform>)
+}
+
+beforeAll(() => {
+  vol.fromJSON({ 'redwood.toml': '' }, TEST_CEDAR_CWD)
+})
+
+afterAll(() => {
+  process.env.CEDAR_CWD = CEDAR_CWD
+})
+
+describe('cedarRoutesAutoLoaderPlugin', () => {
+  it('skips files that are not the Routes file', () => {
+    const transform = getPluginTransform()
+
+    const result = transform(
+      `import React from 'react'`,
+      '/some/other/file.tsx',
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('adds lazy declarations for all pages not already imported', () => {
+    const routesCode = dedent`
+      import { Router, Route } from '@cedarjs/router'
+
+      const Routes = () => {
+        return (
+          <Router>
+            <Route path="/" page={HomePage} name="home" />
+            <Route path="/about" page={AboutPage} name="about" />
+            <Route notfound page={NotFoundPage} />
+          </Router>
+        )
+      }
+
+      export default Routes
+    `
+
+    const transform = getPluginTransform()
+    const result = transform(routesCode, ROUTES_FILE)
+
+    expect(result).not.toBeNull()
+    expect(result?.code).toContain(
+      dedent`
+        const HomePage = {
+          name: "HomePage",
+          prerenderLoader: (name) => ({ default: globalThis.__REDWOOD__PRERENDER_PAGES[name] }),
+          LazyComponent: lazy(() => import("./pages/HomePage/HomePage")),
+        }
+      `,
+    )
+    expect(result?.code).toContain(
+      dedent`
+        const AboutPage = {
+          name: "AboutPage",
+          prerenderLoader: (name) => ({ default: globalThis.__REDWOOD__PRERENDER_PAGES[name] }),
+          LazyComponent: lazy(() => import("./pages/AboutPage/AboutPage")),
+        }
+      `,
+    )
+    expect(result?.code).toContain(
+      dedent`
+        const NotFoundPage = {
+          name: "NotFoundPage",
+          prerenderLoader: (name) => ({ default: globalThis.__REDWOOD__PRERENDER_PAGES[name] }),
+          LazyComponent: lazy(() => import("./pages/NotFoundPage/NotFoundPage")),
+        }
+      `,
+    )
+    expect(result?.code).toContain(`import { lazy } from 'react'`)
+    // Original code should be preserved
+    expect(result?.code).toContain(
+      `import { Router, Route } from '@cedarjs/router'`,
+    )
+  })
+
+  it('does not add a lazy declaration for an explicitly imported page', () => {
+    const routesCode = dedent`
+      import { Router, Route } from '@cedarjs/router'
+      import HomePage from 'src/pages/HomePage'
+
+      const Routes = () => {
+        return (
+          <Router>
+            <Route path="/" page={HomePage} name="home" />
+            <Route path="/about" page={AboutPage} name="about" />
+            <Route notfound page={NotFoundPage} />
+          </Router>
+        )
+      }
+
+      export default Routes
+    `
+
+    const transform = getPluginTransform()
+    const result = transform(routesCode, ROUTES_FILE)
+
+    expect(result).not.toBeNull()
+    // HomePage should not get a lazy declaration since it's explicitly imported
+    expect(result?.code).not.toContain('const HomePage =')
+    // Other pages should still get declarations
+    expect(result?.code).toContain('const AboutPage =')
+    expect(result?.code).toContain('const NotFoundPage =')
+    // The explicit import should be preserved
+    expect(result?.code).toContain(`import HomePage from 'src/pages/HomePage'`)
+  })
+
+  it('returns null when all pages are already explicitly imported', () => {
+    const routesCode = dedent`
+      import { Router, Route } from '@cedarjs/router'
+      import HomePage from 'src/pages/HomePage'
+      import AboutPage from 'src/pages/AboutPage'
+      import NotFoundPage from 'src/pages/NotFoundPage'
+
+      const Routes = () => {
+        return <Router><Route path="/" page={HomePage} name="home" /></Router>
+      }
+
+      export default Routes
+    `
+
+    const transform = getPluginTransform()
+    const result = transform(routesCode, ROUTES_FILE)
+
+    expect(result).toBeNull()
+  })
+
+  it('map is null in the result', () => {
+    const routesCode = dedent`
+      import { Router, Route } from '@cedarjs/router'
+
+      const Routes = () => (
+        <Router>
+          <Route path="/" page={HomePage} name="home" />
+        </Router>
+      )
+
+      export default Routes
+    `
+
+    const transform = getPluginTransform()
+    const result = transform(routesCode, ROUTES_FILE)
+
+    expect(result?.map).toBeNull()
+  })
+})
+
+describe('cedarRoutesAutoLoaderPlugin — duplicate pages', () => {
+  it('throws for duplicate page names', () => {
+    vi.mocked(processPagesDir).mockReturnValueOnce([
+      ...mockPages,
+      {
+        importName: 'HomePage',
+        constName: 'HomePage',
+        importPath: path.join(
+          TEST_CEDAR_CWD,
+          'web/src/pages/HomePage/useHomePage',
+        ),
+        path: path.join(
+          TEST_CEDAR_CWD,
+          'web/src/pages/HomePage/useHomePage.tsx',
+        ),
+        importStatement: '',
+      },
+    ])
+
+    expect(() => cedarRoutesAutoLoaderPlugin()).toThrow(
+      "Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' " +
+        "in the following page directories: 'HomePage'",
+    )
+  })
+})

--- a/packages/vite/src/plugins/vite-plugin-cedar-routes-auto-loader.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-routes-auto-loader.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import type { Plugin } from 'vite'
+import { normalizePath } from 'vite'
+
+import type { PagesDependency } from '@cedarjs/project-config'
+import {
+  ensurePosixPath,
+  getPaths,
+  importStatementPath,
+  processPagesDir,
+  resolveFile,
+} from '@cedarjs/project-config'
+
+function getPathRelativeToSrc(maybeAbsolutePath: string): string {
+  // Handle src/ bare specifiers (e.g. 'src/pages/FooPage').
+  // When `forVite` is true, babel-plugin-module-resolver's src alias does not
+  // run, so these specifiers arrive here unresolved. We resolve them via the
+  // filesystem so that this auto-loader can correctly match and deregister
+  // pages that have been explicitly imported by the user.
+  if (maybeAbsolutePath.startsWith('src/')) {
+    const basePath = path.join(getPaths().web.base, maybeAbsolutePath)
+
+    const resolved =
+      resolveFile(basePath) ||
+      resolveFile(path.join(basePath, 'index')) ||
+      resolveFile(path.join(basePath, path.basename(basePath)))
+
+    if (resolved) {
+      const withoutExt = resolved.replace(/\.[^/.]+$/, '')
+      return './' + path.relative(getPaths().web.src, withoutExt)
+    }
+
+    // Fallback: should not happen in a well-formed project
+    return './' + maybeAbsolutePath.slice('src/'.length)
+  }
+
+  if (!path.isAbsolute(maybeAbsolutePath)) {
+    return maybeAbsolutePath
+  }
+
+  return `./${path.relative(getPaths().web.src, maybeAbsolutePath)}`
+}
+
+function withRelativeImports(page: PagesDependency) {
+  return {
+    ...page,
+    relativeImport: ensurePosixPath(getPathRelativeToSrc(page.importPath)),
+  }
+}
+
+/**
+ * Vite plugin to auto-load page components into the Routes file.
+ *
+ * For each page found in `web/src/pages` that is not already explicitly
+ * imported in Routes.tsx, this plugin prepends a lazy-loaded declaration:
+ *
+ * ```js
+ * const PageName = {
+ *   name: "PageName",
+ *   prerenderLoader: (name) => ({ default: globalThis.__REDWOOD__PRERENDER_PAGES[name] }),
+ *   LazyComponent: lazy(() => import("./pages/PageName/PageName")),
+ * }
+ * ```
+ *
+ * Pages already imported by App.tsx are also excluded to avoid Vite's
+ * "dynamically imported by Routes.tsx but also statically imported by App.tsx"
+ * warning.
+ *
+ * This replaces `babel-plugin-redwood-routes-auto-loader` for Vite builds.
+ * The babel plugin is still used for Jest and prerender.
+ */
+export function cedarRoutesAutoLoaderPlugin(): Plugin {
+  const routesFileId = normalizePath(getPaths().web.routes)
+
+  // Check for duplicate page names upfront (same as babel plugin)
+  const initialPages = processPagesDir().map(withRelativeImports)
+  const duplicatePageImportNames = new Set<string>()
+  const sortedPageImportNames = initialPages
+    .map((page) => page.importName)
+    .sort()
+  for (let i = 0; i < sortedPageImportNames.length - 1; i++) {
+    if (sortedPageImportNames[i + 1] === sortedPageImportNames[i]) {
+      duplicatePageImportNames.add(sortedPageImportNames[i])
+    }
+  }
+  if (duplicatePageImportNames.size > 0) {
+    const pageNames = Array.from(duplicatePageImportNames)
+      .map((name) => `'${name}'`)
+      .join(', ')
+    throw new Error(
+      "Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' in " +
+        `the following page directories: ${pageNames}`,
+    )
+  }
+
+  return {
+    name: 'cedar-routes-auto-loader',
+
+    transform(code, id) {
+      if (normalizePath(id) !== routesFileId) {
+        return null
+      }
+
+      let pages = processPagesDir().map(withRelativeImports)
+
+      // De-register pages that are already statically imported in App.tsx.
+      // Leaving them in would cause Vite to warn:
+      // "dynamically imported by Routes.tsx but also statically imported by App.tsx
+      //  – dynamic import will not move module into another chunk"
+      const appPath = resolveFile(path.join(getPaths().web.src, 'App'))
+      if (appPath) {
+        const appSource = fs.readFileSync(appPath, 'utf8')
+        const appImportRe = /^import\s+\w+\s+from\s+['"]([^'"]+)['"]/gm
+        let appMatch: RegExpExecArray | null
+        while ((appMatch = appImportRe.exec(appSource)) !== null) {
+          const rel = ensurePosixPath(
+            getPathRelativeToSrc(importStatementPath(appMatch[1])),
+          )
+          pages = pages.filter((page) => page.relativeImport !== rel)
+        }
+      }
+
+      // De-register pages that are already explicitly imported in Routes.tsx.
+      // The user has opted in to a static (non-lazy) import for these.
+      const routesImportRe = /^import\s+(?:\w+)\s+from\s+['"]([^'"]+)['"]/gm
+      let routesMatch: RegExpExecArray | null
+      while ((routesMatch = routesImportRe.exec(code)) !== null) {
+        const userImportRelativePath = ensurePosixPath(
+          getPathRelativeToSrc(importStatementPath(routesMatch[1])),
+        )
+        pages = pages.filter(
+          (page) => page.relativeImport !== userImportRelativePath,
+        )
+      }
+
+      if (pages.length === 0) {
+        return null
+      }
+
+      // Build the auto-loader declarations to prepend to the Routes file.
+      const lines: string[] = [`import { lazy } from 'react'`]
+
+      for (const { importName, relativeImport } of pages) {
+        lines.push(
+          `const ${importName} = {`,
+          `  name: "${importName}",`,
+          `  prerenderLoader: (name) => ({ default: globalThis.__REDWOOD__PRERENDER_PAGES[name] }),`,
+          `  LazyComponent: lazy(() => import("${relativeImport}")),`,
+          `}`,
+        )
+      }
+
+      return {
+        code: lines.join('\n') + '\n\n' + code,
+        map: null,
+      }
+    },
+  }
+}

--- a/packages/vite/src/plugins/vite-plugin-cedar-routes-auto-loader.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-routes-auto-loader.ts
@@ -116,9 +116,13 @@ export function cedarRoutesAutoLoaderPlugin(): Plugin {
       const appPath = resolveFile(path.join(getPaths().web.src, 'App'))
       if (appPath) {
         const appSource = fs.readFileSync(appPath, 'utf8')
-        // Match both default imports (import Foo from) and composite imports (import Foo, { ... } from)
+        // Match all import patterns:
+        // - default: import Foo from
+        // - named: import { Foo } from
+        // - namespace: import * as Foo from
+        // - composite: import Foo, { ... } from
         const appImportRe =
-          /^import\s+\w+(?:\s*,\s*\{[^}]*\})?\s+from\s+['"]([^'"]+)['"]/gm
+          /^import\s+(?:\{[^}]*\}|\*\s+as\s+\w+|\w+(?:\s*,\s*\{[^}]*\})?)\s+from\s+['"]([^'"]+)['"]/gm
         let appMatch: RegExpExecArray | null
         while ((appMatch = appImportRe.exec(appSource)) !== null) {
           const rel = ensurePosixPath(
@@ -130,9 +134,13 @@ export function cedarRoutesAutoLoaderPlugin(): Plugin {
 
       // De-register pages that are already explicitly imported in Routes.tsx.
       // The user has opted in to a static (non-lazy) import for these.
-      // Match both default imports (import Foo from) and composite imports (import Foo, { ... } from)
+      // Match all import patterns:
+      // - default: import Foo from
+      // - named: import { Foo } from
+      // - namespace: import * as Foo from
+      // - composite: import Foo, { ... } from
       const routesImportRe =
-        /^import\s+\w+(?:\s*,\s*\{[^}]*\})?\s+from\s+['"]([^'"]+)['"]/gm
+        /^import\s+(?:\{[^}]*\}|\*\s+as\s+\w+|\w+(?:\s*,\s*\{[^}]*\})?)\s+from\s+['"]([^'"]+)['"]/gm
       let routesMatch: RegExpExecArray | null
       while ((routesMatch = routesImportRe.exec(code)) !== null) {
         const userImportRelativePath = ensurePosixPath(

--- a/packages/vite/src/plugins/vite-plugin-cedar-routes-auto-loader.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-routes-auto-loader.ts
@@ -109,6 +109,8 @@ export function cedarRoutesAutoLoaderPlugin(): Plugin {
 
       let pages = processPagesDir().map(withRelativeImports)
 
+      const importRe = /^import\s+\w+\s+from\s+['"]([^'"]+)['"]/gm
+
       // De-register pages that are already statically imported in App.tsx.
       // Leaving them in would cause Vite to warn:
       // "dynamically imported by Routes.tsx but also statically imported by App.tsx
@@ -116,15 +118,8 @@ export function cedarRoutesAutoLoaderPlugin(): Plugin {
       const appPath = resolveFile(path.join(getPaths().web.src, 'App'))
       if (appPath) {
         const appSource = fs.readFileSync(appPath, 'utf8')
-        // Match all import patterns:
-        // - default: import Foo from
-        // - named: import { Foo } from
-        // - namespace: import * as Foo from
-        // - composite: import Foo, { ... } from
-        const appImportRe =
-          /^import\s+(?:\{[^}]*\}|\*\s+as\s+\w+|\w+(?:\s*,\s*\{[^}]*\})?)\s+from\s+['"]([^'"]+)['"]/gm
         let appMatch: RegExpExecArray | null
-        while ((appMatch = appImportRe.exec(appSource)) !== null) {
+        while ((appMatch = importRe.exec(appSource)) !== null) {
           const rel = ensurePosixPath(
             getPathRelativeToSrc(importStatementPath(appMatch[1])),
           )
@@ -134,21 +129,13 @@ export function cedarRoutesAutoLoaderPlugin(): Plugin {
 
       // De-register pages that are already explicitly imported in Routes.tsx.
       // The user has opted in to a static (non-lazy) import for these.
-      // Match all import patterns:
-      // - default: import Foo from
-      // - named: import { Foo } from
-      // - namespace: import * as Foo from
-      // - composite: import Foo, { ... } from
-      const routesImportRe =
-        /^import\s+(?:\{[^}]*\}|\*\s+as\s+\w+|\w+(?:\s*,\s*\{[^}]*\})?)\s+from\s+['"]([^'"]+)['"]/gm
+      importRe.lastIndex = 0
       let routesMatch: RegExpExecArray | null
-      while ((routesMatch = routesImportRe.exec(code)) !== null) {
-        const userImportRelativePath = ensurePosixPath(
+      while ((routesMatch = importRe.exec(code)) !== null) {
+        const rel = ensurePosixPath(
           getPathRelativeToSrc(importStatementPath(routesMatch[1])),
         )
-        pages = pages.filter(
-          (page) => page.relativeImport !== userImportRelativePath,
-        )
+        pages = pages.filter((page) => page.relativeImport !== rel)
       }
 
       if (pages.length === 0) {

--- a/packages/vite/src/plugins/vite-plugin-cedar-routes-auto-loader.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-routes-auto-loader.ts
@@ -14,13 +14,17 @@ import {
 } from '@cedarjs/project-config'
 
 function getPathRelativeToSrc(maybeAbsolutePath: string): string {
+  // Strip file extension upfront so explicit imports like
+  // './pages/HomePage/HomePage.tsx' match discovered pages like './pages/HomePage/HomePage'
+  const withoutExt = maybeAbsolutePath.replace(/\.[^/.]+$/, '')
+
   // Handle src/ bare specifiers (e.g. 'src/pages/FooPage').
   // When `forVite` is true, babel-plugin-module-resolver's src alias does not
   // run, so these specifiers arrive here unresolved. We resolve them via the
   // filesystem so that this auto-loader can correctly match and deregister
   // pages that have been explicitly imported by the user.
-  if (maybeAbsolutePath.startsWith('src/')) {
-    const basePath = path.join(getPaths().web.base, maybeAbsolutePath)
+  if (withoutExt.startsWith('src/')) {
+    const basePath = path.join(getPaths().web.base, withoutExt)
 
     const resolved =
       resolveFile(basePath) ||
@@ -28,19 +32,19 @@ function getPathRelativeToSrc(maybeAbsolutePath: string): string {
       resolveFile(path.join(basePath, path.basename(basePath)))
 
     if (resolved) {
-      const withoutExt = resolved.replace(/\.[^/.]+$/, '')
-      return './' + path.relative(getPaths().web.src, withoutExt)
+      const resolvedWithoutExt = resolved.replace(/\.[^/.]+$/, '')
+      return './' + path.relative(getPaths().web.src, resolvedWithoutExt)
     }
 
     // Fallback: should not happen in a well-formed project
-    return './' + maybeAbsolutePath.slice('src/'.length)
+    return './' + withoutExt.slice('src/'.length)
   }
 
-  if (!path.isAbsolute(maybeAbsolutePath)) {
-    return maybeAbsolutePath
+  if (!path.isAbsolute(withoutExt)) {
+    return withoutExt
   }
 
-  return `./${path.relative(getPaths().web.src, maybeAbsolutePath)}`
+  return `./${path.relative(getPaths().web.src, withoutExt)}`
 }
 
 function withRelativeImports(page: PagesDependency) {
@@ -112,7 +116,9 @@ export function cedarRoutesAutoLoaderPlugin(): Plugin {
       const appPath = resolveFile(path.join(getPaths().web.src, 'App'))
       if (appPath) {
         const appSource = fs.readFileSync(appPath, 'utf8')
-        const appImportRe = /^import\s+\w+\s+from\s+['"]([^'"]+)['"]/gm
+        // Match both default imports (import Foo from) and composite imports (import Foo, { ... } from)
+        const appImportRe =
+          /^import\s+\w+(?:\s*,\s*\{[^}]*\})?\s+from\s+['"]([^'"]+)['"]/gm
         let appMatch: RegExpExecArray | null
         while ((appMatch = appImportRe.exec(appSource)) !== null) {
           const rel = ensurePosixPath(
@@ -124,7 +130,9 @@ export function cedarRoutesAutoLoaderPlugin(): Plugin {
 
       // De-register pages that are already explicitly imported in Routes.tsx.
       // The user has opted in to a static (non-lazy) import for these.
-      const routesImportRe = /^import\s+(?:\w+)\s+from\s+['"]([^'"]+)['"]/gm
+      // Match both default imports (import Foo from) and composite imports (import Foo, { ... } from)
+      const routesImportRe =
+        /^import\s+\w+(?:\s*,\s*\{[^}]*\})?\s+from\s+['"]([^'"]+)['"]/gm
       let routesMatch: RegExpExecArray | null
       while ((routesMatch = routesImportRe.exec(code)) !== null) {
         const userImportRelativePath = ensurePosixPath(


### PR DESCRIPTION
## Summary

Converts `babel-plugin-redwood-routes-auto-loader` to a Vite plugin for Vite builds, following the same pattern as #2042.

- Adds `vite-plugin-cedar-routes-auto-loader` — scans `web/src/pages` and prepends lazy declarations to `Routes.tsx` at build time
- Pages already imported in `App.tsx` or explicitly imported in `Routes.tsx` are skipped (avoiding the "dynamically imported but also statically imported" Vite warning)
- Adds a `!forVite` guard in `babel-config/src/web.ts` so the babel plugin is no longer invoked for Vite builds
- Prerender is already covered by the existing `rollup-plugin-cedarjs-routes-auto-loader` — no changes needed there
- Jest continues to use the babel plugin unchanged

## Generated lazy declaration format

```js
const HomePage = {
  name: "HomePage",
  prerenderLoader: (name) => ({ default: globalThis.__REDWOOD__PRERENDER_PAGES[name] }),
  LazyComponent: lazy(() => import("./pages/HomePage/HomePage")),
}
```

## Test plan

- [x] New vitest tests covering: skip non-Routes files, add lazy declarations, skip explicitly imported pages, return null when all pages explicit, map is null, throw for duplicate page names
- [x] All existing plugin tests pass (83 tests, 1 skipped, 4 todo)
- [x] `!rscEnabled && cedarRoutesAutoLoaderPlugin()` wired into `cedar()` plugin list in `packages/vite/src/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)