### PR TITLE
chore(vite): fully gate web-side babel-plugin-module-resolver on !forVite

### DIFF
--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -60,16 +60,17 @@ export const getWebSideBabelPlugins = (
     useReactCompiler && ['babel-plugin-react-compiler', { target: '19' }],
     ...(forJest ? getCommonPlugins() : []),
     // === Import path handling
-    [
+    // Vite resolves the src/ and $api/ aliases via
+    // cedarjsResolveCedarStyleImportsPlugin, and tsconfig `paths` aliases via
+    // vite-tsconfig-paths, instead of this babel plugin
+    !forVite && [
       'babel-plugin-module-resolver',
       {
         alias: {
-          ...(!forVite && {
-            // Jest monorepo and multi project runner is not correctly
-            // determining the `cwd`:
-            // https://github.com/facebook/jest/issues/7359
-            src: forJest ? rwjsPaths.web.src : './src',
-          }),
+          // Jest monorepo and multi project runner is not correctly
+          // determining the `cwd`:
+          // https://github.com/facebook/jest/issues/7359
+          src: forJest ? rwjsPaths.web.src : './src',
           // adds the paths from [ts|js]config.json to the module resolver
           ...getPathsFromTypeScriptConfig(tsConfigs.web, rwjsPaths.web.base),
           $api: rwjsPaths.api.base,


### PR DESCRIPTION
## Summary

Follow-up to #2080: on the web side, `babel-plugin-module-resolver` (`rwjs-module-resolver`) was still unconditionally active even when `forVite: true`, handling the `$api` alias and tsconfig `paths` aliases. This overlapped with mechanisms already registered in `cedar()`'s Vite pipeline:

- `src/` and `$api/` bare specifiers are resolved by `cedarjsResolveCedarStyleImportsPlugin`'s `resolveId` hook (including directory-named-import and extensionless/`.js`→`.jsx` fallback resolution, matching the Babel plugin's custom `resolvePath` override).
- `vite-tsconfig-paths` (`tsconfigPaths()`) is already registered in `cedar()`'s plugin array and resolves the same tsconfig `paths` aliases that `getPathsFromTypeScriptConfig` fed into the Babel plugin.

So for `forVite: true`, `babel-plugin-module-resolver` was doing nothing that wasn't already handled earlier in Vite's resolution pipeline. This PR gates it off with `!forVite &&`, matching the pattern already used for the neighboring `babel-plugin-redwood-directory-named-import`, `babel-plugin-auto-import`, and `babel-plugin-graphql-tag` entries in the same plugin list.

It mirrors the API-side port of the same plugin done in #2109 / #2116.

**What's covered / not covered:**
- ✅ `buildApp` / `cedar()` Vite plugin (`forVite: true`) — plugin fully gated off, replacement already in place and unaffected by this change
- ✅ Jest (web tests), prerender (`registerWebSideBabelHook`), CLI exec (`execBabel.ts`) — none of these pass `forVite: true`, so the plugin remains active exactly as before

## A second, pre-existing redundancy found and removed along the way

While tracing the actual `$api` resolution mechanism, I found `packages/vite/src/lib/getMergedConfig.ts` *also* had a native Vite `resolve.alias.$api` entry, wired into `cedar()` via `cedarMergedConfig()` — completely independent of, and redundant with, `cedarjsResolveCedarStyleImportsPlugin`'s own `$api/` handling. Native `resolve.alias` wins over any plugin's `resolveId`, so the plugin's `$api/` branch was fully dead code whenever it ran inside `cedar()`.

I checked all 5 places `cedarjsResolveCedarStyleImportsPlugin()` is used (`cedar()`, `node-runner.ts`, `upHandlerEsm.ts`, `vite-plugin-cedar-vitest-api-preset.ts`, `exec.ts`) — the other four don't define their own `$api` alias, so the plugin's handling is load-bearing there and must stay. Only the `cedar()` path had the duplicate, because `cedarjsResolveCedarStyleImportsPlugin()` is unconditionally included alongside `cedarMergedConfig()` in the same plugin list. So I removed just the duplicate alias entry from `getMergedConfig.ts`, leaving the shared plugin untouched.

Verified with a disable-and-rebuild check: with only the alias removed, the build still passes (plugin picks up the slack); with the plugin's `$api/` branch also disabled, the build fails with an unresolved-import error — confirming the plugin's branch is genuinely exercised now, not dead code.

## Changes

- **`packages/babel-config/src/web.ts`** — gate the `babel-plugin-module-resolver` entry in `getWebSideBabelPlugins` on `!forVite`; simplify the now-always-true `!forVite` conditional inside its `alias.src` config since it's now inside the outer `!forVite` gate
- **`packages/vite/src/lib/getMergedConfig.ts`** — remove the now-redundant `resolve.alias.$api` entry (see above)

## On test coverage for `$api` specifically

I initially added a test that imported `$api/...` from a page component to exercise this change directly, but reverted it: `$api` is documented for use only from `*.routeHooks.ts` files and `scripts/*.js` (`yarn cedar exec`), never from web page/component code, so that test modeled usage nobody should rely on.

The trouble is the realistic usage doesn't help either — route hooks and scripts never go through `cedar()`'s Vite pipeline (they build via `buildRouteHooks.ts`'s esbuild step, or ad-hoc `createServer()` calls in `exec.ts`/`node-runner.ts`, none of which set `forVite: true`), so a route-hook/script-based test would pass identically regardless of whether this fix is applied — it wouldn't cover this change at all.

Digging further: the *only* place `cedar()`'s pipeline genuinely needs `$api` resolution for its intended purpose is `rw dev`'s live streaming SSR requests, where `triggerRouteHooks.ts`'s `viteSsrDevServer.ssrLoadModule()` runs a route hook's `meta()` hook through the project's real `vite.config.ts` → `cedar()`. `cedar()`'s plugin list applies uniformly to both the `client` and `ssr` Vite environments (nothing scopes it), which is *why* `$api` also happens to resolve from client-bundled code today — an unscoped side effect, not a deliberate feature. Filed #2141 to track properly scoping `$api` resolution to the `ssr` environment only, which is a real (if separate) improvement, but a bigger behavior change deserving its own review.

Given that, this PR's regression protection for the alias replacement rests on the `src/`-alias coverage, which *is* realistic, load-bearing usage (`App.tsx`/`Routes.tsx` in the `cedar-ud-app` fixture import from `src/...`) and is already exercised by the existing `ud-build.test.ts`.

## Testing

- `yarn workspace @cedarjs/babel-config test --run` — 46/46 passing
- `yarn workspace @cedarjs/babel-config build` — passes
- `yarn workspace @cedarjs/vite test --run` — 27/27 test files passing (202 passed, 1 skipped, 4 todo)
- `yarn eslint` — clean on all changed files
- Manually confirmed (for both the `babel-plugin-module-resolver` gating and the `getMergedConfig.ts` dedup) that disabling the real resolution code causes `ud-build.test.ts`'s existing `src/`-import-dependent assertions to fail with a genuine Rollup unresolved-import error, then restored the working code before committing
