### PR TITLE
chore(ci): include cli-helpers in the Windows always-run package list

### DIFF
--- a/.github/actions/detect-changes/cases/windows.mjs
+++ b/.github/actions/detect-changes/cases/windows.mjs
@@ -7,9 +7,11 @@
 // against the last 100 merged PRs (~35% of them skip Windows entirely):
 //
 // 1. The added lines of the PR diff use a path- or process-sensitive API.
-// 2. The PR touches packages/cli or packages/vite (the packages with the
-//    most Windows history; also covers Windows bugs that no grep can see,
-//    like a bad path inside an HTML template string).
+// 2. The PR touches packages/cli, packages/cli-helpers, or packages/vite
+//    (the packages with the most Windows history — cli-helpers holds the
+//    process-spawning/package-manager-shim machinery; also covers Windows
+//    bugs that no grep can see, like a bad path inside an HTML template
+//    string).
 //
 // A daily full Windows run on main (nightly-windows.yml) catches anything
 // that slips through, and the `windows` label on a PR forces the full matrix.
@@ -39,7 +41,7 @@ const WINDOWS_SENSITIVE_PATTERN = new RegExp(
   ].join('|'),
 )
 
-const ALWAYS_RUN_PACKAGES = /^packages\/(cli|vite)\//
+const ALWAYS_RUN_PACKAGES = /^packages\/(cli|cli-helpers|vite)\//
 
 const CODE_FILE = /\.[mc]?[jt]sx?$/
 


### PR DESCRIPTION
## Summary

Adds `packages/cli-helpers` to the Windows filter's always-run package list (`cli`, `vite` → `cli`, `cli-helpers`, `vite`).

`cli-helpers` holds the process-spawning and package-manager-shim machinery (`runTransitiveBinSync` and friends) — exactly the code class the Windows filter exists to guard, as the #2125 quoting bug demonstrated (the buggy call site was in `cli`, but the execution semantics that made it a bug live in `cli-helpers`). The `cli` case in detect-changes already groups `cli-helpers` with CLI-related changes, so this also makes the two cases consistent.

## Cost

Measured against the last 100 merged PRs: **zero additional Windows runs** — every PR touching `cli-helpers` also touched `cli`/`vite` or tripped the content grep. The list entry only matters for a `cli-helpers` refactor subtle enough that no grep pattern fires, which is precisely the kind of change that breaks Windows shim handling.

## Testing

- `node --check` on the modified module.
- Asserted `packages/cli-helpers/**` triggers the filter and that a hypothetical `packages/cli-something-else/**` does not (the regex alternation stays anchored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)