### PR TITLE
chore(vite): Don't build ESM-only bin related files for CJS

### DIFF
--- a/packages/vite/build.ts
+++ b/packages/vite/build.ts
@@ -15,13 +15,17 @@ await build({
     ignore: [
       ...defaultIgnorePatterns,
       '**/bundled',
-      // These use `import.meta.url` and are only ever reached through our
-      // ESM-only bins (`cedar-dev-fe`, `cedar-serve-fe`) - never `require()`d.
-      // Skip them here instead of emitting a CJS build with a broken
-      // `import.meta`.
+      // This whole chain is only ever reached through our ESM-only bins
+      // (`cedar-dev-fe`, `cedar-serve-fe`) - never `require()`d. Skip it here
+      // instead of emitting a CJS build with a broken `import.meta` (in
+      // devFeServer.ts, registerFwGlobalsAndShims.ts, streamHelpers.ts) or
+      // dangling requires of those files (in runFeServer.ts,
+      // createReactStreamingHandler.ts).
       'src/devFeServer.ts',
+      'src/runFeServer.ts',
       'src/lib/registerFwGlobalsAndShims.ts',
       'src/streaming/streamHelpers.ts',
+      'src/streaming/createReactStreamingHandler.ts',
     ],
   },
   buildOptions: {

--- a/packages/vite/build.ts
+++ b/packages/vite/build.ts
@@ -12,7 +12,17 @@ import {
 // CJS Build
 await build({
   entryPointOptions: {
-    ignore: [...defaultIgnorePatterns, '**/bundled'],
+    ignore: [
+      ...defaultIgnorePatterns,
+      '**/bundled',
+      // These use `import.meta.url` and are only ever reached through our
+      // ESM-only bins (`cedar-dev-fe`, `cedar-serve-fe`) - never `require()`d.
+      // Skip them here instead of emitting a CJS build with a broken
+      // `import.meta`.
+      'src/devFeServer.ts',
+      'src/lib/registerFwGlobalsAndShims.ts',
+      'src/streaming/streamHelpers.ts',
+    ],
   },
   buildOptions: {
     ...defaultBuildOptions,


### PR DESCRIPTION
Fix these warnings

```
❯ ✅ > nx run @cedarjs/auth-supabase-web:build
  ✅ > nx run storybook-framework-cedarjs:build
  ✅ > nx run @cedarjs/auth-netlify-web:build
  ✅ > nx run @cedarjs/vite:build
    Warning: G] "import.meta" is not available with the "cjs" output format and will be empty [empty-import-meta]
        src/lib/registerFwGlobalsAndShims.ts:147:55:
          147 │ ...alThis.__non_webpack_require__ ||= createRequire(import.meta.url)
              ╵                                                     ~~~~~~~~~~~
      You need to set the output format to "esm" for "import.meta" to work correctly.
    Warning: G] "import.meta" is not available with the "cjs" output format and will be empty [empty-import-meta]
        src/devFeServer.ts:424:46:
          424 │ ... new URL('./rsc/rscRequestHandler.js', import.meta.url).pathname,
              ╵                                           ~~~~~~~~~~~
      You need to set the output format to "esm" for "import.meta" to work correctly.
    Warning: G] "import.meta" is not available with the "cjs" output format and will be empty [empty-import-meta]
        src/streaming/streamHelpers.ts:95:46:
          95 │ ...new URL('../../inject/reactRefresh.js', import.meta.url).pathname,
             ╵                                            ~~~~~~~~~~~
      You need to set the output format to "esm" for "import.meta" to work correctly.
    3 warnings
      dist\cjs\devFeServer.js                               17.1kb
      dist\cjs\apiDevMiddleware.js                          17.0kb
      dist\cjs\plugins\vite-plugin-rsc-transform-server.js  15.5kb
      dist\cjs\buildApp.js                                  13.4kb
      dist\cjs\plugins\vite-plugin-cedar-cjs-compat.js      13.4kb
      ...and 71 more output files...
    Done in 412ms
      dist\devFeServer.js                                 15.1kb
      dist\plugins\vite-plugin-rsc-transform-server.js    13.8kb
      dist\apiDevMiddleware.js                            13.7kb
      dist\plugins\vite-plugin-cedar-cjs-compat.js        11.6kb
      dist\plugins\vite-plugin-cedar-universal-deploy.js  10.7kb
      ...and 71 more output files...
    Done in 182ms
      dist\bundled\react-server-dom-webpack.server.js  412.1kb
    Done in 131ms
    10:39:29 PM - Projects in this build:
        * ../framework-tools/tsconfig.json
        * ../cookie-jar/tsconfig.json
        * ../internal/tsconfig.build.json
        * ../project-config/tsconfig.json
        * ../auth/tsconfig.build.json
        * ../server-store/tsconfig.json
        * ../router/tsconfig.build.json
        * ../testing/tsconfig.build.json
        * ../web/tsconfig.build.json
        * tsconfig.build.json
    10:39:29 PM - Project '../framework-tools/tsconfig.json' is up to date because newest input '../framework-tools/src/attw.ts' is older than output '../framework-tools/tsconfig.tsbuildinfo'
    10:39:29 PM - Project '../cookie-jar/tsconfig.json' is up to date because newest input '../cookie-jar/src/CookieJar.ts' is older than output '../cookie-jar/tsconfig.tsbuildinfo'
```

All the bins that touch streaming (`cedar-dev-fe` → `dist/devFeServer.js`, `cedar-serve-fe` → `dist/runFeServer.js`, `cedar-unified-dev` → `bins/cedar-unified-dev.mjs`) point exclusively at the ESM build — there's no `dist/cjs/...` bin entry anywhere. So streaming support runs as an ESM process regardless of whether the app itself is CJS or ESM; that's why it's safe to drop `devFeServer.ts`/`runFeServer.ts`/`createReactStreamingHandler.ts`/etc. from the CJS build entirely.