### PR TITLE
chore(build): Use node instead of tsx to run build script

### DIFF
--- a/packages/adapters/fastify/web/package.json
+++ b/packages/adapters/fastify/web/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-fastify-web.tgz",
     "build:types": "tsc --build --verbose",
     "prepublishOnly": "NODE_ENV=production yarn build",

--- a/packages/adapters/fastify/web/package.json
+++ b/packages/adapters/fastify/web/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
     "fastify": "5.8.5",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -120,7 +120,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-api-server.tgz",
     "build:types": "tsc --build --verbose tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose tsconfig.cjs.json",

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -165,7 +165,6 @@
     "memfs": "4.57.7",
     "pino-abstract-transport": "1.2.0",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -120,7 +120,6 @@
     "redis": "5.12.1",
     "split2": "4.2.0",
     "ts-toolbelt": "9.6.0",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -86,7 +86,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-api.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/auth0/api/package.json
+++ b/packages/auth-providers/auth0/api/package.json
@@ -49,7 +49,6 @@
     "@types/jsonwebtoken": "9.0.10",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/auth0/api/package.json
+++ b/packages/auth-providers/auth0/api/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-auth0-api.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/auth0/setup/package.json
+++ b/packages/auth-providers/auth0/setup/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-auth0-setup.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/auth0/setup/package.json
+++ b/packages/auth-providers/auth0/setup/package.json
@@ -47,7 +47,6 @@
     "@types/yargs": "17.0.35",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/auth0/web/package.json
+++ b/packages/auth-providers/auth0/web/package.json
@@ -58,7 +58,6 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "react": "19.2.3",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/auth0/web/package.json
+++ b/packages/auth-providers/auth0/web/package.json
@@ -37,7 +37,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.ts",
+    "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-auth0-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/auth-providers/azureActiveDirectory/api/package.json
+++ b/packages/auth-providers/azureActiveDirectory/api/package.json
@@ -50,7 +50,6 @@
     "@types/jsonwebtoken": "9.0.10",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/azureActiveDirectory/api/package.json
+++ b/packages/auth-providers/azureActiveDirectory/api/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-azure-active-directory-api.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/azureActiveDirectory/setup/package.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-azure-active-directory-setup.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/azureActiveDirectory/setup/package.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/package.json
@@ -47,7 +47,6 @@
     "@types/yargs": "17.0.35",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/azureActiveDirectory/web/package.json
+++ b/packages/auth-providers/azureActiveDirectory/web/package.json
@@ -60,7 +60,6 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "react": "19.2.3",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/azureActiveDirectory/web/package.json
+++ b/packages/auth-providers/azureActiveDirectory/web/package.json
@@ -37,7 +37,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-azure-active-directory-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/auth-providers/clerk/api/package.json
+++ b/packages/auth-providers/clerk/api/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-clerk-api.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/clerk/api/package.json
+++ b/packages/auth-providers/clerk/api/package.json
@@ -48,7 +48,6 @@
     "@types/aws-lambda": "8.10.162",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/clerk/setup/package.json
+++ b/packages/auth-providers/clerk/setup/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-clerk-setup.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/clerk/setup/package.json
+++ b/packages/auth-providers/clerk/setup/package.json
@@ -45,7 +45,6 @@
     "@types/yargs": "17.0.35",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/packages/auth-providers/clerk/web/package.json
+++ b/packages/auth-providers/clerk/web/package.json
@@ -37,7 +37,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.ts",
+    "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-clerk-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/auth-providers/clerk/web/package.json
+++ b/packages/auth-providers/clerk/web/package.json
@@ -59,7 +59,6 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "react": "19.2.3",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/custom/setup/package.json
+++ b/packages/auth-providers/custom/setup/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-custom-setup.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/custom/setup/package.json
+++ b/packages/auth-providers/custom/setup/package.json
@@ -47,7 +47,6 @@
     "@types/yargs": "17.0.35",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/dbAuth/api/package.json
+++ b/packages/auth-providers/dbAuth/api/package.json
@@ -46,7 +46,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-dbauth-api.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/dbAuth/api/package.json
+++ b/packages/auth-providers/dbAuth/api/package.json
@@ -69,7 +69,6 @@
     "@types/md5": "2.3.6",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-dbauth-middleware.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose tsconfig.cjs.json",

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -49,7 +49,6 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "ts-toolbelt": "9.6.0",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -28,7 +28,7 @@
     "webAuthn"
   ],
   "scripts": {
-    "build": "tsx ./build.ts",
+    "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-dbauth-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -51,7 +51,6 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "react": "19.2.3",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/firebase/api/package.json
+++ b/packages/auth-providers/firebase/api/package.json
@@ -48,7 +48,6 @@
     "@types/aws-lambda": "8.10.162",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/firebase/api/package.json
+++ b/packages/auth-providers/firebase/api/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-firebase-api.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/firebase/setup/package.json
+++ b/packages/auth-providers/firebase/setup/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-firebase-setup.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/firebase/setup/package.json
+++ b/packages/auth-providers/firebase/setup/package.json
@@ -47,7 +47,6 @@
     "@types/yargs": "17.0.35",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/firebase/web/package.json
+++ b/packages/auth-providers/firebase/web/package.json
@@ -37,7 +37,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.ts",
+    "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-firebase-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/auth-providers/firebase/web/package.json
+++ b/packages/auth-providers/firebase/web/package.json
@@ -58,7 +58,6 @@
     "firebase": "10.14.1",
     "publint": "0.3.21",
     "react": "19.2.3",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/netlify/api/package.json
+++ b/packages/auth-providers/netlify/api/package.json
@@ -49,7 +49,6 @@
     "@types/jsonwebtoken": "9.0.10",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/netlify/api/package.json
+++ b/packages/auth-providers/netlify/api/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-netlify-api.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/netlify/setup/package.json
+++ b/packages/auth-providers/netlify/setup/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-netlify-setup.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/netlify/setup/package.json
+++ b/packages/auth-providers/netlify/setup/package.json
@@ -47,7 +47,6 @@
     "@types/yargs": "17.0.35",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/netlify/web/package.json
+++ b/packages/auth-providers/netlify/web/package.json
@@ -37,7 +37,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.ts",
+    "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-netlify-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/auth-providers/netlify/web/package.json
+++ b/packages/auth-providers/netlify/web/package.json
@@ -58,7 +58,6 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "react": "19.2.3",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/supabase/api/package.json
+++ b/packages/auth-providers/supabase/api/package.json
@@ -50,7 +50,6 @@
     "@types/jsonwebtoken": "9.0.10",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/supabase/api/package.json
+++ b/packages/auth-providers/supabase/api/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-supabase-api.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/supabase/middleware/package.json
+++ b/packages/auth-providers/supabase/middleware/package.json
@@ -27,7 +27,7 @@
     "cjsWrappers"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-supabase-middleware.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/auth-providers/supabase/middleware/package.json
+++ b/packages/auth-providers/supabase/middleware/package.json
@@ -52,7 +52,6 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "ts-toolbelt": "9.6.0",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/supabase/setup/package.json
+++ b/packages/auth-providers/supabase/setup/package.json
@@ -45,7 +45,6 @@
     "@types/yargs": "17.0.35",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/packages/auth-providers/supabase/setup/package.json
+++ b/packages/auth-providers/supabase/setup/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-supabase-setup.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/supabase/web/package.json
+++ b/packages/auth-providers/supabase/web/package.json
@@ -59,7 +59,6 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "react": "19.2.3",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/supabase/web/package.json
+++ b/packages/auth-providers/supabase/web/package.json
@@ -37,7 +37,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.ts",
+    "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-supabase-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/auth-providers/supertokens/api/package.json
+++ b/packages/auth-providers/supertokens/api/package.json
@@ -49,7 +49,6 @@
     "@types/jsonwebtoken": "9.0.10",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/supertokens/api/package.json
+++ b/packages/auth-providers/supertokens/api/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-supertokens-api.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/supertokens/setup/package.json
+++ b/packages/auth-providers/supertokens/setup/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth-supertokens-setup.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",

--- a/packages/auth-providers/supertokens/setup/package.json
+++ b/packages/auth-providers/supertokens/setup/package.json
@@ -48,7 +48,6 @@
     "concurrently": "9.2.1",
     "memfs": "4.57.7",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/supertokens/web/package.json
+++ b/packages/auth-providers/supertokens/web/package.json
@@ -58,7 +58,6 @@
     "publint": "0.3.21",
     "react": "19.2.3",
     "supertokens-auth-react": "0.51.2",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/auth-providers/supertokens/web/package.json
+++ b/packages/auth-providers/supertokens/web/package.json
@@ -37,7 +37,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.ts",
+    "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-supertokens-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -75,7 +75,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.ts && yarn build:types",
+    "build": "node ./build.ts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-auth.tgz",
     "build:types": "tsc --build --verbose tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose tsconfig.cjs.json",

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && run build:types",
+    "build": "node ./build.mts && run build:types",
     "build:pack": "yarn pack -o cedarjs-babel-config.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -51,7 +51,6 @@
     "@types/babel__register": "7.17.3",
     "@types/node": "24.10.4",
     "babel-plugin-tester": "11.0.4",
-    "tsx": "4.22.4",
     "vitest": "3.2.6"
   },
   "engines": {

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -95,7 +95,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.ts && yarn build:types",
+    "build": "node ./build.ts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-cli-helpers.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -133,7 +133,6 @@
     "@types/yargs": "17.0.35",
     "@types/yargs-parser": "21.0.3",
     "prettier-plugin-tailwindcss": "0.8.0",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -41,7 +41,6 @@
     "@prisma/client": "7.8.0",
     "@types/yargs": "17.0.35",
     "memfs": "4.57.7",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-cli-data-migrate.tgz",
     "build:types": "tsc --build --verbose",
     "prepublishOnly": "NODE_ENV=production yarn build",

--- a/packages/cli-packages/storybook-vite/package.json
+++ b/packages/cli-packages/storybook-vite/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-cli-storybook-vite.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/cli-packages/storybook-vite/package.json
+++ b/packages/cli-packages/storybook-vite/package.json
@@ -38,7 +38,6 @@
     "@cedarjs/framework-tools": "workspace:*",
     "@types/semver": "^7",
     "@types/yargs": "17.0.35",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -101,7 +101,6 @@
     "memfs": "4.57.7",
     "node-ssh": "13.2.1",
     "ts-dedent": "2.3.0",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-cli.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build && yarn fix:permissions\"",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-codemods.tgz",
     "build:watch": "nodemon --watch src --ignore dist --exec \"yarn build\"",
     "check:package": "yarn publint",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -55,7 +55,6 @@
     "memfs": "4.57.7",
     "publint": "0.3.21",
     "ts-dedent": "2.3.0",
-    "tsx": "4.22.4",
     "vitest": "3.2.6"
   },
   "engines": {

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -61,7 +61,6 @@
     "@cedarjs/framework-tools": "workspace:*",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -47,7 +47,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-context.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/cookie-jar/package.json
+++ b/packages/cookie-jar/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && run build:types",
+    "build": "node ./build.mts && run build:types",
     "build:pack": "yarn pack -o cedarjs-cookie-jar.tgz",
     "build:types": "tsc --build --verbose",
     "test": "vitest run"

--- a/packages/cookie-jar/package.json
+++ b/packages/cookie-jar/package.json
@@ -29,7 +29,6 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,8 +62,7 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
-    "publint": "0.3.21",
-    "tsx": "4.22.4"
+    "publint": "0.3.21"
   },
   "engines": {
     "node": ">=24"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-core.tgz",
     "check:package": "yarn publint",
     "prepublishOnly": "NODE_ENV=production yarn build"

--- a/packages/create-cedar-rsc-app/build.ts
+++ b/packages/create-cedar-rsc-app/build.ts
@@ -1,4 +1,4 @@
-import { build, defaultBuildOptions } from './framework-tools.js'
+import { build, defaultBuildOptions } from './framework-tools.ts'
 
 await build({
   buildOptions: {

--- a/packages/create-cedar-rsc-app/package.json
+++ b/packages/create-cedar-rsc-app/package.json
@@ -19,7 +19,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsx build.ts",
+    "build": "node ./build.ts",
     "check": "concurrently yarn:knip yarn:publint",
     "check:knip": "knip",
     "check:package": "publint",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -32,7 +32,6 @@
     "@types/estree": "1.0.9",
     "@typescript-eslint/parser": "8.60.1",
     "@typescript-eslint/rule-tester": "8.60.1",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-eslint-plugin.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-forms.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -51,7 +51,6 @@
     "publint": "0.3.21",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/framework-tools/build.ts
+++ b/packages/framework-tools/build.ts
@@ -1,4 +1,4 @@
-import { build, defaultBuildOptions } from './src/buildDefaults'
+import { build, defaultBuildOptions } from './src/buildDefaults.ts'
 
 await build({
   buildOptions: {

--- a/packages/framework-tools/package.json
+++ b/packages/framework-tools/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.ts && run build:types",
+    "build": "node ./build.ts && run build:types",
     "build:types": "tsc --build --verbose"
   },
   "dependencies": {

--- a/packages/framework-tools/package.json
+++ b/packages/framework-tools/package.json
@@ -37,7 +37,6 @@
     "fast-glob": "3.3.3"
   },
   "devDependencies": {
-    "tsx": "4.22.4",
     "type-fest": "5.6.0",
     "typescript": "5.9.3"
   },

--- a/packages/gqlorm/package.json
+++ b/packages/gqlorm/package.json
@@ -126,7 +126,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.ts",
+    "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-gqlorm.tgz",
     "build:types": "tsc --build --verbose tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose tsconfig.cjs.json",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -73,7 +73,6 @@
     "concurrently": "9.2.1",
     "jsonwebtoken": "9.0.3",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -25,7 +25,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-graphql-server.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -140,7 +140,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:clean-dist": "rimraf 'dist/**/*/__tests__' --glob",
     "build:pack": "yarn pack -o cedarjs-internal.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -210,7 +210,6 @@
     "concurrently": "9.2.1",
     "graphql-tag": "2.12.6",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "vitest": "3.2.6"
   },
   "engines": {

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -49,7 +49,6 @@
     "@prisma/client": "7.8.0",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-jobs.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/mailer/core/package.json
+++ b/packages/mailer/core/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@cedarjs/api": "workspace:*",
     "@cedarjs/framework-tools": "workspace:*",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/mailer/core/package.json
+++ b/packages/mailer/core/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-mailer-core.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/mailer/handlers/in-memory/package.json
+++ b/packages/mailer/handlers/in-memory/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-mailer-handler-in-memory.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/mailer/handlers/in-memory/package.json
+++ b/packages/mailer/handlers/in-memory/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "publishConfig": {

--- a/packages/mailer/handlers/nodemailer/package.json
+++ b/packages/mailer/handlers/nodemailer/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-mailer-handler-nodemailer.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/mailer/handlers/nodemailer/package.json
+++ b/packages/mailer/handlers/nodemailer/package.json
@@ -27,7 +27,6 @@
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
     "@types/nodemailer": "^6",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "publishConfig": {

--- a/packages/mailer/handlers/resend/package.json
+++ b/packages/mailer/handlers/resend/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "publishConfig": {

--- a/packages/mailer/handlers/resend/package.json
+++ b/packages/mailer/handlers/resend/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-mailer-handler-resend.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/mailer/handlers/studio/package.json
+++ b/packages/mailer/handlers/studio/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-mailer-handler-studio.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/mailer/handlers/studio/package.json
+++ b/packages/mailer/handlers/studio/package.json
@@ -27,7 +27,6 @@
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
     "@types/nodemailer": "^6",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "publishConfig": {

--- a/packages/mailer/renderers/mjml-react/package.json
+++ b/packages/mailer/renderers/mjml-react/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
     "@types/mjml": "4",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "publishConfig": {

--- a/packages/mailer/renderers/mjml-react/package.json
+++ b/packages/mailer/renderers/mjml-react/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-mailer-renderer-mjml-react.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/mailer/renderers/react-email/package.json
+++ b/packages/mailer/renderers/react-email/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-mailer-renderer-react-email.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/mailer/renderers/react-email/package.json
+++ b/packages/mailer/renderers/react-email/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "publishConfig": {

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -52,7 +52,6 @@
     "@cedarjs/router": "workspace:*",
     "@playwright/test": "1.61.1",
     "ts-toolbelt": "9.6.0",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vite": "7.3.5",
     "vitest": "3.2.6"

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -32,7 +32,7 @@
     "empty.js"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-ogimage-gen.tgz",
     "build:types": "tsc --build --verbose",
     "prepublishOnly": "NODE_ENV=production yarn build",

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -100,7 +100,6 @@
     "babel-plugin-tester": "11.0.4",
     "concurrently": "9.2.1",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -55,7 +55,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-prerender.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -69,7 +69,6 @@
     "prisma": "7.8.0",
     "publint": "0.3.21",
     "rimraf": "6.1.3",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -45,7 +45,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.ts && run build:types",
+    "build": "node ./build.ts && run build:types",
     "build:pack": "yarn pack -o cedarjs-project-config.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -39,7 +39,6 @@
     "@prisma/internals": "7.8.0",
     "esbuild": "0.27.7",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "vitest": "3.2.6"
   },
   "engines": {

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-record.tgz",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "check:package": "yarn publint",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -81,7 +81,7 @@
     "skip-nav.css"
   ],
   "scripts": {
-    "build": "tsx ./build.ts",
+    "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-router.tgz",
     "build:types": "tsc --build --verbose tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose tsconfig.cjs.json",

--- a/packages/server-store/package.json
+++ b/packages/server-store/package.json
@@ -29,7 +29,6 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/packages/server-store/package.json
+++ b/packages/server-store/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && run build:types",
+    "build": "node ./build.mts && run build:types",
     "build:pack": "yarn pack -o cedarjs-server-store.tgz",
     "build:types": "tsc --build --verbose"
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -41,7 +41,7 @@
     "!dist/**/*.test.d.*"
   ],
   "scripts": {
-    "build": "tsx ./build.mts",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-storage.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose tsconfig.types-cjs.json",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -42,7 +42,7 @@
     "!src/**/*"
   ],
   "scripts": {
-    "build": "tsx build.ts && yarn build:types",
+    "build": "node ./build.ts && yarn build:types",
     "build:pack": "yarn pack -o storybook-framework-cedarjs.tgz",
     "build:types": "tsc --build --verbose",
     "test": "vitest run",
@@ -64,7 +64,6 @@
   "devDependencies": {
     "@storybook/types": "8.6.14",
     "@types/node": "24.10.4",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vite": "7.3.5",
     "vitest": "3.2.6"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx build.mts && yarn build:types",
+    "build": "node build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-telemetry.tgz",
     "build:types": "tsc --build --verbose",
     "prepublishOnly": "NODE_ENV=production yarn build",
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@types/envinfo": "7.8.4",
     "@types/yargs": "17.0.35",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -147,7 +147,6 @@
     "concurrently": "9.2.1",
     "jsdom": "27.4.0",
     "publint": "0.3.21",
-    "tsx": "4.22.4",
     "typescript": "5.9.3",
     "vitest": "3.2.6"
   },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -104,7 +104,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-testing.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-tui.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -49,7 +49,7 @@
     "inject"
   ],
   "scripts": {
-    "build": "tsx build.ts && yarn build:types",
+    "build": "node ./build.ts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-vite.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "check:attw": "tsx ./attw.ts",

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
-    "tsx": "4.22.4",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -19,7 +19,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "node ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-web-server.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build && yarn fix:permissions\"",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -127,7 +127,7 @@
     "toast"
   ],
   "scripts": {
-    "build": "tsx ./build.ts && yarn build:types",
+    "build": "node ./build.ts && yarn build:types",
     "build:pack": "yarn pack -o cedarjs-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,7 +2201,6 @@ __metadata:
     publint: "npm:0.3.21"
     split2: "npm:4.2.0"
     termi-link: "npm:1.1.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
     yargs: "npm:17.7.2"
@@ -2247,7 +2246,6 @@ __metadata:
     split2: "npm:4.2.0"
     title-case: "npm:3.0.3"
     ts-toolbelt: "npm:9.6.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
@@ -2280,7 +2278,6 @@ __metadata:
     jsonwebtoken: "npm:9.0.3"
     jwks-rsa: "npm:3.2.2"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2296,7 +2293,6 @@ __metadata:
     "@types/yargs": "npm:17.0.35"
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2313,7 +2309,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
@@ -2334,7 +2329,6 @@ __metadata:
     jsonwebtoken: "npm:9.0.3"
     jwks-rsa: "npm:3.2.2"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2350,7 +2344,6 @@ __metadata:
     "@types/yargs": "npm:17.0.35"
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2369,7 +2362,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
@@ -2388,7 +2380,6 @@ __metadata:
     "@types/aws-lambda": "npm:8.10.162"
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2404,7 +2395,6 @@ __metadata:
     "@types/yargs": "npm:17.0.35"
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -2421,7 +2411,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
@@ -2439,7 +2428,6 @@ __metadata:
     "@types/yargs": "npm:17.0.35"
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2458,7 +2446,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     md5: "npm:2.3.0"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     uuid: "npm:11.1.0"
     vitest: "npm:3.2.6"
@@ -2479,7 +2466,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     ts-toolbelt: "npm:9.6.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2517,7 +2503,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2534,7 +2519,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     firebase-admin: "npm:13.8.0"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2550,7 +2534,6 @@ __metadata:
     "@types/yargs": "npm:17.0.35"
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2567,7 +2550,6 @@ __metadata:
     firebase: "npm:10.14.1"
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
@@ -2587,7 +2569,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     jsonwebtoken: "npm:9.0.3"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2603,7 +2584,6 @@ __metadata:
     "@types/yargs": "npm:17.0.35"
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2620,7 +2600,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
@@ -2641,7 +2620,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     jsonwebtoken: "npm:9.0.3"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2663,7 +2641,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     ts-toolbelt: "npm:9.6.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2679,7 +2656,6 @@ __metadata:
     "@types/yargs": "npm:17.0.35"
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -2696,7 +2672,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
@@ -2716,7 +2691,6 @@ __metadata:
     jsonwebtoken: "npm:9.0.3"
     jwks-rsa: "npm:3.2.2"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
@@ -2735,7 +2709,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     memfs: "npm:4.57.7"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2752,7 +2725,6 @@ __metadata:
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
     supertokens-auth-react: "npm:0.51.2"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
@@ -2805,7 +2777,6 @@ __metadata:
     babel-plugin-tester: "npm:11.0.4"
     fast-glob: "npm:3.3.3"
     graphql: "npm:16.13.2"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -2827,7 +2798,6 @@ __metadata:
     listr2: "npm:10.2.1"
     memfs: "npm:4.57.7"
     termi-link: "npm:1.1.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
     yargs: "npm:17.7.2"
@@ -2866,7 +2836,6 @@ __metadata:
     semver: "npm:7.7.4"
     smol-toml: "npm:1.6.1"
     termi-link: "npm:1.1.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
     yargs-parser: "npm:21.1.1"
@@ -2888,7 +2857,6 @@ __metadata:
     storybook: "npm:8.6.18"
     storybook-framework-cedarjs: "workspace:*"
     termi-link: "npm:1.1.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
     yargs: "npm:17.7.2"
@@ -2964,7 +2932,6 @@ __metadata:
     termi-link: "npm:1.1.0"
     title-case: "npm:3.0.3"
     ts-dedent: "npm:2.3.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     unionfs: "npm:4.6.0"
     uuid: "npm:11.1.0"
@@ -3010,7 +2977,6 @@ __metadata:
     publint: "npm:0.3.21"
     tasuku: "npm:2.3.0"
     ts-dedent: "npm:2.3.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
     yargs: "npm:17.7.2"
@@ -3027,7 +2993,6 @@ __metadata:
     "@cedarjs/framework-tools": "workspace:*"
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -3040,7 +3005,6 @@ __metadata:
     cookie: "npm:1.1.1"
     esbuild: "npm:0.27.7"
     fast-glob: "npm:3.3.3"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -3062,7 +3026,6 @@ __metadata:
     graphql-tag: "npm:2.12.6"
     nodemon: "npm:3.1.14"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   bin:
     cedar: ./dist/bins/cedar.js
@@ -3138,7 +3101,6 @@ __metadata:
     "@typescript-eslint/rule-tester": "npm:8.60.1"
     "@typescript-eslint/utils": "npm:8.60.1"
     eslint: "npm:8.57.1"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -3155,7 +3117,6 @@ __metadata:
     "@fastify/url-data": "npm:6.0.3"
     fast-glob: "npm:3.3.3"
     fastify: "npm:5.8.5"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -3181,7 +3142,6 @@ __metadata:
     react: "npm:19.2.3"
     react-dom: "npm:19.2.3"
     react-hook-form: "npm:7.74.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   peerDependencies:
@@ -3197,7 +3157,6 @@ __metadata:
     esbuild: "npm:0.27.7"
     execa: "npm:5.1.1"
     fast-glob: "npm:3.3.3"
-    tsx: "npm:4.22.4"
     type-fest: "npm:5.6.0"
     typescript: "npm:5.9.3"
   bin:
@@ -3277,7 +3236,6 @@ __metadata:
     jsonwebtoken: "npm:9.0.3"
     lodash: "npm:4.18.1"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     uuid: "npm:11.1.0"
     vitest: "npm:3.2.6"
@@ -3340,7 +3298,6 @@ __metadata:
     systeminformation: "npm:5.31.7"
     termi-link: "npm:1.1.0"
     ts-node: "npm:10.9.2"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vite: "npm:7.3.5"
     vitest: "npm:3.2.6"
@@ -3361,7 +3318,6 @@ __metadata:
     concurrently: "npm:9.2.1"
     cron-parser: "npm:5.5.0"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     type-fest: "npm:5.6.0"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
@@ -3378,7 +3334,6 @@ __metadata:
   dependencies:
     "@cedarjs/api": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -3390,7 +3345,6 @@ __metadata:
   dependencies:
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/mailer-core": "workspace:*"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -3403,7 +3357,6 @@ __metadata:
     "@cedarjs/mailer-core": "workspace:*"
     "@types/nodemailer": "npm:^6"
     nodemailer: "npm:8.0.4"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -3415,7 +3368,6 @@ __metadata:
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/mailer-core": "workspace:*"
     resend: "npm:4.8.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -3428,7 +3380,6 @@ __metadata:
     "@cedarjs/mailer-core": "workspace:*"
     "@cedarjs/mailer-handler-nodemailer": "workspace:*"
     "@types/nodemailer": "npm:^6"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -3442,7 +3393,6 @@ __metadata:
     "@faire/mjml-react": "npm:3.5.4"
     "@types/mjml": "npm:4"
     mjml: "npm:4.18.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -3454,7 +3404,6 @@ __metadata:
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/mailer-core": "workspace:*"
     "@react-email/render": "npm:0.0.17"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -3473,7 +3422,6 @@ __metadata:
     react: "npm:19.2.3"
     react-dom: "npm:19.2.3"
     ts-toolbelt: "npm:9.6.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vite: "npm:7.3.5"
     vitest: "npm:3.2.6"
@@ -3514,7 +3462,6 @@ __metadata:
     publint: "npm:0.3.21"
     rollup: "npm:4.60.4"
     rollup-plugin-swc3: "npm:0.12.1"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     unimport: "npm:5.7.0"
     unplugin-auto-import: "npm:19.3.0"
@@ -3543,7 +3490,6 @@ __metadata:
     rimraf: "npm:6.1.3"
     smol-toml: "npm:1.6.1"
     string-env-interpolation: "npm:1.0.1"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -3593,7 +3539,6 @@ __metadata:
     camelcase: "npm:6.3.0"
     esbuild: "npm:0.27.7"
     publint: "npm:0.3.21"
-    tsx: "npm:4.22.4"
     vitest: "npm:3.2.6"
   languageName: unknown
   linkType: soft
@@ -3636,7 +3581,6 @@ __metadata:
     "@cedarjs/framework-tools": "workspace:*"
     esbuild: "npm:0.27.7"
     fast-glob: "npm:3.3.3"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -3702,7 +3646,6 @@ __metadata:
     ci-info: "npm:4.4.0"
     envinfo: "npm:7.21.0"
     systeminformation: "npm:5.31.7"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     uuid: "npm:11.1.0"
     vitest: "npm:3.2.6"
@@ -3741,7 +3684,6 @@ __metadata:
     msw: "npm:1.3.5"
     publint: "npm:0.3.21"
     ts-toolbelt: "npm:9.6.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     unplugin-auto-import: "npm:19.3.0"
     vitest: "npm:3.2.6"
@@ -3765,7 +3707,6 @@ __metadata:
     ansis: "npm:4.2.0"
     enquirer: "npm:2.4.1"
     stdout-update: "npm:1.6.8"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -3884,7 +3825,6 @@ __metadata:
     ansis: "npm:4.2.0"
     dotenv-defaults: "npm:5.0.2"
     fastify: "npm:5.8.5"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     yargs: "npm:17.7.2"
   bin:
@@ -27374,7 +27314,6 @@ __metadata:
     magic-string: "npm:0.30.21"
     react-docgen: "npm:7.1.1"
     tsconfig-paths: "npm:^3.15.0"
-    tsx: "npm:4.22.4"
     typescript: "npm:5.9.3"
     unplugin-auto-import: "npm:19.3.0"
     vite: "npm:7.3.5"


### PR DESCRIPTION
tsx is largely not needed anymore now that node can run TypeScript natively. This PR switches from tsx to node for running build scripts