### PR TITLE
fix(pm): pnpm cedar-gen from yarn dlx

### DIFF
--- a/packages/create-cedar-app/src/create-cedar-app.ts
+++ b/packages/create-cedar-app/src/create-cedar-app.ts
@@ -52,6 +52,27 @@ const { telemetry } = Parser(hideBin(process.argv), {
   },
 })
 
+/**
+ * When CCA is run via `yarn dlx`, Yarn injects its PnP ESM loader into
+ * NODE_OPTIONS. If this leaks to the spawned install process, it can interfere
+ * with other package managers' module resolution (e.g. pnpm trying to import()
+ * .pnpmfile.mjs). Strip just that loader flag.
+ */
+function getEnvWithoutYarnPnPLoader() {
+  const env = { ...process.env }
+
+  if (env.NODE_OPTIONS) {
+    // This uses the same regex pattern that Yarn itself uses in its
+    // setupScriptEnvironment hook
+    // https://github.com/yarnpkg/berry/blob/0a230c14e71247576f6b51fa811ae08edb6608aa/packages/plugin-pnp/sources/index.ts#L42
+    const PNP_LOADER_REGEX =
+      /\s*--experimental-loader\s+\S*\.pnp\.loader\.mjs\s*/g
+    env.NODE_OPTIONS = env.NODE_OPTIONS.replace(PNP_LOADER_REGEX, ' ').trim()
+  }
+
+  return env
+}
+
 async function installNodeModules(
   newAppDir: string,
   packageManager: PackageManager,
@@ -71,22 +92,10 @@ async function installNodeModules(
 
   const installCommand = getInstallCommand(packageManager)
 
-  // When CCA is run via `yarn dlx`, Yarn injects its PnP ESM loader into
-  // NODE_OPTIONS. If this leaks to the spawned install process, it can
-  // interfere with other package managers' module resolution (e.g. pnpm trying
-  // to import() .pnpmfile.mjs). Strip just that loader flag. This uses the same
-  // regex pattern that Yarn itself uses in its setupScriptEnvironment hook
-  // https://github.com/yarnpkg/berry/blob/0a230c14e71247576f6b51fa811ae08edb6608aa/packages/plugin-pnp/sources/index.ts#L42
-  const PNP_ESM_LOADER = /\s*--experimental-loader\s+\S*\.pnp\.loader\.mjs\s*/g
-  const env = { ...process.env }
-  if (env.NODE_OPTIONS) {
-    env.NODE_OPTIONS = env.NODE_OPTIONS.replace(PNP_ESM_LOADER, ' ').trim()
-  }
-
   const installSubprocess = execa(installCommand, {
     shell: true,
     cwd: newAppDir,
-    env,
+    env: getEnvWithoutYarnPnPLoader(),
     extendEnv: false,
   })
 
@@ -138,7 +147,11 @@ async function generateTypes(
   const binExec = getBinExecutor(packageManager)
 
   try {
-    await execa(binExec, ['cedar-gen'], { cwd: newAppDir })
+    await execa(binExec, ['cedar-gen'], {
+      cwd: newAppDir,
+      env: getEnvWithoutYarnPnPLoader(),
+      extendEnv: false,
+    })
   } catch (error) {
     const prettyGenCommand = RedwoodStyling.info(`'${binExec} cedar-gen'`)
     tui.stopReactive(true)


### PR DESCRIPTION
Continuation of #2066 
Now also fixing this bug

```
✔ Do you want to run pnpm install? · no / Yes
✔ Project files created
✔ Installed node modules

────  ⚠ Error: Couldn't generate types  ────────────────────────────────────────
────────────────────────────────────────────────────────────────────────────────

  We could not generate types using 'pnpm cedar-gen'. Please see below for the full error message.

Error: Command failed with exit code 1: pnpm cedar-gen
[ERROR] Error during pnpmfile execution. pnpmfile: "/Users/tobbe/tmp/cedar-5-canary-2610/.pnpmfile.mjs". Error: "Cannot find module '/Users/tobbe/tmp/cedar-5-canary-2610/.pnpmfile.mjs' imported from /Users/tobbe/.cache/node/corepack/v1/pnpm/11.8.0/dist/pnpm.mjs".
For help, run: pnpm help run

────────────────────────────────────────────────────────────────────────────────
```