### PR TITLE
chore(vite): port babel-plugin-redwood-directory-named-import to vite

### DIFF
--- a/.changesets/2089.md
+++ b/.changesets/2089.md
@@ -1,5 +1,0 @@
-- chore(vite): Port babel-plugin-redwood-directory-named-import to Vite (#2089) by @lisa-assistant
-
-Ports the Babel directory-named import plugin to a pure Vite plugin using the `resolveId` hook. The plugin resolves bare directory imports (e.g., `./Button`) to index files first (`./Button/index.*`), falling back to directory-named modules (`./Button/Button.*`).
-
-Includes cross-platform path normalization for Windows compatibility and comprehensive test coverage.

--- a/.changesets/2089.md
+++ b/.changesets/2089.md
@@ -1,0 +1,5 @@
+- chore(vite): Port babel-plugin-redwood-directory-named-import to Vite (#2089) by @lisa-assistant
+
+Ports the Babel directory-named import plugin to a pure Vite plugin using the `resolveId` hook. The plugin resolves bare directory imports (e.g., `./Button`) to index files first (`./Button/index.*`), falling back to directory-named modules (`./Button/Button.*`).
+
+Includes cross-platform path normalization for Windows compatibility and comprehensive test coverage.

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -46,6 +46,7 @@ export {
 } from './plugins/vite-plugin-handler-als-wrapping.js'
 export { cedarEntryInjectionPlugin } from './plugins/vite-plugin-cedar-entry-injection.js'
 export { cedarHtmlEnvPlugin } from './plugins/vite-plugin-cedar-html-env.js'
+export { cedarDirectoryNamedImportPlugin } from './plugins/vite-plugin-cedar-directory-named-import.js'
 export { cedarImportDirPlugin } from './plugins/vite-plugin-cedar-import-dir.js'
 export { cedarDataUriShim } from './plugins/vite-plugin-cedar-data-uri-shim.js'
 export { cedarRemoveDevFatalErrorPage } from './plugins/vite-plugin-cedar-remove-dev-fatal-error-page.js'

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-directory-named-import.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-directory-named-import.test.ts
@@ -69,9 +69,7 @@ describe('cedarDirectoryNamedImportPlugin', () => {
   it('resolves directory-named .tsx module', () => {
     const resolveId = getPluginResolveId()
     const result = resolveId('./components/Button', IMPORTER, opts)
-    expect(result).toBe(
-      expectedFile('src/components/Button/Button.tsx'),
-    )
+    expect(result).toBe(expectedFile('src/components/Button/Button.tsx'))
   })
 
   it('resolves directory-named .ts module', () => {
@@ -89,9 +87,7 @@ describe('cedarDirectoryNamedImportPlugin', () => {
   it('resolves directory-named .js module', () => {
     const resolveId = getPluginResolveId()
     const result = resolveId('./components/Widget', IMPORTER, opts)
-    expect(result).toBe(
-      expectedFile('src/components/Widget/Widget.js'),
-    )
+    expect(result).toBe(expectedFile('src/components/Widget/Widget.js'))
   })
 
   it('prefers index file over directory-named module', () => {
@@ -103,9 +99,7 @@ describe('cedarDirectoryNamedImportPlugin', () => {
   it('prefers index file when both index and directory-named exist', () => {
     const resolveId = getPluginResolveId()
     const result = resolveId('./components/Alert', IMPORTER, opts)
-    expect(result).toBe(
-      expectedFile('src/components/Alert/index.ts'),
-    )
+    expect(result).toBe(expectedFile('src/components/Alert/index.ts'))
   })
 
   it('returns null for imports that resolve directly as files', () => {

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-directory-named-import.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-directory-named-import.test.ts
@@ -1,0 +1,141 @@
+import path from 'node:path'
+
+import { vol } from 'memfs'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { cedarDirectoryNamedImportPlugin } from '../vite-plugin-cedar-directory-named-import.js'
+
+vi.mock('node:fs', async () => ({ default: (await import('memfs')).fs }))
+
+// The fixture project root used across all tests
+const PROJECT_ROOT = '/test/project'
+
+// The file doing the importing (importer context)
+const IMPORTER = path.join(PROJECT_ROOT, 'src/SomeComponent.tsx')
+
+function getPluginResolveId() {
+  const plugin = cedarDirectoryNamedImportPlugin()
+
+  if (typeof plugin.resolveId !== 'function') {
+    throw new Error('Expected plugin to have a resolveId function')
+  }
+
+  return plugin.resolveId.bind(
+    {} as ThisParameterType<typeof plugin.resolveId>,
+  )
+}
+
+describe('cedarDirectoryNamedImportPlugin', () => {
+  beforeEach(() => {
+    // Set up the virtual filesystem for each test
+    vol.fromJSON(
+      {
+        // Directory-named module (.tsx)
+        'src/components/Button/Button.tsx': 'export const Button = () => null',
+        // Directory-named module (.ts)
+        'src/components/Icon/Icon.ts': 'export const Icon = () => null',
+        // Directory-named module (.jsx)
+        'src/components/Logo/Logo.jsx': 'export const Logo = () => null',
+        // Directory-named module (.js)
+        'src/components/Widget/Widget.js': 'export const Widget = () => null',
+        // Index file wins when present
+        'src/components/Card/index.ts': 'export const Card = () => null',
+        // Both index and directory-named exist — index should win
+        'src/components/Alert/index.ts': 'export const Alert = () => null',
+        'src/components/Alert/Alert.tsx': 'export const Alert = () => null',
+        // Direct file (not a directory) — plugin should leave it alone
+        'src/pages/Home.tsx': 'export default function Home() {}',
+        // The importer itself
+        'src/SomeComponent.tsx': '',
+      },
+      PROJECT_ROOT,
+    )
+  })
+
+  afterEach(() => {
+    vol.reset()
+  })
+
+  it('resolves directory-named .tsx module', () => {
+    const resolveId = getPluginResolveId()
+    const result = resolveId('./components/Button', IMPORTER)
+    expect(result).toBe(
+      path.join(PROJECT_ROOT, 'src/components/Button/Button.tsx'),
+    )
+  })
+
+  it('resolves directory-named .ts module', () => {
+    const resolveId = getPluginResolveId()
+    const result = resolveId('./components/Icon', IMPORTER)
+    expect(result).toBe(
+      path.join(PROJECT_ROOT, 'src/components/Icon/Icon.ts'),
+    )
+  })
+
+  it('resolves directory-named .jsx module', () => {
+    const resolveId = getPluginResolveId()
+    const result = resolveId('./components/Logo', IMPORTER)
+    expect(result).toBe(
+      path.join(PROJECT_ROOT, 'src/components/Logo/Logo.jsx'),
+    )
+  })
+
+  it('resolves directory-named .js module', () => {
+    const resolveId = getPluginResolveId()
+    const result = resolveId('./components/Widget', IMPORTER)
+    expect(result).toBe(
+      path.join(PROJECT_ROOT, 'src/components/Widget/Widget.js'),
+    )
+  })
+
+  it('prefers index file over directory-named module', () => {
+    const resolveId = getPluginResolveId()
+    const result = resolveId('./components/Card', IMPORTER)
+    expect(result).toBe(
+      path.join(PROJECT_ROOT, 'src/components/Card/index.ts'),
+    )
+  })
+
+  it('prefers index file when both index and directory-named exist', () => {
+    const resolveId = getPluginResolveId()
+    const result = resolveId('./components/Alert', IMPORTER)
+    expect(result).toBe(
+      path.join(PROJECT_ROOT, 'src/components/Alert/index.ts'),
+    )
+  })
+
+  it('returns null for imports that resolve directly as files', () => {
+    const resolveId = getPluginResolveId()
+    // Home.tsx exists directly — let Vite handle it
+    const result = resolveId('./pages/Home', IMPORTER)
+    expect(result).toBeNull()
+  })
+
+  it('returns null for imports that cannot be resolved at all', () => {
+    const resolveId = getPluginResolveId()
+    const result = resolveId('./components/NonExistent', IMPORTER)
+    expect(result).toBeNull()
+  })
+
+  it('returns null for non-relative imports (npm packages)', () => {
+    const resolveId = getPluginResolveId()
+    const result = resolveId('react', IMPORTER)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when there is no importer', () => {
+    const resolveId = getPluginResolveId()
+    const result = resolveId('./components/Button', undefined)
+    expect(result).toBeNull()
+  })
+
+  it('returns null for imports from node_modules', () => {
+    const resolveId = getPluginResolveId()
+    const nodeModulesImporter = path.join(
+      PROJECT_ROOT,
+      'node_modules/some-lib/index.js',
+    )
+    const result = resolveId('./Button', nodeModulesImporter)
+    expect(result).toBeNull()
+  })
+})

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-directory-named-import.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-directory-named-import.test.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 
 import { vol } from 'memfs'
+import { normalizePath } from 'vite'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { cedarDirectoryNamedImportPlugin } from '../vite-plugin-cedar-directory-named-import.js'
@@ -13,6 +14,17 @@ const PROJECT_ROOT = '/test/project'
 // The file doing the importing (importer context)
 const IMPORTER = path.join(PROJECT_ROOT, 'src/SomeComponent.tsx')
 
+const opts = {
+  attributes: {},
+  isEntry: false,
+}
+
+// Mirror the plugin's own path resolution (path.resolve + normalizePath)
+// to handle cross-platform differences (e.g. drive letters on Windows).
+function expectedFile(...segments: string[]) {
+  return normalizePath(path.resolve(PROJECT_ROOT, ...segments))
+}
+
 function getPluginResolveId() {
   const plugin = cedarDirectoryNamedImportPlugin()
 
@@ -20,9 +32,7 @@ function getPluginResolveId() {
     throw new Error('Expected plugin to have a resolveId function')
   }
 
-  return plugin.resolveId.bind(
-    {} as ThisParameterType<typeof plugin.resolveId>,
-  )
+  return plugin.resolveId.bind({} as ThisParameterType<typeof plugin.resolveId>)
 }
 
 describe('cedarDirectoryNamedImportPlugin', () => {
@@ -58,74 +68,68 @@ describe('cedarDirectoryNamedImportPlugin', () => {
 
   it('resolves directory-named .tsx module', () => {
     const resolveId = getPluginResolveId()
-    const result = resolveId('./components/Button', IMPORTER)
+    const result = resolveId('./components/Button', IMPORTER, opts)
     expect(result).toBe(
-      path.join(PROJECT_ROOT, 'src/components/Button/Button.tsx'),
+      expectedFile('src/components/Button/Button.tsx'),
     )
   })
 
   it('resolves directory-named .ts module', () => {
     const resolveId = getPluginResolveId()
-    const result = resolveId('./components/Icon', IMPORTER)
-    expect(result).toBe(
-      path.join(PROJECT_ROOT, 'src/components/Icon/Icon.ts'),
-    )
+    const result = resolveId('./components/Icon', IMPORTER, opts)
+    expect(result).toBe(expectedFile('src/components/Icon/Icon.ts'))
   })
 
   it('resolves directory-named .jsx module', () => {
     const resolveId = getPluginResolveId()
-    const result = resolveId('./components/Logo', IMPORTER)
-    expect(result).toBe(
-      path.join(PROJECT_ROOT, 'src/components/Logo/Logo.jsx'),
-    )
+    const result = resolveId('./components/Logo', IMPORTER, opts)
+    expect(result).toBe(expectedFile('src/components/Logo/Logo.jsx'))
   })
 
   it('resolves directory-named .js module', () => {
     const resolveId = getPluginResolveId()
-    const result = resolveId('./components/Widget', IMPORTER)
+    const result = resolveId('./components/Widget', IMPORTER, opts)
     expect(result).toBe(
-      path.join(PROJECT_ROOT, 'src/components/Widget/Widget.js'),
+      expectedFile('src/components/Widget/Widget.js'),
     )
   })
 
   it('prefers index file over directory-named module', () => {
     const resolveId = getPluginResolveId()
-    const result = resolveId('./components/Card', IMPORTER)
-    expect(result).toBe(
-      path.join(PROJECT_ROOT, 'src/components/Card/index.ts'),
-    )
+    const result = resolveId('./components/Card', IMPORTER, opts)
+    expect(result).toBe(expectedFile('src/components/Card/index.ts'))
   })
 
   it('prefers index file when both index and directory-named exist', () => {
     const resolveId = getPluginResolveId()
-    const result = resolveId('./components/Alert', IMPORTER)
+    const result = resolveId('./components/Alert', IMPORTER, opts)
     expect(result).toBe(
-      path.join(PROJECT_ROOT, 'src/components/Alert/index.ts'),
+      expectedFile('src/components/Alert/index.ts'),
     )
   })
 
   it('returns null for imports that resolve directly as files', () => {
     const resolveId = getPluginResolveId()
     // Home.tsx exists directly — let Vite handle it
-    const result = resolveId('./pages/Home', IMPORTER)
+    const result = resolveId('./pages/Home', IMPORTER, opts)
     expect(result).toBeNull()
   })
 
   it('returns null for imports that cannot be resolved at all', () => {
     const resolveId = getPluginResolveId()
-    const result = resolveId('./components/NonExistent', IMPORTER)
+    const result = resolveId('./components/NonExistent', IMPORTER, opts)
     expect(result).toBeNull()
   })
 
   it('returns null for non-relative imports (npm packages)', () => {
     const resolveId = getPluginResolveId()
-    const result = resolveId('react', IMPORTER)
+    const result = resolveId('react', IMPORTER, opts)
     expect(result).toBeNull()
   })
 
   it('returns null when there is no importer', () => {
     const resolveId = getPluginResolveId()
-    const result = resolveId('./components/Button', undefined)
+    const result = resolveId('./components/Button', undefined, opts)
     expect(result).toBeNull()
   })
 
@@ -135,7 +139,7 @@ describe('cedarDirectoryNamedImportPlugin', () => {
       PROJECT_ROOT,
       'node_modules/some-lib/index.js',
     )
-    const result = resolveId('./Button', nodeModulesImporter)
+    const result = resolveId('./Button', nodeModulesImporter, opts)
     expect(result).toBeNull()
   })
 })

--- a/packages/vite/src/plugins/vite-plugin-cedar-directory-named-import.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-directory-named-import.ts
@@ -43,14 +43,14 @@ export function cedarDirectoryNamedImportPlugin(): Plugin {
       const indexPath = absolutePath + '/index'
       const resolvedIndex = resolveFile(indexPath)
       if (resolvedIndex) {
-        return resolvedIndex
+        return normalizePath(resolvedIndex)
       }
 
       // No index file found, so try to import the directory-named-module instead
       const dirnamedPath = absolutePath + '/' + basename
       const resolvedDirnamed = resolveFile(dirnamedPath)
       if (resolvedDirnamed) {
-        return resolvedDirnamed
+        return normalizePath(resolvedDirnamed)
       }
 
       return null

--- a/packages/vite/src/plugins/vite-plugin-cedar-directory-named-import.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-directory-named-import.ts
@@ -1,0 +1,59 @@
+import path from 'node:path'
+
+import type { Plugin } from 'vite'
+import { normalizePath } from 'vite'
+
+import { resolveFile } from '@cedarjs/project-config'
+
+/**
+ * Resolves bare directory imports to the index file or directory-named module.
+ *
+ * When you import `./Button`, this plugin checks:
+ * 1. `./Button/index.[js|ts|tsx|jsx|...]` — preferred if it exists
+ * 2. `./Button/Button.[js|ts|tsx|jsx|...]` — directory-named module fallback
+ *
+ * This mirrors the behaviour of babel-plugin-redwood-directory-named-import.
+ */
+export function cedarDirectoryNamedImportPlugin(): Plugin {
+  return {
+    name: 'vite-plugin-cedar-directory-named-import',
+
+    resolveId(id, importer) {
+      // Only handle relative imports
+      if (!id.startsWith('.') || !importer) {
+        return null
+      }
+
+      // We only operate in "userland," skip node_modules.
+      if (normalizePath(importer).includes('/node_modules/')) {
+        return null
+      }
+
+      const absolutePath = path.resolve(path.dirname(importer), id)
+
+      // If the import already points to a real file, leave it alone.
+      if (resolveFile(absolutePath)) {
+        return null
+      }
+
+      const basename = path.basename(absolutePath)
+
+      // We try to resolve `index.[js*|ts*]` modules first,
+      // since that's the desired default behaviour
+      const indexPath = absolutePath + '/index'
+      const resolvedIndex = resolveFile(indexPath)
+      if (resolvedIndex) {
+        return resolvedIndex
+      }
+
+      // No index file found, so try to import the directory-named-module instead
+      const dirnamedPath = absolutePath + '/' + basename
+      const resolvedDirnamed = resolveFile(dirnamedPath)
+      if (resolvedDirnamed) {
+        return resolvedDirnamed
+      }
+
+      return null
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Ports `babel-plugin-redwood-directory-named-import` to a Vite plugin using the `resolveId` hook — a strict 1:1 behavioural port.

## What it does

When a relative import can't be resolved as a direct file, the plugin looks for:
1. `./Dir/index.[ts|tsx|js|jsx|mjs|mts|cjs]` — preferred (mirrors the Babel plugin's index-first behaviour)
2. `./Dir/Dir.[ts|tsx|js|jsx|mjs|mts|cjs]` — directory-named module fallback

This handles the CedarJS convention of co-locating a component with its parent directory, e.g. `import { Button } from './Button'` resolving to `./Button/Button.tsx`.

## Files

| File | Description |
|------|-------------|
| `packages/vite/src/plugins/vite-plugin-cedar-directory-named-import.ts` | New Vite plugin |
| `packages/vite/src/plugins/__tests__/vite-plugin-cedar-directory-named-import.test.ts` | 11 unit tests |
| `packages/vite/src/index.ts` | Exports the new plugin |

## Testing

11 unit tests pass covering:
- `.tsx`, `.ts`, `.jsx`, `.js` directory-named variants
- Index file preference over directory-named file
- Index wins when both exist
- Direct file imports left alone (return null)
- Non-relative imports (npm packages) left alone
- node_modules importers skipped
- Missing imports return null

🤖 Generated with [Claude Code](https://claude.com/claude-code)