### PR TITLE
fix(cli): pass vite build bin path as argv array in buildHandler

### DIFF
--- a/packages/cli/src/commands/build/buildHandler.ts
+++ b/packages/cli/src/commands/build/buildHandler.ts
@@ -256,11 +256,18 @@ export const handler = async ({
             '@cedarjs/vite/bins/cedar-vite-build.mjs',
           )
 
+          // Args are passed as an array without a shell so that paths
+          // containing spaces (bin path and webDir) survive as single argv
+          // entries.
           await execa(
-            `node ${buildBinPath} --webDir="${cedarPaths.web.base}" --verbose=${verbose}`,
+            'node',
+            [
+              buildBinPath,
+              `--webDir=${cedarPaths.web.base}`,
+              `--verbose=${verbose}`,
+            ],
             {
               stdio: verbose ? 'inherit' : 'pipe',
-              shell: true,
               cwd: cedarPaths.web.base,
             },
           )
@@ -320,13 +327,20 @@ export const handler = async ({
           // it could affect other things that run in parallel while building.
           // We don't have any parallel tasks right now, but someone might add
           // one in the future as a performance optimization.
+          // Args are passed as an array without a shell so that paths
+          // containing spaces (bin path and webDir) survive as single argv
+          // entries.
           await execa(
-            `node ${buildBinPath} --webDir="${cedarPaths.web.base}" --verbose=${verbose}`,
+            'node',
+            [
+              buildBinPath,
+              `--webDir=${cedarPaths.web.base}`,
+              `--verbose=${verbose}`,
+            ],
             {
               stdio: verbose ? 'inherit' : 'pipe',
-              shell: true,
-              // `cwd` is needed for the package manager (e.g. yarn) to find the
-              // cedar-vite-build binary
+              // `cwd` makes postcss/tailwind config resolution work (see the
+              // @NOTE above)
               // It won't change process.cwd for anything else here, in this
               // process
               cwd: cedarPaths.web.base,


### PR DESCRIPTION
## Summary

Next iteration of the #2123 fix-forward loop. After #2125 fixed the prisma layer, `cedar build` became the first failure: the web build step assembled a shell command string where the resolved `cedar-vite-build.mjs` bin path was **unquoted**, so with `shell: true` the shell word-split project paths containing spaces:

```
Command: node /home/runner/work/cedar/test project/node_modules/@cedarjs/vite/bins/cedar-vite-build.mjs --webDir="…"
Error: Cannot find module '/home/runner/work/cedar/test'
```

It's the mirror image of #2125: prisma had *quotes without a shell*; this had *a shell without quotes*. Both call sites (streaming-SSR and regular web build) are converted to array-form execa with no shell, so the bin path and `--webDir` value each survive as a single argv entry regardless of spaces. Nothing in the command needed a shell. The `cwd` option stays (it's what makes postcss/tailwind config resolution work — see the existing `@NOTE`); the stale comment claiming `cwd` was needed for package-manager bin lookup is corrected.

## Testing

- `build.test.ts` (6 tests) passes — execa is mocked there with no command-shape assertions, so no test changes were needed.
- End-to-end verification comes from #2123: this unblocks the smoke-tests, ESM, React 18, fragments, CLI smoke, and SSR suites, which all currently die at `cedar build --no-prerender`. Note that later pipeline steps (`prerender`, `test web/api`, storybook) get their first spaces exposure once build passes, so #2123 may surface the next instance after this merges — that's the coverage working as designed.

Part of the spaces-in-path hardening: #2123 (coverage), #2125 (prisma quoting), this (vite build bin path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)