### PR TITLE
fix(project-config): update page count in paths test for AggregatedBlogPostPage

### DIFF
--- a/packages/project-config/src/__tests__/paths.test.ts
+++ b/packages/project-config/src/__tests__/paths.test.ts
@@ -660,10 +660,11 @@ describe('paths', () => {
 
         const pages = processPagesDir(pagesDir)
 
-        expect(pages.length).toEqual(21)
+        expect(pages.length).toEqual(22)
 
         const pageNames = [
           'AboutPage',
+          'AggregatedBlogPostPage',
           'BlogPostPage',
           'ContactUsPage',
           'FatalErrorPage',


### PR DESCRIPTION
PR #2107 added `AggregatedBlogPostPage` to `__fixtures__/test-project` but didn't update the expected page count in `paths.test.ts`, leaving the test broken on main (and any branch that merges from main).

## Change

`packages/project-config/src/__tests__/paths.test.ts`:
- `expect(pages.length).toEqual(21)` → `toEqual(22)`
- Added `'AggregatedBlogPostPage'` to the `pageNames` assertion array
