### PR TITLE
feat(vite): Add Vite job path injector plugin to buildApp

### DIFF
--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -165,6 +165,7 @@ export const getApiSideBabelConfigPath = () => {
 }
 
 export const getApiSideBabelOverrides = ({
+  forVite = false,
   projectIsEsm = false,
   forJest = false,
 } = {}) => {
@@ -183,8 +184,9 @@ export const getApiSideBabelOverrides = ({
         ],
       ],
     },
-    // Add import names and paths to job definitions
-    {
+    // Add import names and paths to job definitions. Vite uses
+    // cedarjsJobPathInjectorPlugin instead.
+    !forVite && {
       // match */api/src/jobs/*.js|ts
       test: /.+api(?:[\\|/])src(?:[\\|/])jobs(?:[\\|/]).+.(?:js|ts)$/,
       plugins: [[pluginRedwoodJobPathInjector]],
@@ -194,13 +196,14 @@ export const getApiSideBabelOverrides = ({
 }
 
 export const getApiSideDefaultBabelConfig = ({
+  forVite = false,
   projectIsEsm = false,
   forJest = false,
 } = {}) => {
   return {
     presets: getApiSideBabelPresets(),
-    plugins: getApiSideBabelPlugins({ projectIsEsm }),
-    overrides: getApiSideBabelOverrides({ projectIsEsm, forJest }),
+    plugins: getApiSideBabelPlugins({ forVite, projectIsEsm }),
+    overrides: getApiSideBabelOverrides({ forVite, projectIsEsm, forJest }),
     extends: getApiSideBabelConfigPath(),
     babelrc: false,
     ignore: ['node_modules'],
@@ -233,8 +236,10 @@ export const transformWithBabel = async (
   filename: string,
   plugins: TransformOptions['plugins'],
   sourceMaps: TransformOptions['sourceMaps'] = 'inline',
+  forVite = false,
 ) => {
   const defaultOptions = getApiSideDefaultBabelConfig({
+    forVite,
     projectIsEsm: projectSideIsEsm('api'),
   })
 

--- a/packages/vite/src/api/vite-plugin-cedar-vitest-api-preset.ts
+++ b/packages/vite/src/api/vite-plugin-cedar-vitest-api-preset.ts
@@ -4,10 +4,12 @@ import {
   trackDbImportsPlugin,
 } from '@cedarjs/testing/api/vitest'
 
+import { cedarjsJobPathInjectorPlugin } from '../plugins/vite-plugin-cedarjs-job-path-injector.js'
 import { cedarjsResolveCedarStyleImportsPlugin } from '../plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.js'
 
 export function cedarVitestPreset() {
   return [
+    cedarjsJobPathInjectorPlugin(),
     cedarVitestApiConfigPlugin(),
     autoImportsPlugin(),
     cedarjsResolveCedarStyleImportsPlugin(),

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -24,6 +24,7 @@ import { getWorkspacePackageAliases } from './lib/workspacePackageAliases.js'
 import { cedarAutoImportsPlugin } from './plugins/vite-plugin-cedar-auto-import.js'
 import { applyGraphqlOptionsExtract } from './plugins/vite-plugin-cedar-graphql-options-extract.js'
 import { applyOtelWrapping } from './plugins/vite-plugin-cedar-otel-wrapping.js'
+import { cedarjsJobPathInjectorPlugin } from './plugins/vite-plugin-cedarjs-job-path-injector.js'
 
 const LAMBDA_FUNCTIONS: Record<string, CedarHandler> = {}
 
@@ -196,6 +197,7 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
     },
     plugins: [
       cedarAutoImportsPlugin(),
+      cedarjsJobPathInjectorPlugin(),
       (() => {
         const p = gqlTagPlugin() as Plugin
         p.enforce = 'post'
@@ -251,6 +253,7 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
               sourceCode,
               id,
               babelPlugins,
+              true,
               true,
             )
 

--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -384,6 +384,7 @@ export async function buildCedarApp({
           id,
           babelPlugins,
           true,
+          true,
         )
 
         if (transformedCode?.code) {

--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -30,6 +30,7 @@ import { cedarGqlormInjectPlugin } from './plugins/vite-plugin-cedar-gqlorm-inje
 import { cedarGraphqlOptionsExtractPlugin } from './plugins/vite-plugin-cedar-graphql-options-extract.js'
 import { cedarMockCellDataPlugin } from './plugins/vite-plugin-cedar-mock-cell-data.js'
 import { cedarOtelWrappingPlugin } from './plugins/vite-plugin-cedar-otel-wrapping.js'
+import { cedarjsJobPathInjectorPlugin } from './plugins/vite-plugin-cedarjs-job-path-injector.js'
 import { handlerAlsWrappingPlugin } from './plugins/vite-plugin-handler-als-wrapping.js'
 
 function resolveWithExtensions(id: string): string {
@@ -353,6 +354,7 @@ export async function buildCedarApp({
     plugins.push(cedarGraphqlOptionsExtractPlugin())
     plugins.push(cedarGqlormInjectPlugin())
     plugins.push(cedarOtelWrappingPlugin())
+    plugins.push(cedarjsJobPathInjectorPlugin())
     plugins.push(
       handlerAlsWrappingPlugin({ projectIsEsm: projectSideIsEsm('api') }),
     )


### PR DESCRIPTION
Use the dedicated `vite-plugin-cedarjs-job-path-injector` instead of relying on the Babel version for job path injection. This is part of the ongoing effort to convert Babel-only transforms to pure Vite plugins.

The Vite plugin uses ast-grep for AST matching and is more performant than the Babel equivalent.