### PR TITLE
chore(knip): remove stale router Jest config

### DIFF
--- a/packages/router/jest.config.js
+++ b/packages/router/jest.config.js
@@ -1,6 +1,0 @@
-/** @type {import('@jest/types').Config.InitialOptions} */
-module.exports = {
-  setupFilesAfterEnv: ['./jest.setup.ts'],
-  testEnvironment: 'jest-environment-jsdom',
-  testMatch: ['**/*.test.+(ts|tsx|js|jsx)', '!**/__typetests__/*.ts'],
-}


### PR DESCRIPTION
Removes the stale Jest config from the router package.

The router package uses Vitest, and Knip reported unresolved references from `packages/router/jest.config.js` to `jest-environment-jsdom` and `jest.setup.ts`.