### PR TITLE
chore(vite): remove duplicate $api resolve.alias from getMergedConfig

### DIFF
--- a/packages/vite/src/lib/getMergedConfig.ts
+++ b/packages/vite/src/lib/getMergedConfig.ts
@@ -51,11 +51,10 @@ export function getMergedConfig(cedarConfig: Config, cedarPaths: Paths) {
       resolve: {
         alias: {
           ...workspaceAliases,
-          // Resolve $api/ bare specifiers to the API base directory.
-          // When the user's web tsconfig has "$api/*": ["../api/*"], Vite needs
-          // this alias to resolve imports like "from '$api/src/lib/db'" at
-          // build time. Previously handled by babel-plugin-module-resolver.
-          $api: cedarPaths.api.base,
+          // $api/ bare specifiers (e.g. "from '$api/src/lib/db'") are
+          // resolved by cedarjsResolveCedarStyleImportsPlugin, which is
+          // always included alongside this config in cedar()'s plugin list
+          // (see packages/vite/src/index.ts) — no alias needed here too.
           // In test mode, register the virtual module alias so that
           // MockProviders can resolve the user's Routes file
           ...(env.mode === 'test'


### PR DESCRIPTION
## Summary

Follow-up to #2080 / #2138, split out into its own PR since #2138 got merged before this part landed on that branch.

While tracing the actual `$api` resolution mechanism for #2138, I found `packages/vite/src/lib/getMergedConfig.ts` had a native Vite `resolve.alias.$api` entry, wired into `cedar()` via `cedarMergedConfig()` — completely independent of, and redundant with, `cedarjsResolveCedarStyleImportsPlugin`'s own `$api/` handling (`packages/vite/src/plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.ts`). Native `resolve.alias` wins over any plugin's `resolveId`, so the plugin's `$api/` branch was fully dead code whenever it ran inside `cedar()`.

I checked all 5 places `cedarjsResolveCedarStyleImportsPlugin()` is used (`cedar()`, `node-runner.ts`, `upHandlerEsm.ts`, `vite-plugin-cedar-vitest-api-preset.ts`, `exec.ts`) — the other four don't define their own `$api` alias, so the plugin's handling is load-bearing there and must stay. Only the `cedar()` path had the duplicate, because `cedarjsResolveCedarStyleImportsPlugin()` is unconditionally included alongside `cedarMergedConfig()` in the same plugin list. So this PR removes just the duplicate alias entry from `getMergedConfig.ts`, leaving the shared plugin untouched.

## Changes

- **`packages/vite/src/lib/getMergedConfig.ts`** — remove the now-redundant `resolve.alias.$api` entry and its stale comment

## Testing

- Verified with a disable-and-rebuild check against the `cedar-ud-app` fixture: with only the alias removed, `buildCedarApp()` still succeeds (proving `cedarjsResolveCedarStyleImportsPlugin` picks up the slack); with the plugin's `$api/` branch also disabled, the build fails with a genuine Rollup unresolved-import error — confirming the plugin's branch is the one actually doing the work now, not dead code.
- `yarn workspace @cedarjs/vite build` — passes
- `yarn workspace @cedarjs/vite test --run` — 27/27 test files passing (202 passed, 1 skipped, 4 todo)
- `yarn eslint packages/vite/src/lib/getMergedConfig.ts` — clean
