### PR TITLE
fix(ci): map the windows output through the detect-changes job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       cli: ${{ steps.detect-changes.outputs.cli }}
       rsc: ${{ steps.detect-changes.outputs.rsc }}
       ssr: ${{ steps.detect-changes.outputs.ssr }}
+      windows: ${{ steps.detect-changes.outputs.windows }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6


### PR DESCRIPTION
## Summary

One-line fix for a bug in #2122: the `windows` output was set by the detect-changes action and referenced by the Windows matrix expressions, but never mapped through the detect-changes **job's** `outputs:` block. Job outputs are an explicit allowlist, so `needs.detect-changes.outputs.windows` always evaluated to empty and the Windows legs could never run — with or without the `windows` label.

Discovered on #2123, which ran zero Windows jobs despite carrying the `windows` label and having a diff full of `path.join` calls (either of which should have triggered the Windows legs).

## Testing

- Verified against #2123's run: `detect-changes` logs show the label short-circuit took effect (no `windowsChanged` output printed), yet zero `windows-latest` jobs were created — consistent with the output being dropped at the job boundary, not the action.
- After merge, re-running CI on #2123 should produce the eight Windows legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)