### PR TITLE
fix(pm): pnpm prisma dev dep

### DIFF
--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -5,7 +5,8 @@
     "@cedarjs/core": "3.1.0",
     "@cedarjs/eslint-config": "3.1.0",
     "@cedarjs/project-config": "3.1.0",
-    "@cedarjs/testing": "3.1.0"
+    "@cedarjs/testing": "3.1.0",
+    "prisma": "7.8.0"
   },
   "engines": {
     "node": "=24.x",
@@ -17,8 +18,5 @@
       "version": "11.8.0",
       "onFail": "download"
     }
-  },
-  "pnpm": {
-    "hooks": {}
   }
 }

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -5,7 +5,8 @@
     "@cedarjs/core": "3.1.0",
     "@cedarjs/eslint-config": "3.1.0",
     "@cedarjs/project-config": "3.1.0",
-    "@cedarjs/testing": "3.1.0"
+    "@cedarjs/testing": "3.1.0",
+    "prisma": "7.8.0"
   },
   "engines": {
     "node": "=24.x",
@@ -17,8 +18,5 @@
       "version": "11.8.0",
       "onFail": "download"
     }
-  },
-  "pnpm": {
-    "hooks": {}
   }
 }


### PR DESCRIPTION
`prisma/client` is used from `prisma.config.cjs`, so should be declared as a development dependency

Also removing `pnpm.hooks` as it's not really needed. Plus it produces a "Property hooks is not allowed." warning in my IDE