### PR TITLE
fix(framework-tools): atomically rewrite package.json in generateTypesCjs

### DIFF
--- a/packages/framework-tools/src/generateTypes.ts
+++ b/packages/framework-tools/src/generateTypes.ts
@@ -23,7 +23,13 @@ export async function generateTypesCjs() {
     readFileSync('./package.json', 'utf-8'),
   )
   packageJson.type = 'commonjs'
-  writeFileSync('./package.json', JSON.stringify(packageJson, null, 2))
+  // Write to a temp file and rename it into place. Rename is atomic, whereas
+  // writing directly to package.json would truncate it first, letting any
+  // concurrently starting `yarn` process (which parses every workspace
+  // manifest during setup) read a partially written file and crash with a
+  // JSON syntax error.
+  writeFileSync('./package.json.tmp', JSON.stringify(packageJson, null, 2))
+  renameSync('./package.json.tmp', './package.json')
 
   try {
     await execa('yarn', ['build:types-cjs'], { stdio: 'inherit' })


### PR DESCRIPTION
## Summary

Fixes a long-standing intermittent CI failure where `yarn build` would fail with a JSON syntax error while parsing a seemingly random package's `package.json`, e.g. in [this ESM smoke test run](https://github.com/cedarjs/cedar/actions/runs/29682339669/job/88180724646):

```
SyntaxError: Expected ',' or '}' after property value in JSON at position 5105
(line 182 column 1) (when parsing /home/runner/work/cedar/cedar/packages/testing/package.json)
    at JSON.parse (<anonymous>)
    at e.loadFile (/home/runner/.cache/node/corepack/v1/yarn/4.14.1/yarn.js:140:115732)
    at async e.fromFile (/home/runner/.cache/node/corepack/v1/yarn/4.14.1/yarn.js:140:115416)
    at async e.tryFind (/home/runner/.cache/node/corepack/v1/yarn/4.14.1/yarn.js:140:115139)
    at async jI.setup (/home/runner/.cache/node/corepack/v1/yarn/4.14.1/yarn.js:204:5716)
```

## Investigation

The failure has been hard to track down because it's a race between two *unrelated* parallel Nx tasks, so it only reproduces when the timing lines up, and it blames a different (innocent) package each time.

In the run above, the failing task was `@cedarjs/auth-clerk-setup:build`, but the malformed file belonged to `@cedarjs/testing`. Three clues in the log pinpointed the cause:

1. `packages/testing/package.json` is checked into git and valid — if it were genuinely malformed, every run would fail, not one in N. So the file had to be *mid-modification* at read time.
2. The stack trace is inside Yarn's own startup (`setup` → `tryFind` → `fromFile` → `loadFile`). During startup, Yarn Berry parses **every workspace manifest** in the monorepo — so any `yarn <script>` spawned from any package's build reads all 70+ `package.json` files.
3. The parse error is at "line 182 column 1" — and the file is exactly 182 lines long. Yarn read a file that was cut off right at the closing brace: a truncated, partially-written file.

The writer is `generateTypesCjs()` in `packages/framework-tools/src/generateTypes.ts`. To generate CJS type definitions it temporarily rewrites the package's `package.json` with `"type": "commonjs"`, runs `yarn build:types-cjs`, then restores the original. The rewrite used a direct `writeFileSync`, which **truncates the file first and then writes** — a window during which the file on disk is incomplete.

So the sequence was:

1. Nx runs `@cedarjs/testing:build` and `@cedarjs/auth-clerk-setup:build` in parallel.
2. `testing`'s build calls `generateTypesCjs()`, which starts rewriting `packages/testing/package.json` (truncate, then write).
3. `auth-clerk-setup`'s build script runs `yarn build:types`; the freshly spawned Yarn process enumerates all workspace manifests and reads `packages/testing/package.json` inside the truncate/write window.
4. Yarn crashes with a JSON syntax error, failing the innocent bystander's build task.

Since many packages use `generateTypesCjs()` and many build scripts spawn `yarn <script>`, any pair can collide — which is why the failure moves around between runs. The stable signal across occurrences is the `(when parsing .../package.json)` part of the error: the named package will always be one that uses `generateTypesCjs()`.

## Fix

Write the modified JSON to a temp file (`package.json.tmp`) and `renameSync` it over `package.json`. Rename is atomic on the same filesystem, so a concurrent Yarn startup always sees either the old or the new complete file. The temporarily changed `"type": "commonjs"` content is valid JSON, so a reader seeing it mid-swap is harmless — only the truncation was a problem. The restore path already used `renameSync` and was safe as-is.
