### PR TITLE
feat(cli): Add `cedar dev --node-args`, pass `--no-maglev` on Windows CI

### DIFF
--- a/docs/implementation-plans/flaky-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-smoke-tests-investigation.md
@@ -1277,15 +1277,17 @@ try to bind the inspector port.
 - `packages/cli/src/commands/dev.ts` — new `--node-args` option.
 - `packages/cli/src/commands/dev/devHandler.ts` — `formatViteDevBinCommand()`
   (single explicit `node`/`yarn node` launch, `--node-args` passthrough, hard
-  error on resolution failure, no `cross-env`); `NODE_ENV` moved to the web job's
-  `env`; `cedar-dev-fe` (streaming) shim also shed its `cross-env`.
+  error on resolution failure, no `cross-env`). The bin entry point is read from
+  `@cedarjs/vite`'s own `bin` field, so it covers `cedar-vite-dev`,
+  `cedar-unified-dev`, **and** `cedar-dev-fe` (streaming SSR, a compiled `dist/`
+  entry — previously a TODO). `NODE_ENV` moved to the web job's `env`.
 - `packages/cli/src/commands/dev/__tests__/dev.test.ts` — updated web/unified/
   streaming/npm/pnpm assertions to the explicit-launch, no-`cross-env` shape;
   added tests for `--node-args` forwarding (web + unified).
 - `tasks/smoke-tests/basePlaywright.config.mts` — `windowsNoMaglevDevArgs`
   export (` --node-args="--no-maglev"` on Windows, else empty).
-- `tasks/smoke-tests/{dev,fragments-dev,rsc-dev}/playwright.config.ts` — append
-  `windowsNoMaglevDevArgs` to the `cedar dev` webServer command.
+- `tasks/smoke-tests/{dev,fragments-dev,rsc-dev,streaming-ssr-dev}/playwright.config.ts`
+  — append `windowsNoMaglevDevArgs` to the `cedar dev` webServer command.
 
 ### Verified
 
@@ -1309,8 +1311,9 @@ branch + CI run.
 
 ### Still to wire (follow-ups)
 
-Covers the two `cedar dev` web crashers. The remaining signature-A surfaces use
-different (compiled) entry points and a more tangled launch path:
+Covers all three `cedar dev` web crashers (`cedar-vite-dev`,
+`cedar-unified-dev`, and `cedar-dev-fe` streaming SSR). The remaining
+signature-A surfaces use different entry points and a more tangled launch path:
 
 - `cedar serve` web server — `cedar-serve-fe` (`packages/vite/dist/runFeServer.js`)
   and the `@cedarjs/web-server` bins (`cedar-web-server` / `rw-web-server`,
@@ -1318,7 +1321,6 @@ different (compiled) entry points and a more tangled launch path:
   (`packages/cli/src/commands/serve.ts`) also serves in-process via `srvx` /
   `serveWebHandler`. Covers the `serve`, `fragments-serve`, `prerender`, `rsa`,
   `rsc`, `streaming-ssr-prod` suites.
-- `cedar-dev-fe` (`packages/vite/dist/devFeServer.js`) — streaming SSR dev.
 - The api-server watch bins (`cedar-api-server-watch` / `cedarjs-api-server-watch`).
 - `cedar storybook` (signature is less clear there — Storybook also has the
   Vite 7 incompat, signature E).

--- a/docs/implementation-plans/flaky-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-smoke-tests-investigation.md
@@ -1196,3 +1196,133 @@ Server tests, Create Cedar App, constraints check.
 - Refactor branches carrying genuine TS-error build cascades (a single build
   break failing all ~18–64 downstream jobs) correctly land in REAL — this is why
   `Build, lint, test (ubuntu)` shows 0% flaky despite 67 failures.
+
+---
+
+## Update 2026-07-18 — Applied mitigation: `--node-args` flag + `--no-maglev` from Windows CI
+
+### What
+
+Signature A (the V8 Maglev JIT crash, nodejs/node#62260) is 52% of all observed
+flakiness. The fix is to run the affected node processes with `--no-maglev`,
+which disables only the Maglev tier and eliminates the crash. `--no-maglev` is a
+V8 flag, so it **cannot** be set via `NODE_OPTIONS` (node rejects V8 flags
+there) — it must be passed directly to `node` on the command line.
+
+The crashing processes are the web dev server that `yarn cedar dev` spawns via
+`concurrently` — `cedar-vite-dev` (fallback mode) or `cedar-unified-dev` (unified
+mode). Those bins are normally launched as package-manager shims, and a node flag
+can't be forwarded through the shim, so the flag has to be on the command line of
+the node process that actually runs the bin.
+
+### How (chosen approach)
+
+Two parts:
+
+1. **A generic `cedar dev --node-args="..."` flag** that forwards arbitrary CLI
+   args to the node process running the web/unified dev server (e.g. `--inspect`,
+   `--max-old-space-size=8192`, or `--no-maglev`).
+2. **CI passes `--node-args="--no-maglev"` on Windows** — the way an end user
+   would — from the dev-type smoke-test Playwright configs.
+
+`--no-maglev` is deliberately **not** hardcoded in the framework. Routing it
+through the public flag means CI dogfoods the real mechanism end-to-end, and the
+code path stays exercised even after Node fixes the Maglev bug and we drop the
+flag from CI.
+
+**Single launch path, no fallback.** `formatViteDevBinCommand(binName,
+extraNodeArgs)` always builds an explicit `<launcher> <flags> "<binPath>"`
+command (never the bin shim) and resolves the bin path via
+`require.resolve('@cedarjs/vite/package.json')` (the `./bins/*.mjs` subpaths
+aren't in the package's `exports` map, but `./package.json` is) joined with
+`bins/<binName>.mjs`. `@cedarjs/vite` is a direct dependency of the CLI, so if
+resolution fails the install is broken and dev can't run — it **throws** with a
+clear message rather than silently degrading to a shim (which, on Windows, would
+silently drop the Maglev mitigation and reintroduce the flakiness). One path,
+continuously exercised on every `cedar dev`, so bugs surface immediately.
+
+**No `cross-env`.** `NODE_ENV=development` is set via the `concurrently` job's
+`env` (as the api and unified jobs already did), so the command is just
+`<launcher> ... "<binPath>"`. Dropping `cross-env` removes a whole node process
+from the chain — the explicit launch is now **leaner than the old bin-shim
+command** (`yarn node "<path>"` = one yarn, vs the shim's `yarn cross-env … bin`
+= yarn + a cross-env node process).
+
+**Package-manager / Yarn PnP support.** The launcher is `yarn node` under Yarn
+and bare `node` under npm/pnpm. This matters for **Yarn PnP**: there is no
+`node_modules`, so the resolved bin path is a virtual path inside a Yarn cache
+zip, and only `yarn node` loads the PnP runtime needed to resolve the bin's
+imports and read that path. The path is resolved inside the CLI process, which
+`yarn cedar dev` already launched with PnP active, so resolver and launcher
+agree. Under the node-modules linker `yarn node` is just node-in-project; npm and
+pnpm always have a real `node_modules` tree (pnpm's store is native
+`node_modules`), so bare `node` is correct there.
+
+**Why one branch, no fallback** (debated at length): a two-branch "shim when no
+flags, explicit when flags" keeps the common path on the PM's shim, but the
+explicit path then only runs when someone passes `--node-args` — so it rots and
+its bugs surface late. One always-explicit path is continuously exercised (unit
+tests + Windows smoke CI), never rots, and — once `cross-env` is dropped — is
+also cheaper. A resolution fallback was rejected because a fallback that silently
+drops `--no-maglev` is worse than a loud failure.
+
+**Why not a bin-level re-exec guard** (the first thing tried): re-executing from
+inside the bin adds a second supervisor node process per dev/serve, hides the
+behaviour in a published bin, and creates a debugging footgun — with
+`NODE_OPTIONS=--inspect` (inherited), both the supervisor and the re-exec'd child
+try to bind the inspector port.
+
+### Changed files
+
+- `packages/cli/src/commands/dev.ts` — new `--node-args` option.
+- `packages/cli/src/commands/dev/devHandler.ts` — `formatViteDevBinCommand()`
+  (single explicit `node`/`yarn node` launch, `--node-args` passthrough, hard
+  error on resolution failure, no `cross-env`); `NODE_ENV` moved to the web job's
+  `env`; `cedar-dev-fe` (streaming) shim also shed its `cross-env`.
+- `packages/cli/src/commands/dev/__tests__/dev.test.ts` — updated web/unified/
+  streaming/npm/pnpm assertions to the explicit-launch, no-`cross-env` shape;
+  added tests for `--node-args` forwarding (web + unified).
+- `tasks/smoke-tests/basePlaywright.config.mts` — `windowsNoMaglevDevArgs`
+  export (` --node-args="--no-maglev"` on Windows, else empty).
+- `tasks/smoke-tests/{dev,fragments-dev,rsc-dev}/playwright.config.ts` — append
+  `windowsNoMaglevDevArgs` to the `cedar dev` webServer command.
+
+### Verified
+
+- `require.resolve('@cedarjs/vite/package.json')` resolves from the CLI
+  (`@cedarjs/vite` is a runtime `dependency`); the bin subpath does _not_ resolve
+  (`ERR_PACKAGE_PATH_NOT_EXPORTED`), confirming the package.json-based derivation
+  is necessary. Node follows the symlink to the real path, so it works under the
+  hoisted (npm/yarn) and symlinked (pnpm) layouts alike.
+- `yarn node` exists in Yarn 4 (Cedar pins `yarn@4.14.1`) and forwards args to
+  node (`yarn node --help` prints node's help).
+- `eslint` + `prettier --check` clean; `tsc` reports no new errors in the changed
+  files (the two `dev.ts` `TS2578` "unused @ts-expect-error" diagnostics
+  pre-date this change); all 15 `dev.test.ts` unit tests pass (covering yarn, npm
+  and pnpm launch shapes). The unit-test job also runs on `windows-latest`.
+
+### Not yet validated
+
+Verified structurally (command shape, resolution, PM handling, tests) but **not**
+yet run against a real Windows CI runner or a Yarn-PnP project — those need a
+branch + CI run.
+
+### Still to wire (follow-ups)
+
+Covers the two `cedar dev` web crashers. The remaining signature-A surfaces use
+different (compiled) entry points and a more tangled launch path:
+
+- `cedar serve` web server — `cedar-serve-fe` (`packages/vite/dist/runFeServer.js`)
+  and the `@cedarjs/web-server` bins (`cedar-web-server` / `rw-web-server`,
+  `packages/web-server/dist/bin.js`); the `serve` command itself
+  (`packages/cli/src/commands/serve.ts`) also serves in-process via `srvx` /
+  `serveWebHandler`. Covers the `serve`, `fragments-serve`, `prerender`, `rsa`,
+  `rsc`, `streaming-ssr-prod` suites.
+- `cedar-dev-fe` (`packages/vite/dist/devFeServer.js`) — streaming SSR dev.
+- The api-server watch bins (`cedar-api-server-watch` / `cedarjs-api-server-watch`).
+- `cedar storybook` (signature is less clear there — Storybook also has the
+  Vite 7 incompat, signature E).
+
+Note: signature D (Ubuntu esbuild `"service is no longer running"` in UD /
+E2E-node tests) is **not** a Maglev crash and is unaffected by `--no-maglev` — it
+needs the separate `afterEach`/esbuild hardening from the 2026-06-26 UD entry.

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -57,6 +57,12 @@ export const builder = (yargs: Argv) => {
         'Use the unified Vite dev server that handles both web and API in a ' +
         'single process (experimental).',
     })
+    .option('nodeArgs', {
+      type: 'string',
+      description:
+        'CLI args to pass to the node process running the web dev server, for ' +
+        'example: `--node-args="--inspect --max-old-space-size=8192"`.',
+    })
     .middleware(() => {
       const check = checkNodeVersion()
 

--- a/packages/cli/src/commands/dev/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/dev.test.ts
@@ -274,10 +274,10 @@ describe('yarn cedar dev', () => {
 
     const { webCommand, apiCommand, generateCommand } = findSeparateCommands()
 
-    // In streaming SSR mode the web side uses the cedar-dev-fe server
-    expect(webCommand?.command).toContain(
-      'yarn cross-env NODE_ENV=development cedar-dev-fe',
-    )
+    // In streaming SSR mode the web side uses the cedar-dev-fe server.
+    // NODE_ENV comes from the job env, not a cross-env wrapper.
+    expect(webCommand?.command).toContain('yarn cedar-dev-fe')
+    expect(webCommand?.env?.NODE_ENV).toEqual('development')
 
     // API side uses nodemon with cedar-api-server-watch in streaming SSR fallback mode
     expect(
@@ -326,9 +326,12 @@ describe('yarn cedar dev', () => {
 
     const { webCommand } = findSeparateCommands()
 
-    expect(webCommand?.command).toContain(
-      'yarn cross-env NODE_ENV=development cedar-vite-dev',
-    )
+    // The bin is launched via an explicit `node <flags> <path>` (under yarn:
+    // `yarn node`) so node flags can be applied. NODE_ENV comes from the job
+    // env, not a cross-env wrapper. See `formatViteDevBinCommand`.
+    expect(webCommand?.command).toContain('yarn node ')
+    expect(webCommand?.command).toContain('cedar-vite-dev.mjs')
+    expect(webCommand?.env?.NODE_ENV).toEqual('development')
 
     // No unified dev command and no api command
     const concurrentlyArgs = vi.mocked(concurrently).mock.lastCall![0]
@@ -336,6 +339,31 @@ describe('yarn cedar dev', () => {
     const apiCommand = find(concurrentlyArgs, { name: 'api' })
     expect(devCommand).toBeUndefined()
     expect(apiCommand).toBeUndefined()
+  })
+
+  it('Should forward --node-args to the web dev server node process', async () => {
+    await handler({ workspace: ['web'], nodeArgs: '--inspect' })
+
+    const { webCommand } = findSeparateCommands()
+
+    // Node flags must appear before the bin path (node-flag position), not after.
+    expect(webCommand?.command).toMatch(
+      /yarn node .*--inspect.*cedar-vite-dev\.mjs/,
+    )
+  })
+
+  it('Should forward --node-args to the unified dev server node process', async () => {
+    await handler({
+      workspace: ['api', 'web'],
+      ud: true,
+      nodeArgs: '--inspect',
+    })
+
+    const devCommand = findUnifiedDevCommand()
+
+    expect(devCommand.command).toMatch(
+      /yarn node .*--inspect.*cedar-unified-dev\.mjs/,
+    )
   })
 
   it('Should use esm api-server-watch bin in fallback mode for esm projects', async () => {
@@ -451,9 +479,13 @@ describe('npm and pnpm', () => {
 
     const { webCommand, apiCommand, generateCommand } = findSeparateCommands()
 
-    // npm uses npx for local binaries
-    expect(webCommand?.command).toContain('npx cross-env')
-    expect(webCommand?.command).toContain('cedar-vite-dev')
+    // npm uses npx for local binaries, except the web dev server, which is
+    // launched with bare `node` (npm/pnpm always have a real node_modules tree,
+    // so no PnP-aware `yarn node` launcher is needed).
+    expect(webCommand?.command).toContain('node "')
+    expect(webCommand?.command).toContain('cedar-vite-dev.mjs')
+    expect(webCommand?.command).not.toContain('npx')
+    expect(webCommand?.env?.NODE_ENV).toEqual('development')
     expect(apiCommand?.command).toContain('npx nodemon')
     expect(apiCommand?.command).toContain('cedar-api-server-watch')
     expect(generateCommand?.command).toEqual('npx cedar-gen-watch')
@@ -466,9 +498,13 @@ describe('npm and pnpm', () => {
 
     const { webCommand, apiCommand, generateCommand } = findSeparateCommands()
 
-    // pnpm uses pnpm exec for local binaries
-    expect(webCommand?.command).toContain('pnpm exec cross-env')
-    expect(webCommand?.command).toContain('cedar-vite-dev')
+    // pnpm uses pnpm exec for local binaries, except the web dev server, which
+    // is launched with bare `node` (npm/pnpm always have a real node_modules
+    // tree, so no PnP-aware `yarn node` launcher is needed).
+    expect(webCommand?.command).toContain('node "')
+    expect(webCommand?.command).toContain('cedar-vite-dev.mjs')
+    expect(webCommand?.command).not.toContain('pnpm exec')
+    expect(webCommand?.env?.NODE_ENV).toEqual('development')
     expect(apiCommand?.command).toContain('pnpm exec nodemon')
     expect(apiCommand?.command).toContain('cedar-api-server-watch')
     expect(generateCommand?.command).toEqual('pnpm exec cedar-gen-watch')

--- a/packages/cli/src/commands/dev/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/dev.test.ts
@@ -275,11 +275,11 @@ describe('yarn cedar dev', () => {
     const { webCommand, apiCommand, generateCommand } = findSeparateCommands()
 
     // In streaming SSR mode the web side uses the cedar-dev-fe server.
-    // NODE_ENV comes from the job env, not a cross-env wrapper.
     expect(webCommand?.command).toContain('yarn cedar-dev-fe')
     expect(webCommand?.env?.NODE_ENV).toEqual('development')
 
-    // API side uses nodemon with cedar-api-server-watch in streaming SSR fallback mode
+    // API side uses nodemon with cedar-api-server-watch in streaming SSR
+    // fallback mode
     expect(
       apiCommand?.command
         .replace(/\s+/g, ' ')
@@ -328,7 +328,9 @@ describe('yarn cedar dev', () => {
 
     // The bin is launched via an explicit `node <flags> <path>` (under yarn:
     // `yarn node`) so node flags can be applied. NODE_ENV comes from the job
-    // env, not a cross-env wrapper. See `formatViteDevBinCommand`.
+    // env. See `formatViteDevBinCommand`.
+    // The full command will be something like:
+    // yarn node "/Users/tobbe/dev/cedarjs/cedar/packages/vite/bins/cedar-vite-dev.mjs"
     expect(webCommand?.command).toContain('yarn node ')
     expect(webCommand?.command).toContain('cedar-vite-dev.mjs')
     expect(webCommand?.env?.NODE_ENV).toEqual('development')
@@ -346,7 +348,8 @@ describe('yarn cedar dev', () => {
 
     const { webCommand } = findSeparateCommands()
 
-    // Node flags must appear before the bin path (node-flag position), not after.
+    // Node flags must appear before the bin path (node-flag position), not
+    // after.
     expect(webCommand?.command).toMatch(
       /yarn node .*--inspect.*cedar-vite-dev\.mjs/,
     )

--- a/packages/cli/src/commands/dev/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/dev.test.ts
@@ -274,8 +274,11 @@ describe('yarn cedar dev', () => {
 
     const { webCommand, apiCommand, generateCommand } = findSeparateCommands()
 
-    // In streaming SSR mode the web side uses the cedar-dev-fe server.
-    expect(webCommand?.command).toContain('yarn cedar-dev-fe')
+    // In streaming SSR mode the web side uses the cedar-dev-fe server, launched
+    // explicitly (like the other dev servers) so node flags apply. NODE_ENV
+    // comes from the job env, not a cross-env wrapper.
+    expect(webCommand?.command).toContain('yarn node ')
+    expect(webCommand?.command).toContain('devFeServer.js')
     expect(webCommand?.env?.NODE_ENV).toEqual('development')
 
     // API side uses nodemon with cedar-api-server-watch in streaming SSR

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -35,9 +35,13 @@ interface DevHandlerOptions {
   nodeArgs?: string
 }
 
+interface VitePackageJson {
+  bin?: Record<string, string>
+}
+
 /**
  * Builds the command that launches one of `@cedarjs/vite`'s dev-server bins
- * (`cedar-vite-dev`, `cedar-unified-dev`).
+ * (`cedar-vite-dev`, `cedar-unified-dev`, or `cedar-dev-fe` for streaming SSR).
  *
  * We launch the bin via an explicit `node <flags> <binPath>` rather than the
  * package-manager bin shim so node-level CLI flags can be applied.
@@ -48,6 +52,10 @@ interface DevHandlerOptions {
  * the dev web server mid-run. See https://github.com/nodejs/node/issues/62260
  * and docs/implementation-plans/flaky-smoke-tests-investigation.md. `--no-maglev`
  * is a V8 flag, so it can't go through `NODE_OPTIONS` or the bin shim.
+ *
+ * The bin's entry point is read from `@cedarjs/vite`'s own `bin` field rather
+ * than assuming a location: `cedar-vite-dev` / `cedar-unified-dev` live in
+ * `bins/*.mjs`, but `cedar-dev-fe` is a compiled `dist/` entry.
  *
  * Under Yarn we launch with `yarn node` rather than bare `node`: with the PnP
  * linker there is no `node_modules` — the resolved bin path is a virtual path
@@ -64,12 +72,15 @@ interface DevHandlerOptions {
 function formatViteDevBinCommand(binName: string, extraNodeArgs = '') {
   // `@cedarjs/vite` is a direct dependency of the CLI. If it can't be resolved
   // the install is broken and dev can't run, so fail loudly rather than
-  // silently degrade. The `bins/*.mjs` subpaths aren't in `@cedarjs/vite`'s
-  // `exports` map, but `./package.json` is, so resolve that and derive the bin
-  // path from it.
+  // silently degrade. `./package.json` is in the package's `exports` map (the
+  // bin subpaths are not). We `require` the JSON (rather than `fs`-read it) so
+  // it goes through Node's real module system — which also keeps this working
+  // when `node:fs` is mocked in unit tests.
   let vitePackageJsonPath: string
+  let vitePackageJson: VitePackageJson
   try {
     vitePackageJsonPath = createdRequire.resolve('@cedarjs/vite/package.json')
+    vitePackageJson = createdRequire('@cedarjs/vite/package.json')
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e)
     throw new Error(
@@ -78,11 +89,14 @@ function formatViteDevBinCommand(binName: string, extraNodeArgs = '') {
     )
   }
 
-  const binPath = path.join(
-    path.dirname(vitePackageJsonPath),
-    'bins',
-    `${binName}.mjs`,
-  )
+  const binRelativePath = vitePackageJson.bin?.[binName]
+  if (!binRelativePath) {
+    throw new Error(
+      `@cedarjs/vite does not declare a "${binName}" bin. This is a bug in CedarJS.`,
+    )
+  }
+
+  const binPath = path.join(path.dirname(vitePackageJsonPath), binRelativePath)
 
   const nodeLauncher = getPackageManager() === 'yarn' ? 'yarn node' : 'node'
   const flags = extraNodeArgs ? `${extraNodeArgs} ` : ''
@@ -402,10 +416,7 @@ export const handler = async ({
       let webCommand = `${formatViteDevBinCommand('cedar-vite-dev', nodeArgs)} ${forward}`
 
       if (streamingSsrEnabled) {
-        // TODO: `cedar-dev-fe` (streaming SSR) is a compiled `dist/` entry, not
-        // a `bins/*.mjs`, so it isn't covered by the explicit-launch /
-        // `--node-args` handling yet. See the investigation doc's follow-ups.
-        webCommand = `${formatRunBinCommand('cedar-dev-fe')} ${forward}`
+        webCommand = `${formatViteDevBinCommand('cedar-dev-fe', nodeArgs)} ${forward}`
       }
 
       jobs.push({

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -23,7 +23,7 @@ import { serverFileExists } from '../../lib/project.js'
 import { getApiDebugFlag } from './apiDebugFlag.js'
 import { getPackageWatchCommands } from './packageWatchCommands.js'
 
-const require = createRequire(import.meta.url)
+const createdRequire = createRequire(import.meta.url)
 
 interface DevHandlerOptions {
   workspace?: string[]
@@ -69,7 +69,7 @@ function formatViteDevBinCommand(binName: string, extraNodeArgs = '') {
   // path from it.
   let vitePackageJsonPath: string
   try {
-    vitePackageJsonPath = require.resolve('@cedarjs/vite/package.json')
+    vitePackageJsonPath = createdRequire.resolve('@cedarjs/vite/package.json')
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e)
     throw new Error(

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import { Writable } from 'node:stream'
 
@@ -10,6 +11,7 @@ import { formatRunBinCommand } from '@cedarjs/cli-helpers/packageManager/display
 import { shutdownPort } from '@cedarjs/internal/dist/dev'
 import { generateGqlormArtifacts } from '@cedarjs/internal/dist/generate/gqlormSchema'
 import { getConfig, getConfigPath } from '@cedarjs/project-config'
+import { getPackageManager } from '@cedarjs/project-config/packageManager'
 import { errorTelemetry } from '@cedarjs/telemetry'
 
 import { exitWithError } from '../../lib/exit.js'
@@ -21,6 +23,8 @@ import { serverFileExists } from '../../lib/project.js'
 import { getApiDebugFlag } from './apiDebugFlag.js'
 import { getPackageWatchCommands } from './packageWatchCommands.js'
 
+const require = createRequire(import.meta.url)
+
 interface DevHandlerOptions {
   workspace?: string[]
   forward?: string
@@ -28,6 +32,62 @@ interface DevHandlerOptions {
   apiDebugPort?: number
   debugBrk?: boolean
   ud?: boolean
+  nodeArgs?: string
+}
+
+/**
+ * Builds the command that launches one of `@cedarjs/vite`'s dev-server bins
+ * (`cedar-vite-dev`, `cedar-unified-dev`).
+ *
+ * We launch the bin via an explicit `node <flags> <binPath>` rather than the
+ * package-manager bin shim so node-level CLI flags can be applied.
+ * `extraNodeArgs` carries whatever the user passed via `cedar dev
+ * --node-args="..."`. The main use is our smoke-test CI passing
+ * `--node-args="--no-maglev"` on Windows to dodge V8's Maglev JIT crash
+ * (STATUS_STACK_BUFFER_OVERRUN, exit code 3221226505) which otherwise takes down
+ * the dev web server mid-run. See https://github.com/nodejs/node/issues/62260
+ * and docs/implementation-plans/flaky-smoke-tests-investigation.md. `--no-maglev`
+ * is a V8 flag, so it can't go through `NODE_OPTIONS` or the bin shim.
+ *
+ * Under Yarn we launch with `yarn node` rather than bare `node`: with the PnP
+ * linker there is no `node_modules` — the resolved bin path is a virtual path
+ * inside a Yarn cache zip, and only `yarn node` loads the PnP runtime needed to
+ * resolve the bin's imports and read that path. Under the node-modules linker
+ * `yarn node` is just node-in-project. npm and pnpm always have a real
+ * `node_modules` tree (pnpm's store is still native `node_modules`), so bare
+ * `node` is correct there.
+ *
+ * `NODE_ENV=development` is set by the caller via the `concurrently` job's `env`
+ * (like the api and unified jobs already do), so no `cross-env` wrapper is
+ * needed.
+ */
+function formatViteDevBinCommand(binName: string, extraNodeArgs = '') {
+  // `@cedarjs/vite` is a direct dependency of the CLI. If it can't be resolved
+  // the install is broken and dev can't run, so fail loudly rather than
+  // silently degrade. The `bins/*.mjs` subpaths aren't in `@cedarjs/vite`'s
+  // `exports` map, but `./package.json` is, so resolve that and derive the bin
+  // path from it.
+  let vitePackageJsonPath: string
+  try {
+    vitePackageJsonPath = require.resolve('@cedarjs/vite/package.json')
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    throw new Error(
+      `Could not resolve @cedarjs/vite, which the dev server needs to run. ` +
+        `Is it installed? (${message})`,
+    )
+  }
+
+  const binPath = path.join(
+    path.dirname(vitePackageJsonPath),
+    'bins',
+    `${binName}.mjs`,
+  )
+
+  const nodeLauncher = getPackageManager() === 'yarn' ? 'yarn node' : 'node'
+  const flags = extraNodeArgs ? `${extraNodeArgs} ` : ''
+
+  return `${nodeLauncher} ${flags}"${binPath}"`
 }
 
 export const handler = async ({
@@ -37,6 +97,7 @@ export const handler = async ({
   apiDebugPort,
   debugBrk,
   ud = false,
+  nodeArgs = '',
 }: DevHandlerOptions) => {
   recordTelemetryAttributes({
     command: 'dev',
@@ -254,7 +315,7 @@ export const handler = async ({
     }
 
     return [
-      `${formatRunBinCommand('cross-env', ['NODE_ENV=development', 'cedar-unified-dev'])}`,
+      formatViteDevBinCommand('cedar-unified-dev', nodeArgs),
       `  --port ${webAvailablePort}`,
       `  --apiPort ${apiAvailablePort}`,
       getApiDebugFlag(apiDebugPort, apiAvailablePort),
@@ -338,15 +399,21 @@ export const handler = async ({
     }
 
     if (workspace.includes('web')) {
-      let webCommand = `${formatRunBinCommand('cross-env', ['NODE_ENV=development', 'cedar-vite-dev'])} ${forward}`
+      let webCommand = `${formatViteDevBinCommand('cedar-vite-dev', nodeArgs)} ${forward}`
 
       if (streamingSsrEnabled) {
-        webCommand = `${formatRunBinCommand('cross-env', ['NODE_ENV=development', 'cedar-dev-fe'])} ${forward}`
+        // TODO: `cedar-dev-fe` (streaming SSR) is a compiled `dist/` entry, not
+        // a `bins/*.mjs`, so it isn't covered by the explicit-launch /
+        // `--node-args` handling yet. See the investigation doc's follow-ups.
+        webCommand = `${formatRunBinCommand('cedar-dev-fe')} ${forward}`
       }
 
       jobs.push({
         name: 'web',
         command: webCommand,
+        env: {
+          NODE_ENV: 'development',
+        },
         prefixColor: 'blue',
         cwd: cedarPaths.web.base,
         runWhen: () => fs.existsSync(cedarPaths.web.src),

--- a/tasks/smoke-tests/basePlaywright.config.mts
+++ b/tasks/smoke-tests/basePlaywright.config.mts
@@ -3,6 +3,21 @@ import * as fs from 'node:fs'
 import type { PlaywrightTestConfig } from '@playwright/test'
 import { devices } from '@playwright/test'
 
+/**
+ * Extra `cedar dev` args to dodge V8's Maglev JIT crash on Windows
+ * (STATUS_STACK_BUFFER_OVERRUN, exit code 3221226505), which otherwise takes
+ * down the dev web server mid-run and fails these smoke tests with
+ * `net::ERR_CONNECTION_REFUSED`. See
+ * https://github.com/nodejs/node/issues/62260 and
+ * docs/implementation-plans/flaky-smoke-tests-investigation.md.
+ *
+ * `--no-maglev` is a V8 flag, so it has to be passed as an actual node CLI arg
+ * (not via `NODE_OPTIONS`); `cedar dev --node-args` forwards it to the node
+ * process running the web dev server. Empty on non-Windows platforms.
+ */
+export const windowsNoMaglevDevArgs =
+  process.platform === 'win32' ? ' --node-args="--no-maglev"' : ''
+
 // See https://playwright.dev/docs/test-configuration#global-configuration
 export const basePlaywrightConfig: PlaywrightTestConfig = {
   testDir: './tests',

--- a/tasks/smoke-tests/dev/playwright.config.ts
+++ b/tasks/smoke-tests/dev/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from '@playwright/test'
 
-import { basePlaywrightConfig } from '../basePlaywright.config.mts'
+import {
+  basePlaywrightConfig,
+  windowsNoMaglevDevArgs,
+} from '../basePlaywright.config.mts'
 
 // See https://playwright.dev/docs/test-configuration#global-configuration
 export default defineConfig({
@@ -14,7 +17,7 @@ export default defineConfig({
 
   // Run your local dev server before starting the tests
   webServer: {
-    command: 'yarn cedar dev --no-generate --fwd="--no-open"',
+    command: `yarn cedar dev --no-generate --fwd="--no-open"${windowsNoMaglevDevArgs}`,
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
     // We wait for the api server to be ready instead of the web server
     // because web starts much faster with Vite.

--- a/tasks/smoke-tests/fragments-dev/playwright.config.ts
+++ b/tasks/smoke-tests/fragments-dev/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from '@playwright/test'
 
-import { basePlaywrightConfig } from '../basePlaywright.config.mts'
+import {
+  basePlaywrightConfig,
+  windowsNoMaglevDevArgs,
+} from '../basePlaywright.config.mts'
 
 // See https://playwright.dev/docs/test-configuration#global-configuration
 export default defineConfig({
@@ -14,7 +17,7 @@ export default defineConfig({
 
   // Run your local dev server before starting the tests
   webServer: {
-    command: 'yarn cedar dev --no-generate --fwd="--no-open"',
+    command: `yarn cedar dev --no-generate --fwd="--no-open"${windowsNoMaglevDevArgs}`,
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
     // We wait for the api server to be ready instead of the web server
     // because web starts much faster with Vite.

--- a/tasks/smoke-tests/rsc-dev/playwright.config.ts
+++ b/tasks/smoke-tests/rsc-dev/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from '@playwright/test'
 
-import { basePlaywrightConfig } from '../basePlaywright.config.mts'
+import {
+  basePlaywrightConfig,
+  windowsNoMaglevDevArgs,
+} from '../basePlaywright.config.mts'
 
 // See https://playwright.dev/docs/test-configuration#global-configuration
 export default defineConfig({
@@ -12,7 +15,7 @@ export default defineConfig({
 
   // Run your local dev server before starting the tests
   webServer: {
-    command: 'yarn cedar dev',
+    command: `yarn cedar dev${windowsNoMaglevDevArgs}`,
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
     url: 'http://127.0.0.1:8910',
     reuseExistingServer: !process.env.CI,

--- a/tasks/smoke-tests/streaming-ssr-dev/playwright.config.ts
+++ b/tasks/smoke-tests/streaming-ssr-dev/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from '@playwright/test'
 
-import { basePlaywrightConfig } from '../basePlaywright.config.mts'
+import {
+  basePlaywrightConfig,
+  windowsNoMaglevDevArgs,
+} from '../basePlaywright.config.mts'
 
 // See https://playwright.dev/docs/test-configuration#global-configuration
 export default defineConfig({
@@ -12,7 +15,7 @@ export default defineConfig({
 
   // Run your local dev server before starting the tests
   webServer: {
-    command: 'yarn cedar dev --no-generate --fwd="--no-open"',
+    command: `yarn cedar dev --no-generate --fwd="--no-open"${windowsNoMaglevDevArgs}`,
     cwd: process.env.CEDAR_TEST_PROJECT_PATH,
     url: 'http://127.0.0.1:8911/graphql?query={redwood{version}}',
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
## Summary

The Windows smoke tests are the single biggest source of CI flakiness. A survey of the last 100 merged PRs (in `docs/implementation-plans/flaky-smoke-tests-investigation.md`) found that V8's **Maglev JIT crash on Windows** ([nodejs/node#62260](https://github.com/nodejs/node/issues/62260) — `STATUS_STACK_BUFFER_OVERRUN` / exit code `3221226505`) accounts for **~52% of all flaky failures**: it takes down the `cedar dev` web server mid-run, and every subsequent request fails with `net::ERR_CONNECTION_REFUSED`.

`--no-maglev` eliminates the crash, but it's a **V8 flag** — it can't be set via `NODE_OPTIONS` and can't be forwarded through the package-manager bin shim, so it has to be an actual `node` CLI arg on the process running the web dev server.

## What this does

- **New `cedar dev --node-args="..."` flag** — forwards arbitrary CLI args to the node process running the web/unified dev server (e.g. `--inspect`, `--max-old-space-size=8192`, `--no-maglev`).
- **Explicit launch** — the dev-server bin is launched via `node` / `yarn node "<binPath>"` (path resolved from `@cedarjs/vite/package.json`) instead of the bin shim, so node flags can be applied. `yarn node` is used under Yarn so it also works with the **PnP** linker; bare `node` under npm/pnpm (which always have a real `node_modules` tree). Resolution failure **throws loudly** rather than silently degrading — `@cedarjs/vite` is a direct CLI dependency, so if it can't be resolved the install is broken.
- **No `cross-env`** — `NODE_ENV` is set via the `concurrently` job `env` (as the api/unified jobs already did). Dropping `cross-env` removes a whole node process from the chain, so the explicit launch is actually *leaner* than the old shim command.
- **CI passes `--no-maglev` the way a user would** — via `--node-args` from the Windows dev-type smoke Playwright configs. `--no-maglev` is deliberately **not** hardcoded in the framework, so CI dogfoods the real mechanism and the code path stays exercised even after Node fixes the bug and we drop the flag.

## Testing

- `yarn eslint` + `yarn prettier --check` clean on all changed files.
- `tsc` reports no new errors in the changed files (two pre-existing `dev.ts` `TS2578` diagnostics are unrelated).
- All 15 `dev.test.ts` unit tests pass, covering the yarn, npm and pnpm launch shapes plus `--node-args` forwarding. The unit-test job also runs on `windows-latest`.

## Not yet validated / follow-ups

- Verified structurally only — **not** yet run against a real Windows CI runner or a Yarn-PnP project (this PR's CI is the first real Windows exercise).
- Not covered yet: `cedar serve`, streaming `cedar-dev-fe` (so `streaming-ssr-dev` is unchanged), the api-server watch bins, and storybook.
- Signature D (Ubuntu esbuild `"service is no longer running"`) is a separate, non-Maglev issue.