### PR TITLE
fix(testing): recognize Node-style MODULE_NOT_FOUND errors in MockProviders

### DIFF
--- a/packages/testing/src/web/MockProviders.tsx
+++ b/packages/testing/src/web/MockProviders.tsx
@@ -55,7 +55,9 @@ function isModuleNotFoundError(error: unknown, module: string) {
     return false
   }
 
-  // Jest sets moduleName; plain Node does not
+  // Jest sets moduleName; plain Node does not.
+  // TODO: once Cedar is ESM-only and Jest is no longer used, remove this branch
+  // and rely solely on the message check below.
   if ('moduleName' in error) {
     return error.moduleName === module
   }

--- a/packages/testing/src/web/MockProviders.tsx
+++ b/packages/testing/src/web/MockProviders.tsx
@@ -62,10 +62,12 @@ function isModuleNotFoundError(error: unknown, module: string) {
     return error.moduleName === module
   }
 
-  // Node-style error: module name appears in the message string
+  // Node-style error: module name appears in the message string.
+  // Check for the quoted form to avoid substring collisions with similar module names.
   return (
     'message' in error &&
     typeof error.message === 'string' &&
-    error.message.includes(module)
+    (error.message.includes(`'${module}'`) ||
+      error.message.includes(`"${module}"`))
   )
 }

--- a/packages/testing/src/web/MockProviders.tsx
+++ b/packages/testing/src/web/MockProviders.tsx
@@ -46,12 +46,24 @@ export const MockProviders: React.FunctionComponent<{
 }
 
 function isModuleNotFoundError(error: unknown, module: string) {
+  if (
+    !error ||
+    typeof error !== 'object' ||
+    !('code' in error) ||
+    error.code !== 'MODULE_NOT_FOUND'
+  ) {
+    return false
+  }
+
+  // Jest sets moduleName; plain Node does not
+  if ('moduleName' in error) {
+    return error.moduleName === module
+  }
+
+  // Node-style error: module name appears in the message string
   return (
-    !!error &&
-    typeof error === 'object' &&
-    'code' in error &&
-    error.code === 'MODULE_NOT_FOUND' &&
-    'moduleName' in error &&
-    error.moduleName === module
+    'message' in error &&
+    typeof error.message === 'string' &&
+    error.message.includes(module)
   )
 }


### PR DESCRIPTION
## Problem

In Vitest runs, `MockProviders.tsx` emits spurious `console.warn` output with a full stack trace for the expected `~__CEDAR__USER_ROUTES_FOR_MOCK` module miss. Tests still pass, but the noise is confusing.

## Root cause

`isModuleNotFoundError()` guards on `error.moduleName === module`. Jest's runtime attaches `moduleName` to module-not-found errors, but plain Node (which resolves the `require` under Vitest) does not — it only includes the module name in the `message` string. So the guard evaluated to `false`, the `console.warn` path was taken, but the error was still swallowed and execution continued with the empty-routes fallback.

## Fix

When `moduleName` is absent, fall back to checking `error.message.includes(module)`. This covers the Node-style error shape without breaking the Jest path.

```
Cannot find module '~__CEDAR__USER_ROUTES_FOR_MOCK'   ← message contains the module name
Require stack: ...
```

Closes the stderr noise for ESM test projects running under Vitest.