### PR TITLE
fix(pm): pnpm install from yarn dlx

### DIFF
--- a/packages/create-cedar-app/src/create-cedar-app.ts
+++ b/packages/create-cedar-app/src/create-cedar-app.ts
@@ -70,9 +70,24 @@ async function installNodeModules(
   process.chdir(newAppDir)
 
   const installCommand = getInstallCommand(packageManager)
+
+  // When CCA is run via `yarn dlx`, Yarn injects its PnP ESM loader into
+  // NODE_OPTIONS. If this leaks to the spawned install process, it can
+  // interfere with other package managers' module resolution (e.g. pnpm trying
+  // to import() .pnpmfile.mjs). Strip just that loader flag. This uses the same
+  // regex pattern that Yarn itself uses in its setupScriptEnvironment hook
+  // https://github.com/yarnpkg/berry/blob/0a230c14e71247576f6b51fa811ae08edb6608aa/packages/plugin-pnp/sources/index.ts#L42
+  const PNP_ESM_LOADER = /\s*--experimental-loader\s+\S*\.pnp\.loader\.mjs\s*/g
+  const env = { ...process.env }
+  if (env.NODE_OPTIONS) {
+    env.NODE_OPTIONS = env.NODE_OPTIONS.replace(PNP_ESM_LOADER, ' ').trim()
+  }
+
   const installSubprocess = execa(installCommand, {
     shell: true,
     cwd: newAppDir,
+    env,
+    extendEnv: false,
   })
 
   try {

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -17,5 +17,8 @@
       "version": "11.8.0",
       "onFail": "download"
     }
+  },
+  "pnpm": {
+    "hooks": {}
   }
 }

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -17,5 +17,8 @@
       "version": "11.8.0",
       "onFail": "download"
     }
+  },
+  "pnpm": {
+    "hooks": {}
   }
 }


### PR DESCRIPTION
This PR fixes this bug:

```
✔ Do you want to run pnpm install? · no / Yes
✔ Project files created

────  ⚠ Error: Couldn't install node modules  ──────────────────────────────────
────────────────────────────────────────────────────────────────────────────────

  We couldn't install node modules via 'pnpm install'. Please see below for the full error message.

Error: Command failed with exit code 1: pnpm install
[ERROR] Error during pnpmfile execution. pnpmfile: "/Users/tobbe/tmp/cedar-5-rc-273-pnpm/.pnpmfile.mjs". Error: "Cannot find module '/Users/tobbe/tmp/cedar-5-rc-273-pnpm/.pnpmfile.mjs' imported from /Users/tobbe/.cache/node/corepack/v1/pnpm/11.8.0/dist/pnpm.mjs".
For help, run: pnpm help install

──────────────────────────────────────────────────────────────────────────────── 

Why does it work with yarn (the default), but not with pnpm?
```