### PR TITLE
chore(knip): clean up router dependencies

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -94,15 +94,15 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
+    "@cedarjs/project-config": "workspace:*",
     "@cedarjs/server-store": "workspace:*",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-server-dom-webpack": "19.2.4"
+    "react-server-dom-webpack": "19.2.4",
+    "ts-toolbelt": "9.6.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.4",
-    "@babel/cli": "7.29.7",
-    "@babel/core": "^7.26.10",
     "@cedarjs/auth": "workspace:*",
     "@cedarjs/framework-tools": "workspace:*",
     "@testing-library/jest-dom": "6.9.1",
@@ -112,6 +112,7 @@
     "publint": "0.3.21",
     "tstyche": "5.0.2",
     "typescript": "5.9.3",
+    "vite": "7.3.5",
     "vitest": "3.2.6"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3545,10 +3545,9 @@ __metadata:
   resolution: "@cedarjs/router@workspace:packages/router"
   dependencies:
     "@arethetypeswrong/cli": "npm:0.18.4"
-    "@babel/cli": "npm:7.29.7"
-    "@babel/core": "npm:^7.26.10"
     "@cedarjs/auth": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
+    "@cedarjs/project-config": "workspace:*"
     "@cedarjs/server-store": "workspace:*"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@types/react": "npm:^18.2.55"
@@ -3558,8 +3557,10 @@ __metadata:
     react: "npm:19.2.3"
     react-dom: "npm:19.2.3"
     react-server-dom-webpack: "npm:19.2.4"
+    ts-toolbelt: "npm:9.6.0"
     tstyche: "npm:5.0.2"
     typescript: "npm:5.9.3"
+    vite: "npm:7.3.5"
     vitest: "npm:3.2.6"
   peerDependencies:
     "@cedarjs/auth": "workspace:*"


### PR DESCRIPTION
## Summary

This PR cleans up the dependencies for `@cedarjs/router` based on Knip's findings.

## Changes

Removed unused dependencies:

  * `@babel/cli`
  * `@babel/core`

Added missing declared dependencies:

  * `@cedarjs/project-config`
  * `ts-toolbelt`
  * `vite`

## Validation

```sh
yarn knip --workspace @cedarjs/router
yarn workspace @cedarjs/router test
yarn workspace @cedarjs/router build
yarn check
yarn prettier --check packages/router/package.json
```

All commands completed successfully.
