### PR TITLE
chore(ci): eliminate cache reservation race in concurrent matrix jobs

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -136,6 +136,22 @@ runs:
         path: ${{ steps.prebuild-cache-path.outputs.cache-path }}
         key: prebuild-cache-${{ runner.os }}-${{ steps.bs3-version.outputs.version }}
 
+    - name: 💾 Save yarn's cache
+      if: inputs.set-up-yarn-cache == 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      continue-on-error: true
+      with:
+        path: ${{ steps.set-up-yarn-cache.outputs.yarn-cache-directory }}
+        key: yarn-cache-${{ runner.os }}-${{ github.run_id }}
+
+    - name: 💾 Save yarn's install state
+      if: inputs.set-up-yarn-cache == 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      continue-on-error: true
+      with:
+        path: .yarn/install-state.gz
+        key: yarn-install-state-${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock', '.yarnrc.yml') }}-${{ github.run_id }}
+
     - name: 🏗️ Build
       if: inputs.build == 'true'
       shell: bash

--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -136,22 +136,6 @@ runs:
         path: ${{ steps.prebuild-cache-path.outputs.cache-path }}
         key: prebuild-cache-${{ runner.os }}-${{ steps.bs3-version.outputs.version }}
 
-    - name: 💾 Save yarn's cache
-      if: inputs.set-up-yarn-cache == 'true'
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      continue-on-error: true
-      with:
-        path: ${{ steps.set-up-yarn-cache.outputs.yarn-cache-directory }}
-        key: yarn-cache-${{ runner.os }}-${{ github.run_id }}
-
-    - name: 💾 Save yarn's install state
-      if: inputs.set-up-yarn-cache == 'true'
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      continue-on-error: true
-      with:
-        path: .yarn/install-state.gz
-        key: yarn-install-state-${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock', '.yarnrc.yml') }}-${{ github.run_id }}
-
     - name: 🏗️ Build
       if: inputs.build == 'true'
       shell: bash

--- a/.github/actions/set-up-yarn-cache/action.yml
+++ b/.github/actions/set-up-yarn-cache/action.yml
@@ -11,8 +11,6 @@ outputs:
     value: ${{ steps.node-modules-cache.outputs.cache-hit }}
   create-cedar-rsc-app-cache-hit:
     value: ${{ steps.node-modules-cache-create-cedar-rsc-app.outputs.cache-hit }}
-  yarn-cache-directory:
-    value: ${{ steps.get-yarn-cache-directory.outputs.CACHE_DIRECTORY }}
 
 runs:
   using: composite
@@ -23,21 +21,19 @@ runs:
       run: echo "CACHE_DIRECTORY=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: ♻️ Restore yarn's cache
-      id: cache-yarn-cache
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    - name: ♻️ Cache yarn's cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.get-yarn-cache-directory.outputs.CACHE_DIRECTORY }}
-        key: yarn-cache-${{ runner.os }}-${{ github.run_id }}
+        key: yarn-cache-${{ runner.os }}-${{ github.job }}-${{ github.run_id }}
         restore-keys: |
           yarn-cache-${{ runner.os }}-
 
-    - name: ♻️ Restore yarn's install state
-      id: cache-install-state
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    - name: ♻️ Cache yarn's install state
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .yarn/install-state.gz
-        key: yarn-install-state-${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock', '.yarnrc.yml') }}-${{ github.run_id }}
+        key: yarn-install-state-${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock', '.yarnrc.yml') }}-${{ github.job }}-${{ github.run_id }}
         restore-keys: |
           yarn-install-state-${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock', '.yarnrc.yml') }}-
 

--- a/.github/actions/set-up-yarn-cache/action.yml
+++ b/.github/actions/set-up-yarn-cache/action.yml
@@ -11,6 +11,8 @@ outputs:
     value: ${{ steps.node-modules-cache.outputs.cache-hit }}
   create-cedar-rsc-app-cache-hit:
     value: ${{ steps.node-modules-cache-create-cedar-rsc-app.outputs.cache-hit }}
+  yarn-cache-directory:
+    value: ${{ steps.get-yarn-cache-directory.outputs.CACHE_DIRECTORY }}
 
 runs:
   using: composite
@@ -21,16 +23,18 @@ runs:
       run: echo "CACHE_DIRECTORY=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: ♻️ Cache yarn's cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    - name: ♻️ Restore yarn's cache
+      id: cache-yarn-cache
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.get-yarn-cache-directory.outputs.CACHE_DIRECTORY }}
         key: yarn-cache-${{ runner.os }}-${{ github.run_id }}
         restore-keys: |
           yarn-cache-${{ runner.os }}-
 
-    - name: ♻️ Cache yarn's install state
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    - name: ♻️ Restore yarn's install state
+      id: cache-install-state
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .yarn/install-state.gz
         key: yarn-install-state-${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock', '.yarnrc.yml') }}-${{ github.run_id }}


### PR DESCRIPTION
## Problem

When multiple CI matrix jobs run concurrently on the same OS, they all
share `github.run_id`, so the yarn cache directory and install state
caches use an identical save key. The first job to finish creates the
cache entry; the rest log the noisy warning:

> Failed to save: Unable to reserve cache with key
> yarn-install-state-Windows-..., another job may be creating this cache.

## Fix

Add `github.job` to both cache keys. Since `github.job` is unique per
job definition within a workflow run, concurrent matrix jobs never
collide on the save key and the race warning disappears entirely.

The restore-keys are unchanged (OS-level prefixes), so any job still
reads from the broadest available cache regardless of which job
originally saved it.