### PR TITLE
feat(deps)!: Upgrade to Vitest 4

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -36,4 +36,4 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@97330871fe1b7d3529392ea000e3d2c4b357e403 # v3
 
       - name: 🧪 Test
-        run: yarn test-ci --minWorkers=1 --maxWorkers=${{ steps.cpu-cores.outputs.count }}
+        run: yarn test-ci --maxWorkers=${{ steps.cpu-cores.outputs.count }}

--- a/__fixtures__/test-project-esm/package.json
+++ b/__fixtures__/test-project-esm/package.json
@@ -12,7 +12,7 @@
     "@cedarjs/project-config": "5.0.0",
     "@cedarjs/testing": "5.0.0",
     "prisma": "7.8.0",
-    "vitest": "3.2.6",
+    "vitest": "4.1.10",
     "prettier-plugin-tailwindcss": "^0.8.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "tstyche": "5.0.2",
     "typescript": "5.9.3",
     "typescript-eslint": "8.60.1",
-    "vitest": "3.2.6",
+    "vitest": "4.1.10",
     "ws": "8.20.0",
     "yargs": "17.7.3",
     "zx": "8.8.5"

--- a/packages/adapters/fastify/web/package.json
+++ b/packages/adapters/fastify/web/package.json
@@ -32,7 +32,7 @@
     "@cedarjs/framework-tools": "workspace:*",
     "fastify": "5.8.5",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/api-server/dist.test.ts
+++ b/packages/api-server/dist.test.ts
@@ -3,7 +3,9 @@ import path from 'path'
 
 import { describe, it, expect } from 'vitest'
 
-const distPath = path.join(__dirname, 'dist')
+// Vitest 4's module runner no longer provides the CJS `__dirname` shim in ES
+// module scope, so use `import.meta.dirname` instead
+const distPath = path.join(import.meta.dirname, 'dist')
 const packageConfig = JSON.parse(fs.readFileSync('./package.json', 'utf-8'))
 
 describe('dist', () => {

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -166,7 +166,7 @@
     "pino-abstract-transport": "1.2.0",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@cedarjs/graphql-server": "workspace:*"

--- a/packages/api-server/src/__tests__/fastify.test.ts
+++ b/packages/api-server/src/__tests__/fastify.test.ts
@@ -52,16 +52,37 @@ const userConfig = {
   requestTimeout: 25_000,
 }
 
-const configPath = await vi.hoisted(async () => {
+const mockedConfigSpecifiers = await vi.hoisted(async () => {
   const path = await import('node:path')
+  const url = await import('node:url')
+
+  // Vitest 4's module runner no longer provides the CJS `__dirname` shim in
+  // ES module scope, so derive the directory from `import.meta`
+  const testDir = path.dirname(url.fileURLToPath(import.meta.url))
 
   // This will be `D:\` on Windows (or some other drive letter) and `/` on Unix
-  const osRoot = path.parse(__dirname).root.replace('\\', '/')
+  const osRoot = path.parse(testDir).root.replace('\\', '/')
 
-  return osRoot + 'graphql/cedar-app/api/server.config.js'
+  const configPath = osRoot + 'graphql/cedar-app/api/server.config.js'
+
+  return {
+    configPath,
+    // Vitest 4's module runner resolves the dynamic import in fastify.ts to
+    // the file:// URL produced by pathToFileURL(), so the mock has to be
+    // registered under that exact specifier as well
+    configUrl: url.pathToFileURL(configPath).href,
+  }
 })
 
-vi.mock(configPath, () => {
+vi.mock(mockedConfigSpecifiers.configPath, () => {
+  return {
+    default: {
+      config: userConfig,
+    },
+  }
+})
+
+vi.mock(mockedConfigSpecifiers.configUrl, () => {
   return {
     default: {
       config: userConfig,

--- a/packages/api-server/src/__tests__/fastify.test.ts
+++ b/packages/api-server/src/__tests__/fastify.test.ts
@@ -64,13 +64,18 @@ const mockedConfigSpecifiers = await vi.hoisted(async () => {
   const osRoot = path.parse(testDir).root.replace('\\', '/')
 
   const configPath = osRoot + 'graphql/cedar-app/api/server.config.js'
+  const configFileUrl = url.pathToFileURL(configPath)
 
   return {
     configPath,
     // Vitest 4's module runner resolves the dynamic import in fastify.ts to
     // the file:// URL produced by pathToFileURL(), so the mock has to be
     // registered under that exact specifier as well
-    configUrl: url.pathToFileURL(configPath).href,
+    configUrl: configFileUrl.href,
+    // On Windows the module runner's internal module ids use the URL pathname
+    // form (`/D:/graphql/...`), so the mock has to be registered under that
+    // specifier too. On Unix this is identical to configPath
+    configUrlPathname: configFileUrl.pathname,
   }
 })
 
@@ -83,6 +88,14 @@ vi.mock(mockedConfigSpecifiers.configPath, () => {
 })
 
 vi.mock(mockedConfigSpecifiers.configUrl, () => {
+  return {
+    default: {
+      config: userConfig,
+    },
+  }
+})
+
+vi.mock(mockedConfigSpecifiers.configUrlPathname, () => {
   return {
     default: {
       config: userConfig,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -121,7 +121,7 @@
     "split2": "4.2.0",
     "ts-toolbelt": "9.6.0",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "memjs": "1.3.2",

--- a/packages/auth-providers/auth0/api/package.json
+++ b/packages/auth-providers/auth0/api/package.json
@@ -50,7 +50,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/auth0/setup/package.json
+++ b/packages/auth-providers/auth0/setup/package.json
@@ -48,7 +48,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/auth0/web/package.json
+++ b/packages/auth-providers/auth0/web/package.json
@@ -59,7 +59,7 @@
     "publint": "0.3.21",
     "react": "19.2.3",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@auth0/auth0-spa-js": "2.22.0"

--- a/packages/auth-providers/azureActiveDirectory/api/package.json
+++ b/packages/auth-providers/azureActiveDirectory/api/package.json
@@ -51,7 +51,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/azureActiveDirectory/setup/package.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/package.json
@@ -48,7 +48,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/azureActiveDirectory/web/package.json
+++ b/packages/auth-providers/azureActiveDirectory/web/package.json
@@ -61,7 +61,7 @@
     "publint": "0.3.21",
     "react": "19.2.3",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@azure/msal-browser": "2.39.0"

--- a/packages/auth-providers/clerk/api/package.json
+++ b/packages/auth-providers/clerk/api/package.json
@@ -49,7 +49,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/clerk/web/package.json
+++ b/packages/auth-providers/clerk/web/package.json
@@ -60,7 +60,7 @@
     "publint": "0.3.21",
     "react": "19.2.3",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@clerk/clerk-react": "5.61.3"

--- a/packages/auth-providers/custom/setup/package.json
+++ b/packages/auth-providers/custom/setup/package.json
@@ -48,7 +48,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/dbAuth/api/package.json
+++ b/packages/auth-providers/dbAuth/api/package.json
@@ -70,7 +70,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -50,7 +50,7 @@
     "publint": "0.3.21",
     "ts-toolbelt": "9.6.0",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -36,7 +36,7 @@
     "nodemon": "3.1.14",
     "ts-dedent": "2.3.0",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -52,7 +52,7 @@
     "publint": "0.3.21",
     "react": "19.2.3",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/dbAuth/web/src/__tests__/webAuthn.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/webAuthn.test.ts
@@ -29,7 +29,14 @@ const xhrMock: Partial<XMLHttpRequest> = {
 }
 
 vi.spyOn(global, 'XMLHttpRequest').mockImplementation(
-  () => xhrMock as XMLHttpRequest,
+  // Vitest 4 calls mock implementations with `new` when the source code does
+  // `new XMLHttpRequest()`, so the implementation must be constructible.
+  // A regular function (not an arrow function) that returns the partial mock
+  // satisfies that: `new fn()` yields the returned object.
+  function () {
+    // The partial mock covers everything WebAuthnClient uses
+    return xhrMock as XMLHttpRequest
+  },
 )
 
 function clearCookies() {

--- a/packages/auth-providers/firebase/api/package.json
+++ b/packages/auth-providers/firebase/api/package.json
@@ -49,7 +49,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/firebase/setup/package.json
+++ b/packages/auth-providers/firebase/setup/package.json
@@ -48,7 +48,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/firebase/web/package.json
+++ b/packages/auth-providers/firebase/web/package.json
@@ -59,7 +59,7 @@
     "publint": "0.3.21",
     "react": "19.2.3",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "firebase": "10.14.1"

--- a/packages/auth-providers/netlify/api/package.json
+++ b/packages/auth-providers/netlify/api/package.json
@@ -50,7 +50,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/netlify/setup/package.json
+++ b/packages/auth-providers/netlify/setup/package.json
@@ -48,7 +48,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/netlify/web/package.json
+++ b/packages/auth-providers/netlify/web/package.json
@@ -59,7 +59,7 @@
     "publint": "0.3.21",
     "react": "19.2.3",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "netlify-identity-widget": "1.9.2"

--- a/packages/auth-providers/supabase/api/package.json
+++ b/packages/auth-providers/supabase/api/package.json
@@ -51,7 +51,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/supabase/middleware/package.json
+++ b/packages/auth-providers/supabase/middleware/package.json
@@ -53,7 +53,7 @@
     "publint": "0.3.21",
     "ts-toolbelt": "9.6.0",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/supabase/web/package.json
+++ b/packages/auth-providers/supabase/web/package.json
@@ -60,7 +60,7 @@
     "publint": "0.3.21",
     "react": "19.2.3",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@supabase/supabase-js": "2.110.7"

--- a/packages/auth-providers/supertokens/api/package.json
+++ b/packages/auth-providers/supertokens/api/package.json
@@ -50,7 +50,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "supertokens-node": "15.2.3"

--- a/packages/auth-providers/supertokens/setup/package.json
+++ b/packages/auth-providers/supertokens/setup/package.json
@@ -49,7 +49,7 @@
     "memfs": "4.64.0",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/auth-providers/supertokens/web/package.json
+++ b/packages/auth-providers/supertokens/web/package.json
@@ -59,7 +59,7 @@
     "react": "19.2.3",
     "supertokens-auth-react": "0.51.2",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "supertokens-auth-react": "0.51.2"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -100,7 +100,7 @@
     "publint": "0.3.21",
     "type-fest": "5.6.0",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -51,7 +51,7 @@
     "@types/babel__register": "7.17.3",
     "@types/node": "24.10.4",
     "babel-plugin-tester": "11.0.4",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -134,7 +134,7 @@
     "@types/yargs-parser": "21.0.3",
     "prettier-plugin-tailwindcss": "0.8.0",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/cli-helpers/src/auth/__tests__/setupHelpers.test.ts
+++ b/packages/cli-helpers/src/auth/__tests__/setupHelpers.test.ts
@@ -65,7 +65,9 @@ describe('Auth generator tests', () => {
 
   const mockListrRun = vi.fn()
 
-  ;(Listr as MockedFunction<Mock>).mockImplementation(() => {
+  // Vitest 4 requires mock implementations invoked with `new` to be
+  // constructible, so use a `function` expression instead of an arrow function
+  ;(Listr as MockedFunction<Mock>).mockImplementation(function () {
     return {
       run: mockListrRun,
     }

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -43,7 +43,7 @@
     "@types/yargs": "17.0.35",
     "memfs": "4.64.0",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/cli-packages/storybook-vite/package.json
+++ b/packages/cli-packages/storybook-vite/package.json
@@ -31,7 +31,7 @@
     "storybook": "8.6.18",
     "storybook-framework-cedarjs": "workspace:*",
     "termi-link": "1.1.0",
-    "vitest": "3.2.6",
+    "vitest": "4.1.10",
     "yargs": "17.7.3"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -102,7 +102,7 @@
     "node-ssh": "13.2.1",
     "ts-dedent": "2.3.0",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/cli/src/commands/build/__tests__/buildPackagesTask.test.ts
+++ b/packages/cli/src/commands/build/__tests__/buildPackagesTask.test.ts
@@ -99,7 +99,10 @@ function createMockTask() {
 }
 
 afterEach(() => {
-  vi.restoreAllMocks()
+  // In Vitest 4 `restoreAllMocks` only affects `vi.spyOn` spies, so use
+  // `resetAllMocks` to clear call history on the module-factory `vi.fn()`
+  // mocks and reset them to their original factory implementations
+  vi.resetAllMocks()
 })
 
 describe('buildPackagesTask', () => {

--- a/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.postInstallMessage.test.ts
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.postInstallMessage.test.ts
@@ -17,11 +17,15 @@ import * as dbAuth from '../dbAuthHandler.js'
 
 vi.mock('listr2', async () => {
   return {
-    // Return a constructor function, since we're calling `new` on Listr
-    Listr: vi.fn().mockImplementation(() => ({
-      run: () => {},
-      ctx: {},
-    })),
+    // Return a constructor function (not an arrow function), since we're
+    // calling `new` on Listr and Vitest 4 forwards `new` calls to the mock
+    // implementation
+    Listr: vi.fn().mockImplementation(function () {
+      return {
+        run: () => {},
+        ctx: {},
+      }
+    }),
   }
 })
 

--- a/packages/cli/src/commands/setup/deploy/__tests__/netlify.test.ts
+++ b/packages/cli/src/commands/setup/deploy/__tests__/netlify.test.ts
@@ -19,7 +19,12 @@ vi.mock('@cedarjs/project-config', async (importOriginal) => {
 vi.mock('listr2', async (importOriginal) => {
   const mod = await importOriginal<typeof Listr2Module>()
 
-  const Listr = vi.fn((tasks, options) => {
+  // Needs to be a `function` (not an arrow function), since Vitest 4 forwards
+  // `new Listr(...)` calls to the mock implementation
+  const Listr = vi.fn(function (
+    tasks: Listr2Module.ListrTask[],
+    options?: Listr2Module.ListrOptions,
+  ) {
     return new mod.Listr(tasks, { ...options, renderer: 'silent' })
   })
 

--- a/packages/cli/src/commands/setup/package/__tests__/packageHandler.test.ts
+++ b/packages/cli/src/commands/setup/package/__tests__/packageHandler.test.ts
@@ -44,7 +44,9 @@ vi.mock('@cedarjs/cli-helpers/packageManager/exec', async () => {
 vi.mock('enquirer', () => {
   return {
     default: {
-      Select: vi.fn(() => {
+      // Needs to be a `function` (not an arrow function), since Vitest 4
+      // forwards `new Select(...)` calls to the mock implementation
+      Select: vi.fn(function () {
         return {
           run: vi.fn(() => {
             throw new Error('Mock Not Implemented')
@@ -127,7 +129,7 @@ describe('packageHandler', () => {
       throw new Error('No compatible version found')
     })
 
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'cancel'),
       }
@@ -140,7 +142,7 @@ describe('packageHandler', () => {
     expect(mockEnq.Select).toHaveBeenCalledTimes(1)
     expect(dlx).not.toHaveBeenCalled()
 
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'continue'),
       }
@@ -193,7 +195,7 @@ describe('packageHandler', () => {
       },
     })
 
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'useLatestCompatibleVersion'),
       }
@@ -214,7 +216,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'usePreferredVersion'),
       }
@@ -235,7 +237,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'cancel'),
       }
@@ -292,7 +294,7 @@ describe('packageHandler', () => {
       },
     })
 
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'useLatestCompatibleVersion'),
       }
@@ -313,7 +315,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'usePreferredVersion'),
       }
@@ -334,7 +336,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'cancel'),
       }
@@ -389,7 +391,7 @@ describe('packageHandler', () => {
       },
     })
 
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'useLatestCompatibleVersion'),
       }
@@ -410,7 +412,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'usePreferredVersion'),
       }
@@ -431,7 +433,7 @@ describe('packageHandler', () => {
       cwd: path.join('mocked', 'project'),
     })
 
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'cancel'),
       }
@@ -473,7 +475,7 @@ describe('packageHandler', () => {
     )
 
     // No force should prompt
-    vi.mocked(mockEnq.Select).mockImplementation(() => {
+    vi.mocked(mockEnq.Select).mockImplementation(function () {
       return {
         run: vi.fn(() => 'useLatestCompatibleVersion'),
       }

--- a/packages/cli/src/commands/setup/realtime/__tests__/addRealtimeToGraphql.test.ts
+++ b/packages/cli/src/commands/setup/realtime/__tests__/addRealtimeToGraphql.test.ts
@@ -90,6 +90,10 @@ describe('addRealtimeToGraphqlHandler (filesystem)', () => {
 
   afterEach(() => {
     functionsDir = null
+    // In Vitest 4 `restoreAllMocks` only affects `vi.spyOn` spies, so also
+    // clear call history on the module-factory `vi.fn()` mocks (like
+    // fs.writeFileSync) to keep tests isolated
+    vi.clearAllMocks()
     vi.restoreAllMocks()
   })
 

--- a/packages/cli/src/commands/test/__tests__/datasourceWarning.test.ts
+++ b/packages/cli/src/commands/test/__tests__/datasourceWarning.test.ts
@@ -32,6 +32,10 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  // In Vitest 4 `restoreAllMocks` only affects `vi.spyOn` spies, so also
+  // clear call history on the module-factory `vi.fn()` mocks (like
+  // Enquirer.prompt) to keep tests isolated
+  vi.clearAllMocks()
   vi.restoreAllMocks()
 })
 

--- a/packages/cli/vitest.config.mts
+++ b/packages/cli/vitest.config.mts
@@ -40,10 +40,10 @@ export default defineConfig({
       },
     ],
     env: {
-      // If NO_COLOR is set in the parent shell, Node prints a warning, which
-      // breaks assertions in a few tests (i.e. cwd.test.js). Clearing NO_COLOR
-      // here fixes that issue
-      NO_COLOR: undefined,
+      // NO_COLOR is cleared in vitest.setup.mts. (In Vitest 4 setting
+      // `NO_COLOR: undefined` here would set it to the string "undefined"
+      // instead of removing it, which makes Node print a warning that breaks
+      // assertions in a few tests (i.e. cwd.test.ts))
       FORCE_COLOR: 'true',
     },
   },

--- a/packages/cli/vitest.setup.mts
+++ b/packages/cli/vitest.setup.mts
@@ -1,5 +1,13 @@
 import { beforeAll, vi } from 'vitest'
 
+// If NO_COLOR is set (e.g. inherited from the parent shell) while FORCE_COLOR
+// is also set (see vitest.config.mts), Node prints a warning, which breaks
+// assertions in a few tests (i.e. cwd.test.ts). It also disables colors in
+// libraries like chalk, which breaks snapshot tests that expect colored
+// output. This runs before test files are imported, so both in-process color
+// detection and child processes spawned by tests are covered
+delete process.env.NO_COLOR
+
 vi.mock('prisma/config', () => {
   return {
     defineConfig: (config: unknown) => config,

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -54,7 +54,7 @@
     "memfs": "4.64.0",
     "publint": "0.3.21",
     "ts-dedent": "2.3.0",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/cookie-jar/package.json
+++ b/packages/cookie-jar/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/create-cedar-app/package.json
+++ b/packages/create-cedar-app/package.json
@@ -47,7 +47,7 @@
     "termi-link": "1.1.0",
     "untildify": "4.0.0",
     "uuid": "11.1.0",
-    "vitest": "3.2.6",
+    "vitest": "4.1.10",
     "yargs": "17.7.3"
   },
   "engines": {

--- a/packages/create-cedar-app/templates/esm-js/package.json
+++ b/packages/create-cedar-app/templates/esm-js/package.json
@@ -10,7 +10,7 @@
     "@cedarjs/eslint-config": "5.0.0",
     "@cedarjs/project-config": "5.0.0",
     "@cedarjs/testing": "5.0.0",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": "=24.x"

--- a/packages/create-cedar-app/templates/esm-ts/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/package.json
@@ -10,7 +10,7 @@
     "@cedarjs/eslint-config": "5.0.0",
     "@cedarjs/project-config": "5.0.0",
     "@cedarjs/testing": "5.0.0",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": "=24.x"

--- a/packages/create-cedar-app/templates/overlays/esm/yarn/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/yarn/package.json
@@ -11,7 +11,7 @@
     "@cedarjs/project-config": "5.0.0",
     "@cedarjs/testing": "5.0.0",
     "prisma": "7.8.0",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": "=24.x"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/parser": "8.60.1",
     "@typescript-eslint/rule-tester": "8.60.1",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -52,7 +52,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "react": "19.2.3"

--- a/packages/gqlorm/package.json
+++ b/packages/gqlorm/package.json
@@ -154,7 +154,7 @@
     "publint": "0.3.21",
     "tstyche": "5.0.2",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@cedarjs/web": "workspace:*",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -74,7 +74,7 @@
     "jsonwebtoken": "9.0.3",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -235,7 +235,7 @@
     "graphql-tag": "2.12.6",
     "publint": "0.3.21",
     "ts-dedent": "2.3.0",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/internal/src/__tests__/__fixtures__/graphqlCodeGen/mockPrismaClient.mjs
+++ b/packages/internal/src/__tests__/__fixtures__/graphqlCodeGen/mockPrismaClient.mjs
@@ -1,0 +1,12 @@
+// Stand-in for a generated Prisma client. The graphqlCodeGen tests point
+// `resolveGeneratedPrismaClient` at this file so that
+// `importGeneratedPrismaClient` loads it instead of shelling out to
+// `yarn cedar prisma generate`.
+export const Prisma = {
+  ModelName: {
+    PrismaModelOne: 'PrismaModelOne',
+    PrismaModelTwo: 'PrismaModelTwo',
+    Post: 'Post',
+    Todo: 'Todo',
+  },
+}

--- a/packages/internal/src/__tests__/graphqlCodeGen.test.ts
+++ b/packages/internal/src/__tests__/graphqlCodeGen.test.ts
@@ -9,7 +9,7 @@ const { mockPrismaClientPath } = await vi.hoisted(async () => {
   // `importGeneratedPrismaClient` imports the client), so we point it at an
   // actual fixture module instead
   const mockPrismaClientPath = path.resolve(
-    __dirname,
+    import.meta.dirname,
     '__fixtures__/graphqlCodeGen/mockPrismaClient.mjs',
   )
   return { mockPrismaClientPath }

--- a/packages/internal/src/__tests__/graphqlCodeGen.test.ts
+++ b/packages/internal/src/__tests__/graphqlCodeGen.test.ts
@@ -1,17 +1,19 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-const { mockPrismaClientPath, mockPrismaClientFileUrl } = await vi.hoisted(
-  async () => {
-    const path = await import('node:path')
-    const { pathToFileURL } = await import('node:url')
+const { mockPrismaClientPath } = await vi.hoisted(async () => {
+  const path = await import('node:path')
 
-    // On Windows, path.resolve('/foo') gives e.g. 'C:\foo'
-    const mockPrismaClientPath = path.resolve('/mock-prisma-client-path')
-    const mockPrismaClientFileUrl = pathToFileURL(mockPrismaClientPath)
-    return { mockPrismaClientPath, mockPrismaClientFileUrl }
-  },
-)
+  // A real file on disk that acts as the generated Prisma client. Vitest 4's
+  // module runner can't mock `file://` URLs (which is how
+  // `importGeneratedPrismaClient` imports the client), so we point it at an
+  // actual fixture module instead
+  const mockPrismaClientPath = path.resolve(
+    __dirname,
+    '__fixtures__/graphqlCodeGen/mockPrismaClient.mjs',
+  )
+  return { mockPrismaClientPath }
+})
 
 import {
   beforeAll,
@@ -58,25 +60,8 @@ vi.mock('@cedarjs/project-config', async (importOriginal) => {
   }
 })
 
-const mockNow = vi.hoisted(() => new Date().getTime())
-
-vi.mock(mockPrismaClientFileUrl + '?t=' + mockNow, () => {
-  return {
-    Prisma: {
-      ModelName: {
-        PrismaModelOne: 'PrismaModelOne',
-        PrismaModelTwo: 'PrismaModelTwo',
-        Post: 'Post',
-        Todo: 'Todo',
-      },
-    },
-  }
-})
-
 test('Generate gql typedefs web', async () => {
   await generateGraphQLSchema()
-
-  vi.setSystemTime(mockNow)
 
   vi.spyOn(fs, 'writeFileSync').mockImplementation(
     (file: fs.PathOrFileDescriptor, data: string | ArrayBufferView) => {

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -50,7 +50,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/mailer/core/package.json
+++ b/packages/mailer/core/package.json
@@ -26,7 +26,7 @@
     "@cedarjs/api": "workspace:*",
     "@cedarjs/framework-tools": "workspace:*",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -54,7 +54,7 @@
     "ts-toolbelt": "9.6.0",
     "typescript": "5.9.3",
     "vite": "7.3.5",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@cedarjs/router": "workspace:*"

--- a/packages/ogimage-gen/src/OgImageMiddleware.test.ts
+++ b/packages/ogimage-gen/src/OgImageMiddleware.test.ts
@@ -14,6 +14,35 @@ import OgImageMiddleware from './OgImageMiddleware'
 // Memfs mocks the redwood project-config stuff
 vi.mock('node:fs', () => ({ ...memfs, default: { ...memfs } }))
 
+// The source builds og component paths with path.join(), which produces
+// backslash paths on Windows, and Vitest 4's module runner keys mocked
+// modules by the exact specifier the dynamic import uses. So in addition to
+// the posix-literal mocks registered inside the tests below, the same
+// factories have to be registered under the OS-native (joined) path form.
+// On Unix these are identical to the posix literals
+const osNativeOgPaths = await vi.hoisted(async () => {
+  const nodePath = await import('node:path')
+
+  return {
+    contactPage: nodePath.join(
+      '/redwood-app/web/dist/ssr/ogImage/pages/Contact/ContactPage/ContactPage.og.mjs',
+    ),
+    homePage: nodePath.join(
+      '/redwood-app/web/dist/ssr/ogImage/pages/HomePage/HomePage.og.mjs',
+    ),
+  }
+})
+
+vi.mock(osNativeOgPaths.contactPage, () => ({
+  data: () => 'mocked data function',
+  output: () => 'Mocked component render',
+}))
+
+vi.mock(osNativeOgPaths.homePage, () => ({
+  data: () => 'mocked data function',
+  output: () => 'Mocked component render',
+}))
+
 // Mock getRoutesList function
 vi.mock('./getRoutesList', () => ({
   getRoutesList: vi.fn().mockResolvedValue([

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -101,7 +101,7 @@
     "concurrently": "9.2.1",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@cedarjs/router": "workspace:*",

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -70,7 +70,7 @@
     "publint": "0.3.21",
     "rimraf": "6.1.3",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -48,7 +48,7 @@
     "ioredis": "5.11.1",
     "nodemon": "3.1.14",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "ioredis": "^5.3.2"

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -39,7 +39,7 @@
     "@prisma/internals": "7.8.0",
     "esbuild": "0.27.7",
     "publint": "0.3.21",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -113,7 +113,7 @@
     "tstyche": "5.0.2",
     "typescript": "5.9.3",
     "vite": "7.3.5",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@cedarjs/auth": "workspace:*",

--- a/packages/router/src/__tests__/history.test.tsx
+++ b/packages/router/src/__tests__/history.test.tsx
@@ -160,6 +160,12 @@ describe('blocking', () => {
 
     it('removes beforeUnload listener when unblocking the last blocker', () => {
       const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+      // Vitest 4 reuses the existing spy when `vi.spyOn` is called on a
+      // method that is already spied on, so the spy still holds the call
+      // recorded by the previous test's `afterEach` (unblocking the last
+      // blocker there removes the beforeunload listener). Clear that stale
+      // history so we only count calls made by this test.
+      removeEventListenerSpy.mockClear()
 
       block(blocker1.id, blocker1.callback)
       block(blocker2.id, blocker2.callback)

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -71,7 +71,7 @@
     "publint": "0.3.21",
     "tstyche": "5.0.2",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -66,7 +66,7 @@
     "@types/node": "24.10.4",
     "typescript": "5.9.3",
     "vite": "7.3.5",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@cedarjs/project-config": "workspace:*",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -72,7 +72,7 @@
     "@types/lodash": "4.17.24",
     "@types/node": "24.10.4",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -35,7 +35,7 @@
     "@types/envinfo": "7.8.4",
     "@types/yargs": "17.0.35",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -149,13 +149,13 @@
     "jsdom": "27.4.0",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@cedarjs/auth": "workspace:*",
     "@cedarjs/router": "workspace:*",
     "@cedarjs/web": "workspace:*",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependenciesMeta": {
     "vitest": {

--- a/packages/testing/src/api/vitest/CedarApiVitestEnv.ts
+++ b/packages/testing/src/api/vitest/CedarApiVitestEnv.ts
@@ -9,7 +9,7 @@ import { getPackageManager } from '@cedarjs/project-config/packageManager'
 
 const CedarApiVitestEnvironment: Environment = {
   name: 'cedar-api',
-  transformMode: 'ssr',
+  viteEnvironment: 'ssr',
 
   async setup() {
     if (process.env.SKIP_DB_PUSH === '1') {

--- a/packages/testing/src/api/vitest/vite-plugin-cedar-vitest-api-config.ts
+++ b/packages/testing/src/api/vitest/vite-plugin-cedar-vitest-api-config.ts
@@ -20,13 +20,13 @@ export function cedarVitestApiConfigPlugin(): Plugin {
         },
         test: {
           environment: path.join(import.meta.dirname, 'CedarApiVitestEnv.js'),
-          // fileParallelism: false,
-          // fileParallelism doesn't work with vitest projects (which is what
-          // we're using in the root vitest.config.ts). As a workaround we set
-          // poolOptions instead, which also shouldn't work, but was suggested
-          // by Vitest team member AriPerkkio (Hiroshi's answer didn't work).
-          // https://github.com/vitest-dev/vitest/discussions/7416
-          poolOptions: { forks: { singleFork: true } },
+          // All api test files share a single test database, so they can't
+          // run in parallel. In Vitest 3 project-level fileParallelism didn't
+          // work (https://github.com/vitest-dev/vitest/discussions/7416) and
+          // we used the now-removed `poolOptions: { forks: { singleFork:
+          // true } }` as a workaround. Vitest 4 removed `poolOptions` and
+          // supports `fileParallelism` in project configs.
+          fileParallelism: false,
           setupFiles: [path.join(import.meta.dirname, 'vitest-api.setup.js')],
         },
       }

--- a/packages/testing/src/api/vitest/vitest-api.setup.ts
+++ b/packages/testing/src/api/vitest/vitest-api.setup.ts
@@ -113,8 +113,8 @@ function buildScenario(itFunc: It) {
       throw new Error('scenario() requires 2 or 3 arguments')
     }
 
-    return itFunc(testName, async (ctx) => {
-      const testPath = ctx.task.file.filepath
+    return itFunc(testName, async ({ task }) => {
+      const testPath = task.file.filepath
       const { scenario } = await loadScenarios(testPath, scenarioName)
 
       const scenarioData = await seedScenario(scenario)
@@ -154,8 +154,11 @@ function buildDescribeScenario(describeFunc: Describe) {
     return describeFunc(describeBlockName, () => {
       let scenarioData: Record<string, any>
 
-      beforeAll(async (ctx) => {
-        const testPath = ctx.file.filepath
+      // In Vitest 4 hook listeners receive the fixture context first and the
+      // suite second, and the first parameter must use a destructuring pattern
+      // eslint-disable-next-line no-empty-pattern
+      beforeAll(async ({}, suite) => {
+        const testPath = suite.file.filepath
         const { scenario } = await loadScenarios(testPath, scenarioName)
         scenarioData = await seedScenario(scenario)
       })

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -39,7 +39,7 @@
     "nodemon": "3.1.14",
     "publint": "0.3.21",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": ">=24"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -126,7 +126,7 @@
     "rollup": "4.60.4",
     "ts-dedent": "2.3.0",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@cedarjs/auth": "workspace:*",

--- a/packages/vite/src/__tests__/cedar-unified-dev.test.ts
+++ b/packages/vite/src/__tests__/cedar-unified-dev.test.ts
@@ -11,7 +11,9 @@ const mockSessionPost = vi.fn((method, _params) => {
 })
 const mockSessionOnce = vi.fn()
 const mockSessionDisconnect = vi.fn()
-const mockSession = vi.fn(() => {
+// Vitest 4 requires mocks called with `new` to use a constructible
+// implementation (arrow functions throw "is not a constructor")
+const mockSession = vi.fn(function () {
   const sessionObj = {
     connect: mockSessionConnect,
     post: mockSessionPost,

--- a/packages/vite/src/middleware/createMiddlewareRouter.test.ts
+++ b/packages/vite/src/middleware/createMiddlewareRouter.test.ts
@@ -33,30 +33,36 @@ vi.mock('@cedarjs/project-config', () => {
 })
 
 const distRegisterMwMock = vi.fn()
-vi.mock('/proj/web/dist/ssr/entry-server.mjs', () => {
-  return {
-    registerMiddleware: distRegisterMwMock,
-  }
-})
-vi.mock('/C:/proj/web/dist/ssr/entry-server.mjs', () => {
-  return {
-    registerMiddleware: distRegisterMwMock,
-  }
-})
-vi.mock('C:/proj/web/dist/ssr/entry-server.mjs', () => {
-  return {
-    registerMiddleware: distRegisterMwMock,
-  }
-})
+
 // Vitest 4's module runner resolves the dynamic import in register.ts to the
-// full file:// URL produced by makeFilePath(), so the mock has to be
-// registered under that exact specifier as well
-vi.mock('file:///proj/web/dist/ssr/entry-server.mjs', () => {
+// file:// URL produced by makeFilePath(), and internally keys mocks by both
+// path- and URL-style ids, so the mock has to be registered under every
+// specifier form the current platform can produce. The Unix-style
+// 'file:///proj/...' form must never be registered on Windows —
+// fileURLToPath() throws on drive-less file URLs there.
+const entryServerSpecifiers = await vi.hoisted(async () => {
+  const url = await import('node:url')
+
+  const entryPath =
+    process.platform === 'win32'
+      ? 'C:/proj/web/dist/ssr/entry-server.mjs'
+      : '/proj/web/dist/ssr/entry-server.mjs'
+  const entryUrl = url.pathToFileURL(entryPath)
+
+  return [entryPath, entryUrl.pathname, entryUrl.href]
+})
+
+vi.mock(entryServerSpecifiers[0], () => {
   return {
     registerMiddleware: distRegisterMwMock,
   }
 })
-vi.mock('file:///C:/proj/web/dist/ssr/entry-server.mjs', () => {
+vi.mock(entryServerSpecifiers[1], () => {
+  return {
+    registerMiddleware: distRegisterMwMock,
+  }
+})
+vi.mock(entryServerSpecifiers[2], () => {
   return {
     registerMiddleware: distRegisterMwMock,
   }

--- a/packages/vite/src/middleware/createMiddlewareRouter.test.ts
+++ b/packages/vite/src/middleware/createMiddlewareRouter.test.ts
@@ -48,6 +48,19 @@ vi.mock('C:/proj/web/dist/ssr/entry-server.mjs', () => {
     registerMiddleware: distRegisterMwMock,
   }
 })
+// Vitest 4's module runner resolves the dynamic import in register.ts to the
+// full file:// URL produced by makeFilePath(), so the mock has to be
+// registered under that exact specifier as well
+vi.mock('file:///proj/web/dist/ssr/entry-server.mjs', () => {
+  return {
+    registerMiddleware: distRegisterMwMock,
+  }
+})
+vi.mock('file:///C:/proj/web/dist/ssr/entry-server.mjs', () => {
+  return {
+    registerMiddleware: distRegisterMwMock,
+  }
+})
 
 describe('createMiddlewareRouter', () => {
   beforeEach(() => {

--- a/packages/web/build.ts
+++ b/packages/web/build.ts
@@ -17,6 +17,9 @@ await build({
   entryPointOptions: {
     ignore: [
       ...defaultIgnorePatterns,
+      // defaultIgnorePatterns only covers .test.{ts,js}, so also ignore the
+      // .tsx test files to keep them out of the build output
+      '**/*.test.tsx',
       'src/__typetests__/**',
       'src/bundled/**', // <-- ⭐
     ],
@@ -34,7 +37,14 @@ await build({
   entryPointOptions: {
     // @NOTE: building the cjs bins only...
     // I haven't tried esm bins yet...
-    ignore: [...defaultIgnorePatterns, 'src/bins/**', 'src/__typetests__/**'],
+    ignore: [
+      ...defaultIgnorePatterns,
+      // defaultIgnorePatterns only covers .test.{ts,js}, so also ignore the
+      // .tsx test files to keep them out of the build output
+      '**/*.test.tsx',
+      'src/bins/**',
+      'src/__typetests__/**',
+    ],
   },
   buildOptions: {
     ...defaultBuildOptions,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -187,7 +187,7 @@
     "react-dom": "19.2.3",
     "tstyche": "5.0.2",
     "typescript": "5.9.3",
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   },
   "peerDependencies": {
     "@cedarjs/auth": "workspace:*",

--- a/packages/web/vitest.config.mts
+++ b/packages/web/vitest.config.mts
@@ -2,7 +2,16 @@ import { defineConfig, configDefaults } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    exclude: [...configDefaults.exclude, '**/fixtures', '**/__typetests__'],
+    exclude: [
+      ...configDefaults.exclude,
+      // Vitest 4 removed `**/dist/**` from its default excludes. Compiled
+      // copies of the .tsx test files end up in dist (and dist/cjs, where
+      // they'd crash since Vitest can't be require()d from CJS), so keep
+      // excluding them like Vitest 3 did
+      '**/dist/**',
+      '**/fixtures',
+      '**/__typetests__',
+    ],
     environment: 'jsdom',
     setupFiles: ['vitest.setup.mts'],
   },

--- a/tasks/git-hooks/__tests__/utils.test.mts
+++ b/tasks/git-hooks/__tests__/utils.test.mts
@@ -1,10 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { buildWindowsCommand } from '../utils.mts'
 
 describe('buildWindowsCommand', () => {
   beforeEach(() => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    // In Vitest 4, vi.spyOn returns the existing spy (with its call history)
+    // when the method is already spied on, so restore between tests to avoid
+    // call counts leaking from one test into the next.
+    vi.restoreAllMocks()
   })
 
   it('builds a command string with all args sanitized', () => {

--- a/tasks/git-hooks/package.json
+++ b/tasks/git-hooks/package.json
@@ -14,6 +14,6 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
-    "vitest": "3.2.6"
+    "vitest": "4.1.10"
   }
 }

--- a/tasks/server-tests/vitest.config.mts
+++ b/tasks/server-tests/vitest.config.mts
@@ -8,10 +8,6 @@ export default defineConfig({
     // which is necessary because we are starting and stopping servers
     // at the same host and port between test cases.
     pool: 'threads',
-    poolOptions: {
-      threads: {
-        singleThread: true,
-      },
-    },
+    fileParallelism: false,
   },
 })

--- a/tasks/ud-tests/vitest.config.mts
+++ b/tasks/ud-tests/vitest.config.mts
@@ -7,10 +7,6 @@ export default defineConfig({
     // Run test suites in series because we start and stop servers
     // on the same host and port between test cases.
     pool: 'threads',
-    poolOptions: {
-      threads: {
-        singleThread: true,
-      },
-    },
+    fileParallelism: false,
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,7 +2185,7 @@ __metadata:
     split2: "npm:4.2.0"
     termi-link: "npm:1.1.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     yargs: "npm:17.7.3"
   peerDependencies:
     "@cedarjs/graphql-server": "workspace:*"
@@ -2230,7 +2230,7 @@ __metadata:
     title-case: "npm:3.0.3"
     ts-toolbelt: "npm:9.6.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     memjs: 1.3.2
     redis: 5.12.1
@@ -2262,7 +2262,7 @@ __metadata:
     jwks-rsa: "npm:3.2.2"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2277,7 +2277,7 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2293,7 +2293,7 @@ __metadata:
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     "@auth0/auth0-spa-js": 2.22.0
   languageName: unknown
@@ -2313,7 +2313,7 @@ __metadata:
     jwks-rsa: "npm:3.2.2"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2328,7 +2328,7 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2346,7 +2346,7 @@ __metadata:
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     "@azure/msal-browser": 2.39.0
   languageName: unknown
@@ -2364,7 +2364,7 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2395,7 +2395,7 @@ __metadata:
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     "@clerk/clerk-react": 5.61.3
   languageName: unknown
@@ -2412,7 +2412,7 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2431,7 +2431,7 @@ __metadata:
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
     uuid: "npm:11.1.0"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2450,7 +2450,7 @@ __metadata:
     publint: "npm:0.3.21"
     ts-toolbelt: "npm:9.6.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2469,7 +2469,7 @@ __metadata:
     termi-link: "npm:1.1.0"
     ts-dedent: "npm:2.3.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2487,7 +2487,7 @@ __metadata:
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2503,7 +2503,7 @@ __metadata:
     firebase-admin: "npm:13.8.0"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2518,7 +2518,7 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2534,7 +2534,7 @@ __metadata:
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     firebase: 10.14.1
   languageName: unknown
@@ -2553,7 +2553,7 @@ __metadata:
     jsonwebtoken: "npm:9.0.3"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2568,7 +2568,7 @@ __metadata:
     concurrently: "npm:9.2.1"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2584,7 +2584,7 @@ __metadata:
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     netlify-identity-widget: 1.9.2
   languageName: unknown
@@ -2604,7 +2604,7 @@ __metadata:
     jsonwebtoken: "npm:9.0.3"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2625,7 +2625,7 @@ __metadata:
     publint: "npm:0.3.21"
     ts-toolbelt: "npm:9.6.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2656,7 +2656,7 @@ __metadata:
     publint: "npm:0.3.21"
     react: "npm:19.2.3"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     "@supabase/supabase-js": 2.110.7
   languageName: unknown
@@ -2675,7 +2675,7 @@ __metadata:
     jwks-rsa: "npm:3.2.2"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     supertokens-node: 15.2.3
   languageName: unknown
@@ -2693,7 +2693,7 @@ __metadata:
     memfs: "npm:4.64.0"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2709,7 +2709,7 @@ __metadata:
     react: "npm:19.2.3"
     supertokens-auth-react: "npm:0.51.2"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     supertokens-auth-react: 0.51.2
   languageName: unknown
@@ -2730,7 +2730,7 @@ __metadata:
     react: "npm:19.2.3"
     type-fest: "npm:5.6.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2761,7 +2761,7 @@ __metadata:
     fast-glob: "npm:3.3.3"
     graphql: "npm:16.14.2"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -2783,7 +2783,7 @@ __metadata:
     termi-link: "npm:1.1.0"
     typescript: "npm:5.9.3"
     vite: "npm:7.3.5"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     yargs: "npm:17.7.3"
   bin:
     up: ./dist/bin.js
@@ -2821,7 +2821,7 @@ __metadata:
     smol-toml: "npm:1.6.1"
     termi-link: "npm:1.1.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     yargs-parser: "npm:21.1.1"
   languageName: unknown
   linkType: soft
@@ -2842,7 +2842,7 @@ __metadata:
     storybook-framework-cedarjs: "workspace:*"
     termi-link: "npm:1.1.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     yargs: "npm:17.7.3"
   languageName: unknown
   linkType: soft
@@ -2919,7 +2919,7 @@ __metadata:
     typescript: "npm:5.9.3"
     unionfs: "npm:4.6.0"
     uuid: "npm:11.1.0"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     yargs: "npm:17.7.3"
   bin:
     cedar: ./dist/index.js
@@ -2961,7 +2961,7 @@ __metadata:
     tasuku: "npm:2.3.0"
     ts-dedent: "npm:2.3.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     yargs: "npm:17.7.3"
   bin:
     codemods: ./dist/codemods.js
@@ -2989,7 +2989,7 @@ __metadata:
     esbuild: "npm:0.27.7"
     fast-glob: "npm:3.3.3"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -3089,7 +3089,7 @@ __metadata:
     "@typescript-eslint/utils": "npm:8.60.1"
     eslint: "npm:8.57.1"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -3105,7 +3105,7 @@ __metadata:
     fast-glob: "npm:3.3.3"
     fastify: "npm:5.8.5"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -3130,7 +3130,7 @@ __metadata:
     react-dom: "npm:19.2.3"
     react-hook-form: "npm:7.74.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     react: 19.2.3
   languageName: unknown
@@ -3155,7 +3155,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/git-hooks-tests@workspace:tasks/git-hooks"
   dependencies:
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -3177,7 +3177,7 @@ __metadata:
     publint: "npm:0.3.21"
     tstyche: "npm:5.0.2"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     "@cedarjs/web": "workspace:*"
     react: 19.2.3
@@ -3224,7 +3224,7 @@ __metadata:
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
     uuid: "npm:11.1.0"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -3291,7 +3291,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vite: "npm:7.3.5"
     vite-tsconfig-paths: "npm:^6.1.1"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   bin:
     cedar-gen: ./dist/generate/generate.js
     cedar-gen-watch: ./dist/generate/watch.js
@@ -3311,7 +3311,7 @@ __metadata:
     publint: "npm:0.3.21"
     type-fest: "npm:5.6.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   bin:
     cedar-jobs: ./dist/bins/cedar-jobs.js
     cedar-jobs-worker: ./dist/bins/cedar-jobs-worker.js
@@ -3326,7 +3326,7 @@ __metadata:
     "@cedarjs/api": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -3415,7 +3415,7 @@ __metadata:
     ts-toolbelt: "npm:9.6.0"
     typescript: "npm:5.9.3"
     vite: "npm:7.3.5"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     "@cedarjs/router": "workspace:*"
   languageName: unknown
@@ -3457,7 +3457,7 @@ __metadata:
     unimport: "npm:5.7.0"
     unplugin-auto-import: "npm:19.3.0"
     vite: "npm:7.3.5"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     "@cedarjs/router": "workspace:*"
     "@cedarjs/web": "workspace:*"
@@ -3482,7 +3482,7 @@ __metadata:
     smol-toml: "npm:1.6.1"
     string-env-interpolation: "npm:1.0.1"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -3508,7 +3508,7 @@ __metadata:
     ioredis: "npm:5.11.1"
     nodemon: "npm:3.1.14"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     ioredis: ^5.3.2
   peerDependenciesMeta:
@@ -3529,7 +3529,7 @@ __metadata:
     camelcase: "npm:6.3.0"
     esbuild: "npm:0.27.7"
     publint: "npm:0.3.21"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -3554,7 +3554,7 @@ __metadata:
     tstyche: "npm:5.0.2"
     typescript: "npm:5.9.3"
     vite: "npm:7.3.5"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     "@cedarjs/auth": "workspace:*"
     react: 19.2.3
@@ -3595,7 +3595,7 @@ __metadata:
     tstyche: "npm:5.0.2"
     typescript: "npm:5.9.3"
     ulid: "npm:3.0.2"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -3618,7 +3618,7 @@ __metadata:
     smol-toml: "npm:1.6.1"
     ts-morph: "npm:23.0.0"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     yargs-parser: "npm:21.1.1"
   languageName: unknown
   linkType: soft
@@ -3637,7 +3637,7 @@ __metadata:
     systeminformation: "npm:5.31.7"
     typescript: "npm:5.9.3"
     uuid: "npm:11.1.0"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     yargs: "npm:17.7.3"
   languageName: unknown
   linkType: soft
@@ -3676,13 +3676,13 @@ __metadata:
     ts-toolbelt: "npm:9.6.0"
     typescript: "npm:5.9.3"
     unplugin-auto-import: "npm:19.3.0"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     whatwg-fetch: "npm:3.6.20"
   peerDependencies:
     "@cedarjs/auth": "workspace:*"
     "@cedarjs/router": "workspace:*"
     "@cedarjs/web": "workspace:*"
-    vitest: 3.2.6
+    vitest: 4.1.10
   peerDependenciesMeta:
     vitest:
       optional: true
@@ -3718,7 +3718,7 @@ __metadata:
     pluralize: "npm:8.0.0"
     publint: "npm:0.3.21"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -3790,7 +3790,7 @@ __metadata:
     vite-plugin-cjs-interop: "npm:2.4.4"
     vite-plugin-graphql-tag: "npm:0.1.1"
     vite-tsconfig-paths: "npm:^6.1.1"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     ws: "npm:8.20.0"
     yargs-parser: "npm:21.1.1"
   peerDependencies:
@@ -3865,7 +3865,7 @@ __metadata:
     ts-toolbelt: "npm:9.6.0"
     tstyche: "npm:5.0.2"
     typescript: "npm:5.9.3"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     "@cedarjs/auth": "workspace:*"
     react: 19.2.3
@@ -9939,10 +9939,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@standard-schema/spec@npm:1.0.0"
-  checksum: 10c0/a1ab9a8bdc09b5b47aa8365d0e0ec40cc2df6437be02853696a0e377321653b0d3ac6f079a8c67d5ddbe9821025584b1fb71d9cc041a6666a96f1fadf2ece15f
+"@standard-schema/spec@npm:^1.0.0, @standard-schema/spec@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
   languageName: node
   linkType: hard
 
@@ -12033,86 +12033,85 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:3.2.6":
-  version: 3.2.6
-  resolution: "@vitest/expect@npm:3.2.6"
+"@vitest/expect@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/expect@npm:4.1.10"
   dependencies:
+    "@standard-schema/spec": "npm:^1.1.0"
     "@types/chai": "npm:^5.2.2"
-    "@vitest/spy": "npm:3.2.6"
-    "@vitest/utils": "npm:3.2.6"
-    chai: "npm:^5.2.0"
-    tinyrainbow: "npm:^2.0.0"
-  checksum: 10c0/bb51fa6a1f0740b3ee994347bc5067c8a17c2f3dea56b76a8c2c328885cdbfbafbb99b0b94b8166dc605eedbb9f467d37a6a0e0c81855eb18e232417cca4ccbd
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/a817ad0d9bd6a039776a7228d54fb8319c17e4af15917407f5566ac61781a8511f591d302519d6999217399915bc3c0290028189fc73f5c38f80cb01b6f19c8d
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:3.2.6":
-  version: 3.2.6
-  resolution: "@vitest/mocker@npm:3.2.6"
+"@vitest/mocker@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/mocker@npm:4.1.10"
   dependencies:
-    "@vitest/spy": "npm:3.2.6"
+    "@vitest/spy": "npm:4.1.10"
     estree-walker: "npm:^3.0.3"
-    magic-string: "npm:^0.30.17"
+    magic-string: "npm:^0.30.21"
   peerDependencies:
     msw: ^2.4.9
-    vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     msw:
       optional: true
     vite:
       optional: true
-  checksum: 10c0/0429d72e52ca1cc25d7ac44fbc251d0486974d8e0e59860c605d72456c0a17fa1d464b2a5e34690c17afcc7be562d7c22595f53503244a858f1f5903998da100
+  checksum: 10c0/4aa70b0df58681652e2e28093437fb2e8f4d02a6d03f5619abc266ac1c5ae5f43326148061d13ae6e071e0f6cfcf7634659af63644de8ce098a7c98949a3d1ad
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:3.2.6, @vitest/pretty-format@npm:^3.2.6":
-  version: 3.2.6
-  resolution: "@vitest/pretty-format@npm:3.2.6"
+"@vitest/pretty-format@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/pretty-format@npm:4.1.10"
   dependencies:
-    tinyrainbow: "npm:^2.0.0"
-  checksum: 10c0/9fc2887ef4206c90392de4e205d0109add35382446914d0124c53d1da327f49b9e9535fb336cb260394c176e4bb14b1b3aba0a42ab12b0f8b95034ccd4fed4eb
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/1a5daba730ffe23f2000bff484b4b2842f3b178d93663cb487b215516b8d3b62caa3e2bb2a3c63307b61a9fe58fb9bfff38559bc0c5e49d8aa403d6803a1d918
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:3.2.6":
-  version: 3.2.6
-  resolution: "@vitest/runner@npm:3.2.6"
+"@vitest/runner@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/runner@npm:4.1.10"
   dependencies:
-    "@vitest/utils": "npm:3.2.6"
+    "@vitest/utils": "npm:4.1.10"
     pathe: "npm:^2.0.3"
-    strip-literal: "npm:^3.0.0"
-  checksum: 10c0/bfc552ee2424ec62e4d6c075d000348a8187eb1be7ce9ae4673139c2f4a71e271ac15bef4d6af27cb5a29f4776dd437bea9d5819f62f0b5ece3c6dd857fa300d
+  checksum: 10c0/554b72639de9694271b99be8ae273fe12ec793093ec91cce143816cd1187d40b7138a4d9d4de4f456cfca9567de986825bff97e107c05b9eb4abc130e854286d
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:3.2.6":
-  version: 3.2.6
-  resolution: "@vitest/snapshot@npm:3.2.6"
+"@vitest/snapshot@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/snapshot@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:3.2.6"
-    magic-string: "npm:^0.30.17"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    magic-string: "npm:^0.30.21"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/b8f73cc2bc50ca6cd013e2dae1f531aa2132d053e52d2055da8544290e6e8a92dd06f8cf07e8fce15137f27e8156f2936eb6bd9fa63c76e6f6a9813cf0820022
+  checksum: 10c0/e71398725f51af5fd0c07bb4b957d0f987daf9b4c564ac24cb2a4d1afde1a6939f535ac17761a32dcc41b0a1e6d4088af66dc44df89fdebebb92aabed1a92b5f
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:3.2.6":
-  version: 3.2.6
-  resolution: "@vitest/spy@npm:3.2.6"
-  dependencies:
-    tinyspy: "npm:^4.0.3"
-  checksum: 10c0/b4b022546523168f361cd640dff68feb9709b259aacc05e12055a4f278d07e58fbb280ae70454425199f91e62729b03f0a16bdfe880c5a0b1b10c02bc334fc30
+"@vitest/spy@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/spy@npm:4.1.10"
+  checksum: 10c0/e5c08012560af6727fd66741c5cda25560d7c5442103d0c83e4276a9b0dd90b9da6cdf823a461195229a16c6ff87768ce788a68d0fa29dea73ee285618668178
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:3.2.6":
-  version: 3.2.6
-  resolution: "@vitest/utils@npm:3.2.6"
+"@vitest/utils@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/utils@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:3.2.6"
-    loupe: "npm:^3.1.4"
-    tinyrainbow: "npm:^2.0.0"
-  checksum: 10c0/452da757082ebcadf43ce697bf4077d546ea06e094763969440c3cb0d7bb950be0f69d6dbdab297cd0307bdf956294e20b0184d0218a4ef942d3d253995d44ed
+    "@vitest/pretty-format": "npm:4.1.10"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/05b0ecec6997ec22fc08377e57dbd8fa37992e05961f3a7a916d98b1ab56d15c2a87dbd83d392b628242bdc156b1705e7fa60a3bf0c54bdb51158c153e05fc5d
   languageName: node
   linkType: hard
 
@@ -12865,13 +12864,6 @@ __metadata:
     object.assign: "npm:^4.1.4"
     util: "npm:^0.12.5"
   checksum: 10c0/7271a5da883c256a1fa690677bf1dd9d6aa882139f2bed1cd15da4f9e7459683e1da8e32a203d6cc6767e5e0f730c77a9532a87b896b4b0af0dd535f668775f0
-  languageName: node
-  linkType: hard
-
-"assertion-error@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "assertion-error@npm:2.0.1"
-  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
   languageName: node
   linkType: hard
 
@@ -13744,13 +13736,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cac@npm:^6.7.14":
-  version: 6.7.14
-  resolution: "cac@npm:6.7.14"
-  checksum: 10c0/4ee06aaa7bab8981f0d54e5f5f9d4adcd64058e9697563ce336d8a3878ed018ee18ebe5359b2430eceae87e0758e62ea2019c3f52ae6e211b1bd2e133856cd10
-  languageName: node
-  linkType: hard
-
 "cacache@npm:^17.0.0":
   version: 17.1.3
   resolution: "cacache@npm:17.1.3"
@@ -13895,16 +13880,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "chai@npm:5.2.0"
-  dependencies:
-    assertion-error: "npm:^2.0.1"
-    check-error: "npm:^2.1.1"
-    deep-eql: "npm:^5.0.1"
-    loupe: "npm:^3.1.0"
-    pathval: "npm:^2.0.0"
-  checksum: 10c0/dfd1cb719c7cebb051b727672d382a35338af1470065cb12adb01f4ee451bbf528e0e0f9ab2016af5fc1eea4df6e7f4504dc8443f8f00bd8fb87ad32dc516f7d
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
   languageName: node
   linkType: hard
 
@@ -14004,13 +13983,6 @@ __metadata:
   dependencies:
     "@kurkle/color": "npm:^0.3.0"
   checksum: 10c0/3f2a11dcaae9079e8e6b8ad077e2ae311f04996f9da14815730891e66215ee8b5f2c0eb70b5a156e5bde0f89a41bae13506dc6153e50fd22dcb282b21eec706f
-  languageName: node
-  linkType: hard
-
-"check-error@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "check-error@npm:2.1.1"
-  checksum: 10c0/979f13eccab306cf1785fa10941a590b4e7ea9916ea2a4f8c87f0316fc3eab07eabefb6e587424ef0f88cbcd3805791f172ea739863ca3d7ce2afc54641c7f0e
   languageName: node
   linkType: hard
 
@@ -14769,7 +14741,7 @@ __metadata:
     termi-link: "npm:1.1.0"
     untildify: "npm:4.0.0"
     uuid: "npm:11.1.0"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     yargs: "npm:17.7.3"
   bin:
     create-cedar-app: ./dist/create-cedar-app.js
@@ -15255,13 +15227,6 @@ __metadata:
     babel-plugin-macros:
       optional: true
   checksum: 10c0/d94bde6e6f780be4da4fd760288fcf755ec368872f4ac5218197200d86430aeb8d90a003a840bff1c20221188e3f23adced0119cb811c6873c70d0ac66d12832
-  languageName: node
-  linkType: hard
-
-"deep-eql@npm:^5.0.1":
-  version: 5.0.2
-  resolution: "deep-eql@npm:5.0.2"
-  checksum: 10c0/7102cf3b7bb719c6b9c0db2e19bf0aa9318d141581befe8c7ce8ccd39af9eaa4346e5e05adef7f9bd7015da0f13a3a25dcfe306ef79dc8668aedbecb658dd247
   languageName: node
   linkType: hard
 
@@ -16151,10 +16116,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "es-module-lexer@npm:1.7.0"
-  checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
+"es-module-lexer@npm:^2.0.0":
+  version: 2.3.1
+  resolution: "es-module-lexer@npm:2.3.1"
+  checksum: 10c0/ada8b222772b5b8ea92eb6054c383233207418621855a07b480fdd36979b658a41414be09e793fcdd8a67a182741475f47830a01ff2ebd4353d7f6965c7c45f9
   languageName: node
   linkType: hard
 
@@ -16946,10 +16911,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect-type@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "expect-type@npm:1.2.1"
-  checksum: 10c0/b775c9adab3c190dd0d398c722531726cdd6022849b4adba19dceab58dda7e000a7c6c872408cd73d665baa20d381eca36af4f7b393a4ba60dd10232d1fb8898
+"expect-type@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "expect-type@npm:1.4.0"
+  checksum: 10c0/d40d76b8570695d36587beb3cc28494da2ca3ec8f04e67f5622ed2d372d850e401a9adef19c6835e1a8173903f157c79540b34c7b3fbd7cd8ce726cc903c57b7
   languageName: node
   linkType: hard
 
@@ -21258,13 +21223,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loupe@npm:^3.1.0, loupe@npm:^3.1.4":
-  version: 3.1.4
-  resolution: "loupe@npm:3.1.4"
-  checksum: 10c0/5c2e6aefaad25f812d361c750b8cf4ff91d68de289f141d7c85c2ce9bb79eeefa06a93c85f7b87cba940531ed8f15e492f32681d47eed23842ad1963eb3a154d
-  languageName: node
-  linkType: hard
-
 "lower-case-first@npm:^2.0.2":
   version: 2.0.2
   resolution: "lower-case-first@npm:2.0.2"
@@ -23268,6 +23226,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obug@npm:^2.1.1":
+  version: 2.1.4
+  resolution: "obug@npm:2.1.4"
+  checksum: 10c0/34a0ee97cd88573cfd97d384c2a79f07118ae5680d7e45d1de6e99c74eddefe145e8ca27a2db02195a1ee5fded5aa22b924869c842728c201b9f109a27d0ef19
+  languageName: node
+  linkType: hard
+
 "ohash@npm:^2.0.11":
   version: 2.0.11
   resolution: "ohash@npm:2.0.11"
@@ -24176,13 +24141,6 @@ __metadata:
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
   checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
-  languageName: node
-  linkType: hard
-
-"pathval@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "pathval@npm:2.0.0"
-  checksum: 10c0/602e4ee347fba8a599115af2ccd8179836a63c925c23e04bd056d0674a64b39e3a081b643cc7bc0b84390517df2d800a46fcc5598d42c155fe4977095c2f77c5
   languageName: node
   linkType: hard
 
@@ -26109,7 +26067,7 @@ __metadata:
     tstyche: "npm:5.0.2"
     typescript: "npm:5.9.3"
     typescript-eslint: "npm:8.60.1"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
     ws: "npm:8.20.0"
     yargs: "npm:17.7.3"
     zx: "npm:8.8.5"
@@ -27093,6 +27051,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.2.0
+  resolution: "std-env@npm:4.2.0"
+  checksum: 10c0/40ac525ce7b7c556abc332a7376f14356eeb1a7f17f6ff9a003eb9f52326ff1f3745d3e1b43452675b1ec6fcc319f1b1d6f3b0d386cf3f91058479ad883cff69
+  languageName: node
+  linkType: hard
+
 "stdin-discarder@npm:^0.3.2":
   version: 0.3.2
   resolution: "stdin-discarder@npm:0.3.2"
@@ -27141,7 +27106,7 @@ __metadata:
     unplugin-auto-import: "npm:19.3.0"
     vite: "npm:7.3.5"
     vite-plugin-node-polyfills: "npm:0.26.0"
-    vitest: "npm:3.2.6"
+    vitest: "npm:4.1.10"
   peerDependencies:
     "@cedarjs/project-config": "workspace:*"
     "@cedarjs/router": "workspace:*"
@@ -27874,14 +27839,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "tinyexec@npm:0.3.2"
-  checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
+"tinyexec@npm:^1.0.2":
+  version: 1.2.4
+  resolution: "tinyexec@npm:1.2.4"
+  checksum: 10c0/153b8db6b080194b558ff145b9cffc36b80a6e07babd644dcfbe49c807eee668c876049d28bdee90b96304476f883352f2dad91b3f86bc23832532f4363e66ff
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17":
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17":
   version: 0.2.17
   resolution: "tinyglobby@npm:0.2.17"
   dependencies:
@@ -27901,24 +27866,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinypool@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "tinypool@npm:1.1.1"
-  checksum: 10c0/bf26727d01443061b04fa863f571016950888ea994ba0cd8cba3a1c51e2458d84574341ab8dbc3664f1c3ab20885c8cf9ff1cc4b18201f04c2cde7d317fff69b
-  languageName: node
-  linkType: hard
-
-"tinyrainbow@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "tinyrainbow@npm:2.0.0"
-  checksum: 10c0/c83c52bef4e0ae7fb8ec6a722f70b5b6fa8d8be1c85792e829f56c0e1be94ab70b293c032dc5048d4d37cfe678f1f5babb04bdc65fd123098800148ca989184f
-  languageName: node
-  linkType: hard
-
-"tinyspy@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "tinyspy@npm:4.0.3"
-  checksum: 10c0/0a92a18b5350945cc8a1da3a22c9ad9f4e2945df80aaa0c43e1b3a3cfb64d8501e607ebf0305e048e3c3d3e0e7f8eb10cea27dc17c21effb73e66c4a3be36373
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "tinyrainbow@npm:3.1.0"
+  checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
   languageName: node
   linkType: hard
 
@@ -29106,21 +29057,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-node@npm:3.2.4":
-  version: 3.2.4
-  resolution: "vite-node@npm:3.2.4"
-  dependencies:
-    cac: "npm:^6.7.14"
-    debug: "npm:^4.4.1"
-    es-module-lexer: "npm:^1.7.0"
-    pathe: "npm:^2.0.3"
-    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
-  bin:
-    vite-node: vite-node.mjs
-  checksum: 10c0/6ceca67c002f8ef6397d58b9539f80f2b5d79e103a18367288b3f00a8ab55affa3d711d86d9112fce5a7fa658a212a087a005a045eb8f4758947dd99af2a6c6b
-  languageName: node
-  linkType: hard
-
 "vite-plugin-cjs-interop@npm:2.4.4":
   version: 2.4.4
   resolution: "vite-plugin-cjs-interop@npm:2.4.4"
@@ -29234,49 +29170,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:3.2.6":
-  version: 3.2.6
-  resolution: "vitest@npm:3.2.6"
+"vitest@npm:4.1.10":
+  version: 4.1.10
+  resolution: "vitest@npm:4.1.10"
   dependencies:
-    "@types/chai": "npm:^5.2.2"
-    "@vitest/expect": "npm:3.2.6"
-    "@vitest/mocker": "npm:3.2.6"
-    "@vitest/pretty-format": "npm:^3.2.6"
-    "@vitest/runner": "npm:3.2.6"
-    "@vitest/snapshot": "npm:3.2.6"
-    "@vitest/spy": "npm:3.2.6"
-    "@vitest/utils": "npm:3.2.6"
-    chai: "npm:^5.2.0"
-    debug: "npm:^4.4.1"
-    expect-type: "npm:^1.2.1"
-    magic-string: "npm:^0.30.17"
+    "@vitest/expect": "npm:4.1.10"
+    "@vitest/mocker": "npm:4.1.10"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/runner": "npm:4.1.10"
+    "@vitest/snapshot": "npm:4.1.10"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
     pathe: "npm:^2.0.3"
-    picomatch: "npm:^4.0.2"
-    std-env: "npm:^3.9.0"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^4.0.0-rc.1"
     tinybench: "npm:^2.9.0"
-    tinyexec: "npm:^0.3.2"
-    tinyglobby: "npm:^0.2.14"
-    tinypool: "npm:^1.1.1"
-    tinyrainbow: "npm:^2.0.0"
-    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
-    vite-node: "npm:3.2.4"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
     why-is-node-running: "npm:^2.3.0"
   peerDependencies:
     "@edge-runtime/vm": "*"
-    "@types/debug": ^4.1.12
-    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-    "@vitest/browser": 3.2.6
-    "@vitest/ui": 3.2.6
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.1.10
+    "@vitest/browser-preview": 4.1.10
+    "@vitest/browser-webdriverio": 4.1.10
+    "@vitest/coverage-istanbul": 4.1.10
+    "@vitest/coverage-v8": 4.1.10
+    "@vitest/ui": 4.1.10
     happy-dom: "*"
     jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     "@edge-runtime/vm":
       optional: true
-    "@types/debug":
+    "@opentelemetry/api":
       optional: true
     "@types/node":
       optional: true
-    "@vitest/browser":
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
       optional: true
     "@vitest/ui":
       optional: true
@@ -29284,9 +29230,11 @@ __metadata:
       optional: true
     jsdom:
       optional: true
+    vite:
+      optional: false
   bin:
-    vitest: vitest.mjs
-  checksum: 10c0/ea222dcd7310188479e37dbea4fbcbdcdb8db97f952b4813e7e7b370b329485c2de4622551e61076ffd75d4d811a6800a0da1e31520067614c51528f26704758
+    vitest: ./vitest.mjs
+  checksum: 10c0/ff07294a57f9c62f3b503f7cf88a52ee0753ed26389a49cda430387a3898f39d80af47180b0af19e27acab5bd11ae95706bd4b44ce8befc97d3ae49af6ca4fc1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrades Vitest from 3.2.6 to 4.1.10 across the framework and the ESM app templates.

See the Vitest 3 -> 4 migration guide here https://vitest.dev/guide/migration.html

## Who is affected

Only **ESM Cedar apps** run their tests with Vitest, so only they are affected. CJS Cedar apps keep testing with Jest and need no changes.

## What Cedar app developers need to pay special attention to

### Dependencies

- Bump `vitest` to `4.1.10` in your app's root `package.json`.
- Make sure your root `package.json` has a `"vite": "7.3.5"` entry in `resolutions`. New apps created from the ESM template already have it. Without it, Vitest 4 installs its own nested Vite 8, which breaks the JSX transform in web-side tests (`Parse failure: Unexpected JSX expression`).

### Mocking behavior changes (most likely to break app tests)

- **Mocks called with `new` need constructible implementations.** `vi.fn(() => obj)` used to work for code doing `new MockedThing()`; in Vitest 4 the implementation is invoked as a constructor, so arrow functions throw `... is not a constructor`. Use a `function` expression or a `class` instead: `vi.fn(function () { return obj })`.
- **`vi.spyOn` on an already-spied method returns the existing spy** including its accumulated call history, instead of a fresh one. Call counts can leak between tests — clear spies in `beforeEach`/`afterEach` (`spy.mockClear()` or `vi.restoreAllMocks()`).
- **`vi.restoreAllMocks()` (and the `restoreMocks` config option) now only restores `vi.spyOn` spies.** It no longer touches `vi.fn()` mocks from `vi.mock` factories — use `vi.resetAllMocks()` or `vi.clearAllMocks()` for those.

### Snapshots

- **Obsolete snapshots now fail the run in CI mode** (`Obsolete snapshots found when no snapshot update is expected`). Remove stale entries locally with `yarn vitest run <file> -u` and review the diff.

### Test hooks

- `beforeAll`/`afterAll` callbacks now receive `(context, suite)` — the suite moved to the **second** argument, and the first parameter must use object destructuring (e.g. `({ task })` in test callbacks). If a test relied on `beforeAll(async (ctx) => ctx.file.filepath)`, it now needs `async ({}, suite) => suite.file.filepath`.

### If you customized your Vitest config

- `poolOptions` was removed. `singleThread`/`singleFork` become `maxWorkers: 1, isolate: false`; for plain serial file execution use `fileParallelism: false` (now also supported in project-level configs). Cedar's API-side test preset handles serializing api test files against the shared test database automatically — no app action needed.
- `minWorkers`, `--minWorkers`, `maxThreads`/`minThreads`, and the `workspace` option are gone (`workspace` -> `projects`).
- `test.env` values set to `undefined` are now stringified to `"undefined"` instead of being removed — delete such keys instead.
- The default `exclude` no longer contains `**/dist/**`. Cedar app builds don't emit test files into dist, but if you have compiled test artifacts lying around inside a test root, add your own exclude.

### Misc

- `require('vitest')` from CommonJS modules now throws — Vitest can only be `import`ed.
- Custom Vitest environments should use `viteEnvironment` instead of the deprecated `transformMode` (already handled inside `@cedarjs/testing` — `scenario()` and `describeScenario()` keep working unchanged).
