### PR TITLE
fix(deps): Make the `@prisma/client` dep explicit

### DIFF
--- a/__fixtures__/test-project-esm/api/package.json
+++ b/__fixtures__/test-project-esm/api/package.json
@@ -9,6 +9,7 @@
     "@cedarjs/graphql-server": "4.2.0",
     "@my-org/validators": "workspace:*",
     "@prisma/adapter-better-sqlite3": "7.8.0",
+    "@prisma/client": "7.8.0",
     "better-sqlite3": "12.9.0"
   }
 }

--- a/__fixtures__/test-project/api/package.json
+++ b/__fixtures__/test-project/api/package.json
@@ -9,6 +9,7 @@
     "@cedarjs/graphql-server": "4.2.0",
     "@my-org/validators": "workspace:*",
     "@prisma/adapter-better-sqlite3": "7.8.0",
+    "@prisma/client": "7.8.0",
     "better-sqlite3": "12.9.0"
   }
 }

--- a/packages/create-cedar-app/templates/esm-js/api/package.json
+++ b/packages/create-cedar-app/templates/esm-js/api/package.json
@@ -7,6 +7,7 @@
     "@cedarjs/api": "4.2.0",
     "@cedarjs/graphql-server": "4.2.0",
     "@prisma/adapter-better-sqlite3": "7.8.0",
+    "@prisma/client": "7.8.0",
     "better-sqlite3": "12.9.0"
   }
 }

--- a/packages/create-cedar-app/templates/esm-ts/api/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/api/package.json
@@ -7,6 +7,7 @@
     "@cedarjs/api": "4.2.0",
     "@cedarjs/graphql-server": "4.2.0",
     "@prisma/adapter-better-sqlite3": "7.8.0",
+    "@prisma/client": "7.8.0",
     "better-sqlite3": "12.9.0"
   }
 }

--- a/packages/create-cedar-app/templates/js/api/package.json
+++ b/packages/create-cedar-app/templates/js/api/package.json
@@ -7,6 +7,7 @@
     "@cedarjs/api": "4.2.0",
     "@cedarjs/graphql-server": "4.2.0",
     "@prisma/adapter-better-sqlite3": "7.8.0",
+    "@prisma/client": "7.8.0",
     "better-sqlite3": "12.9.0"
   }
 }

--- a/packages/create-cedar-app/templates/ts/api/package.json
+++ b/packages/create-cedar-app/templates/ts/api/package.json
@@ -7,6 +7,7 @@
     "@cedarjs/api": "4.2.0",
     "@cedarjs/graphql-server": "4.2.0",
     "@prisma/adapter-better-sqlite3": "7.8.0",
+    "@prisma/client": "7.8.0",
     "better-sqlite3": "12.9.0"
   }
 }


### PR DESCRIPTION
pnpm, and yarn in stricter modes than with its node_modules linker, needs `@prisma/client` to be listed as a direct dependency because they don't hoist it from `@cedarjs/api` as npm does