### PR TITLE
feat(data-migrate): Use vite to run migrations

### DIFF
--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -29,11 +29,12 @@
     "@cedarjs/babel-config": "workspace:*",
     "@cedarjs/cli-helpers": "workspace:*",
     "@cedarjs/project-config": "workspace:*",
-    "bundle-require": "^5.1.0",
+    "@cedarjs/vite": "workspace:*",
     "dotenv-defaults": "5.0.2",
     "execa": "5.1.1",
     "listr2": "10.2.1",
     "termi-link": "1.1.0",
+    "vite": "^6.3.5",
     "yargs": "17.7.3"
   },
   "devDependencies": {

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -34,7 +34,7 @@
     "execa": "5.1.1",
     "listr2": "10.2.1",
     "termi-link": "1.1.0",
-    "vite": "^6.3.5",
+    "vite": "7.3.5",
     "yargs": "17.7.3"
   },
   "devDependencies": {

--- a/packages/cli-packages/dataMigrate/src/__tests__/upHandlerEsm.test.ts
+++ b/packages/cli-packages/dataMigrate/src/__tests__/upHandlerEsm.test.ts
@@ -70,21 +70,35 @@ afterEach(() => {
 
 const mockDataMigrations: { current: any[] } = { current: [] }
 
-vi.mock('bundle-require', () => {
-  return {
-    bundleRequire: ({ filepath }: { filepath: string }) => {
-      return {
-        mod: {
-          default: () => {
+vi.mock('vite', () => ({
+  createServer: vi.fn(async () => ({
+    environments: {
+      nodeRunnerEnv: {
+        runner: {
+          import: vi.fn(async (filepath: string) => {
             if (filepath.endsWith('20230822075443-wip.ts')) {
-              throw new Error('oops')
+              return {
+                default: () => {
+                  throw new Error('oops')
+                },
+              }
             }
-          },
+            return { default: () => {} }
+          }),
         },
-      }
+      },
     },
-  }
-})
+    close: vi.fn(async () => {}),
+  })),
+  isRunnableDevEnvironment: vi.fn(() => true),
+}))
+
+vi.mock('@cedarjs/vite', () => ({
+  cedarCjsCompatPlugin: () => ({}) as any,
+  cedarImportDirPlugin: () => ({}) as any,
+  cedarAutoImportsPlugin: () => ({}) as any,
+  cedarjsResolveCedarStyleImportsPlugin: () => ({}) as any,
+}))
 
 vi.mock('/redwood-app/api/dist/lib/db.js', () => {
   return {

--- a/packages/cli-packages/dataMigrate/src/commands/upHandlerEsm.ts
+++ b/packages/cli-packages/dataMigrate/src/commands/upHandlerEsm.ts
@@ -1,28 +1,19 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-// @ts-expect-error - bundle-require has a missing types export for the "."
-// specifier in its package.json
-import { bundleRequire } from 'bundle-require'
 import { Listr } from 'listr2'
+import { createServer, isRunnableDevEnvironment } from 'vite'
 
 import { colors as c } from '@cedarjs/cli-helpers'
 import {
   getPaths,
   getDataMigrationsPath,
   resolveFile,
+  importStatementPath,
 } from '@cedarjs/project-config'
 
 import type { DataMigrateUpOptions, DataMigration } from '../types'
 
-/**
- * The subset of a Prisma client that the dataMigrate up handler requires.
- *
- * Using a structural interface rather than importing PrismaClient keeps this
- * package decoupled from wherever the generated Prisma client lives (v6
- * node_modules default or a v7 custom output path). A real PrismaClient
- * instance always satisfies this interface.
- */
 interface DataMigrateDb {
   rW_DataMigration: {
     findMany(args?: {
@@ -33,11 +24,100 @@ interface DataMigrateDb {
   $disconnect(): Promise<void>
 }
 
+function resolveId(id: string): string {
+  if (fs.existsSync(id) && fs.statSync(id).isFile()) {
+    return id
+  }
+
+  const withoutExt = /\.jsx?$/.test(id) ? id.replace(/\.jsx?$/, '') : id
+  for (const ext of ['.ts', '.tsx', '.js', '.jsx']) {
+    if (fs.existsSync(withoutExt + ext)) {
+      return withoutExt + ext
+    }
+  }
+
+  if (fs.existsSync(id) && fs.statSync(id).isDirectory()) {
+    for (const base of ['index', path.basename(id)]) {
+      for (const ext of ['.ts', '.tsx', '.js', '.jsx']) {
+        const candidate = path.join(id, base + ext)
+        if (fs.existsSync(candidate)) {
+          return candidate
+        }
+      }
+    }
+  }
+
+  return id
+}
+
 export async function handler({
   importDbClientFromDist,
   distPath,
 }: DataMigrateUpOptions) {
   let db: any
+  let server: any = null
+  let cedarPlugins: Record<string, (...args: any[]) => any>
+
+  async function getRunner() {
+    if (!server) {
+      if (!cedarPlugins) {
+        // Dynamic import works in both CJS and ESM contexts. The CJS barrel
+        // uses `export type *` which makes TypeScript see only types, but the
+        // real CJS module has values at runtime.
+        const mod = await import('@cedarjs/vite')
+        cedarPlugins = mod as Record<string, (...args: any[]) => any>
+      }
+
+      server = await createServer({
+        mode: 'production',
+        optimizeDeps: {
+          noDiscovery: true,
+          include: undefined,
+        },
+        server: {
+          hmr: false,
+          watch: null,
+        },
+        environments: {
+          nodeRunnerEnv: {},
+        },
+        resolve: {
+          alias: [
+            {
+              find: /^api\//,
+              replacement: getPaths().api.base + '/',
+            },
+            {
+              find: /^src\//,
+              replacement: 'src/',
+              customResolver: (id, importer, _options) => {
+                const apiImportBase = importStatementPath(getPaths().api.base)
+                if (importer?.startsWith(apiImportBase)) {
+                  const apiImportSrc = importStatementPath(getPaths().api.src)
+                  const apiId = id.replace('src', apiImportSrc)
+                  return { id: resolveId(apiId) }
+                }
+                return null
+              },
+            },
+          ],
+        },
+        plugins: [
+          cedarPlugins.cedarCjsCompatPlugin(),
+          cedarPlugins.cedarjsResolveCedarStyleImportsPlugin(),
+          cedarPlugins.cedarImportDirPlugin(),
+          cedarPlugins.cedarAutoImportsPlugin(),
+        ],
+      })
+    }
+
+    const env = server.environments.nodeRunnerEnv
+    if (!env || !isRunnableDevEnvironment(env)) {
+      throw new Error('Vite environment is not runnable.')
+    }
+
+    return env.runner
+  }
 
   if (importDbClientFromDist) {
     if (!fs.existsSync(distPath)) {
@@ -71,18 +151,9 @@ export async function handler({
       return
     }
 
-    // Needed plugins:
-    // - babel-plugin-module-resolver: 'src' -> './src' etc
-    // - rwjs-babel-directory-named-modules: 'src/services/userExamples' -> './src/services/userExamples/userExamples.ts'
-    // - babel-plugin-auto-import: `import gql from 'graphql-tag`, `import { context } from '@cedarjs/context`
-    // - rwjs-babel-glob-import-dir: Handle imports like src/services/**/*.{js,ts}
-    // - rwjs-babel-otel-wrapping: Wrap code in OpenTelemetry spans
-    const { mod } = await bundleRequire({
-      filepath: dbPath,
-      // TODO: Add plugins
-    })
-
-    db = mod.db
+    const runner = await getRunner()
+    const dbModule = await runner.import(dbPath)
+    db = dbModule.db
   }
 
   const pendingDataMigrations = await getPendingDataMigrations(db)
@@ -90,6 +161,7 @@ export async function handler({
   if (!pendingDataMigrations.length) {
     console.info(c.success(`\n${NO_PENDING_MIGRATIONS_MESSAGE}\n`))
     process.exitCode = 0
+    await server?.close()
     return
   }
 
@@ -123,9 +195,8 @@ export async function handler({
           })
         } catch (e) {
           counters.error++
-          console.error(
-            c.error(`Error in data migration: ${(e as Error).message}`),
-          )
+          const message = e instanceof Error ? e.message : String(e)
+          console.error(c.error(`Error in data migration: ${message}`))
         }
       },
     }
@@ -153,10 +224,28 @@ export async function handler({
     console.log()
     reportDataMigrations(counters)
     console.log()
+  } finally {
+    if (server) {
+      await server.close()
+    }
+  }
+
+  async function runDataMigration(
+    db: DataMigrateDb,
+    dataMigrationPath: string,
+  ) {
+    const runner = await getRunner()
+    const dataMigrationModule = await runner.import(dataMigrationPath)
+    const dataMigration = dataMigrationModule.default
+
+    const startedAt = new Date()
+    await dataMigration({ db })
+    const finishedAt = new Date()
+
+    return { startedAt, finishedAt }
   }
 }
 
-/** Return the list of migrations that haven't run against the database yet */
 async function getPendingDataMigrations(db: DataMigrateDb) {
   const dataMigrationsPath = await getDataMigrationsPath(
     getPaths().api.prismaConfig,
@@ -168,7 +257,6 @@ async function getPendingDataMigrations(db: DataMigrateDb) {
 
   const dataMigrations = fs
     .readdirSync(dataMigrationsPath)
-    // There may be a `.keep` file in the data migrations directory.
     .filter((dataMigrationFileName) =>
       ['js', '.ts'].some((extension) =>
         dataMigrationFileName.endsWith(extension),
@@ -201,9 +289,6 @@ async function getPendingDataMigrations(db: DataMigrateDb) {
   return pendingDataMigrations
 }
 
-/**
- * Sorts migrations by date, oldest first
- */
 function sortDataMigrationsByVersion(
   dataMigrationA: { version: string },
   dataMigrationB: { version: string },
@@ -220,27 +305,9 @@ function sortDataMigrationsByVersion(
   return 0
 }
 
-async function runDataMigration(db: DataMigrateDb, dataMigrationPath: string) {
-  const { mod } = await bundleRequire({
-    filepath: dataMigrationPath,
-    // TODO: Add plugins
-  })
-
-  const dataMigration = mod.default
-
-  const startedAt = new Date()
-  await dataMigration({ db })
-  const finishedAt = new Date()
-
-  return { startedAt, finishedAt }
-}
-
 export const NO_PENDING_MIGRATIONS_MESSAGE =
   'No pending data migrations run, already up-to-date.'
 
-/**
- * Adds data for completed migrations to the DB
- */
 async function recordDataMigration(
   db: DataMigrateDb,
   { version, name, startedAt, finishedAt }: DataMigration,
@@ -250,9 +317,6 @@ async function recordDataMigration(
   })
 }
 
-/**
- * Output run status to the console
- */
 function reportDataMigrations(counters: {
   run: number
   skipped: number

--- a/packages/cli-packages/dataMigrate/src/commands/upHandlerEsm.ts
+++ b/packages/cli-packages/dataMigrate/src/commands/upHandlerEsm.ts
@@ -151,9 +151,14 @@ export async function handler({
       return
     }
 
-    const runner = await getRunner()
-    const dbModule = await runner.import(dbPath)
-    db = dbModule.db
+    try {
+      const runner = await getRunner()
+      const dbModule = await runner.import(dbPath)
+      db = dbModule.db
+    } catch (e) {
+      await server?.close()
+      throw e
+    }
   }
 
   const pendingDataMigrations = await getPendingDataMigrations(db)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,7 +2786,7 @@ __metadata:
     memfs: "npm:4.64.0"
     termi-link: "npm:1.1.0"
     typescript: "npm:5.9.3"
-    vite: "npm:^6.3.5"
+    vite: "npm:7.3.5"
     vitest: "npm:3.2.6"
     yargs: "npm:17.7.3"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,15 +2777,16 @@ __metadata:
     "@cedarjs/cli-helpers": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
+    "@cedarjs/vite": "workspace:*"
     "@prisma/client": "npm:7.8.0"
     "@types/yargs": "npm:17.0.35"
-    bundle-require: "npm:^5.1.0"
     dotenv-defaults: "npm:5.0.2"
     execa: "npm:5.1.1"
     listr2: "npm:10.2.1"
     memfs: "npm:4.64.0"
     termi-link: "npm:1.1.0"
     typescript: "npm:5.9.3"
+    vite: "npm:^6.3.5"
     vitest: "npm:3.2.6"
     yargs: "npm:17.7.3"
   bin:
@@ -13698,17 +13699,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bundle-require@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "bundle-require@npm:5.1.0"
-  dependencies:
-    load-tsconfig: "npm:^0.2.3"
-  peerDependencies:
-    esbuild: ">=0.18"
-  checksum: 10c0/8bff9df68eb686f05af952003c78e70ffed2817968f92aebb2af620cc0b7428c8154df761d28f1b38508532204278950624ef86ce63644013dc57660a9d1810f
-  languageName: node
-  linkType: hard
-
 "busboy@npm:^1.6.0":
   version: 1.6.0
   resolution: "busboy@npm:1.6.0"
@@ -21103,13 +21093,6 @@ __metadata:
     rfdc: "npm:^1.4.1"
     wrap-ansi: "npm:^9.0.0"
   checksum: 10c0/46448d1ba0addc9d71aeafd05bb8e86ded9641ccad930ac302c2bd2ad71580375604743e18586fcb8f11906edf98e8e17fca75ba0759947bf275d381f68e311d
-  languageName: node
-  linkType: hard
-
-"load-tsconfig@npm:^0.2.3":
-  version: 0.2.5
-  resolution: "load-tsconfig@npm:0.2.5"
-  checksum: 10c0/bf2823dd26389d3497b6567f07435c5a7a58d9df82e879b0b3892f87d8db26900f84c85bc329ef41c0540c0d6a448d1c23ddc64a80f3ff6838b940f3915a3fcb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In an effort to consolidate on Vite usage everywhere, I'm moving data-migrate from bundle-require (which uses esbuild under the hood) to vite. And with that we can also use all our vite plugins