### PR TITLE
chore(vite): port babel-plugin-redwood-directory-named-import to API build

### DIFF
--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -143,9 +143,9 @@ cedar build:
   manifest, SSR client+server builds.
 
 Vite plugins: cell transform | entry injection | html env | data-uri-to-buffer shim |
-  auto-imports | import-dir | js-as-jsx | merged config | api-babel-transform |
-  cedar-routes-auto-loader | cedar-universal-deploy | cedar-wait-for-api-server |
-  resolve-cedar-style-imports
+  auto-imports | import-dir | directory-named-import | js-as-jsx | merged config |
+  api-babel-transform | cedar-routes-auto-loader | cedar-universal-deploy |
+  cedar-wait-for-api-server | resolve-cedar-style-imports
   *SSR/RSC: adds RSC transforms
 ```
 

--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -119,7 +119,9 @@ export const getApiSideBabelPlugins = ({
       },
       'rwjs-api-module-resolver',
     ],
-    [
+    // Vite/esbuild use cedarDirectoryNamedImportPlugin / applyDirectoryNamedImport
+    // instead of this babel plugin
+    !forVite && [
       pluginRedwoodDirectoryNamedImport,
       undefined,
       'rwjs-babel-directory-named-modules',

--- a/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/DirectFile.ts
+++ b/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/DirectFile.ts
@@ -1,0 +1,1 @@
+export const direct = 'direct'

--- a/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/JSX/JSX.jsx
+++ b/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/JSX/JSX.jsx
@@ -1,0 +1,1 @@
+export const pew = 'pew'

--- a/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/Module/Module.js
+++ b/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/Module/Module.js
@@ -1,0 +1,2 @@
+export const ImpModule = 'ImpModule'
+export const ExpModule = 'ExpModule'

--- a/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/TS/TS.ts
+++ b/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/TS/TS.ts
@@ -1,0 +1,1 @@
+export const pew = 'pew'

--- a/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/TSWithIndex/TSWithIndex.ts
+++ b/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/TSWithIndex/TSWithIndex.ts
@@ -1,0 +1,1 @@
+export const notUsed = 'notUsed'

--- a/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/TSWithIndex/index.js
+++ b/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/TSWithIndex/index.js
@@ -1,0 +1,1 @@
+export const TSWithIndex = 'TSWithIndex'

--- a/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/TSX/TSX.tsx
+++ b/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/TSX/TSX.tsx
@@ -1,0 +1,2 @@
+export const ImpTSX = 'ImpTSX'
+export const pew = 'pew'

--- a/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/indexModule/index.js
+++ b/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/indexModule/index.js
@@ -1,0 +1,1 @@
+export const ExpIndex = 'ExpIndex'

--- a/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/indexModule/indexModule.js
+++ b/packages/internal/src/build/__tests__/__fixtures__/directory-named-imports/indexModule/indexModule.js
@@ -1,0 +1,1 @@
+export const notUsed = 'notUsed'

--- a/packages/internal/src/build/__tests__/directory-named-import.test.ts
+++ b/packages/internal/src/build/__tests__/directory-named-import.test.ts
@@ -1,0 +1,76 @@
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { applyDirectoryNamedImport } from '../directory-named-import.js'
+
+const FIXTURE_FILE = path.join(
+  __dirname,
+  '__fixtures__/directory-named-imports/importer.ts',
+)
+
+describe('applyDirectoryNamedImport', () => {
+  it('rewrites a directory-named import to its directory-named module (.js)', () => {
+    const code = `import { ImpModule } from './Module'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `import { ImpModule } from './Module/Module'`,
+    )
+  })
+
+  it('rewrites a directory-named import to its directory-named module (.tsx)', () => {
+    const code = `import { ImpTSX } from './TSX'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `import { ImpTSX } from './TSX/TSX'`,
+    )
+  })
+
+  it('rewrites a directory-named export', () => {
+    const code = `export { ExpModule } from './Module'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `export { ExpModule } from './Module/Module'`,
+    )
+  })
+
+  it('prefers index.* over the directory-named module', () => {
+    const code = `export { ExpIndex } from './indexModule'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `export { ExpIndex } from './indexModule/index'`,
+    )
+  })
+
+  it('supports .ts modules', () => {
+    const code = `export { pew } from './TS'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `export { pew } from './TS/TS'`,
+    )
+  })
+
+  it('supports .jsx modules', () => {
+    const code = `export { pew } from './JSX'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `export { pew } from './JSX/JSX'`,
+    )
+  })
+
+  it('leaves imports that already resolve directly to a file alone', () => {
+    const code = `import { direct } from './DirectFile'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(code)
+  })
+
+  it('leaves imports that cannot be resolved at all alone', () => {
+    const code = `import { nope } from './DoesNotExist'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(code)
+  })
+
+  it('leaves bare package imports alone', () => {
+    const code = `import React from 'react'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(code)
+  })
+
+  it('handles double-quoted imports', () => {
+    const code = `import { ImpModule } from "./Module"`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `import { ImpModule } from "./Module/Module"`,
+    )
+  })
+})

--- a/packages/internal/src/build/__tests__/directory-named-import.test.ts
+++ b/packages/internal/src/build/__tests__/directory-named-import.test.ts
@@ -73,4 +73,42 @@ describe('applyDirectoryNamedImport', () => {
       `import { ImpModule } from "./Module/Module"`,
     )
   })
+
+  it('rewrites a side-effect-only import (no `from` clause)', () => {
+    const code = `import './Module'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `import './Module/Module'`,
+    )
+  })
+
+  it('rewrites a namespace import', () => {
+    const code = `import * as mod from './Module'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `import * as mod from './Module/Module'`,
+    )
+  })
+
+  it('rewrites a bare `export *` re-export', () => {
+    const code = `export * from './Module'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `export * from './Module/Module'`,
+    )
+  })
+
+  it('does not rewrite dynamic import() calls', () => {
+    const code = `const mod = await import('./Module')`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(code)
+  })
+
+  it('does not rewrite import-like text inside a string that is not at the start of a line', () => {
+    const code = `const doc = "See: import { ImpModule } from './Module'"`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(code)
+  })
+
+  it('does not rewrite import-like text in a comment before the real import', () => {
+    const code = `// import { ImpModule } from './Module'\nimport { ImpModule } from './Module'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `// import { ImpModule } from './Module'\nimport { ImpModule } from './Module/Module'`,
+    )
+  })
 })

--- a/packages/internal/src/build/__tests__/directory-named-import.test.ts
+++ b/packages/internal/src/build/__tests__/directory-named-import.test.ts
@@ -111,4 +111,18 @@ describe('applyDirectoryNamedImport', () => {
       `// import { ImpModule } from './Module'\nimport { ImpModule } from './Module/Module'`,
     )
   })
+
+  it('rewrites a Prettier-wrapped multiline import', () => {
+    const code = `import {\n  ImpModule,\n  AnotherThing,\n} from './Module'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `import {\n  ImpModule,\n  AnotherThing,\n} from './Module/Module'`,
+    )
+  })
+
+  it('rewrites a multiline export', () => {
+    const code = `export {\n  ExpModule,\n  AnotherThing,\n} from './Module'`
+    expect(applyDirectoryNamedImport(code, FIXTURE_FILE)).toBe(
+      `export {\n  ExpModule,\n  AnotherThing,\n} from './Module/Module'`,
+    )
+  })
 })

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -10,7 +10,12 @@ import {
   getApiSideBabelPlugins,
   transformWithBabel,
 } from '@cedarjs/babel-config'
-import { getConfig, getPaths, projectSideIsEsm } from '@cedarjs/project-config'
+import {
+  getConfig,
+  getPaths,
+  projectSideIsEsm,
+  resolveFile,
+} from '@cedarjs/project-config'
 
 import { findApiFiles } from '../files.js'
 
@@ -19,6 +24,7 @@ import {
   applyGraphqlOptionsExtract,
 } from './api-graphql-transforms.js'
 import { applyAutoImports } from './auto-import.js'
+import { applyDirectoryNamedImport } from './directory-named-import.js'
 import { cedarApiGraphqlPlugin } from './esbuild-plugin-api-graphql.js'
 import { applyOtelWrapping } from './esbuild-plugin-cedar-otel-wrapping.js'
 import { applyHandlerAlsWrapping } from './esbuild-plugin-handler-als-wrapping.js'
@@ -63,6 +69,9 @@ const runCedarBabelTransformsPlugin = {
           path.relative(build.initialOptions.absWorkingDir + '/src', args.path),
         ),
       )
+      // Rewrite relative directory imports (e.g. `./Button`) to their index
+      // or directory-named module file.
+      fileContents = applyDirectoryNamedImport(fileContents, args.path)
       fileContents = applyAutoImports(fileContents)
       // Expand glob imports (e.g. `import x from 'src/services/**/*.ts'`)
       // before Babel runs.  The Babel import-dir plugin is disabled for these
@@ -148,6 +157,57 @@ function createImportDirVitePlugin(): Plugin {
         return null
       }
       return { code: result.code, map: result.map }
+    },
+  }
+}
+
+/**
+ * Vite plugin that resolves relative directory imports (e.g. `./Button`) to
+ * their index or directory-named module file. This is the buildApiWithVite
+ * equivalent of:
+ *   - cedarDirectoryNamedImportPlugin  in @cedarjs/vite  (used by buildApp
+ *     and apiDevMiddleware)
+ *   - applyDirectoryNamedImport        applied inline      (used by
+ *     runCedarBabelTransformsPlugin and cedarApiGraphqlPlugin)
+ *
+ * Inlined here to avoid a circular dependency (@cedarjs/internal ↔
+ * @cedarjs/vite). Code duplication is intentional.
+ */
+function createDirectoryNamedImportVitePlugin(): Plugin {
+  return {
+    name: 'cedar-internal-directory-named-import',
+    enforce: 'pre',
+    resolveId(id, importer) {
+      // Only handle relative imports
+      if (!id.startsWith('.') || !importer) {
+        return null
+      }
+
+      if (importer.includes('node_modules')) {
+        return null
+      }
+
+      const absolutePath = path.resolve(path.dirname(importer), id)
+
+      // If the import already points to a real file, leave it alone.
+      if (resolveFile(absolutePath)) {
+        return null
+      }
+
+      const indexPath = path.join(absolutePath, 'index')
+      const resolvedIndex = resolveFile(indexPath)
+      if (resolvedIndex) {
+        return normalizePath(resolvedIndex)
+      }
+
+      const basename = path.basename(absolutePath)
+      const dirNamedPath = path.join(absolutePath, basename)
+      const resolvedDirNamed = resolveFile(dirNamedPath)
+      if (resolvedDirNamed) {
+        return normalizePath(resolvedDirNamed)
+      }
+
+      return null
     },
   }
 }
@@ -296,7 +356,11 @@ export const buildApiWithVite = async () => {
     // are expanded before Babel sees the code.  The Babel import-dir plugin is
     // disabled for forVite:true builds; this inline Vite plugin is its
     // replacement for this code path (both CJS and ESM output via Rollup).
-    plugins: [createImportDirVitePlugin(), createCedarViteApiPlugin()],
+    plugins: [
+      createImportDirVitePlugin(),
+      createDirectoryNamedImportVitePlugin(),
+      createCedarViteApiPlugin(),
+    ],
   })
 }
 

--- a/packages/internal/src/build/directory-named-import.ts
+++ b/packages/internal/src/build/directory-named-import.ts
@@ -16,9 +16,18 @@ import { importStatementPath, resolveFile } from '@cedarjs/project-config'
  * `./Button.*` does not), this rewrites the import to `./Button/Button`.
  * Mirrors the precedence used by `cedarDirectoryNamedImportPlugin` (Vite):
  * an index file wins over a directory-named module.
+ *
+ * Matches static `import`/`export` statements, including side-effect-only
+ * imports (`import './Button'`) — the babel plugin this replaces visits every
+ * `ImportDeclaration`/`ExportDeclaration`, which covers those too. Anchored to
+ * the start of a line (like `applyImportDir`'s glob-import regex) so that
+ * text resembling an import inside a string, template literal, or comment
+ * isn't rewritten, and excludes dynamic `import(...)` calls (the babel plugin
+ * doesn't rewrite those either).
  */
 
-const RELATIVE_IMPORT_RE = /\bfrom\s+(['"])(\.\.?\/[^'"]+)\1/g
+const RELATIVE_IMPORT_RE =
+  /^(\s*(?:import|export)\s[^'"\n]*?)(['"])(\.\.?\/[^'"]+)\2/gm
 
 export function applyDirectoryNamedImport(
   code: string,
@@ -28,7 +37,7 @@ export function applyDirectoryNamedImport(
 
   return code.replace(
     RELATIVE_IMPORT_RE,
-    (match: string, quote: string, importPath: string) => {
+    (match: string, prefix: string, quote: string, importPath: string) => {
       const absolutePath = path.join(fileDir, importPath)
 
       // Already resolves directly to a file — leave it alone.
@@ -37,12 +46,12 @@ export function applyDirectoryNamedImport(
       }
 
       if (resolveFile(path.join(absolutePath, 'index'))) {
-        return `from ${quote}${importStatementPath(importPath + '/index')}${quote}`
+        return `${prefix}${quote}${importStatementPath(importPath + '/index')}${quote}`
       }
 
       const basename = path.basename(absolutePath)
       if (resolveFile(path.join(absolutePath, basename))) {
-        return `from ${quote}${importStatementPath(importPath + '/' + basename)}${quote}`
+        return `${prefix}${quote}${importStatementPath(importPath + '/' + basename)}${quote}`
       }
 
       return match

--- a/packages/internal/src/build/directory-named-import.ts
+++ b/packages/internal/src/build/directory-named-import.ts
@@ -1,0 +1,51 @@
+import path from 'node:path'
+
+import { importStatementPath, resolveFile } from '@cedarjs/project-config'
+
+/**
+ * Rewrites relative imports/re-exports of a directory to that directory's
+ * index file or directory-named module, so that the esbuild API build (with
+ * `bundle: false`) produces output files with resolvable import paths at
+ * runtime.
+ *
+ * This replaces `babel-plugin-redwood-directory-named-import` for the esbuild
+ * build paths. It is a plain function called inline from the existing esbuild
+ * `onLoad` handlers — not an esbuild plugin itself.
+ *
+ * For a file importing `./Button` where `./Button/Button.tsx` exists (but
+ * `./Button.*` does not), this rewrites the import to `./Button/Button`.
+ * Mirrors the precedence used by `cedarDirectoryNamedImportPlugin` (Vite):
+ * an index file wins over a directory-named module.
+ */
+
+const RELATIVE_IMPORT_RE = /\bfrom\s+(['"])(\.\.?\/[^'"]+)\1/g
+
+export function applyDirectoryNamedImport(
+  code: string,
+  filePath: string,
+): string {
+  const fileDir = path.dirname(filePath)
+
+  return code.replace(
+    RELATIVE_IMPORT_RE,
+    (match: string, quote: string, importPath: string) => {
+      const absolutePath = path.join(fileDir, importPath)
+
+      // Already resolves directly to a file — leave it alone.
+      if (resolveFile(absolutePath)) {
+        return match
+      }
+
+      if (resolveFile(path.join(absolutePath, 'index'))) {
+        return `from ${quote}${importStatementPath(importPath + '/index')}${quote}`
+      }
+
+      const basename = path.basename(absolutePath)
+      if (resolveFile(path.join(absolutePath, basename))) {
+        return `from ${quote}${importStatementPath(importPath + '/' + basename)}${quote}`
+      }
+
+      return match
+    },
+  )
+}

--- a/packages/internal/src/build/directory-named-import.ts
+++ b/packages/internal/src/build/directory-named-import.ts
@@ -18,16 +18,18 @@ import { importStatementPath, resolveFile } from '@cedarjs/project-config'
  * an index file wins over a directory-named module.
  *
  * Matches static `import`/`export` statements, including side-effect-only
- * imports (`import './Button'`) — the babel plugin this replaces visits every
- * `ImportDeclaration`/`ExportDeclaration`, which covers those too. Anchored to
- * the start of a line (like `applyImportDir`'s glob-import regex) so that
- * text resembling an import inside a string, template literal, or comment
- * isn't rewritten, and excludes dynamic `import(...)` calls (the babel plugin
- * doesn't rewrite those either).
+ * imports (`import './Button'`) and specifier lists wrapped across multiple
+ * lines (as Prettier does for long import statements) — the babel plugin
+ * this replaces visits every `ImportDeclaration`/`ExportDeclaration`
+ * regardless of formatting. Anchored to the start of a line (like
+ * `applyImportDir`'s glob-import regex) so that text resembling an import
+ * elsewhere on a line — inside a string or comment sharing that line, say —
+ * isn't rewritten, and excludes dynamic `import(...)` calls (the babel
+ * plugin doesn't rewrite those either).
  */
 
 const RELATIVE_IMPORT_RE =
-  /^(\s*(?:import|export)\s[^'"\n]*?)(['"])(\.\.?\/[^'"]+)\2/gm
+  /^(\s*(?:import|export)\s[^'"]*?)(['"])(\.\.?\/[^'"]+)\2/gm
 
 export function applyDirectoryNamedImport(
   code: string,

--- a/packages/internal/src/build/esbuild-plugin-api-graphql.ts
+++ b/packages/internal/src/build/esbuild-plugin-api-graphql.ts
@@ -25,6 +25,7 @@ import {
   applyGraphqlOptionsExtract,
 } from './api-graphql-transforms.js'
 import { applyAutoImports } from './auto-import.js'
+import { applyDirectoryNamedImport } from './directory-named-import.js'
 import { applyOtelWrapping } from './esbuild-plugin-cedar-otel-wrapping.js'
 import { applyHandlerAlsWrapping } from './esbuild-plugin-handler-als-wrapping.js'
 import { applyImportDir } from './import-dir.js'
@@ -49,6 +50,10 @@ export const cedarApiGraphqlPlugin = {
           path.relative(build.initialOptions.absWorkingDir + '/src', args.path),
         ),
       )
+
+      // Rewrite relative directory imports (e.g. `./Button`) to their index
+      // or directory-named module file.
+      fileContents = applyDirectoryNamedImport(fileContents, args.path)
 
       // Apply graphql-specific string transforms on the raw TypeScript BEFORE
       // Babel CJS compilation. TypeScript always uses ESM syntax, so the ESM

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -22,6 +22,7 @@ import { getConfig, getPaths, projectSideIsEsm } from '@cedarjs/project-config'
 
 import { getWorkspacePackageAliases } from './lib/workspacePackageAliases.js'
 import { cedarAutoImportsPlugin } from './plugins/vite-plugin-cedar-auto-import.js'
+import { cedarDirectoryNamedImportPlugin } from './plugins/vite-plugin-cedar-directory-named-import.js'
 import { applyGraphqlOptionsExtract } from './plugins/vite-plugin-cedar-graphql-options-extract.js'
 import { cedarImportDirPlugin } from './plugins/vite-plugin-cedar-import-dir.js'
 import { applyOtelWrapping } from './plugins/vite-plugin-cedar-otel-wrapping.js'
@@ -198,6 +199,7 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
     },
     plugins: [
       cedarImportDirPlugin(),
+      cedarDirectoryNamedImportPlugin(),
       cedarAutoImportsPlugin(),
       cedarjsJobPathInjectorPlugin(),
       (() => {

--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -26,6 +26,7 @@ import { getConfig, getPaths, projectSideIsEsm } from '@cedarjs/project-config'
 
 import { getWorkspacePackageAliases } from './lib/workspacePackageAliases.js'
 import { cedarAutoImportsPlugin } from './plugins/vite-plugin-cedar-auto-import.js'
+import { cedarDirectoryNamedImportPlugin } from './plugins/vite-plugin-cedar-directory-named-import.js'
 import { cedarGqlormInjectPlugin } from './plugins/vite-plugin-cedar-gqlorm-inject.js'
 import { cedarGraphqlOptionsExtractPlugin } from './plugins/vite-plugin-cedar-graphql-options-extract.js'
 import { cedarImportDirPlugin } from './plugins/vite-plugin-cedar-import-dir.js'
@@ -355,6 +356,7 @@ export async function buildCedarApp({
     plugins.push(cedarGraphqlOptionsExtractPlugin())
     plugins.push(cedarGqlormInjectPlugin())
     plugins.push(cedarImportDirPlugin())
+    plugins.push(cedarDirectoryNamedImportPlugin())
     plugins.push(cedarOtelWrappingPlugin())
     plugins.push(cedarjsJobPathInjectorPlugin())
     plugins.push(


### PR DESCRIPTION
## Summary

`babel-plugin-redwood-directory-named-import` was already ported to a Vite plugin (`cedarDirectoryNamedImportPlugin`, #2089) and wired into the web build (#2090), but never wired into the **API** build/dev pipelines. On the API side the Babel plugin has no `!forVite` guard (unlike the web side), so it was still doing real, load-bearing directory-named-import resolution in every API Vite/esbuild pipeline.

This PR closes that gap:

- **`buildApiWithVite`** (`packages/internal/src/build/api.ts`) — adds an inlined `createDirectoryNamedImportVitePlugin()` Vite plugin (duplicated rather than imported, to avoid the existing `@cedarjs/internal` ↔ `@cedarjs/vite` circular dependency — same pattern already used for `createImportDirVitePlugin`).
- **esbuild `bundle: false` API build** (`packages/internal/src/build/api.ts`, `esbuild-plugin-api-graphql.ts`) — adds a new `applyDirectoryNamedImport` text-rewriter (`packages/internal/src/build/directory-named-import.ts`), since esbuild's `bundle: false` mode has no `resolveId` hook to hang a Vite plugin off of. Mirrors the existing `applySrcAlias` pattern.
- **`apiDevMiddleware.ts`** and **`buildApp.ts`** — wire in the already-existing (but previously unused) `cedarDirectoryNamedImportPlugin`.
- **`packages/babel-config/src/api.ts`** — gates the Babel plugin behind `!forVite`, matching the web side, so it now only runs for Jest/console/prerender/data-migrate as intended.