### PR TITLE
fix(vite): resolve two correctness issues in buildApp's cedar-api-src-redirect

### DIFF
--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -35,7 +35,12 @@ import { cedarjsJobPathInjectorPlugin } from './plugins/vite-plugin-cedarjs-job-
 import { handlerAlsWrappingPlugin } from './plugins/vite-plugin-handler-als-wrapping.js'
 
 function resolveWithExtensions(id: string): string {
-  if (fs.existsSync(id)) {
+  // A bare `fs.existsSync(id)` also returns true for directories (e.g. a
+  // directory-named-import target). Since this plugin's resolveId return
+  // short-circuits Vite's resolveId chain, that would incorrectly claim the
+  // bare directory path as fully resolved instead of letting a later plugin
+  // (e.g. one resolving directory-named imports) handle it.
+  if (fs.existsSync(id) && fs.statSync(id).isFile()) {
     return id
   }
   for (const ext of ['.js', '.ts', '.jsx', '.tsx', '.mjs', '.mts']) {
@@ -336,7 +341,14 @@ export async function buildCedarApp({
       name: 'cedar-api-src-redirect',
       enforce: 'pre',
       resolveId(id: string, importer: string | undefined) {
-        if (!importer?.startsWith(cedarPaths.api.src)) {
+        // Normalize both sides: on Windows, cedarPaths.api.src can contain
+        // backslashes while Vite supplies forward-slash importer ids, so a
+        // raw startsWith would never match. The trailing separator guards
+        // against matching an adjacent directory (e.g. `api/src-extra`).
+        const normalizedImporter = importer && normalizePath(importer)
+        const normalizedApiSrc = normalizePath(cedarPaths.api.src)
+
+        if (!normalizedImporter?.startsWith(`${normalizedApiSrc}/`)) {
           return null
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #2109. During review of that PR, Greptile flagged two correctness issues in `apiDevMiddleware.ts`'s `cedar-api-src-redirect` plugin (a new plugin added there). Both bugs turned out to be inherited from this exact plugin's pre-existing implementation in `buildApp.ts` (`--ud` unified build), which I mirrored. #2109 fixed the copy in `apiDevMiddleware.ts` but deliberately left `buildApp.ts` untouched as out of scope — this PR applies the same two fixes there.

- **`resolveWithExtensions` treated directories as resolved files.** A bare `fs.existsSync(id)` is also `true` for directories, so a directory-named-import target (e.g. `src/components/Button` where `Button` is a folder) would get incorrectly claimed as "resolved" to the bare directory path. Since this plugin's `resolveId` return short-circuits Vite's resolveId chain, that would prevent a later plugin from applying index/directory-named resolution rules. Now requires `fs.statSync(id).isFile()`.

- **The importer prefix check didn't normalize path separators.** `cedarPaths.api.src` can contain backslashes on Windows, while Vite supplies forward-slash importer ids — so the raw `startsWith` check would never match on Windows, making the whole plugin silently inert there. It also lacked a trailing separator, so it could incorrectly match an unrelated adjacent directory (e.g. `api/src-extra`). Both fixed by normalizing both sides with `normalizePath` and requiring a trailing `/`.