### PR TITLE
fix(ud): Add context wrapping to Cedar Functions

### DIFF
--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -476,7 +476,15 @@ async function generateFunctionModule(distPath: string): Promise<string> {
     export default {
       async fetch(request) {
         const ctx = await buildCedarContext(request);
-        return _handler(request, ctx);
+        // Wrap the handler in an AsyncLocalStorage run so the global
+        // @cedarjs/context is available inside it (and isolated per request).
+        // Mirrors the GraphQL module above and the cedarContextWrappingPlugin
+        // used for non-UD builds.
+        const { getAsyncStoreInstance } = await import(
+          '@cedarjs/context/dist/store'
+        );
+        const store = getAsyncStoreInstance();
+        return store.run(new Map(), () => _handler(request, ctx));
       }
     };
   `


### PR DESCRIPTION
Add context wrapping to Cedar Functions for UD deploys. Previously only GraphQL got access to Cedar's context. Now also standard Functions (like web hooks) get access to it