### PR TITLE
chore(vite): Exclude babel transforms vite already handle

### DIFF
--- a/packages/babel-config/src/__tests__/api.test.ts
+++ b/packages/babel-config/src/__tests__/api.test.ts
@@ -129,13 +129,12 @@ describe('api', () => {
       )
 
       const apiSideBabelPlugins = getApiSideBabelPlugins()
-      expect(apiSideBabelPlugins).toHaveLength(7)
+      expect(apiSideBabelPlugins).toHaveLength(6)
 
       const pluginNames = apiSideBabelPlugins.map(([name]) => name)
       expect(pluginNames).toMatchInlineSnapshot(`
         [
           "@babel/plugin-transform-react-jsx",
-          "@babel/plugin-transform-runtime",
           "babel-plugin-module-resolver",
           [Function],
           "babel-plugin-auto-import",
@@ -154,11 +153,6 @@ describe('api', () => {
           "rwjs-babel-glob-import-dir",
         ]
       `)
-
-      expect(apiSideBabelPlugins).toContainEqual([
-        '@babel/plugin-transform-runtime',
-        {},
-      ])
 
       expect(apiSideBabelPlugins).toContainEqual([
         '@babel/plugin-transform-react-jsx',

--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -64,8 +64,10 @@ export const getApiSideBabelPlugins = ({
     ...getCommonPlugins(),
     // Needed to support `/** @jsxImportSource custom-jsx-library */`
     // comments in JSX files
-    ['@babel/plugin-transform-react-jsx', { runtime: 'automatic' }],
-    ['@babel/plugin-transform-runtime', {}],
+    !forVite && ['@babel/plugin-transform-react-jsx', { runtime: 'automatic' }],
+    // Vite/esbuild handles module transforms natively; only keep for non-Vite
+    // consumers.
+    !forVite && ['@babel/plugin-transform-runtime', {}],
     [
       'babel-plugin-module-resolver',
       {

--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -65,9 +65,6 @@ export const getApiSideBabelPlugins = ({
     // Needed to support `/** @jsxImportSource custom-jsx-library */`
     // comments in JSX files
     !forVite && ['@babel/plugin-transform-react-jsx', { runtime: 'automatic' }],
-    // Vite/esbuild handles module transforms natively; only keep for non-Vite
-    // consumers.
-    !forVite && ['@babel/plugin-transform-runtime', {}],
     [
       'babel-plugin-module-resolver',
       {


### PR DESCRIPTION
Vite and esbuild both handle JSX natively

`@babel/plugin-transform-runtime` is dead code, and has been ever since Node natively started supporting the JS features we use, like `class`. 