### PR TITLE
fix(deps): Bump graphql to 16.14.2

### DIFF
--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-graphql-tag": "3.3.0",
     "babel-plugin-module-resolver": "5.0.3",
     "fast-glob": "3.3.3",
-    "graphql": "16.13.2",
+    "graphql": "16.14.2",
     "typescript": "5.9.3"
   },
   "devDependencies": {

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -39,7 +39,7 @@
     "deepmerge": "4.3.1",
     "execa": "5.1.1",
     "fast-glob": "3.3.3",
-    "graphql": "16.13.2",
+    "graphql": "16.14.2",
     "jscodeshift": "17.3.0",
     "pascalcase": "1.0.0",
     "prettier": "3.8.4",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -33,7 +33,7 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "graphql": "16.13.2",
+    "graphql": "16.14.2",
     "pascalcase": "1.0.0",
     "react-hook-form": "7.74.0"
   },

--- a/packages/gqlorm/package.json
+++ b/packages/gqlorm/package.json
@@ -139,7 +139,7 @@
   },
   "dependencies": {
     "@cedarjs/server-store": "workspace:*",
-    "graphql": "16.13.2"
+    "graphql": "16.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.4",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -51,7 +51,7 @@
     "@graphql-yoga/plugin-persisted-operations": "3.21.2",
     "@opentelemetry/api": "1.9.1",
     "cookie": "1.1.1",
-    "graphql": "16.13.2",
+    "graphql": "16.14.2",
     "graphql-scalars": "1.25.0",
     "graphql-tag": "2.12.6",
     "graphql-yoga": "5.21.2",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -192,7 +192,7 @@
     "esbuild": "0.27.7",
     "execa": "5.1.1",
     "fast-glob": "3.3.3",
-    "graphql": "16.13.2",
+    "graphql": "16.14.2",
     "kill-port": "1.6.1",
     "prettier": "3.8.4",
     "rimraf": "6.1.3",

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -83,7 +83,7 @@
     "@whatwg-node/fetch": "0.10.13",
     "babel-plugin-ignore-html-and-css-imports": "0.1.0",
     "cheerio": "1.2.0",
-    "graphql": "16.13.2",
+    "graphql": "16.14.2",
     "mime-types": "2.1.35",
     "rollup": "4.60.4",
     "rollup-plugin-swc3": "0.12.1",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -37,7 +37,7 @@
     "@graphql-yoga/subscription": "5.0.5",
     "@n1ru4l/graphql-live-query": "0.10.0",
     "@n1ru4l/in-memory-live-query-store": "0.10.0",
-    "graphql": "16.13.2"
+    "graphql": "16.14.2"
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -60,7 +60,7 @@
     "camelcase": "6.3.0",
     "deepmerge": "4.3.1",
     "dotenv-defaults": "5.0.2",
-    "graphql": "16.13.2",
+    "graphql": "16.14.2",
     "line-column": "1.0.2",
     "lodash": "4.18.1",
     "lru-cache": "11.3.6",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -145,7 +145,7 @@
     "@whatwg-node/fetch": "0.10.13",
     "apollo-upload-client": "18.0.1",
     "cookie": "1.1.1",
-    "graphql": "16.13.2",
+    "graphql": "16.14.2",
     "graphql-sse": "2.6.0",
     "graphql-tag": "2.12.6",
     "react-hot-toast": "2.6.0",

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -261,6 +261,54 @@ function enforceNotProdAndDevDependencies({ Yarn }) {
 }
 
 /**
+ * This rule will enforce that `graphql` resolves to exactly one version
+ * across the entire dependency graph (both workspace and transitive deps).
+ *
+ * It reads `yarn.lock` and counts the number of lockfile entries whose key
+ * contains `graphql@npm:`.  If there is more than one, different parts of
+ * the module graph resolve to different copies, which causes duplicate
+ * installs under pnpm.
+ *
+ * @param {Context} context
+ */
+function enforceSingleGraphqlVersion() {
+  const lockfilePath = path.join(__dirname, 'yarn.lock')
+
+  if (!fs.existsSync(lockfilePath)) {
+    return
+  }
+
+  const content = fs.readFileSync(lockfilePath, 'utf-8')
+  const lines = content.split('\n')
+
+  /** @type {{ key: string, line: number }[]} */
+  const entries = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    // Match top-level lockfile keys, e.g.:
+    //   "graphql@npm:16.13.2":
+    //   "graphql@npm:14 - 16, graphql@npm:16.14.2, graphql@npm:^16.0.0":
+    if (/^"[^"]*graphql@npm:.*":\s*$/.test(line)) {
+      entries.push({ key: line, line: i + 1 })
+    }
+  }
+
+  if (entries.length <= 1) {
+    return
+  }
+
+  const details = entries.map((e) => `  line ${e.line}: ${e.key}`).join('\n')
+
+  throw new Error(
+    `graphql resolves to multiple versions in the lockfile — this will cause ` +
+      `duplicate installs under pnpm.\n\n${details}\n\n` +
+      `Ensure all workspace and transitive dependencies resolve to the same ` +
+      `graphql version.`,
+  )
+}
+
+/**
  * This rule will enforce that any package built with babel (identified by the
  * presence of a 'build:js' script in its `package.json`) must depend on the
  * '@babel/runtime-corejs3' and 'core-js' packages.
@@ -345,6 +393,7 @@ module.exports = defineConfig({
       enforceWorkspaceDependenciesWhenPossible(ctx)
     }
     enforceNotProdAndDevDependencies(ctx)
+    enforceSingleGraphqlVersion()
     enforceBabelDependencies(ctx)
     enforceFieldsOnAllWorkspaces(ctx, [
       'name',

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -289,7 +289,7 @@ function enforceSingleGraphqlVersion() {
     // Match top-level lockfile keys, e.g.:
     //   "graphql@npm:16.13.2":
     //   "graphql@npm:14 - 16, graphql@npm:16.14.2, graphql@npm:^16.0.0":
-    if (/^"[^"]*graphql@npm:.*":\s*$/.test(line)) {
+    if (/^"(?:graphql@npm:[^"]*)(?:,\s*graphql@npm:[^"]*)*":\s*$/.test(line)) {
       entries.push({ key: line, line: i + 1 })
     }
   }

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -261,15 +261,15 @@ function enforceNotProdAndDevDependencies({ Yarn }) {
 }
 
 /**
- * This rule will enforce that `graphql` resolves to exactly one version
- * across the entire dependency graph (both workspace and transitive deps).
+ * This rule will enforce that `graphql` resolves to exactly one version across
+ * the entire dependency graph (both workspace and transitive deps).
  *
  * It reads `yarn.lock` and counts the number of lockfile entries whose key
- * contains `graphql@npm:`.  If there is more than one, different parts of
- * the module graph resolve to different copies, which causes duplicate
- * installs under pnpm.
- *
- * @param {Context} context
+ * contains `graphql@npm:`.  If there is more than one, different parts of the
+ * module graph resolve to different copies, which causes duplicate installs
+ * under pnpm. graphql is a singleton package. If more than one version is in
+ * use, the instanceof checks within graphql itself fail at runtime because the
+ * two copies are separate module instances, breaking GraphQL execution.
  */
 function enforceSingleGraphqlVersion() {
   const lockfilePath = path.join(__dirname, 'yarn.lock')
@@ -301,7 +301,7 @@ function enforceSingleGraphqlVersion() {
   const details = entries.map((e) => `  line ${e.line}: ${e.key}`).join('\n')
 
   throw new Error(
-    `graphql resolves to multiple versions in the lockfile — this will cause ` +
+    `graphql resolves to multiple versions in the lockfile. This will cause ` +
       `duplicate installs under pnpm.\n\n${details}\n\n` +
       `Ensure all workspace and transitive dependencies resolve to the same ` +
       `graphql version.`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,7 +2969,7 @@ __metadata:
     deepmerge: "npm:4.3.1"
     execa: "npm:5.1.1"
     fast-glob: "npm:3.3.3"
-    graphql: "npm:16.13.2"
+    graphql: "npm:16.14.2"
     jscodeshift: "npm:17.3.0"
     memfs: "npm:4.57.7"
     pascalcase: "npm:1.0.0"
@@ -3135,7 +3135,7 @@ __metadata:
     "@types/react": "npm:^18.2.55"
     "@types/react-dom": "npm:^18.2.19"
     concurrently: "npm:9.2.1"
-    graphql: "npm:16.13.2"
+    graphql: "npm:16.14.2"
     nodemon: "npm:3.1.14"
     pascalcase: "npm:1.0.0"
     publint: "npm:0.3.21"
@@ -3457,7 +3457,7 @@ __metadata:
     babel-plugin-tester: "npm:11.0.4"
     cheerio: "npm:1.2.0"
     concurrently: "npm:9.2.1"
-    graphql: "npm:16.13.2"
+    graphql: "npm:16.14.2"
     mime-types: "npm:2.1.35"
     publint: "npm:0.3.21"
     rollup: "npm:4.60.4"
@@ -3622,7 +3622,7 @@ __metadata:
     camelcase: "npm:6.3.0"
     deepmerge: "npm:4.3.1"
     dotenv-defaults: "npm:5.0.2"
-    graphql: "npm:16.13.2"
+    graphql: "npm:16.14.2"
     line-column: "npm:1.0.2"
     lodash: "npm:4.18.1"
     lru-cache: "npm:11.3.6"
@@ -18626,13 +18626,6 @@ __metadata:
   version: 16.14.2
   resolution: "graphql@npm:16.14.2"
   checksum: 10c0/a95a96961eaff55cc9fe9d31fae6f33499ac988b972d07ea5085024cb1333f515b902f376e7393a5489aa82200a8aff3eb96580e4d1b69d702ed19b6eb1ce97a
-  languageName: node
-  linkType: hard
-
-"graphql@npm:16.13.2":
-  version: 16.13.2
-  resolution: "graphql@npm:16.13.2"
-  checksum: 10c0/64e822a0a0e4398781e4bc9765b88d370c08261498b517add4b878038ef7be2005b6b394a79a5102b9379d57052f60bc7f23fec8f39808d101984a74772ebd9d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2776,7 +2776,7 @@ __metadata:
     babel-plugin-module-resolver: "npm:5.0.3"
     babel-plugin-tester: "npm:11.0.4"
     fast-glob: "npm:3.3.3"
-    graphql: "npm:16.13.2"
+    graphql: "npm:16.14.2"
     typescript: "npm:5.9.3"
     vitest: "npm:3.2.6"
   languageName: unknown
@@ -3186,7 +3186,7 @@ __metadata:
     "@types/react": "npm:^18.2.55"
     "@types/react-dom": "npm:^18.2.19"
     concurrently: "npm:9.2.1"
-    graphql: "npm:16.13.2"
+    graphql: "npm:16.14.2"
     publint: "npm:0.3.21"
     tstyche: "npm:5.0.2"
     tsx: "npm:4.22.4"
@@ -3229,7 +3229,7 @@ __metadata:
     "@whatwg-node/promise-helpers": "npm:^1.3.0"
     concurrently: "npm:9.2.1"
     cookie: "npm:1.1.1"
-    graphql: "npm:16.13.2"
+    graphql: "npm:16.14.2"
     graphql-scalars: "npm:1.25.0"
     graphql-tag: "npm:2.12.6"
     graphql-yoga: "npm:5.21.2"
@@ -3287,7 +3287,7 @@ __metadata:
     esbuild: "npm:0.27.7"
     execa: "npm:5.1.1"
     fast-glob: "npm:3.3.3"
-    graphql: "npm:16.13.2"
+    graphql: "npm:16.14.2"
     graphql-tag: "npm:2.12.6"
     kill-port: "npm:1.6.1"
     prettier: "npm:3.8.4"
@@ -3512,7 +3512,7 @@ __metadata:
     "@graphql-yoga/subscription": "npm:5.0.5"
     "@n1ru4l/graphql-live-query": "npm:0.10.0"
     "@n1ru4l/in-memory-live-query-store": "npm:0.10.0"
-    graphql: "npm:16.13.2"
+    graphql: "npm:16.14.2"
     graphql-yoga: "npm:5.21.2"
     ioredis: "npm:5.11.1"
     nodemon: "npm:3.1.14"
@@ -3857,7 +3857,7 @@ __metadata:
     apollo-upload-client: "npm:18.0.1"
     concurrently: "npm:9.2.1"
     cookie: "npm:1.1.1"
-    graphql: "npm:16.13.2"
+    graphql: "npm:16.14.2"
     graphql-sse: "npm:2.6.0"
     graphql-tag: "npm:2.12.6"
     nodemon: "npm:3.1.14"
@@ -18622,7 +18622,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:14 - 16, graphql@npm:16.13.2, graphql@npm:^16.0.0, graphql@npm:^16.8.1":
+"graphql@npm:14 - 16, graphql@npm:16.14.2, graphql@npm:^16.0.0, graphql@npm:^16.8.1":
+  version: 16.14.2
+  resolution: "graphql@npm:16.14.2"
+  checksum: 10c0/a95a96961eaff55cc9fe9d31fae6f33499ac988b972d07ea5085024cb1333f515b902f376e7393a5489aa82200a8aff3eb96580e4d1b69d702ed19b6eb1ce97a
+  languageName: node
+  linkType: hard
+
+"graphql@npm:16.13.2":
   version: 16.13.2
   resolution: "graphql@npm:16.13.2"
   checksum: 10c0/64e822a0a0e4398781e4bc9765b88d370c08261498b517add4b878038ef7be2005b6b394a79a5102b9379d57052f60bc7f23fec8f39808d101984a74772ebd9d


### PR DESCRIPTION
This fixes a version mismatch for package managers with strict peer dep and version semantics (like yarn in PnP mode and pnpm)