### PR TITLE
chore(rename): use __cedar_ for ALS-related internal names

### DIFF
--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/handler-als-wrapping/auth/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/handler-als-wrapping/auth/output.js
@@ -1,7 +1,7 @@
 import { DbAuthHandler, DbAuthHandlerOptions } from '@cedarjs/auth-dbauth-api'
 import { db } from 'src/lib/db'
-import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
-const __rw_handler = async (event, context) => {
+import { getAsyncStoreInstance as __cedar_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
+const __cedar_handler = async (event, context) => {
   const forgotPasswordOptions = {
     // handler() is invoked after verifying that a user was found with the given
     // username. This is where you can send the user an email with a link to
@@ -150,16 +150,16 @@ const __rw_handler = async (event, context) => {
   })
   return await authHandler.invoke()
 }
-export const handler = async (__rw_event, __rw__context) => {
+export const handler = async (__cedar_event, __cedar_context) => {
   // The store will be undefined if no context isolation has been performed yet
-  const __rw_contextStore = __rw_getAsyncStoreInstance().getStore()
-  if (__rw_contextStore === undefined) {
-    return __rw_getAsyncStoreInstance().run(
+  const __cedar_contextStore = __cedar_getAsyncStoreInstance().getStore()
+  if (__cedar_contextStore === undefined) {
+    return __cedar_getAsyncStoreInstance().run(
       new Map(),
-      __rw_handler,
-      __rw_event,
-      __rw__context
+      __cedar_handler,
+      __cedar_event,
+      __cedar_context
     )
   }
-  return __rw_handler(__rw_event, __rw__context)
+  return __cedar_handler(__cedar_event, __cedar_context)
 }

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/handler-als-wrapping/custom/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/handler-als-wrapping/custom/output.js
@@ -16,8 +16,8 @@ import { logger } from 'src/lib/logger'
  * @param { Context } context - contains information about the invocation,
  * function, and execution environment.
  */
-import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
-const __rw_handler = async (event, _context) => {
+import { getAsyncStoreInstance as __cedar_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
+const __cedar_handler = async (event, _context) => {
   logger.info(`${event.httpMethod} ${event.path}: custom function`)
   return {
     statusCode: 200,
@@ -29,16 +29,16 @@ const __rw_handler = async (event, _context) => {
     }),
   }
 }
-export const handler = async (__rw_event, __rw__context) => {
+export const handler = async (__cedar_event, __cedar_context) => {
   // The store will be undefined if no context isolation has been performed yet
-  const __rw_contextStore = __rw_getAsyncStoreInstance().getStore()
-  if (__rw_contextStore === undefined) {
-    return __rw_getAsyncStoreInstance().run(
+  const __cedar_contextStore = __cedar_getAsyncStoreInstance().getStore()
+  if (__cedar_contextStore === undefined) {
+    return __cedar_getAsyncStoreInstance().run(
       new Map(),
-      __rw_handler,
-      __rw_event,
-      __rw__context
+      __cedar_handler,
+      __cedar_event,
+      __cedar_context
     )
   }
-  return __rw_handler(__rw_event, __rw__context)
+  return __cedar_handler(__cedar_event, __cedar_context)
 }

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/handler-als-wrapping/graphql/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/handler-als-wrapping/graphql/output.js
@@ -6,8 +6,8 @@ import services from 'src/services/**/*.{js,ts}'
 import { getCurrentUser } from 'src/lib/auth'
 import { db } from 'src/lib/db'
 import { logger } from 'src/lib/logger'
-import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
-const __rw_handler = createGraphQLHandler({
+import { getAsyncStoreInstance as __cedar_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
+const __cedar_handler = createGraphQLHandler({
   authDecoder,
   getCurrentUser,
   loggerConfig: {
@@ -22,16 +22,16 @@ const __rw_handler = createGraphQLHandler({
     db.$disconnect()
   },
 })
-export const handler = (__rw_event, __rw__context) => {
+export const handler = (__cedar_event, __cedar_context) => {
   // The store will be undefined if no context isolation has been performed yet
-  const __rw_contextStore = __rw_getAsyncStoreInstance().getStore()
-  if (__rw_contextStore === undefined) {
-    return __rw_getAsyncStoreInstance().run(
+  const __cedar_contextStore = __cedar_getAsyncStoreInstance().getStore()
+  if (__cedar_contextStore === undefined) {
+    return __cedar_getAsyncStoreInstance().run(
       new Map(),
-      __rw_handler,
-      __rw_event,
-      __rw__context
+      __cedar_handler,
+      __cedar_event,
+      __cedar_context
     )
   }
-  return __rw_handler(__rw_event, __rw__context)
+  return __cedar_handler(__cedar_event, __cedar_context)
 }

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-handler-als-wrapping.sourcemaps.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-handler-als-wrapping.sourcemaps.test.ts
@@ -183,10 +183,10 @@ describe('babel-plugin-handler-als-wrapping source maps', () => {
     expect(map.version).toBe(3)
 
     // code should contain the wrapped handler
-    expect(code).toContain('__rw_handler')
+    expect(code).toContain('__cedar_handler')
   })
 
-  it('maps __rw_handler back to the original handler declaration line', () => {
+  it('maps __cedar_handler back to the original handler declaration line', () => {
     const { code, map } = getCodeAndMap(
       runBabelTransform(simpleHandlerInput, 'graphql.ts'),
     )
@@ -194,10 +194,10 @@ describe('babel-plugin-handler-als-wrapping source maps', () => {
     const tracer = new TraceMap(map)
     const codeLines = code.split('\n')
 
-    // __rw_handler = is unique to the handler copy - search for that prefix
+    // __cedar_handler = is unique to the handler copy - search for that prefix
     // then find createGraphQLHandler within that same line.
     const rwLineIndex = codeLines.findIndex((line) =>
-      line.includes('__rw_handler ='),
+      line.includes('__cedar_handler ='),
     )
     expect(rwLineIndex).toBeGreaterThan(0)
 
@@ -222,7 +222,7 @@ describe('babel-plugin-handler-als-wrapping source maps', () => {
     const tracer = new TraceMap(map)
     const codeLines = code.split('\n')
 
-    // new DbAuthHandler in __rw_handler should map back to line 8
+    // new DbAuthHandler in __cedar_handler should map back to line 8
     assertMapsToSource(codeLines, tracer, 'new DbAuthHandler', 'auth.ts', 8)
 
     // return await authHandler.invoke() should map back to line 11
@@ -271,12 +271,12 @@ describe('babel-plugin-handler-als-wrapping source maps', () => {
       const tracer = new TraceMap(map)
       const codeLines = code.split('\n')
 
-      // The output should have __rw_handler (from context-wrapping)
-      expect(code).toContain('__rw_handler')
+      // The output should have __cedar_handler (from context-wrapping)
+      expect(code).toContain('__cedar_handler')
 
-      // createGraphQLHandler in __rw_handler should map back to line 9.
+      // createGraphQLHandler in __cedar_handler should map back to line 9.
       const rwLineIndex = codeLines.findIndex((line) =>
-        line.includes('__rw_handler ='),
+        line.includes('__cedar_handler ='),
       )
       expect(rwLineIndex).toBeGreaterThan(0)
       const rwCol = codeLines[rwLineIndex].indexOf('createGraphQLHandler')
@@ -306,7 +306,7 @@ describe('babel-plugin-handler-als-wrapping source maps', () => {
     // 2. Vite normalizes the map (injectSourcesContent, normalize sources paths)
     // 3. ssrTransform rewrites ESM to SSR format (MagicString + combineSourcemaps)
 
-    it('maps __rw_handler to the original source after full SSR transform', async () => {
+    it('maps __cedar_handler to the original source after full SSR transform', async () => {
       const { code, map } = getCodeAndMap(
         runBabelTransform(simpleHandlerInput, 'graphql.ts'),
       )
@@ -322,9 +322,9 @@ describe('babel-plugin-handler-als-wrapping source maps', () => {
       const tracer = new TraceMap(ssrMap)
       const codeLines = ssrCode.split('\n')
 
-      // __rw_handler = should be present in SSR output
+      // __cedar_handler = should be present in SSR output
       const rwLineIndex = codeLines.findIndex((line) =>
-        line.includes('__rw_handler ='),
+        line.includes('__cedar_handler ='),
       )
       expect(rwLineIndex).toBeGreaterThan(0)
 
@@ -392,15 +392,15 @@ describe('babel-plugin-handler-als-wrapping source maps', () => {
       const tracer = new TraceMap(ssrMap)
       const codeLines = ssrCode.split('\n')
 
-      // After SSR transform, __rw_handler should still map back to the
+      // After SSR transform, __cedar_handler should still map back to the
       // original source line (graphqlHandlerInput line 9).
       // SSR prepends __vite_ssr_exportName__ declarations, so the actual
       // definition is on a later line.
 
-      // __rw_handler = createGraphQLHandler should map to line 9.
+      // __cedar_handler = createGraphQLHandler should map to line 9.
       // SSR rewrites createGraphQLHandler to (0,__vite_ssr_import_1__.createGraphQLHandler).
       const rwLineIndex = codeLines.findIndex((line) =>
-        line.includes('__rw_handler ='),
+        line.includes('__cedar_handler ='),
       )
       expect(rwLineIndex).toBeGreaterThan(0)
       const rwCol = codeLines[rwLineIndex].indexOf('createGraphQLHandler')

--- a/packages/babel-config/src/plugins/babel-plugin-handler-als-wrapping.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-handler-als-wrapping.ts
@@ -7,10 +7,10 @@ import type { PluginObj, types } from '@babel/core'
 function generateWrappedHandler(t: typeof types, isAsync: boolean) {
   const contextStoreVariableDeclaration = t.variableDeclaration('const', [
     t.variableDeclarator(
-      t.identifier('__rw_contextStore'),
+      t.identifier('__cedar_contextStore'),
       t.callExpression(
         t.memberExpression(
-          t.callExpression(t.identifier('__rw_getAsyncStoreInstance'), []),
+          t.callExpression(t.identifier('__cedar_getAsyncStoreInstance'), []),
           t.identifier('getStore'),
         ),
         [],
@@ -24,13 +24,13 @@ function generateWrappedHandler(t: typeof types, isAsync: boolean) {
     true,
   )
   return t.arrowFunctionExpression(
-    [t.identifier('__rw_event'), t.identifier('__rw__context')],
+    [t.identifier('__cedar_event'), t.identifier('__cedar_context')],
     t.blockStatement([
       contextStoreVariableDeclaration,
       t.ifStatement(
         t.binaryExpression(
           '===',
-          t.identifier('__rw_contextStore'),
+          t.identifier('__cedar_contextStore'),
           t.identifier('undefined'),
         ),
         t.blockStatement([
@@ -38,25 +38,25 @@ function generateWrappedHandler(t: typeof types, isAsync: boolean) {
             t.callExpression(
               t.memberExpression(
                 t.callExpression(
-                  t.identifier('__rw_getAsyncStoreInstance'),
+                  t.identifier('__cedar_getAsyncStoreInstance'),
                   [],
                 ),
                 t.identifier('run'),
               ),
               [
                 t.newExpression(t.identifier('Map'), []),
-                t.identifier('__rw_handler'),
-                t.identifier('__rw_event'),
-                t.identifier('__rw__context'),
+                t.identifier('__cedar_handler'),
+                t.identifier('__cedar_event'),
+                t.identifier('__cedar_context'),
               ],
             ),
           ),
         ]),
       ),
       t.returnStatement(
-        t.callExpression(t.identifier('__rw_handler'), [
-          t.identifier('__rw_event'),
-          t.identifier('__rw__context'),
+        t.callExpression(t.identifier('__cedar_handler'), [
+          t.identifier('__cedar_event'),
+          t.identifier('__cedar_context'),
         ]),
       ),
     ]),
@@ -92,11 +92,11 @@ export default function (
           return
         }
         path.insertBefore(
-          // import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
+          // import { getAsyncStoreInstance as __cedar_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
           t.importDeclaration(
             [
               t.importSpecifier(
-                t.identifier('__rw_getAsyncStoreInstance'),
+                t.identifier('__cedar_getAsyncStoreInstance'),
                 t.identifier('getAsyncStoreInstance'),
               ),
             ],
@@ -112,7 +112,7 @@ export default function (
         path.insertBefore(
           t.variableDeclaration('const', [
             t.variableDeclarator(
-              t.identifier('__rw_handler'),
+              t.identifier('__cedar_handler'),
               declaration.declarations[0].init,
             ),
           ]),

--- a/packages/internal/src/build/esbuild-plugin-handler-als-wrapping.ts
+++ b/packages/internal/src/build/esbuild-plugin-handler-als-wrapping.ts
@@ -26,27 +26,27 @@ export function applyHandlerAlsWrapping(
     ? '@cedarjs/context/dist/store.js'
     : '@cedarjs/context/dist/store'
 
-  const importStatement = `import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '${storePath}'\n`
+  const importStatement = `import { getAsyncStoreInstance as __cedar_getAsyncStoreInstance } from '${storePath}'\n`
 
   const handlerStart = handlerMatch.index
   const before = code.slice(0, handlerStart)
   const after = code.slice(handlerStart)
 
-  const renamed = after.replace(handlerRe, 'const __rw_handler =')
+  const renamed = after.replace(handlerRe, 'const __cedar_handler =')
 
   const wrappedHandler =
-    `\nexport const handler = ${isAsync ? 'async ' : ''}(__rw_event, __rw__context) => {\n` +
+    `\nexport const handler = ${isAsync ? 'async ' : ''}(__cedar_event, __cedar_context) => {\n` +
     `  // The store will be undefined if no context isolation has been performed yet\n` +
-    `  const __rw_contextStore = __rw_getAsyncStoreInstance().getStore()\n` +
-    `  if (__rw_contextStore === undefined) {\n` +
-    `    return __rw_getAsyncStoreInstance().run(\n` +
+    `  const __cedar_contextStore = __cedar_getAsyncStoreInstance().getStore()\n` +
+    `  if (__cedar_contextStore === undefined) {\n` +
+    `    return __cedar_getAsyncStoreInstance().run(\n` +
     `      new Map(),\n` +
-    `      __rw_handler,\n` +
-    `      __rw_event,\n` +
-    `      __rw__context\n` +
+    `      __cedar_handler,\n` +
+    `      __cedar_event,\n` +
+    `      __cedar_context\n` +
     `    )\n` +
     `  }\n` +
-    `  return __rw_handler(__rw_event, __rw__context)\n` +
+    `  return __cedar_handler(__cedar_event, __cedar_context)\n` +
     `}\n`
 
   return before + importStatement + renamed + wrappedHandler

--- a/packages/vite/src/plugins/__tests__/vite-plugin-handler-als-wrapping.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-handler-als-wrapping.test.ts
@@ -45,17 +45,21 @@ describe('handlerAlsWrappingPlugin', () => {
     const output = (result as { code: string }).code
 
     expect(output).toContain(
-      "import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '@cedarjs/context/dist/store'",
+      "import { getAsyncStoreInstance as __cedar_getAsyncStoreInstance } from '@cedarjs/context/dist/store'",
     )
-    expect(output).toContain('const __rw_handler = async (event, _context) =>')
     expect(output).toContain(
-      'export const handler = async (__rw_event, __rw__context) =>',
+      'const __cedar_handler = async (event, _context) =>',
     )
-    expect(output).toContain('__rw_getAsyncStoreInstance().getStore()')
     expect(output).toContain(
-      '__rw_getAsyncStoreInstance().run(\n      new Map(),\n      __rw_handler,\n      __rw_event,\n      __rw__context',
+      'export const handler = async (__cedar_event, __cedar_context) =>',
     )
-    expect(output).toContain('return __rw_handler(__rw_event, __rw__context)')
+    expect(output).toContain('__cedar_getAsyncStoreInstance().getStore()')
+    expect(output).toContain(
+      '__cedar_getAsyncStoreInstance().run(\n      new Map(),\n      __cedar_handler,\n      __cedar_event,\n      __cedar_context',
+    )
+    expect(output).toContain(
+      'return __cedar_handler(__cedar_event, __cedar_context)',
+    )
   })
 
   it('wraps a non-async handler (e.g. createGraphQLHandler call) without async keyword', () => {
@@ -74,13 +78,13 @@ describe('handlerAlsWrappingPlugin', () => {
     expect(result).not.toBeNull()
     const output = (result as { code: string }).code
 
-    expect(output).toContain('const __rw_handler = createGraphQLHandler({')
+    expect(output).toContain('const __cedar_handler = createGraphQLHandler({')
     // Wrapper must NOT be async (original was not an async function)
     expect(output).toContain(
-      'export const handler = (__rw_event, __rw__context) =>',
+      'export const handler = (__cedar_event, __cedar_context) =>',
     )
     expect(output).not.toContain(
-      'export const handler = async (__rw_event, __rw__context)',
+      'export const handler = async (__cedar_event, __cedar_context)',
     )
   })
 
@@ -94,7 +98,7 @@ describe('handlerAlsWrappingPlugin', () => {
     const output = (result as { code: string }).code
 
     expect(output).toContain(
-      "import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '@cedarjs/context/dist/store.js'",
+      "import { getAsyncStoreInstance as __cedar_getAsyncStoreInstance } from '@cedarjs/context/dist/store.js'",
     )
   })
 
@@ -155,7 +159,9 @@ describe('handlerAlsWrappingPlugin', () => {
 
     expect(output).toContain("import { db } from 'src/lib/db'")
     expect(output).toContain('const helperFn = () => 42')
-    expect(output).toContain('const __rw_handler = async (event, context) =>')
+    expect(output).toContain(
+      'const __cedar_handler = async (event, context) =>',
+    )
   })
 
   it('handles typed handler exports (TypeScript type annotations)', () => {
@@ -174,10 +180,14 @@ describe('handlerAlsWrappingPlugin', () => {
     const output = (result as { code: string }).code
 
     // Type annotation is stripped on renamed handler (matches Babel plugin behavior)
-    expect(output).toContain('const __rw_handler = async (event, _context) =>')
-    expect(output).not.toContain('const __rw_handler: APIGatewayProxyHandler')
     expect(output).toContain(
-      'export const handler = async (__rw_event, __rw__context) =>',
+      'const __cedar_handler = async (event, _context) =>',
+    )
+    expect(output).not.toContain(
+      'const __cedar_handler: APIGatewayProxyHandler',
+    )
+    expect(output).toContain(
+      'export const handler = async (__cedar_event, __cedar_context) =>',
     )
   })
 
@@ -195,9 +205,11 @@ describe('handlerAlsWrappingPlugin', () => {
     const output = (result as { code: string }).code
 
     // Type annotation stripped, handler value correctly extracted despite => in type
-    expect(output).toContain('const __rw_handler = async (event, context) =>')
     expect(output).toContain(
-      'export const handler = async (__rw_event, __rw__context) =>',
+      'const __cedar_handler = async (event, context) =>',
+    )
+    expect(output).toContain(
+      'export const handler = async (__cedar_event, __cedar_context) =>',
     )
   })
 
@@ -212,7 +224,7 @@ describe('handlerAlsWrappingPlugin', () => {
 
     // Should be marked as async despite missing space
     expect(output).toContain(
-      'export const handler = async (__rw_event, __rw__context) =>',
+      'export const handler = async (__cedar_event, __cedar_context) =>',
     )
   })
 
@@ -230,7 +242,7 @@ describe('handlerAlsWrappingPlugin', () => {
     const output = (result as { code: string }).code
 
     expect(output).toContain(
-      'export const handler = async (__rw_event, __rw__context) =>',
+      'export const handler = async (__cedar_event, __cedar_context) =>',
     )
   })
 })

--- a/packages/vite/src/plugins/vite-plugin-handler-als-wrapping.ts
+++ b/packages/vite/src/plugins/vite-plugin-handler-als-wrapping.ts
@@ -14,18 +14,18 @@ import { getPaths } from '@cedarjs/project-config'
  * For each file in `api/src/functions/` that exports a `handler`, this plugin:
  *
  * 1. Adds an import at the top of the file:
- *      import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
+ *      import { getAsyncStoreInstance as __cedar_getAsyncStoreInstance } from '@cedarjs/context/dist/store'
  *
  * 2. Renames the original handler:
- *      const __rw_handler = <original handler value>
+ *      const __cedar_handler = <original handler value>
  *
  * 3. Replaces the handler export with a wrapper that checks context isolation:
- *      export const handler = (__rw_event, __rw__context) => {
- *        const __rw_contextStore = __rw_getAsyncStoreInstance().getStore()
- *        if (__rw_contextStore === undefined) {
- *          return __rw_getAsyncStoreInstance().run(new Map(), __rw_handler, __rw_event, __rw__context)
+ *      export const handler = (__cedar_event, __cedar_context) => {
+ *        const __cedar_contextStore = __cedar_getAsyncStoreInstance().getStore()
+ *        if (__cedar_contextStore === undefined) {
+ *          return __cedar_getAsyncStoreInstance().run(new Map(), __cedar_handler, __cedar_event, __cedar_context)
  *        }
- *        return __rw_handler(__rw_event, __rw__context)
+ *        return __cedar_handler(__cedar_event, __cedar_context)
  *      }
  *
  * This replaces `babel-plugin-handler-als-wrapping` for Vite builds.
@@ -97,7 +97,7 @@ export function applyHandlerAlsWrapping(
     ? '@cedarjs/context/dist/store.js'
     : '@cedarjs/context/dist/store'
 
-  const importStatement = `import { getAsyncStoreInstance as __rw_getAsyncStoreInstance } from '${storePath}'\n`
+  const importStatement = `import { getAsyncStoreInstance as __cedar_getAsyncStoreInstance } from '${storePath}'\n`
 
   // Insert the import just before the handler declaration, rename the
   // handler export to a private const, then append the wrapped export.
@@ -105,25 +105,25 @@ export function applyHandlerAlsWrapping(
   const before = code.slice(0, handlerStart)
   const after = code.slice(handlerStart)
 
-  // Replace "export const handler [: Type] =" with "const __rw_handler ="
+  // Replace "export const handler [: Type] =" with "const __cedar_handler ="
   // Type annotation is dropped here, matching the Babel plugin which creates a fresh
   // variableDeclarator with just the identifier and init (no type annotation).
-  const renamed = after.replace(handlerRe, 'const __rw_handler =')
+  const renamed = after.replace(handlerRe, 'const __cedar_handler =')
 
-  // Wrapper matches Babel's generateWrappedHandler exactly: explicit (__rw_event, __rw__context)
+  // Wrapper matches Babel's generateWrappedHandler exactly: explicit (__cedar_event, __cedar_context)
   const wrappedHandler =
-    `\nexport const handler = ${isAsync ? 'async ' : ''}(__rw_event, __rw__context) => {\n` +
+    `\nexport const handler = ${isAsync ? 'async ' : ''}(__cedar_event, __cedar_context) => {\n` +
     `  // The store will be undefined if no context isolation has been performed yet\n` +
-    `  const __rw_contextStore = __rw_getAsyncStoreInstance().getStore()\n` +
-    `  if (__rw_contextStore === undefined) {\n` +
-    `    return __rw_getAsyncStoreInstance().run(\n` +
+    `  const __cedar_contextStore = __cedar_getAsyncStoreInstance().getStore()\n` +
+    `  if (__cedar_contextStore === undefined) {\n` +
+    `    return __cedar_getAsyncStoreInstance().run(\n` +
     `      new Map(),\n` +
-    `      __rw_handler,\n` +
-    `      __rw_event,\n` +
-    `      __rw__context\n` +
+    `      __cedar_handler,\n` +
+    `      __cedar_event,\n` +
+    `      __cedar_context\n` +
     `    )\n` +
     `  }\n` +
-    `  return __rw_handler(__rw_event, __rw__context)\n` +
+    `  return __cedar_handler(__cedar_event, __cedar_context)\n` +
     `}\n`
 
   return before + importStatement + renamed + wrappedHandler


### PR DESCRIPTION
Continuing the rw -> cedar rebranding effort. At least some of theses internal names show up when debugging Cedar App code, so it's nice to have them say `__cedar_*`