### PR TITLE
fix(babel-config): only strip .js extension for relative imports

### DIFF
--- a/.changesets/399.md
+++ b/.changesets/399.md
@@ -1,0 +1,19 @@
+- fix(babel-config): only strip .js extension for relative imports (#399) by @01luyicheng
+
+The babel module resolver had two places where the `.js` extension was
+incorrectly stripped, breaking npm packages whose names end in `.js`:
+
+1. In the API-side resolver (`api.ts`), the regex `/.*\/.*\.js$/` matched
+   subpath imports like `@scope/pkg.js` and stripped their extension,
+   causing module resolution to fail.
+
+2. In the Web-side resolver (`web.ts`), the resolved absolute path was
+   unconditionally stripped of its `.js` extension. For bare npm packages
+   like `fraction.js`, `chart.js`, and `pixi.js`, the resolved path ends in
+   `.js` (e.g. `.../node_modules/fraction.js/fraction.js`), and stripping
+   it broke the import.
+
+Both resolvers now only strip the `.js` extension for relative imports
+(paths starting with `.`), so npm packages whose names end in `.js` are
+no longer affected. A smoke test has been added that imports `fraction.js`
+in the prerendered AboutPage to guard against regressions.

--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -17,6 +17,7 @@
     "@cedarjs/router": "4.2.0",
     "@cedarjs/web": "4.2.0",
     "@my-org/validators": "workspace:*",
+    "fraction.js": "5.3.4",
     "humanize-string": "2.1.0",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/__fixtures__/test-project/web/src/pages/AboutPage/AboutPage.tsx
+++ b/__fixtures__/test-project/web/src/pages/AboutPage/AboutPage.tsx
@@ -1,9 +1,15 @@
+import { Fraction } from 'fraction.js'
+
 const AboutPage = () => {
+  const half = new Fraction(1, 2).toFraction()
   return (
-    <p className="font-light">
-      This site was created to demonstrate my mastery of Cedar: Look on my
-      works, ye mighty, and despair!
-    </p>
+    <>
+      <p className="font-light">
+        This site was created to demonstrate my mastery of Cedar: Look on my
+        works, ye mighty, and despair!
+      </p>
+      <p data-testid="fraction-test">Half is {half}</p>
+    </>
   )
 }
 

--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -90,8 +90,15 @@ export const getApiSideBabelPlugins = ({
           // source file is logger.ts) we have to rewrite the extension
           const isDataMigrate = process.argv[2] === 'data-migrate'
           const isPrerender = process.argv[2] === 'prerender'
+          // Only strip the `.js` extension for relative imports, so that we
+          // support `import { logger } from './logger.js'` in data-migrate and
+          // prerender without breaking npm packages whose names end in `.js`
+          // (e.g. `fraction.js`, `chart.js`, `pixi.js`).
+          const isRelativeImport = sourcePath.startsWith('.')
           const importPath =
-            /.*\/.*\.js$/.test(sourcePath) && (isDataMigrate || isPrerender)
+            isRelativeImport &&
+            sourcePath.endsWith('.js') &&
+            (isDataMigrate || isPrerender)
               ? sourcePath.replace(/\.js$/, '')
               : sourcePath
 

--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -81,8 +81,14 @@ export const getWebSideBabelPlugins = (
           const resolvedPath = resolvePath(sourcePath, currentFile, opts)
 
           // This is needed to support .js imports of .jsx files in JavaScript
-          // Cedar apps
-          return resolvedPath?.replace(/\.js$/, '')
+          // Cedar apps. Only strip the .js extension for relative imports to
+          // avoid breaking npm packages whose names end in .js (e.g.
+          // `fraction.js`, `chart.js`, `pixi.js`).
+          // See https://github.com/cedarjs/cedar/issues/399
+          const isRelativeImport = sourcePath.startsWith('.')
+          return isRelativeImport
+            ? resolvedPath?.replace(/\.js$/, '')
+            : resolvedPath
         },
       },
       'rwjs-module-resolver',

--- a/tasks/smoke-tests/prerender/tests/prerender.spec.ts
+++ b/tasks/smoke-tests/prerender/tests/prerender.spec.ts
@@ -242,9 +242,16 @@ test('Check that about is prerendered', async () => {
   await pageWithoutJs.goto('/about')
 
   const aboutPageContent = await pageWithoutJs.locator('main').innerText()
-  expect(aboutPageContent).toBe(
+  expect(aboutPageContent).toContain(
     'This site was created to demonstrate my mastery of Cedar: Look on my works, ye mighty, and despair!',
   )
+  // Make sure npm packages whose names end in `.js` (like `fraction.js`) are
+  // not broken by the babel module resolver stripping the extension.
+  // See https://github.com/cedarjs/cedar/issues/399
+  await expect(
+    pageWithoutJs.getByTestId('fraction-test'),
+  ).toBeVisible()
+  expect(aboutPageContent).toContain('Half is 1/2')
   pageWithoutJs.close()
 })
 

--- a/tasks/smoke-tests/shared/common.ts
+++ b/tasks/smoke-tests/shared/common.ts
@@ -43,6 +43,10 @@ export async function smokeTest({ page }: PlaywrightTestArgs) {
       'This site was created to demonstrate my mastery of Cedar: Look on my works, ye',
     ),
   ).toBeVisible()
+  // Make sure npm packages whose names end in `.js` (like `fraction.js`) work
+  // in dev/serve. See https://github.com/cedarjs/cedar/issues/399
+  const aboutPageContent = await page.locator('main').innerText()
+  expect(aboutPageContent).toContain('Half is 1/2')
 
   // Check the contact us page.
   await page.getByRole('link', { name: 'Contact Us' }).click()

--- a/tasks/test-project/codemods/aboutPage.js
+++ b/tasks/test-project/codemods/aboutPage.js
@@ -1,13 +1,21 @@
-const body = `
-<p className="font-light">
-This site was created to demonstrate my mastery of Cedar: Look on my
-works, ye mighty, and despair!
-</p>
-`
+const body = `(
+        <>
+          <p className="font-light">
+            This site was created to demonstrate my mastery of Cedar: Look on my
+            works, ye mighty, and despair!
+          </p>
+          <p data-testid="fraction-test">Half is {half}</p>
+        </>
+      )`
 
 export default (file, api) => {
   const j = api.jscodeshift
   const root = j(file.source)
+
+  const fractionImport = j.importDeclaration(
+    [j.importSpecifier(j.identifier('Fraction'))],
+    j.stringLiteral('fraction.js'),
+  )
 
   // Remove the `{ Link, routes }` imports that are generated and unused
   root
@@ -28,6 +36,8 @@ export default (file, api) => {
     })
     .remove()
 
+  root.find(j.VariableDeclaration).at(0).insertBefore(fractionImport)
+
   return root
     .find(j.VariableDeclarator, {
       id: {
@@ -37,7 +47,25 @@ export default (file, api) => {
     })
     .replaceWith((nodePath) => {
       const { node } = nodePath
-      node.init.body.body[0].argument = body
+      // Compute `half` before the return statement.
+      node.init.body.body.unshift(
+        j.variableDeclaration('const', [
+          j.variableDeclarator(
+            j.identifier('half'),
+            j.callExpression(
+              j.memberExpression(
+                j.newExpression(j.identifier('Fraction'), [
+                  j.literal(1),
+                  j.literal(2),
+                ]),
+                j.identifier('toFraction'),
+              ),
+              [],
+            ),
+          ),
+        ]),
+      )
+      node.init.body.body[1].argument = body
       return node
     })
     .toSource()

--- a/tasks/test-project/rebuild-test-project-fixture.mts
+++ b/tasks/test-project/rebuild-test-project-fixture.mts
@@ -607,6 +607,11 @@ async function rebuildTestProject() {
       apiPackageJson.dependencies['@my-org/validators'] = 'workspace:*'
       webPackageJson.dependencies['@my-org/validators'] = 'workspace:*'
 
+      // Add a dependency whose package name ends with `.js` to make sure the
+      // babel module resolver does not strip the extension and break the
+      // import. See https://github.com/cedarjs/cedar/issues/399
+      webPackageJson.dependencies['fraction.js'] = '5.3.4'
+
       if (live) {
         webPackageJson.dependencies['@cedarjs/gqlorm'] =
           webPackageJson.dependencies['@cedarjs/web']


### PR DESCRIPTION
## Summary

Fixes #399

The babel module resolver had two places where the `.js` extension was incorrectly stripped, breaking npm packages whose names end in `.js` (like `fraction.js`, `chart.js`, `pixi.js`).

### 1. API-side resolver (`packages/babel-config/src/api.ts`)

The regex `/.*\/.*\.js$/` matched subpath imports like `@scope/pkg.js` and stripped their extension, causing module resolution to fail in `data-migrate` and `prerender`.

### 2. Web-side resolver (`packages/babel-config/src/web.ts`)

The resolved absolute path was unconditionally stripped of its `.js` extension. For bare npm packages like `fraction.js`, the resolved path ends in `.js` (e.g. `.../node_modules/fraction.js/fraction.js`), and stripping it broke the import.

## Fix

Both resolvers now only strip the `.js` extension for **relative imports** (paths starting with `.`), so npm packages whose names end in `.js` are no longer affected.

## Test plan

Following the acceptance criteria in #399:

- [x] Added `fraction.js` (zero-dependency, SSR-safe, ~3KB) to the prerendered `AboutPage`
- [x] Updated the test-project rebuild script (`rebuild-test-project-fixture.mts`) and codemod (`aboutPage.js`) so the fixture can be regenerated consistently
- [x] Added a smoke test assertion in the prerender suite (`prerender.spec.ts`) checking that the `fraction.js` component renders
- [x] Added a smoke test assertion in the shared `common.ts` (used by both `dev` and `serve` suites) checking that `fraction.js` works in dev/serve
- [x] Added a changeset

The smoke tests verify `Half is 1/2` is rendered, confirming `fraction.js` is correctly loaded and executed (since `new Fraction(1, 2).toFraction()` returns `"1/2"`).

## Notes

- I picked `fraction.js` because it is small, has no dependencies, and is SSR-safe (no `window`/`document` access), so it works in the prerender flow. (`chart.js` was ruled out because it touches `window`.)
- The core fix is small (a few lines in `api.ts` and `web.ts`); the rest of the diff is the test fixture and smoke test additions required by the issue.

Closes #399