### PR TITLE
chore(record): Fix async test warning

### DIFF
--- a/packages/record/src/redwoodrecord/__tests__/RedwoodRecord.test.js
+++ b/packages/record/src/redwoodrecord/__tests__/RedwoodRecord.test.js
@@ -52,7 +52,7 @@ describe('save()', () => {
     }
     const user = new User()
 
-    expect(user.save({ throw: true })).rejects.toThrow(
+    await expect(user.save({ throw: true })).rejects.toThrow(
       ValidationErrors.PresenceValidationError,
     )
   })


### PR DESCRIPTION
Fixes this warning

```
✓ src/redwoodrecord/__tests__/Reflection.test.js (5 tests) 19ms
    stderr | src/redwoodrecord/__tests__/RedwoodRecord.test.js > save() > throws an error if given the option
    Promise returned by `expect(actual).rejects.toThrow(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
        at /home/runner/work/cedar/cedar/packages/record/src/redwoodrecord/__tests__/RedwoodRecord.test.js:55:39
✓ src/redwoodrecord/__tests__/RedwoodRecord.test.js (8 tests) 26ms
```