### PR TITLE
fix(cli): don't quote prisma option values containing spaces

### DIFF
--- a/packages/cli/src/commands/__tests__/prisma.test.ts
+++ b/packages/cli/src/commands/__tests__/prisma.test.ts
@@ -57,13 +57,16 @@ test('the prisma command handles spaces', async () => {
     n: 'add bazingas',
   })
 
+  // Values must arrive unquoted: the args are passed to execa as an array
+  // without a shell, so each value is a single argv entry as-is. Quotes
+  // would become part of the value prisma receives.
   expect(vi.mocked(execa.sync).mock.calls[0][1]).toEqual([
     'prisma',
     'migrate',
     'dev',
     '-n',
-    '"add bazingas"',
+    'add bazingas',
     '--config',
-    '"/Users/bazinga/My Projects/rwprj/rwprj/api/prisma.config.js"',
+    '/Users/bazinga/My Projects/rwprj/rwprj/api/prisma.config.js',
   ])
 })

--- a/packages/cli/src/commands/__tests__/prisma.test.ts
+++ b/packages/cli/src/commands/__tests__/prisma.test.ts
@@ -69,4 +69,16 @@ test('the prisma command handles spaces', async () => {
     '--config',
     '/Users/bazinga/My Projects/rwprj/rwprj/api/prisma.config.js',
   ])
+
+  // The informational output, on the other hand, must quote values with
+  // spaces so that copy-pasting the printed command into a shell runs the
+  // same invocation.
+  const loggedCommand = vi
+    .mocked(console.log)
+    .mock.calls.flat()
+    .find((line) => String(line).includes('prisma migrate dev'))
+  expect(loggedCommand).toContain('-n "add bazingas"')
+  expect(loggedCommand).toContain(
+    '--config "/Users/bazinga/My Projects/rwprj/rwprj/api/prisma.config.js"',
+  )
 })

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -71,18 +71,16 @@ export const handler = async ({
     options.config = `${cedarPaths.api.prismaConfig}`
   }
 
-  // Convert command and options into a string that's run via execa
+  // Convert command and options into the args array that's run via execa
   for (const [name, value] of Object.entries(options)) {
     // Allow both long and short form commands, e.g. --name and -n
     args.push(name.length > 1 ? `--${name}` : `-${name}`)
     if (typeof value === 'string') {
-      // Make sure options that take multiple quoted words, like
-      // `-n "create user"` are passed to prisma with quotes.
-      if (value.split(' ').length > 1) {
-        args.push(`"${value}"`)
-      } else {
-        args.push(value)
-      }
+      // The args are passed to execa as an array without a shell, so each
+      // value is already a single argv entry. Wrapping values in quotes here
+      // would make the quotes part of the value itself, breaking e.g.
+      // `--config` paths that contain spaces.
+      args.push(value)
     } else if (typeof value === 'number') {
       args.push(String(value))
     }

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -86,9 +86,16 @@ export const handler = async ({
     }
   }
 
+  // The real invocation passes `args` as an array without a shell, but this
+  // informational line may get copy-pasted into a shell — so args containing
+  // spaces need quotes here (and only here) to represent the same command.
+  const displayCommand = args
+    .map((arg) => (arg.includes(' ') ? `"${arg}"` : arg))
+    .join(' ')
+
   console.log()
   console.log(c.note('Running Prisma CLI...'))
-  console.log(c.underline(`$ <pm exec> prisma ${args.join(' ')}`))
+  console.log(c.underline(`$ <pm exec> prisma ${displayCommand}`))
   console.log()
 
   try {


### PR DESCRIPTION
## Summary

The prisma command handler (`prismaHandler.ts`) wrapped any option value containing a space in literal quote characters. The args are passed to `runTransitiveBinSync` → `execa.sync('npx', [bin, ...args])` — an array without a shell — so the quotes became part of the argument itself instead of grouping words.

For any project whose path contains a space, the auto-injected `--config` path arrived at Prisma as a quoted string, which Prisma resolved as a *relative* path, failing every `cedar prisma` command:

```
$ prisma migrate reset --force --config "/home/runner/work/cedar/test project/api/prisma.config.cjs"
Config file not found at "/home/runner/work/cedar/test project/"/home/runner/work/cedar/test project/api/prisma.config.cjs""
```

The fix removes the quoting entirely: with array-style execa, every value is already a single argv entry, so multi-word values like `-n "create user"` arrive at Prisma correctly without any added quotes. This has been silently broken for all users with spaces in their project paths — CI runner paths never contained a space, so it was invisible until #2123 added that coverage.

## Testing

- Updated `prisma.test.ts`, which previously asserted the quoted (broken) behavior — including for a mocked project path containing a space. It now asserts unquoted argv entries; test passes.
- Verified `runTransitiveBinSync` passes args as an array with no shell (`packages/cli-helpers/src/packageManager/exec.ts`), and that no other call site in `packages/cli`/`cli-helpers` uses the same quote-wrapping pattern (the deploy handlers already pass plain arrays).
- Full verification comes from #2123: once this merges, re-running its CI should turn the seven failing Ubuntu suites green (they all fail at `prisma migrate reset` in test-project setup).

Fixes the failure found by #2123 (spaces-in-path CI coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)