### PR TITLE
chore(release): Stage tagging releases

### DIFF
--- a/.github/actions/detect-changes/cases/code_changes.mts
+++ b/.github/actions/detect-changes/cases/code_changes.mts
@@ -37,8 +37,8 @@ function isNonCodeWorkflowOrAction(filePath: string): boolean {
     '.github/actions/check_changesets/package.json',
     '.github/actions/check_changesets/yarn.lock',
 
-    '.github/workflows/publish-canary.yml',
-    '.github/scripts/publish-canary.mts',
+    '.github/workflows/publish-prerelease.yml',
+    '.github/scripts/publish-prerelease.mts',
 
     '.github/workflows/publish-release-candidate.yml',
     '.github/scripts/publish-release-candidate.mts',

--- a/.github/scripts/publish-canary.mts
+++ b/.github/scripts/publish-canary.mts
@@ -1,15 +1,23 @@
 /**
  * Publishes canary (or "next") versions of all public Cedar packages to npm.
  *
+ * Packages are first published in parallel under a unique, run-scoped
+ * staging dist-tag. Only once every package has been published under that
+ * staging tag do we flip each package's dist-tag over to the real "canary"
+ * or "next" tag (also in parallel). This avoids a race where a consumer
+ * (e.g. `yarn cedar upgrade -t canary`) resolves the "canary" tag to a
+ * version that isn't fully published across all packages yet.
+ *
  * Used in the publish-canary.yml GitHub Action workflow.
  *
  * Usage: node .github/scripts/publish-canary.mts
  * Environment variables required: NPM_AUTH_TOKEN, GITHUB_REF_NAME
  */
 
-import { execSync } from 'node:child_process'
+import { exec as execCb, execSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
 interface PackageJson {
   name?: string
@@ -38,6 +46,15 @@ interface NpmTokenEntry {
 
 const REPO_ROOT = process.cwd()
 
+const exec = util.promisify(execCb)
+
+// How many `npm publish` / `npm dist-tag` calls to run concurrently. Publishes
+// upload a tarball so they're heavier; dist-tag flips are cheap metadata
+// calls. Kept modest to avoid tripping npm's registry rate limits.
+const PUBLISH_CONCURRENCY = Number(process.env.CANARY_PUBLISH_CONCURRENCY) || 4
+const DIST_TAG_CONCURRENCY =
+  Number(process.env.CANARY_DIST_TAG_CONCURRENCY) || 8
+
 function log(message: string) {
   console.log(`• ${message}`)
 }
@@ -57,15 +74,95 @@ function execCommand(command: string, cwd: string = REPO_ROOT): string {
   }
 }
 
-function isPackagePublished(packageName: string, version: string): boolean {
-  try {
-    execSync(`npm view ${packageName}@${version} version`, {
-      stdio: 'ignore',
-    })
-    return true
-  } catch {
-    return false
+function getExecErrorDetails(error: unknown): {
+  message: string
+  stderr: string
+} {
+  if (error instanceof Error) {
+    // Node's promisified child_process.exec attaches stdout/stderr to the
+    // rejected error object; they aren't part of the Error type, so we read
+    // them defensively through a narrow local shape.
+    const { stderr } = error as Error & { stderr?: string }
+    return { message: error.message, stderr: stderr ?? '' }
   }
+
+  return { message: String(error), stderr: '' }
+}
+
+async function execCommandAsync(command: string, cwd: string = REPO_ROOT) {
+  try {
+    const { stdout } = await exec(command, { cwd, encoding: 'utf-8' })
+    return stdout.trim()
+  } catch (error) {
+    const { message, stderr } = getExecErrorDetails(error)
+    console.error(`❌ Command failed: ${command}`)
+    if (stderr) {
+      console.error(stderr)
+    } else {
+      console.error(message)
+    }
+    throw error
+  }
+}
+
+const RATE_LIMIT_PATTERN =
+  /\b429\b|too many requests|ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN/i
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  {
+    retries = 5,
+    baseDelayMs = 1500,
+  }: { retries?: number; baseDelayMs?: number } = {},
+): Promise<T> {
+  let attempt = 0
+
+  for (;;) {
+    try {
+      return await fn()
+    } catch (error) {
+      attempt++
+      const { message, stderr } = getExecErrorDetails(error)
+      const isRateLimited = RATE_LIMIT_PATTERN.test(`${message}\n${stderr}`)
+
+      if (!isRateLimited || attempt > retries) {
+        throw error
+      }
+
+      const delay =
+        baseDelayMs * 2 ** (attempt - 1) + Math.floor(Math.random() * 500)
+      log(
+        `  Rate limited, retrying in ${delay}ms (attempt ${attempt}/${retries})...`,
+      )
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+  }
+}
+
+// Runs `worker` over `items` with at most `concurrency` in flight at once.
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<void>,
+) {
+  let nextIndex = 0
+
+  async function runNext(): Promise<void> {
+    let currentIndex = nextIndex
+    nextIndex++
+
+    while (currentIndex < items.length) {
+      await worker(items[currentIndex], currentIndex)
+      currentIndex = nextIndex
+      nextIndex++
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () =>
+      runNext(),
+    ),
+  )
 }
 
 function getWorkspaces(): WorkspaceInfo[] {
@@ -208,8 +305,16 @@ function updateCreateCedarAppTemplates(version: string) {
   }
 }
 
-function publishPackages(workspaces: WorkspaceInfo[], tag: string) {
-  log(`Publishing all packages with tag ${tag}`)
+interface PublishablePackage {
+  workspace: WorkspaceInfo
+  name: string
+  version: string
+}
+
+function getPublishablePackages(
+  workspaces: WorkspaceInfo[],
+): PublishablePackage[] {
+  const publishable: PublishablePackage[] = []
 
   for (const workspace of workspaces) {
     const pkgJsonPath = path.join(REPO_ROOT, workspace.location, 'package.json')
@@ -220,29 +325,98 @@ function publishPackages(workspaces: WorkspaceInfo[], tag: string) {
       continue
     }
 
-    const packageName = pkgJson.name
-    const packageVersion = pkgJson.version
+    const { name, version } = pkgJson
 
-    if (!packageName || !packageVersion) {
+    if (!name || !version) {
       throw new Error(`Missing name or version in ${pkgJsonPath}`)
     }
 
-    log(`Publishing ${packageName}@${packageVersion}...`)
+    publishable.push({ workspace, name, version })
+  }
 
-    if (isPackagePublished(packageName, packageVersion)) {
-      log('  Already published, skipping')
-      continue
-    }
+  return publishable
+}
 
-    execCommand(
-      `npm publish --tag ${tag} --access public`,
-      path.join(REPO_ROOT, workspace.location),
-    )
-    log(`  ✅ Published ${packageName}@${packageVersion}`)
+async function isPackagePublished(
+  packageName: string,
+  version: string,
+): Promise<boolean> {
+  try {
+    await exec(`npm view ${packageName}@${version} version`)
+    return true
+  } catch {
+    return false
   }
 }
 
-function main() {
+// Publishes every public package under a unique, run-scoped staging tag, in
+// parallel (bounded by PUBLISH_CONCURRENCY). Nothing else in the registry
+// references this tag, so partially-completed runs are invisible to
+// consumers watching the real "canary"/"next" tag.
+async function publishPackagesToStagingTag(
+  packages: PublishablePackage[],
+  stagingTag: string,
+): Promise<void> {
+  log(`Publishing ${packages.length} packages under staging tag ${stagingTag}`)
+
+  await runWithConcurrency(packages, PUBLISH_CONCURRENCY, async (pkg) => {
+    const { name, version, workspace } = pkg
+
+    if (await isPackagePublished(name, version)) {
+      log(`  ${name}@${version} already published, skipping`)
+      return
+    }
+
+    await withRetry(() =>
+      execCommandAsync(
+        `npm publish --tag ${stagingTag} --access public`,
+        path.join(REPO_ROOT, workspace.location),
+      ),
+    )
+    log(`  ✅ Published ${name}@${version} (staging tag: ${stagingTag})`)
+  })
+}
+
+// Flips every package's dist-tag from the staging tag over to the real tag,
+// in parallel (bounded by DIST_TAG_CONCURRENCY). This is the point at which
+// the new version becomes visible to anything resolving the "canary"/"next"
+// tag, and it only happens once every package above has published
+// successfully.
+async function flipToFinalTag(
+  packages: PublishablePackage[],
+  finalTag: string,
+): Promise<void> {
+  log(`Flipping ${packages.length} packages to tag ${finalTag}`)
+
+  await runWithConcurrency(packages, DIST_TAG_CONCURRENCY, async (pkg) => {
+    const { name, version } = pkg
+
+    await withRetry(() =>
+      execCommandAsync(`npm dist-tag add ${name}@${version} ${finalTag}`),
+    )
+    log(`  🏷 ${name}@${version} -> ${finalTag}`)
+  })
+}
+
+// Best-effort cleanup of the staging tag now that the final tag points at
+// the same version. Failures here don't affect the published packages, so
+// they're not fatal.
+async function removeStagingTag(
+  packages: PublishablePackage[],
+  stagingTag: string,
+): Promise<void> {
+  log(`Cleaning up staging tag ${stagingTag}`)
+
+  await runWithConcurrency(packages, DIST_TAG_CONCURRENCY, async (pkg) => {
+    try {
+      await execCommandAsync(`npm dist-tag rm ${pkg.name} ${stagingTag}`)
+    } catch {
+      log(`  Could not remove staging tag for ${pkg.name}, ignoring`)
+    }
+  })
+}
+
+async function main() {
   const npmAuthToken = process.env.NPM_AUTH_TOKEN
 
   if (!npmAuthToken) {
@@ -319,17 +493,20 @@ function main() {
     `git commit -am "Update packages and templates to canary version ${canaryVersion}"`,
   )
 
-  // ── Publish all packages ─────────────────────────────────────────────────
+  // ── Publish all packages under a staging tag, then flip to the real tag ──
 
-  publishPackages(workspaces, tag)
+  const packages = getPublishablePackages(workspaces)
+  const stagingTag = `staging-${process.env.GITHUB_RUN_ID ?? Date.now()}`
+
+  await publishPackagesToStagingTag(packages, stagingTag)
+  await flipToFinalTag(packages, tag)
+  await removeStagingTag(packages, stagingTag)
 
   log('✅ Canary publishing completed successfully!')
 }
 
-try {
-  main()
-} catch (error) {
+main().catch((error) => {
   console.error('❌ Canary publishing failed:')
   console.error(error)
   process.exit(1)
-}
+})

--- a/.github/scripts/publish-prerelease.mts
+++ b/.github/scripts/publish-prerelease.mts
@@ -51,9 +51,8 @@ const exec = util.promisify(execCb)
 // How many `npm publish` / `npm dist-tag` calls to run concurrently. Publishes
 // upload a tarball so they're heavier; dist-tag flips are cheap metadata
 // calls. Kept modest to avoid tripping npm's registry rate limits.
-const PUBLISH_CONCURRENCY = Number(process.env.CANARY_PUBLISH_CONCURRENCY) || 4
-const DIST_TAG_CONCURRENCY =
-  Number(process.env.CANARY_DIST_TAG_CONCURRENCY) || 8
+const PUBLISH_CONCURRENCY = 4
+const DIST_TAG_CONCURRENCY = 8
 
 function log(message: string) {
   console.log(`• ${message}`)
@@ -105,8 +104,11 @@ async function execCommandAsync(command: string, cwd: string = REPO_ROOT) {
   }
 }
 
-const RATE_LIMIT_PATTERN =
-  /\b429\b|too many requests|ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN/i
+// Matches rate-limiting and other transient/network errors from npm — as
+// opposed to a definitive rejection like "404 not found" or "cannot publish
+// over previously published version", which retrying won't fix.
+const TRANSIENT_NPM_ERROR_PATTERN =
+  /\b(429|5\d\d)\b|too many requests|ETIMEDOUT|ECONNRESET|ENOTFOUND|EAI_AGAIN/i
 
 async function withRetry<T>(
   fn: () => Promise<T>,
@@ -123,16 +125,18 @@ async function withRetry<T>(
     } catch (error) {
       attempt++
       const { message, stderr } = getExecErrorDetails(error)
-      const isRateLimited = RATE_LIMIT_PATTERN.test(`${message}\n${stderr}`)
+      const isTransient = TRANSIENT_NPM_ERROR_PATTERN.test(
+        `${message}\n${stderr}`,
+      )
 
-      if (!isRateLimited || attempt > retries) {
+      if (!isTransient || attempt > retries) {
         throw error
       }
 
       const delay =
         baseDelayMs * 2 ** (attempt - 1) + Math.floor(Math.random() * 500)
       log(
-        `  Rate limited, retrying in ${delay}ms (attempt ${attempt}/${retries})...`,
+        `  Transient npm error, retrying in ${delay}ms (attempt ${attempt}/${retries})...`,
       )
       await new Promise((resolve) => setTimeout(resolve, delay))
     }
@@ -342,9 +346,19 @@ async function isPackagePublished(
   version: string,
 ): Promise<boolean> {
   try {
-    await exec(`npm view ${packageName}@${version} version`)
+    await withRetry(() => exec(`npm view ${packageName}@${version} version`))
     return true
-  } catch {
+  } catch (error) {
+    const { message, stderr } = getExecErrorDetails(error)
+
+    // A transient error (rate limit, timeout, 5xx) here doesn't mean the
+    // version is unpublished — treating it as "not published" would trigger
+    // a duplicate `npm publish` that fails with a confusing error instead of
+    // the real, transient one.
+    if (TRANSIENT_NPM_ERROR_PATTERN.test(`${message}\n${stderr}`)) {
+      throw error
+    }
+
     return false
   }
 }
@@ -377,24 +391,96 @@ async function publishPackagesToStagingTag(
   })
 }
 
+// Best-effort lookup of what a tag currently points to for a package, used to
+// roll back a partially-completed flip. Returns null if the package/tag has
+// no prior version (e.g. a brand new package), or if the lookup itself fails.
+async function getCurrentTagVersion(
+  packageName: string,
+  tagName: string,
+): Promise<string | null> {
+  try {
+    const { stdout } = await exec(
+      `npm view ${packageName} dist-tags.${tagName}`,
+    )
+    return stdout.trim() || null
+  } catch {
+    return null
+  }
+}
+
 // Flips every package's dist-tag from the staging tag over to the real tag,
 // in parallel (bounded by DIST_TAG_CONCURRENCY). This is the point at which
 // the new version becomes visible to anything resolving the "canary"/"next"
 // tag, and it only happens once every package above has published
 // successfully.
+//
+// npm has no cross-package transaction, so this can't be made fully atomic:
+// if one package's flip fails after retries (or the job is cancelled
+// mid-flight), some packages will already point at the new version. To avoid
+// leaving that new/old mix in place, a failure here rolls the
+// already-flipped packages back to whatever version the tag pointed to
+// before this run — converging back to a single consistent (if outdated)
+// state rather than a partial one.
 async function flipToFinalTag(
   packages: PublishablePackage[],
   finalTag: string,
 ): Promise<void> {
   log(`Flipping ${packages.length} packages to tag ${finalTag}`)
 
-  await runWithConcurrency(packages, DIST_TAG_CONCURRENCY, async (pkg) => {
-    const { name, version } = pkg
+  const previousVersions = new Map<string, string | null>()
+  const flipped: PublishablePackage[] = []
 
-    await withRetry(() =>
-      execCommandAsync(`npm dist-tag add ${name}@${version} ${finalTag}`),
+  try {
+    await runWithConcurrency(packages, DIST_TAG_CONCURRENCY, async (pkg) => {
+      const { name, version } = pkg
+
+      previousVersions.set(name, await getCurrentTagVersion(name, finalTag))
+
+      await withRetry(() =>
+        execCommandAsync(`npm dist-tag add ${name}@${version} ${finalTag}`),
+      )
+      flipped.push(pkg)
+      log(`  🏷 ${name}@${version} -> ${finalTag}`)
+    })
+  } catch (error) {
+    console.error(
+      `❌ Flipping to ${finalTag} failed after ${flipped.length}/` +
+        `${packages.length} packages succeeded. Rolling back the ones that ` +
+        `already flipped so the registry doesn't end up in a mixed-version ` +
+        `state.`,
     )
-    log(`  🏷 ${name}@${version} -> ${finalTag}`)
+    await rollBackFlips(flipped, finalTag, previousVersions)
+    throw error
+  }
+}
+
+async function rollBackFlips(
+  flipped: PublishablePackage[],
+  finalTag: string,
+  previousVersions: Map<string, string | null>,
+): Promise<void> {
+  await runWithConcurrency(flipped, DIST_TAG_CONCURRENCY, async (pkg) => {
+    const previousVersion = previousVersions.get(pkg.name)
+
+    if (!previousVersion) {
+      console.error(
+        `  ⚠️ No previous version recorded for ${pkg.name} — leaving it on ` +
+          `${finalTag} = ${pkg.version}. Manual check required.`,
+      )
+      return
+    }
+
+    try {
+      await execCommandAsync(
+        `npm dist-tag add ${pkg.name}@${previousVersion} ${finalTag}`,
+      )
+      log(`  ↩️ Rolled back ${pkg.name} to ${previousVersion}`)
+    } catch {
+      console.error(
+        `  ⚠️ Failed to roll back ${pkg.name} — it is still pointing at ` +
+          `${finalTag} = ${pkg.version}. Manual intervention required.`,
+      )
+    }
   })
 }
 

--- a/.github/scripts/publish-prerelease.mts
+++ b/.github/scripts/publish-prerelease.mts
@@ -1,16 +1,16 @@
 /**
  * Publishes canary (or "next") versions of all public Cedar packages to npm.
  *
- * Packages are first published in parallel under a unique, run-scoped
- * staging dist-tag. Only once every package has been published under that
- * staging tag do we flip each package's dist-tag over to the real "canary"
- * or "next" tag (also in parallel). This avoids a race where a consumer
- * (e.g. `yarn cedar upgrade -t canary`) resolves the "canary" tag to a
- * version that isn't fully published across all packages yet.
+ * Packages are first published in parallel under a staging dist-tag unique
+ * to the version being published. Only once every package has been published
+ * under that staging tag do we flip each package's dist-tag over to the real
+ * "canary" or "next" tag (also in parallel). This avoids a race where a
+ * consumer (e.g. `yarn cedar upgrade -t canary`) resolves the "canary" tag to
+ * a version that isn't fully published across all packages yet.
  *
- * Used in the publish-canary.yml GitHub Action workflow.
+ * Used in the publish-prerelease.yml GitHub Action workflow.
  *
- * Usage: node .github/scripts/publish-canary.mts
+ * Usage: node .github/scripts/publish-prerelease.mts
  * Environment variables required: NPM_AUTH_TOKEN, GITHUB_REF_NAME
  */
 
@@ -349,10 +349,10 @@ async function isPackagePublished(
   }
 }
 
-// Publishes every public package under a unique, run-scoped staging tag, in
-// parallel (bounded by PUBLISH_CONCURRENCY). Nothing else in the registry
-// references this tag, so partially-completed runs are invisible to
-// consumers watching the real "canary"/"next" tag.
+// Publishes every public package under a staging tag unique to the version
+// being published, in parallel (bounded by PUBLISH_CONCURRENCY). Nothing else
+// in the registry references this tag, so partially-completed runs are
+// invisible to consumers watching the real "canary"/"next" tag.
 async function publishPackagesToStagingTag(
   packages: PublishablePackage[],
   stagingTag: string,
@@ -496,7 +496,7 @@ async function main() {
   // ── Publish all packages under a staging tag, then flip to the real tag ──
 
   const packages = getPublishablePackages(workspaces)
-  const stagingTag = `staging-${process.env.GITHUB_RUN_ID ?? Date.now()}`
+  const stagingTag = `staging-${canaryVersion}`
 
   await publishPackagesToStagingTag(packages, stagingTag)
   await flipToFinalTag(packages, tag)

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,4 +1,4 @@
-name: 🦜 Publish Canary
+name: 🦜 Publish Prerelease
 
 on:
   push:
@@ -19,8 +19,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  publish-canary:
-    name: 🦜 Publish Canary
+  publish-prerelease:
+    name: 🦜 Publish Prerelease
     if: github.repository == 'cedarjs/cedar'
     runs-on: ubuntu-latest
     outputs:
@@ -45,7 +45,7 @@ jobs:
         run: yarn test
 
       - name: 🚢 Publish
-        run: node .github/scripts/publish-canary.mts
+        run: node .github/scripts/publish-prerelease.mts
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 

--- a/docs/implementation-plans/flaky-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-smoke-tests-investigation.md
@@ -1336,7 +1336,8 @@ needs the separate `afterEach`/esbuild hardening from the 2026-06-26 UD entry.
 The "Caveats" section above (2026-07-17 survey) flagged `canary-registry
 ETARGET` / no-candidates as an unclassified environmental infra failure,
 counted as REAL rather than attributed to a known flaky signature. Root cause:
-`.github/scripts/publish-canary.mts` published packages to the `canary`/`next`
+`.github/scripts/publish-prerelease.mts` (then named `publish-canary.sh`)
+published packages to the `canary`/`next`
 npm dist-tag **one package at a time**. Any CI job that upgraded to canary
 (`yarn cedar upgrade -t canary`, `create-cedar-app@canary`, etc.) while a
 publish run was mid-loop could resolve the dist-tag to a version for which
@@ -1346,12 +1347,12 @@ test.
 
 ### How (fix)
 
-`publish-canary.mts` now publishes in two phases instead of moving the real
-tag as it goes:
+`publish-prerelease.mts` now publishes in two phases instead of moving the
+real tag as it goes:
 
 1. **Stage**: every public package is published in parallel (bounded
-   concurrency, default 4) under a unique, run-scoped staging tag
-   (`staging-<GITHUB_RUN_ID>`). Nothing resolves this tag, so a
+   concurrency, default 4) under a staging tag unique to the version being
+   published (`staging-<version>`). Nothing resolves this tag, so a
    partially-complete run is invisible to consumers watching `canary`/`next`.
 2. **Flip**: only once every package has published successfully does the
    script move the real `canary`/`next` dist-tag onto that version for every
@@ -1366,8 +1367,12 @@ within npm registry rate limits despite the added parallelism.
 
 ### Changed files
 
-- `.github/scripts/publish-canary.mts` — staged publish + dist-tag flip,
-  bounded concurrency, retry with backoff.
+- `.github/scripts/publish-prerelease.mts` (renamed from `publish-canary.mts`
+  — it publishes both the `canary` and `next` tags) — staged publish +
+  dist-tag flip, bounded concurrency, retry with backoff.
+- `.github/workflows/publish-prerelease.yml` (renamed from
+  `publish-canary.yml`) — same rename rationale, job id renamed
+  `publish-canary` -> `publish-prerelease`.
 
 ### Not yet validated
 

--- a/docs/implementation-plans/flaky-smoke-tests-investigation.md
+++ b/docs/implementation-plans/flaky-smoke-tests-investigation.md
@@ -1328,3 +1328,54 @@ signature-A surfaces use different entry points and a more tangled launch path:
 Note: signature D (Ubuntu esbuild `"service is no longer running"` in UD /
 E2E-node tests) is **not** a Maglev crash and is unaffected by `--no-maglev` — it
 needs the separate `afterEach`/esbuild hardening from the 2026-06-26 UD entry.
+
+## Update 2026-07-21 — Root cause identified and fixed: canary-registry `ETARGET` / no-candidates
+
+### What
+
+The "Caveats" section above (2026-07-17 survey) flagged `canary-registry
+ETARGET` / no-candidates as an unclassified environmental infra failure,
+counted as REAL rather than attributed to a known flaky signature. Root cause:
+`.github/scripts/publish-canary.mts` published packages to the `canary`/`next`
+npm dist-tag **one package at a time**. Any CI job that upgraded to canary
+(`yarn cedar upgrade -t canary`, `create-cedar-app@canary`, etc.) while a
+publish run was mid-loop could resolve the dist-tag to a version for which
+some sibling packages hadn't been published yet — an install-time `ETARGET`
+("no candidates found") failure that had nothing to do with the code under
+test.
+
+### How (fix)
+
+`publish-canary.mts` now publishes in two phases instead of moving the real
+tag as it goes:
+
+1. **Stage**: every public package is published in parallel (bounded
+   concurrency, default 4) under a unique, run-scoped staging tag
+   (`staging-<GITHUB_RUN_ID>`). Nothing resolves this tag, so a
+   partially-complete run is invisible to consumers watching `canary`/`next`.
+2. **Flip**: only once every package has published successfully does the
+   script move the real `canary`/`next` dist-tag onto that version for every
+   package, in parallel (bounded concurrency, default 8). This is the single
+   point where the new version becomes visible — and it's atomic-ish across
+   packages instead of trickling in one at a time.
+3. **Cleanup**: the staging tag is removed afterward (best-effort, non-fatal).
+
+Both the publish and dist-tag-flip steps retry with exponential backoff +
+jitter on rate-limit-shaped errors (429, timeouts, connection resets), to stay
+within npm registry rate limits despite the added parallelism.
+
+### Changed files
+
+- `.github/scripts/publish-canary.mts` — staged publish + dist-tag flip,
+  bounded concurrency, retry with backoff.
+
+### Not yet validated
+
+Verified via `tsc`, `eslint`, and `prettier` locally. Needs a real canary
+publish run on `next` (or `main`) to confirm the staged publish + flip behaves
+correctly against the live npm registry, and a following CI run that upgrades
+to canary to confirm the race is gone.
+
+### Reference
+
+PR: https://github.com/cedarjs/cedar/pull/2147

--- a/docs/implementation-plans/release-tooling_unify-version-bumping.md
+++ b/docs/implementation-plans/release-tooling_unify-version-bumping.md
@@ -25,7 +25,7 @@ What it misses:
 - Database overlays (2 directories under `database-overlays/`)
 - Peer deps in `api-server`, `storybook`, `storybook-vite`
 
-### 2. `.github/scripts/publish-canary.mts`
+### 2. `.github/scripts/publish-prerelease.mts`
 
 Does everything inline with Node.js. Covers:
 
@@ -104,7 +104,7 @@ deps) so it covers everything listed above.
 Accept a version argument (already does). Strip optional `v` prefix (already
 does).
 
-### Step 2 — Update `publish-canary.mts`
+### Step 2 — Update `publish-prerelease.mts`
 
 Replace the three inline update blocks (version, workspace deps, template deps)
 with a single call:


### PR DESCRIPTION
The `publish-canary.mts` script now first publishes all packages to npm under a temporary tag. And then once all are published, it flips the temporary tag to `canary`. That way the multi-minute publish flow doesn't leave the registry in a state where half of the `canary` packages point to the new version and the other half to some older version while all packages get published. Now that multi-version window is just a few seconds while the tags flip.