### PR TITLE
chore(vite): port babel-plugin-redwood-context-wrapping to vite

### DIFF
--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-context-wrapping.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-context-wrapping.test.ts
@@ -1,0 +1,160 @@
+import path from 'node:path'
+
+import { dedent } from 'ts-dedent'
+import { describe, it, expect, vi } from 'vitest'
+
+import { cedarContextWrappingPlugin } from '../vite-plugin-cedar-context-wrapping.js'
+
+const TEST_CEDAR_CWD = '/Users/test/cedar-app'
+
+vi.mock('@cedarjs/project-config', () => ({
+  getPaths: () => ({
+    api: {
+      src: path.join(TEST_CEDAR_CWD, 'api/src'),
+    },
+  }),
+}))
+
+function getPluginTransform(options?: { projectIsEsm?: boolean }) {
+  const plugin = cedarContextWrappingPlugin(options)
+
+  if (typeof plugin.transform !== 'function') {
+    expect.fail('Expected plugin to have a transform function')
+  }
+
+  return plugin.transform.bind({} as ThisParameterType<typeof plugin.transform>)
+}
+
+const FUNCTIONS_DIR = path.join(TEST_CEDAR_CWD, 'api/src/functions')
+
+describe('cedarContextWrappingPlugin', () => {
+  it('wraps an async arrow function handler', () => {
+    const transform = getPluginTransform()
+    const code = dedent`
+      import { logger } from 'src/lib/logger'
+
+      export const handler = async (event, _context) => {
+        logger.info('hello')
+        return { statusCode: 200 }
+      }
+    `
+
+    const result = transform(code, path.join(FUNCTIONS_DIR, 'custom.ts'))
+
+    expect(result).not.toBeNull()
+    const output = (result as { code: string }).code
+
+    expect(output).toContain(
+      "import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '@cedarjs/context/dist/store'",
+    )
+    expect(output).toContain('const __rw_handler = async (event, _context) =>')
+    expect(output).toContain(
+      'export const handler = async (__rw_event, __rw__context) =>',
+    )
+    expect(output).toContain('__rw_getAsyncStoreInstance().getStore()')
+    expect(output).toContain(
+      '__rw_getAsyncStoreInstance().run(\n      new Map(),\n      __rw_handler,',
+    )
+    expect(output).toContain('return __rw_handler(__rw_event, __rw__context)')
+  })
+
+  it('wraps a non-async handler (e.g. createGraphQLHandler call) without async keyword', () => {
+    const transform = getPluginTransform()
+    const code = dedent`
+      import { createGraphQLHandler } from '@cedarjs/graphql-server'
+
+      export const handler = createGraphQLHandler({
+        sdls,
+        services,
+      })
+    `
+
+    const result = transform(code, path.join(FUNCTIONS_DIR, 'graphql.ts'))
+
+    expect(result).not.toBeNull()
+    const output = (result as { code: string }).code
+
+    expect(output).toContain('const __rw_handler = createGraphQLHandler({')
+    // Wrapper must NOT be async (original was not an async function)
+    expect(output).toContain(
+      'export const handler = (__rw_event, __rw__context) =>',
+    )
+    expect(output).not.toContain(
+      'export const handler = async (__rw_event, __rw__context)',
+    )
+  })
+
+  it('uses the ESM store path when projectIsEsm is true', () => {
+    const transform = getPluginTransform({ projectIsEsm: true })
+    const code = `export const handler = async (event) => {}`
+
+    const result = transform(code, path.join(FUNCTIONS_DIR, 'custom.ts'))
+
+    expect(result).not.toBeNull()
+    const output = (result as { code: string }).code
+
+    expect(output).toContain(
+      "import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '@cedarjs/context/dist/store.js'",
+    )
+  })
+
+  it('returns null for files outside api/src/functions/', () => {
+    const transform = getPluginTransform()
+    const code = `export const handler = async (event) => {}`
+
+    // web side file - should not be transformed
+    const result = transform(
+      code,
+      path.join(TEST_CEDAR_CWD, 'web/src/pages/HomePage.tsx'),
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for api files outside functions directory', () => {
+    const transform = getPluginTransform()
+    const code = `export const handler = async (event) => {}`
+
+    const result = transform(
+      code,
+      path.join(TEST_CEDAR_CWD, 'api/src/lib/auth.ts'),
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for function files without a handler export', () => {
+    const transform = getPluginTransform()
+    const code = dedent`
+      export const myHelper = () => {
+        return 'not a handler'
+      }
+    `
+
+    const result = transform(code, path.join(FUNCTIONS_DIR, 'helper.ts'))
+
+    expect(result).toBeNull()
+  })
+
+  it('preserves the rest of the file around the handler', () => {
+    const transform = getPluginTransform()
+    const code = dedent`
+      import { db } from 'src/lib/db'
+
+      const helperFn = () => 42
+
+      export const handler = async (event, context) => {
+        return { statusCode: 200 }
+      }
+    `
+
+    const result = transform(code, path.join(FUNCTIONS_DIR, 'custom.ts'))
+
+    expect(result).not.toBeNull()
+    const output = (result as { code: string }).code
+
+    expect(output).toContain("import { db } from 'src/lib/db'")
+    expect(output).toContain('const helperFn = () => 42')
+    expect(output).toContain('const __rw_handler = async (event, context) =>')
+  })
+})

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-context-wrapping.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-context-wrapping.test.ts
@@ -49,13 +49,13 @@ describe('cedarContextWrappingPlugin', () => {
     )
     expect(output).toContain('const __rw_handler = async (event, _context) =>')
     expect(output).toContain(
-      'export const handler = async (__rw_event, __rw__context) =>',
+      'export const handler = async (...__rw_args) =>',
     )
     expect(output).toContain('__rw_getAsyncStoreInstance().getStore()')
     expect(output).toContain(
-      '__rw_getAsyncStoreInstance().run(\n      new Map(),\n      __rw_handler,',
+      '__rw_getAsyncStoreInstance().run(\n      new Map(),\n      __rw_handler,\n      ...__rw_args',
     )
-    expect(output).toContain('return __rw_handler(__rw_event, __rw__context)')
+    expect(output).toContain('return __rw_handler(...__rw_args)')
   })
 
   it('wraps a non-async handler (e.g. createGraphQLHandler call) without async keyword', () => {
@@ -77,10 +77,10 @@ describe('cedarContextWrappingPlugin', () => {
     expect(output).toContain('const __rw_handler = createGraphQLHandler({')
     // Wrapper must NOT be async (original was not an async function)
     expect(output).toContain(
-      'export const handler = (__rw_event, __rw__context) =>',
+      'export const handler = (...__rw_args) =>',
     )
     expect(output).not.toContain(
-      'export const handler = async (__rw_event, __rw__context)',
+      'export const handler = async (...__rw_args)',
     )
   })
 
@@ -156,5 +156,94 @@ describe('cedarContextWrappingPlugin', () => {
     expect(output).toContain("import { db } from 'src/lib/db'")
     expect(output).toContain('const helperFn = () => 42')
     expect(output).toContain('const __rw_handler = async (event, context) =>')
+  })
+
+  it('handles typed handler exports (TypeScript type annotations)', () => {
+    const transform = getPluginTransform()
+    const code = dedent`
+      import type { APIGatewayProxyHandler } from 'aws-lambda'
+
+      export const handler: APIGatewayProxyHandler = async (event, _context) => {
+        return { statusCode: 200 }
+      }
+    `
+
+    const result = transform(code, path.join(FUNCTIONS_DIR, 'custom.ts'))
+
+    expect(result).not.toBeNull()
+    const output = (result as { code: string }).code
+
+    // Type annotation should be preserved on the renamed handler
+    expect(output).toContain('const __rw_handler: APIGatewayProxyHandler = async')
+    // Export wrapper doesn't keep the type annotation (different signature with ...args)
+    expect(output).toContain('export const handler = async (...__rw_args) =>')
+  })
+
+  it('handles complex type annotations', () => {
+    const transform = getPluginTransform()
+    const code = dedent`
+      export const handler: (event: Event, context: Context) => Promise<Response> = async (event, context) => {
+        return { statusCode: 200 }
+      }
+    `
+
+    const result = transform(code, path.join(FUNCTIONS_DIR, 'custom.ts'))
+
+    expect(result).not.toBeNull()
+    const output = (result as { code: string }).code
+
+    // Type annotation should be preserved on the renamed handler
+    expect(output).toContain('const __rw_handler: (event: Event, context: Context) => Promise<Response>')
+    // Export wrapper doesn't keep the type annotation (different signature with ...args)
+    expect(output).toContain('export const handler = (...__rw_args) =>')
+  })
+
+  it('detects async keyword with no space before parenthesis', () => {
+    const transform = getPluginTransform()
+    const code = `export const handler = async(event, context) => { return {} }`
+
+    const result = transform(code, path.join(FUNCTIONS_DIR, 'custom.ts'))
+
+    expect(result).not.toBeNull()
+    const output = (result as { code: string }).code
+
+    // Should be marked as async despite missing space
+    expect(output).toContain('export const handler = async (...__rw_args) =>')
+  })
+
+  it('detects async keyword with comment before it', () => {
+    const transform = getPluginTransform()
+    const code = dedent`
+      export const handler = /* TODO: make this async */ async (event, context) => {
+        return {}
+      }
+    `
+
+    const result = transform(code, path.join(FUNCTIONS_DIR, 'custom.ts'))
+
+    expect(result).not.toBeNull()
+    const output = (result as { code: string }).code
+
+    // Should be marked as async even with comment
+    expect(output).toContain('export const handler = async (...__rw_args) =>')
+  })
+
+  it('forwards all arguments including callback to wrapped handler', () => {
+    const transform = getPluginTransform()
+    const code = dedent`
+      export const handler = (event, context, callback) => {
+        callback(null, { statusCode: 200 })
+      }
+    `
+
+    const result = transform(code, path.join(FUNCTIONS_DIR, 'custom.ts'))
+
+    expect(result).not.toBeNull()
+    const output = (result as { code: string }).code
+
+    // Should use rest parameters to forward all args
+    expect(output).toContain('export const handler = (...__rw_args) =>')
+    expect(output).toContain('__rw_getAsyncStoreInstance().run(\n      new Map(),\n      __rw_handler,\n      ...__rw_args')
+    expect(output).toContain('return __rw_handler(...__rw_args)')
   })
 })

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-context-wrapping.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-context-wrapping.test.ts
@@ -49,13 +49,13 @@ describe('cedarContextWrappingPlugin', () => {
     )
     expect(output).toContain('const __rw_handler = async (event, _context) =>')
     expect(output).toContain(
-      'export const handler = async (...__rw_args) =>',
+      'export const handler = async (__rw_event, __rw__context) =>',
     )
     expect(output).toContain('__rw_getAsyncStoreInstance().getStore()')
     expect(output).toContain(
-      '__rw_getAsyncStoreInstance().run(\n      new Map(),\n      __rw_handler,\n      ...__rw_args',
+      '__rw_getAsyncStoreInstance().run(\n      new Map(),\n      __rw_handler,\n      __rw_event,\n      __rw__context',
     )
-    expect(output).toContain('return __rw_handler(...__rw_args)')
+    expect(output).toContain('return __rw_handler(__rw_event, __rw__context)')
   })
 
   it('wraps a non-async handler (e.g. createGraphQLHandler call) without async keyword', () => {
@@ -77,10 +77,10 @@ describe('cedarContextWrappingPlugin', () => {
     expect(output).toContain('const __rw_handler = createGraphQLHandler({')
     // Wrapper must NOT be async (original was not an async function)
     expect(output).toContain(
-      'export const handler = (...__rw_args) =>',
+      'export const handler = (__rw_event, __rw__context) =>',
     )
     expect(output).not.toContain(
-      'export const handler = async (...__rw_args)',
+      'export const handler = async (__rw_event, __rw__context)',
     )
   })
 
@@ -173,13 +173,13 @@ describe('cedarContextWrappingPlugin', () => {
     expect(result).not.toBeNull()
     const output = (result as { code: string }).code
 
-    // Type annotation should be preserved on the renamed handler
-    expect(output).toContain('const __rw_handler: APIGatewayProxyHandler = async')
-    // Export wrapper doesn't keep the type annotation (different signature with ...args)
-    expect(output).toContain('export const handler = async (...__rw_args) =>')
+    // Type annotation is stripped on renamed handler (matches Babel plugin behavior)
+    expect(output).toContain('const __rw_handler = async (event, _context) =>')
+    expect(output).not.toContain('const __rw_handler: APIGatewayProxyHandler')
+    expect(output).toContain('export const handler = async (__rw_event, __rw__context) =>')
   })
 
-  it('handles complex type annotations', () => {
+  it('handles function type annotations containing =>', () => {
     const transform = getPluginTransform()
     const code = dedent`
       export const handler: (event: Event, context: Context) => Promise<Response> = async (event, context) => {
@@ -192,10 +192,9 @@ describe('cedarContextWrappingPlugin', () => {
     expect(result).not.toBeNull()
     const output = (result as { code: string }).code
 
-    // Type annotation should be preserved on the renamed handler
-    expect(output).toContain('const __rw_handler: (event: Event, context: Context) => Promise<Response>')
-    // Export wrapper doesn't keep the type annotation (different signature with ...args)
-    expect(output).toContain('export const handler = (...__rw_args) =>')
+    // Type annotation stripped, handler value correctly extracted despite => in type
+    expect(output).toContain('const __rw_handler = async (event, context) =>')
+    expect(output).toContain('export const handler = async (__rw_event, __rw__context) =>')
   })
 
   it('detects async keyword with no space before parenthesis', () => {
@@ -208,14 +207,14 @@ describe('cedarContextWrappingPlugin', () => {
     const output = (result as { code: string }).code
 
     // Should be marked as async despite missing space
-    expect(output).toContain('export const handler = async (...__rw_args) =>')
+    expect(output).toContain('export const handler = async (__rw_event, __rw__context) =>')
   })
 
-  it('detects async keyword with comment before it', () => {
+  it('detects async function expressions', () => {
     const transform = getPluginTransform()
     const code = dedent`
-      export const handler = /* TODO: make this async */ async (event, context) => {
-        return {}
+      export const handler = async function (event, context) {
+        return { statusCode: 200 }
       }
     `
 
@@ -224,26 +223,6 @@ describe('cedarContextWrappingPlugin', () => {
     expect(result).not.toBeNull()
     const output = (result as { code: string }).code
 
-    // Should be marked as async even with comment
-    expect(output).toContain('export const handler = async (...__rw_args) =>')
-  })
-
-  it('forwards all arguments including callback to wrapped handler', () => {
-    const transform = getPluginTransform()
-    const code = dedent`
-      export const handler = (event, context, callback) => {
-        callback(null, { statusCode: 200 })
-      }
-    `
-
-    const result = transform(code, path.join(FUNCTIONS_DIR, 'custom.ts'))
-
-    expect(result).not.toBeNull()
-    const output = (result as { code: string }).code
-
-    // Should use rest parameters to forward all args
-    expect(output).toContain('export const handler = (...__rw_args) =>')
-    expect(output).toContain('__rw_getAsyncStoreInstance().run(\n      new Map(),\n      __rw_handler,\n      ...__rw_args')
-    expect(output).toContain('return __rw_handler(...__rw_args)')
+    expect(output).toContain('export const handler = async (__rw_event, __rw__context) =>')
   })
 })

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-context-wrapping.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-context-wrapping.test.ts
@@ -176,7 +176,9 @@ describe('cedarContextWrappingPlugin', () => {
     // Type annotation is stripped on renamed handler (matches Babel plugin behavior)
     expect(output).toContain('const __rw_handler = async (event, _context) =>')
     expect(output).not.toContain('const __rw_handler: APIGatewayProxyHandler')
-    expect(output).toContain('export const handler = async (__rw_event, __rw__context) =>')
+    expect(output).toContain(
+      'export const handler = async (__rw_event, __rw__context) =>',
+    )
   })
 
   it('handles function type annotations containing =>', () => {
@@ -194,7 +196,9 @@ describe('cedarContextWrappingPlugin', () => {
 
     // Type annotation stripped, handler value correctly extracted despite => in type
     expect(output).toContain('const __rw_handler = async (event, context) =>')
-    expect(output).toContain('export const handler = async (__rw_event, __rw__context) =>')
+    expect(output).toContain(
+      'export const handler = async (__rw_event, __rw__context) =>',
+    )
   })
 
   it('detects async keyword with no space before parenthesis', () => {
@@ -207,7 +211,9 @@ describe('cedarContextWrappingPlugin', () => {
     const output = (result as { code: string }).code
 
     // Should be marked as async despite missing space
-    expect(output).toContain('export const handler = async (__rw_event, __rw__context) =>')
+    expect(output).toContain(
+      'export const handler = async (__rw_event, __rw__context) =>',
+    )
   })
 
   it('detects async function expressions', () => {
@@ -223,6 +229,8 @@ describe('cedarContextWrappingPlugin', () => {
     expect(result).not.toBeNull()
     const output = (result as { code: string }).code
 
-    expect(output).toContain('export const handler = async (__rw_event, __rw__context) =>')
+    expect(output).toContain(
+      'export const handler = async (__rw_event, __rw__context) =>',
+    )
   })
 })

--- a/packages/vite/src/plugins/vite-plugin-cedar-context-wrapping.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-context-wrapping.ts
@@ -39,7 +39,8 @@ export function cedarContextWrappingPlugin({
   // Matches the full export declaration up to (and including) the assignment =.
   // (?:[^=]|=>)* handles => inside TypeScript function type annotations without backtracking issues.
   // The final = is matched only when not part of => or == (lookahead (?![>=])).
-  const handlerRe = /^export\s+(?:const|let|var)\s+handler(?:[^=]|=>)*?=(?![>=])/m
+  const handlerRe =
+    /^export\s+(?:const|let|var)\s+handler(?:[^=]|=>)*?=(?![>=])/m
 
   return {
     name: 'cedar-context-wrapping',

--- a/packages/vite/src/plugins/vite-plugin-cedar-context-wrapping.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-context-wrapping.ts
@@ -36,9 +36,10 @@ export function cedarContextWrappingPlugin({
 }: {
   projectIsEsm?: boolean
 } = {}): Plugin {
-  // Captures: (1) const|let|var, (2) optional type annotation, (3) = with surrounding space
-  // Examples: "export const handler =", "export const handler: SomeType =", "export const handler: Type[] ="
-  const handlerRe = /^export\s+(const|let|var)\s+handler((?:\s*:[^=]*?)?)(\s*=)/m
+  // Matches the full export declaration up to (and including) the assignment =.
+  // (?:[^=]|=>)* handles => inside TypeScript function type annotations without backtracking issues.
+  // The final = is matched only when not part of => or == (lookahead (?![>=])).
+  const handlerRe = /^export\s+(?:const|let|var)\s+handler(?:[^=]|=>)*?=(?![>=])/m
 
   return {
     name: 'cedar-context-wrapping',
@@ -65,12 +66,11 @@ export function cedarContextWrappingPlugin({
 
       // Determine if the original handler init is an async function.
       // Matches the Babel plugin's check: t.isFunction(originalInit) && originalInit.async
-      // Handles forms like: async (...), async(...), async function, /* comment */ async, etc.
+      // Handles: async (...) => {}, async(...) => {}, async function() {}, async *gen() {}
       const afterEquals = code
         .slice(handlerMatch.index + handlerMatch[0].length)
         .trimStart()
-      // Allow zero spaces between async and parenthesis to match async(...)
-      const isAsync = /^\s*(?:\/\*[\s\S]*?\*\/\s*)*async\s*[\(\*]/.test(afterEquals)
+      const isAsync = /^async(?:\s*[\(\*]|\s+function)/.test(afterEquals)
 
       const storePath = projectIsEsm
         ? '@cedarjs/context/dist/store.js'
@@ -84,23 +84,25 @@ export function cedarContextWrappingPlugin({
       const before = code.slice(0, handlerStart)
       const after = code.slice(handlerStart)
 
-      // Preserve type annotation (group 2) when renaming
-      // Replace "export const handler [: Type] =" with "const __rw_handler [: Type] ="
-      const renamed = after.replace(handlerRe, 'const __rw_handler$2$3')
+      // Replace "export const handler [: Type] =" with "const __rw_handler ="
+      // Type annotation is dropped here, matching the Babel plugin which creates a fresh
+      // variableDeclarator with just the identifier and init (no type annotation).
+      const renamed = after.replace(handlerRe, 'const __rw_handler =')
 
-      // Use rest parameters to forward all arguments including optional callback
+      // Wrapper matches Babel's generateWrappedHandler exactly: explicit (__rw_event, __rw__context)
       const wrappedHandler =
-        `\nexport const handler = ${isAsync ? 'async ' : ''}(...__rw_args) => {\n` +
+        `\nexport const handler = ${isAsync ? 'async ' : ''}(__rw_event, __rw__context) => {\n` +
         `  // The store will be undefined if no context isolation has been performed yet\n` +
         `  const __rw_contextStore = __rw_getAsyncStoreInstance().getStore()\n` +
         `  if (__rw_contextStore === undefined) {\n` +
         `    return __rw_getAsyncStoreInstance().run(\n` +
         `      new Map(),\n` +
         `      __rw_handler,\n` +
-        `      ...__rw_args\n` +
+        `      __rw_event,\n` +
+        `      __rw__context\n` +
         `    )\n` +
         `  }\n` +
-        `  return __rw_handler(...__rw_args)\n` +
+        `  return __rw_handler(__rw_event, __rw__context)\n` +
         `}\n`
 
       return {

--- a/packages/vite/src/plugins/vite-plugin-cedar-context-wrapping.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-context-wrapping.ts
@@ -1,0 +1,107 @@
+import path from 'node:path'
+
+import type { Plugin } from 'vite'
+import { normalizePath } from 'vite'
+
+import { getPaths } from '@cedarjs/project-config'
+
+/**
+ * Vite plugin that wraps user API functions to ensure context isolation has
+ * been performed. This should already be done at the request level but in
+ * serverless environments like Netlify we need to do this at the function
+ * level as a safeguard.
+ *
+ * For each file in `api/src/functions/` that exports a `handler`, this plugin:
+ *
+ * 1. Adds an import at the top of the file:
+ *      import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
+ *
+ * 2. Renames the original handler:
+ *      const __rw_handler = <original handler value>
+ *
+ * 3. Replaces the handler export with a wrapper that checks context isolation:
+ *      export const handler = (__rw_event, __rw__context) => {
+ *        const __rw_contextStore = __rw_getAsyncStoreInstance().getStore()
+ *        if (__rw_contextStore === undefined) {
+ *          return __rw_getAsyncStoreInstance().run(new Map(), __rw_handler, __rw_event, __rw__context)
+ *        }
+ *        return __rw_handler(__rw_event, __rw__context)
+ *      }
+ *
+ * This replaces `babel-plugin-redwood-context-wrapping` for Vite builds.
+ * The babel plugin is still used for Jest and prerender.
+ */
+export function cedarContextWrappingPlugin({
+  projectIsEsm = false,
+}: {
+  projectIsEsm?: boolean
+} = {}): Plugin {
+  const handlerRe = /^export\s+(const|let|var)\s+handler\s*=/m
+
+  return {
+    name: 'cedar-context-wrapping',
+
+    transform(code, id) {
+      // Only transform API function files
+      let paths: ReturnType<typeof getPaths>
+      try {
+        paths = getPaths()
+      } catch {
+        return null
+      }
+
+      const functionsDir = normalizePath(path.join(paths.api.src, 'functions'))
+
+      if (!normalizePath(id).startsWith(functionsDir + '/')) {
+        return null
+      }
+
+      const handlerMatch = handlerRe.exec(code)
+      if (!handlerMatch) {
+        return null
+      }
+
+      // Determine if the original handler init is an async function.
+      // Matches the Babel plugin's check: t.isFunction(originalInit) && originalInit.async
+      const afterEquals = code
+        .slice(handlerMatch.index + handlerMatch[0].length)
+        .trimStart()
+      const isAsync = afterEquals.startsWith('async ')
+
+      const storePath = projectIsEsm
+        ? '@cedarjs/context/dist/store.js'
+        : '@cedarjs/context/dist/store'
+
+      const importStatement = `import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '${storePath}'\n`
+
+      // Insert the import just before the handler declaration, rename the
+      // handler export to a private const, then append the wrapped export.
+      const handlerStart = handlerMatch.index
+      const before = code.slice(0, handlerStart)
+      const after = code.slice(handlerStart)
+
+      // Replace "export const handler =" with "const __rw_handler ="
+      const renamed = after.replace(handlerRe, 'const __rw_handler =')
+
+      const wrappedHandler =
+        `\nexport const handler = ${isAsync ? 'async ' : ''}(__rw_event, __rw__context) => {\n` +
+        `  // The store will be undefined if no context isolation has been performed yet\n` +
+        `  const __rw_contextStore = __rw_getAsyncStoreInstance().getStore()\n` +
+        `  if (__rw_contextStore === undefined) {\n` +
+        `    return __rw_getAsyncStoreInstance().run(\n` +
+        `      new Map(),\n` +
+        `      __rw_handler,\n` +
+        `      __rw_event,\n` +
+        `      __rw__context\n` +
+        `    )\n` +
+        `  }\n` +
+        `  return __rw_handler(__rw_event, __rw__context)\n` +
+        `}\n`
+
+      return {
+        code: before + importStatement + renamed + wrappedHandler,
+        map: null,
+      }
+    },
+  }
+}

--- a/packages/vite/src/plugins/vite-plugin-cedar-context-wrapping.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-context-wrapping.ts
@@ -36,7 +36,9 @@ export function cedarContextWrappingPlugin({
 }: {
   projectIsEsm?: boolean
 } = {}): Plugin {
-  const handlerRe = /^export\s+(const|let|var)\s+handler\s*=/m
+  // Captures: (1) const|let|var, (2) optional type annotation, (3) = with surrounding space
+  // Examples: "export const handler =", "export const handler: SomeType =", "export const handler: Type[] ="
+  const handlerRe = /^export\s+(const|let|var)\s+handler((?:\s*:[^=]*?)?)(\s*=)/m
 
   return {
     name: 'cedar-context-wrapping',
@@ -63,10 +65,12 @@ export function cedarContextWrappingPlugin({
 
       // Determine if the original handler init is an async function.
       // Matches the Babel plugin's check: t.isFunction(originalInit) && originalInit.async
+      // Handles forms like: async (...), async(...), async function, /* comment */ async, etc.
       const afterEquals = code
         .slice(handlerMatch.index + handlerMatch[0].length)
         .trimStart()
-      const isAsync = afterEquals.startsWith('async ')
+      // Allow zero spaces between async and parenthesis to match async(...)
+      const isAsync = /^\s*(?:\/\*[\s\S]*?\*\/\s*)*async\s*[\(\*]/.test(afterEquals)
 
       const storePath = projectIsEsm
         ? '@cedarjs/context/dist/store.js'
@@ -80,22 +84,23 @@ export function cedarContextWrappingPlugin({
       const before = code.slice(0, handlerStart)
       const after = code.slice(handlerStart)
 
-      // Replace "export const handler =" with "const __rw_handler ="
-      const renamed = after.replace(handlerRe, 'const __rw_handler =')
+      // Preserve type annotation (group 2) when renaming
+      // Replace "export const handler [: Type] =" with "const __rw_handler [: Type] ="
+      const renamed = after.replace(handlerRe, 'const __rw_handler$2$3')
 
+      // Use rest parameters to forward all arguments including optional callback
       const wrappedHandler =
-        `\nexport const handler = ${isAsync ? 'async ' : ''}(__rw_event, __rw__context) => {\n` +
+        `\nexport const handler = ${isAsync ? 'async ' : ''}(...__rw_args) => {\n` +
         `  // The store will be undefined if no context isolation has been performed yet\n` +
         `  const __rw_contextStore = __rw_getAsyncStoreInstance().getStore()\n` +
         `  if (__rw_contextStore === undefined) {\n` +
         `    return __rw_getAsyncStoreInstance().run(\n` +
         `      new Map(),\n` +
         `      __rw_handler,\n` +
-        `      __rw_event,\n` +
-        `      __rw__context\n` +
+        `      ...__rw_args\n` +
         `    )\n` +
         `  }\n` +
-        `  return __rw_handler(__rw_event, __rw__context)\n` +
+        `  return __rw_handler(...__rw_args)\n` +
         `}\n`
 
       return {


### PR DESCRIPTION
## Summary

Ports `babel-plugin-redwood-context-wrapping` to a Vite plugin as a strict 1:1 port.

The plugin wraps user API functions in `api/src/functions/` to ensure async context isolation has been performed — a safeguard for serverless environments like Netlify where this may not happen at the request level.

**Transformation:**

```ts
// Input
export const handler = async (event, context) => { ... }

// Output
import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
const __rw_handler = async (event, context) => { ... }
export const handler = async (__rw_event, __rw__context) => {
  // The store will be undefined if no context isolation has been performed yet
  const __rw_contextStore = __rw_getAsyncStoreInstance().getStore()
  if (__rw_contextStore === undefined) {
    return __rw_getAsyncStoreInstance().run(new Map(), __rw_handler, __rw_event, __rw__context)
  }
  return __rw_handler(__rw_event, __rw__context)
}
```

The `async` keyword on the wrapper is determined from the original handler — non-function values (e.g. `createGraphQLHandler(...)`) produce a synchronous wrapper, matching the Babel plugin's `t.isFunction(originalInit) && originalInit.async` check.

Supports `projectIsEsm` option for the store import path.

## Test plan

- [x] `wraps an async arrow function handler`
- [x] `wraps a non-async handler (e.g. createGraphQLHandler call) without async keyword`
- [x] `uses the ESM store path when projectIsEsm is true`
- [x] `returns null for files outside api/src/functions/`
- [x] `returns null for api files outside functions directory`
- [x] `returns null for function files without a handler export`
- [x] `preserves the rest of the file around the handler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)