### PR TITLE
fix(vite): GraphQL Options extraction plugin sourcemaps

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -92,6 +92,7 @@
     "find-my-way": "8.2.2",
     "http-proxy-middleware": "3.0.7",
     "isbot": "5.1.43",
+    "magic-string": "0.30.21",
     "oxc-parser": "0.137.0",
     "react": "19.2.3",
     "react-server-dom-webpack": "19.2.4",

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -218,7 +218,8 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
               normalizePath(id).endsWith('/graphql.ts') ||
               normalizePath(id).endsWith('/graphql.js')
             ) {
-              sourceCode = applyGraphqlOptionsExtract(sourceCode) ?? sourceCode
+              const extracted = applyGraphqlOptionsExtract(sourceCode)
+              sourceCode = extracted?.code ?? sourceCode
               sourceCode = applyGqlormInject(sourceCode, id) ?? sourceCode
             }
 

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-graphql-options-extract.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-graphql-options-extract.test.ts
@@ -557,4 +557,55 @@ describe('sourcemaps', () => {
     // Handler call (using aliased name) maps to line 3
     assertMapping(outputLines, tracer, 'other(__cedar_graphqlOptions)', 3)
   })
+
+  it('maps correctly with multibyte characters before the handler', () => {
+    const code = dedent`
+      import { createGraphQLHandler } from '@cedarjs/graphql-server'
+
+      // 好 🎉 — multibyte chars that shift byte offsets vs JS indices
+      const greeting = '你好世界'
+
+      export const handler = createGraphQLHandler({
+        greeting,
+      })
+    `
+
+    const result = plugin.transform!(code, 'api/src/functions/graphql.ts')
+
+    expect(result).not.toBeNull()
+    const transformed = result!.code
+    const map = (result as { code: string; map: any }).map
+
+    const tracer = new TraceMap(map)
+    const outputLines = transformed.split('\n')
+
+    // Import maps to line 1
+    assertMapping(outputLines, tracer, "'@cedarjs/graphql-server'", 1)
+
+    // Comment with multibyte chars maps to line 3
+    assertMapping(outputLines, tracer, 'multibyte chars', 3)
+
+    // Greeting variable maps to line 4
+    assertMapping(outputLines, tracer, "const greeting = '你好世界'", 4)
+
+    // Handler call maps to line 6
+    assertMapping(outputLines, tracer, 'handler = createGraphQLHandler(', 6)
+
+    // The overwritten `__cedar_graphqlOptions` argument in the handler call
+    // maps to the original options position (line 6)
+    const firstIdx = outputLines.findIndex((l) =>
+      l.includes('__cedar_graphqlOptions'),
+    )
+    const secondIdx = outputLines.findIndex(
+      (l, i) => i > firstIdx && l.includes('__cedar_graphqlOptions'),
+    )
+    if (secondIdx >= 0) {
+      const col = outputLines[secondIdx].indexOf('__cedar_graphqlOptions')
+      const original = originalPositionFor(tracer, {
+        line: secondIdx + 1,
+        column: col,
+      })
+      expect(original.line).toBe(6)
+    }
+  })
 })

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-graphql-options-extract.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-graphql-options-extract.test.ts
@@ -1,3 +1,4 @@
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
 import { dedent } from 'ts-dedent'
 import { describe, it, expect } from 'vitest'
 
@@ -373,5 +374,187 @@ describe('cedarGraphqlOptionsExtractPlugin', () => {
         'createGraphQLHandler(__cedar_graphqlOptions)',
       )
     }
+  })
+})
+
+describe('sourcemaps', () => {
+  function assertMapping(
+    outputLines: string[],
+    tracer: TraceMap,
+    searchString: string,
+    expectedLine: number,
+  ) {
+    const lineIdx = outputLines.findIndex((l) => l.includes(searchString))
+    expect(lineIdx).toBeGreaterThanOrEqual(0)
+
+    const col = outputLines[lineIdx].indexOf(searchString)
+    expect(col).toBeGreaterThanOrEqual(0)
+
+    const original = originalPositionFor(tracer, {
+      line: lineIdx + 1,
+      column: col,
+    })
+    expect(original.line).toBe(expectedLine)
+  }
+
+  it('returns a valid sourcemap with mappings', () => {
+    const code = dedent`
+      import { createGraphQLHandler } from '@cedarjs/graphql-server'
+
+      export const handler = createGraphQLHandler({
+        directives,
+        sdls,
+        services,
+      })
+    `
+
+    const result = plugin.transform!(code, 'api/src/functions/graphql.ts')
+
+    expect(result).not.toBeNull()
+    const transformed = result!.code
+    const map = (result as { code: string; map: any }).map
+    expect(map).toBeDefined()
+    expect(map.mappings).toBeTruthy()
+
+    const tracer = new TraceMap(map)
+    const outputLines = transformed.split('\n')
+
+    // Import statement should map back to its original line
+    assertMapping(outputLines, tracer, "'@cedarjs/graphql-server'", 1)
+
+    // The handler call should map back to the original handler line
+    assertMapping(
+      outputLines,
+      tracer,
+      'createGraphQLHandler(__cedar_graphqlOptions)',
+      3,
+    )
+  })
+
+  it('maps code before and after the handler correctly', () => {
+    const code = dedent`
+      import { createGraphQLHandler } from '@cedarjs/graphql-server'
+
+      import directives from 'src/directives/**/*.{js,ts}'
+      import sdls from 'src/graphql/**/*.sdl.{js,ts}'
+      import services from 'src/services/**/*.{js,ts}'
+
+      export const handler = createGraphQLHandler({
+        directives,
+        sdls,
+        services,
+      })
+
+      export const somethingElse = 123
+    `
+
+    const result = plugin.transform!(code, 'api/src/functions/graphql.ts')
+
+    expect(result).not.toBeNull()
+    const transformed = result!.code
+    const map = (result as { code: string; map: any }).map
+
+    const tracer = new TraceMap(map)
+    const outputLines = transformed.split('\n')
+
+    // First import maps to line 1
+    assertMapping(outputLines, tracer, "'@cedarjs/graphql-server'", 1)
+
+    // Second import maps to line 3
+    assertMapping(
+      outputLines,
+      tracer,
+      "import directives from 'src/directives",
+      3,
+    )
+
+    // Code after the handler maps to its original line
+    assertMapping(outputLines, tracer, 'export const somethingElse = 123', 13)
+  })
+
+  it('maps variable reference options correctly', () => {
+    const code = dedent`
+      import { createGraphQLHandler } from '@cedarjs/graphql-server'
+
+      const opts = { directives, sdls }
+
+      export const handler = createGraphQLHandler(opts)
+    `
+
+    const result = plugin.transform!(code, 'api/src/functions/graphql.ts')
+
+    expect(result).not.toBeNull()
+    const transformed = result!.code
+    const map = (result as { code: string; map: any }).map
+
+    const tracer = new TraceMap(map)
+    const outputLines = transformed.split('\n')
+
+    // Import maps to line 1
+    assertMapping(outputLines, tracer, "'@cedarjs/graphql-server'", 1)
+
+    // Variable declaration still maps to line 3
+    assertMapping(outputLines, tracer, 'const opts = { directives, sdls }', 3)
+
+    // Handler call maps to line 5
+    assertMapping(
+      outputLines,
+      tracer,
+      'createGraphQLHandler(__cedar_graphqlOptions)',
+      5,
+    )
+  })
+
+  it('maps ternary conditional options correctly', () => {
+    const code = dedent`
+      import { createGraphQLHandler } from '@cedarjs/graphql-server'
+
+      const config = { directives, sdls }
+
+      export const handler = createGraphQLHandler(
+        true ? config : { sadness: true },
+      )
+    `
+
+    const result = plugin.transform!(code, 'api/src/functions/graphql.ts')
+
+    expect(result).not.toBeNull()
+    const transformed = result!.code
+    const map = (result as { code: string; map: any }).map
+
+    const tracer = new TraceMap(map)
+    const outputLines = transformed.split('\n')
+
+    // Import maps to line 1
+    assertMapping(outputLines, tracer, "'@cedarjs/graphql-server'", 1)
+
+    // Handler call maps to line 5 (the handler call may span multiple lines
+    // in the output, but `handler = createGraphQLHandler(` is on one line)
+    assertMapping(outputLines, tracer, 'handler = createGraphQLHandler(', 5)
+  })
+
+  it('maps aliased imports correctly', () => {
+    const code = dedent`
+      import { createGraphQLHandler as other } from '@cedarjs/graphql-server'
+
+      export const handler = other({
+        directives,
+      })
+    `
+
+    const result = plugin.transform!(code, 'api/src/functions/graphql.ts')
+
+    expect(result).not.toBeNull()
+    const transformed = result!.code
+    const map = (result as { code: string; map: any }).map
+
+    const tracer = new TraceMap(map)
+    const outputLines = transformed.split('\n')
+
+    // Import maps to line 1
+    assertMapping(outputLines, tracer, "'@cedarjs/graphql-server'", 1)
+
+    // Handler call (using aliased name) maps to line 3
+    assertMapping(outputLines, tracer, 'other(__cedar_graphqlOptions)', 3)
   })
 })

--- a/packages/vite/src/plugins/vite-plugin-cedar-graphql-options-extract.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-graphql-options-extract.ts
@@ -1,3 +1,5 @@
+import MagicString from 'magic-string'
+import type { SourceMap } from 'magic-string'
 import type { CallExpression } from 'oxc-parser'
 import { parseSync, Visitor } from 'oxc-parser'
 import type { Plugin } from 'vite'
@@ -37,13 +39,14 @@ export function cedarGraphqlOptionsExtractPlugin(): Plugin {
         return null
       }
 
-      const transformed = applyGraphqlOptionsExtract(code)
-      if (!transformed || transformed === code) {
+      const result = applyGraphqlOptionsExtract(code)
+      if (!result) {
         return null
       }
 
       return {
-        code: transformed,
+        code: result.code,
+        map: result.map,
       }
     },
   }
@@ -51,8 +54,8 @@ export function cedarGraphqlOptionsExtractPlugin(): Plugin {
 
 /**
  * Extracts the options argument from createGraphQLHandler calls and stores
- * them in an exported variable. Returns the transformed code, or null if no
- * transformation was needed.
+ * them in an exported variable. Returns the transformed code with a sourcemap,
+ * or null if no transformation was needed.
  *
  * Transforms:
  *   export const handler = createGraphQLHandler({ options })
@@ -64,7 +67,9 @@ export function cedarGraphqlOptionsExtractPlugin(): Plugin {
  * logic can run inside the Vite plugin pipeline without depending on internal's
  * build output.
  */
-export function applyGraphqlOptionsExtract(code: string): string | null {
+export function applyGraphqlOptionsExtract(
+  code: string,
+): { code: string; map: SourceMap } | null {
   // Check if already transformed
   if (code.includes('__cedar_graphqlOptions')) {
     return null
@@ -152,9 +157,12 @@ export function applyGraphqlOptionsExtract(code: string): string | null {
     optionsEnd,
   )}\n`
 
-  const before = code.slice(0, lineStart)
-  const between = code.slice(lineStart, optionsStart)
-  const after = code.slice(optionsEnd)
+  const s = new MagicString(code)
+  s.prependLeft(lineStart, optionsConst)
+  s.overwrite(optionsStart, optionsEnd, '__cedar_graphqlOptions')
 
-  return before + optionsConst + between + '__cedar_graphqlOptions' + after
+  return {
+    code: s.toString(),
+    map: s.generateMap({ hires: true }),
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3773,6 +3773,7 @@ __metadata:
     glob: "npm:11.1.0"
     http-proxy-middleware: "npm:3.0.7"
     isbot: "npm:5.1.43"
+    magic-string: "npm:0.30.21"
     memfs: "npm:4.64.0"
     oxc-parser: "npm:0.137.0"
     publint: "npm:0.3.21"


### PR DESCRIPTION
Saw this message on CI:

> [plugin cedar-graphql-options-extract] Sourcemap is likely to be incorrect: a plugin (cedar-graphql-options-extract) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help 

This PR switches to MagicString to make sure sourcemaps stay correct