### PR TITLE
chore(babel-config): `forJest` sentinel

### DIFF
--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -126,8 +126,9 @@ export const getWebSideBabelPlugins = (
       'rwjs-web-auto-import',
     ],
     ['babel-plugin-graphql-tag', undefined, 'rwjs-babel-graphql-tag'],
-    // Vite uses vite-plugin-cedar-remove-dev-fatal-error-page instead
-    !forVite &&
+    // Prerender uses rollup-plugin-cedar-remove-dev-fatal-error-page
+    // Vite uses        vite-plugin-cedar-remove-dev-fatal-error-page
+    forJest &&
       process.env.NODE_ENV !== 'development' && [
         require('./plugins/babel-plugin-redwood-remove-dev-fatal-error-page')
           .default,


### PR DESCRIPTION
Match #2058 so that we have a consistent pattern going forward for babel -> vite plugin rewrites