### PR TITLE
fix(git-hooks): stop pre-push lint from racing build's dist output

### DIFF
--- a/tasks/git-hooks/__tests__/tasks.test.mts
+++ b/tasks/git-hooks/__tests__/tasks.test.mts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { runPrePushTasks } from '../tasks.mts'
+
+const callOrder: string[] = []
+let resolveBuild: () => void
+let buildDeferred: Promise<void>
+let buildShouldFail: boolean
+
+vi.mock('../utils.mts', () => ({
+  isOnReleaseBranch: () => false,
+  execAsync: vi.fn((command: string, args: string[]) => {
+    const label = `${command} ${args.join(' ')}`.trim()
+    callOrder.push(label)
+
+    if (command === 'yarn' && args[0] === 'build') {
+      if (buildShouldFail) {
+        const err = new Error('[git-hooks] command exited with status 1')
+        ;(err as Error & { exitCode: number }).exitCode = 1
+        return buildDeferred.then(() => Promise.reject(err))
+      }
+      return buildDeferred
+    }
+
+    return Promise.resolve()
+  }),
+}))
+
+describe('runPrePushTasks', () => {
+  beforeEach(() => {
+    callOrder.length = 0
+    buildShouldFail = false
+    buildDeferred = new Promise<void>((resolve) => {
+      resolveBuild = resolve
+    })
+  })
+
+  it('does not start `yarn lint` until `yarn build` has finished, while everything else starts immediately', async () => {
+    const runPromise = runPrePushTasks()
+
+    // Flush microtasks so every task that *doesn't* wait on build has a
+    // chance to be invoked
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(callOrder).toContain('yarn build')
+    expect(callOrder).toContain('yarn prettier --check .')
+    expect(callOrder).toContain('yarn check')
+    expect(callOrder.some((c) => c.includes('check-no-only.mts'))).toBe(true)
+
+    // The bug this test guards against: lint racing build for packages'
+    // compiled dist/ output (e.g. lint:templates requiring
+    // @cedarjs/babel-config's dist before build has written it)
+    expect(callOrder).not.toContain('yarn lint')
+
+    resolveBuild()
+    await runPromise
+
+    expect(callOrder).toContain('yarn lint')
+    // lint must be recorded after build, since it's only invoked once
+    // build's promise resolves
+    expect(callOrder.indexOf('yarn lint')).toBeGreaterThan(
+      callOrder.indexOf('yarn build'),
+    )
+  })
+
+  it('propagates a build failure as the result, without running lint', async () => {
+    buildShouldFail = true
+
+    const runPromise = runPrePushTasks()
+    resolveBuild()
+
+    const exitCode = await runPromise
+
+    expect(exitCode).toEqual(1)
+    expect(callOrder).not.toContain('yarn lint')
+  })
+})

--- a/tasks/git-hooks/tasks.mts
+++ b/tasks/git-hooks/tasks.mts
@@ -131,9 +131,23 @@ export async function runPrePushTasks(): Promise<number> {
     return 0
   }
 
-  const results = await Promise.allSettled([
-    execAsync('yarn', ['build'], 'git-hooks', { env: { NX_TUI: 'false' } }),
+  const buildPromise = execAsync('yarn', ['build'], 'git-hooks', {
+    env: { NX_TUI: 'false' },
+  })
+
+  // `lint` (via `lint:templates`) needs several packages' compiled `dist/`
+  // output to already exist — the templates' eslint config `require()`s
+  // things like `@cedarjs/babel-config`'s dist. Running it at the same time
+  // as `build` races build's writes and intermittently fails with "Cannot
+  // find module" for a dist file build hasn't produced yet. Everything else
+  // below only reads source files, so it can still run alongside `build`.
+  const lintPromise = buildPromise.then(() =>
     execAsync('yarn', ['lint'], 'git-hooks'),
+  )
+
+  const results = await Promise.allSettled([
+    buildPromise,
+    lintPromise,
     execAsync('yarn', ['prettier', '--check', '.'], 'git-hooks'),
     execAsync('yarn', ['check'], 'git-hooks'),
     execAsync(


### PR DESCRIPTION
## Summary

- `runPrePushTasks()` (`tasks/git-hooks/tasks.mts`) ran `yarn build` and
  `yarn lint` concurrently via `Promise.allSettled`, with no ordering
  between them.
- `lint:templates` lints the `create-cedar-app` templates, whose eslint
  config `require()`s several packages' compiled `dist/` output (e.g.
  `@cedarjs/babel-config`). Nothing guaranteed `build` had finished writing
  that output before `lint` started reading it, so the hook intermittently
  failed with `Cannot find module './api.js'` (or similar) for a dist file
  that just hadn't been written yet — non-deterministically, depending on
  which package `build` happened to finish first.
- `lint` now only starts once `build`'s promise has resolved.
  `prettier --check`, `check`, and `check-no-only` only read source files,
  so they're unaffected and still start immediately alongside `build`,
  preserving most of the parallelism.