### PR TITLE
fix(api): don't send body for unsupported status codes

### DIFF
--- a/packages/api/src/__tests__/runtime.test.ts
+++ b/packages/api/src/__tests__/runtime.test.ts
@@ -268,6 +268,23 @@ describe('legacyResultToResponse', () => {
     expect(await response.text()).toBe('')
   })
 
+  it('sends no body for status 205', async () => {
+    const result: APIGatewayProxyResult = {
+      statusCode: 205,
+      headers: {
+        'x-test': 'true',
+      },
+      body: 'this body should be dropped',
+    }
+
+    const response = legacyResultToResponse(result)
+
+    expect(response.status).toBe(205)
+    expect(response.headers.get('x-test')).toBe('true')
+    expect(response.body).toBeNull()
+    expect(await response.text()).toBe('')
+  })
+
   it('sends no body for status 304', async () => {
     const result: APIGatewayProxyResult = {
       statusCode: 304,
@@ -295,6 +312,20 @@ describe('legacyResultToResponse', () => {
     const response = legacyResultToResponse(result)
 
     expect(response.status).toBe(204)
+    expect(response.body).toBeNull()
+    expect(await response.text()).toBe('')
+  })
+
+  it('sends no body for status 205 even when base64 encoded', async () => {
+    const result: APIGatewayProxyResult = {
+      statusCode: 205,
+      isBase64Encoded: true,
+      body: Buffer.from('this body should be dropped').toString('base64'),
+    }
+
+    const response = legacyResultToResponse(result)
+
+    expect(response.status).toBe(205)
     expect(response.body).toBeNull()
     expect(await response.text()).toBe('')
   })

--- a/packages/api/src/__tests__/runtime.test.ts
+++ b/packages/api/src/__tests__/runtime.test.ts
@@ -231,6 +231,88 @@ describe('legacyResultToResponse', () => {
     expect(await response.text()).toBe(JSON.stringify({ ok: true }))
   })
 
+  it('decodes base64 encoded bodies', async () => {
+    const result: APIGatewayProxyResult = {
+      statusCode: 200,
+      isBase64Encoded: true,
+      body: Buffer.from('hello cedar').toString('base64'),
+    }
+
+    const response = legacyResultToResponse(result)
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('hello cedar')
+  })
+
+  it('defaults to status 200 and an empty body', async () => {
+    const response = legacyResultToResponse({} as APIGatewayProxyResult)
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('')
+  })
+
+  it('sends no body for status 204', async () => {
+    const result: APIGatewayProxyResult = {
+      statusCode: 204,
+      headers: {
+        'x-test': 'true',
+      },
+      body: 'this body should be dropped',
+    }
+
+    const response = legacyResultToResponse(result)
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get('x-test')).toBe('true')
+    expect(response.body).toBeNull()
+    expect(await response.text()).toBe('')
+  })
+
+  it('sends no body for status 304', async () => {
+    const result: APIGatewayProxyResult = {
+      statusCode: 304,
+      headers: {
+        'x-test': 'true',
+      },
+      body: 'this body should be dropped',
+    }
+
+    const response = legacyResultToResponse(result)
+
+    expect(response.status).toBe(304)
+    expect(response.headers.get('x-test')).toBe('true')
+    expect(response.body).toBeNull()
+    expect(await response.text()).toBe('')
+  })
+
+  it('sends no body for status 204 even when base64 encoded', async () => {
+    const result: APIGatewayProxyResult = {
+      statusCode: 204,
+      isBase64Encoded: true,
+      body: Buffer.from('this body should be dropped').toString('base64'),
+    }
+
+    const response = legacyResultToResponse(result)
+
+    expect(response.status).toBe(204)
+    expect(response.body).toBeNull()
+    expect(await response.text()).toBe('')
+  })
+
+  it('sends no body for status 304 even when base64 encoded', async () => {
+    const result: APIGatewayProxyResult = {
+      statusCode: 304,
+      isBase64Encoded: true,
+      body: Buffer.from('this body should be dropped').toString('base64'),
+    }
+
+    const response = legacyResultToResponse(result)
+
+    expect(response.status).toBe(304)
+    expect(response.body).toBeNull()
+    expect(await response.text()).toBe('')
+  })
+
   it('returns a Response unchanged when given one', async () => {
     const response = new Response('hello', {
       status: 200,

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -244,17 +244,22 @@ export function legacyResultToResponse(result: LegacyHandlerResult): Response {
     }
   }
 
-  const body = result.body ?? ''
+  const status = result.statusCode ?? 200
 
-  if (result.isBase64Encoded) {
-    return new Response(Buffer.from(body, 'base64'), {
-      status: result.statusCode ?? 200,
+  // All 1xx (Informational), 204 (No Content), and 304 (Not Modified) responses do not include content.
+  // See: https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4.1-8
+  const isNoBodyStatus = status < 200 || status === 204 || status === 304
+  const body = result.body ?? isNoBodyStatus ? null : ''
+
+  if (result.isBase64Encoded && !isNoBodyStatus) {
+    return new Response(Buffer.from(body || '', 'base64'), {
+      status,
       headers,
     })
   }
 
   return new Response(body, {
-    status: result.statusCode ?? 200,
+    status,
     headers,
   })
 }

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -249,7 +249,7 @@ export function legacyResultToResponse(result: LegacyHandlerResult): Response {
   // All 1xx (Informational), 204 (No Content), and 304 (Not Modified) responses do not include content.
   // See: https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4.1-8
   const isNoBodyStatus = status < 200 || status === 204 || status === 304
-  const body = result.body ?? isNoBodyStatus ? null : ''
+  const body = isNoBodyStatus ? null : (result.body ?? '')
 
   if (result.isBase64Encoded && !isNoBodyStatus) {
     return new Response(Buffer.from(body || '', 'base64'), {

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -246,9 +246,12 @@ export function legacyResultToResponse(result: LegacyHandlerResult): Response {
 
   const status = result.statusCode ?? 200
 
-  // All 1xx (Informational), 204 (No Content), and 304 (Not Modified) responses do not include content.
-  // See: https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4.1-8
-  const isNoBodyStatus = status < 200 || status === 204 || status === 304
+  // The `Response` constructor throws a TypeError if a "null body status" is
+  // given a non-null body. Per the WHATWG Fetch spec those statuses are 101,
+  // 103, 204, 205 and 304. The 1xx ones are unreachable here because the same
+  // constructor throws a RangeError for any status outside 200-599.
+  // See: https://fetch.spec.whatwg.org/#null-body-status
+  const isNoBodyStatus = status === 204 || status === 205 || status === 304
   const body = isNoBodyStatus ? null : (result.body ?? '')
 
   if (result.isBase64Encoded && !isNoBodyStatus) {

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -250,7 +250,9 @@ export function legacyResultToResponse(result: LegacyHandlerResult): Response {
   // given a non-null body. Per the WHATWG Fetch spec those statuses are 101,
   // 103, 204, 205 and 304. The 1xx ones are unreachable here because the same
   // constructor throws a RangeError for any status outside 200-599.
-  // See: https://fetch.spec.whatwg.org/#null-body-status
+  // See: https://fetch.spec.whatwg.org/#null-body-status and
+  // https://fetch.spec.whatwg.org/#response-class ('If init["status"] is not in
+  // the range 200 to 599, inclusive, then throw a RangeError.')
   const isNoBodyStatus = status === 204 || status === 205 || status === 304
   const body = isNoBodyStatus ? null : (result.body ?? '')
 


### PR DESCRIPTION
The new `legacyResultToResponse` function defaults to an empty string for response body. If a response status code  204, 205, or 304 the `Response` instantiation will throw an error because the response body must be `null` or `undefined`.

This change accounts for that by selecting the fallback value for `body` based on `result.statusCode`.

(The spec also says the body must be `null` for 1xx status codes, but we can't create `Response` objects for those codes, as the constructor would throw a `RangeError`, see https://fetch.spec.whatwg.org/#response-class)

