### PR TITLE
feat(babel)!: Guard babel config behind reactCompiler flag

### DIFF
--- a/.changesets/2150.md
+++ b/.changesets/2150.md
@@ -1,3 +1,0 @@
-- fix(vite): guard babel config behind reactCompiler flag (#2150)
-
-Babel config is now only passed to Vite's React plugin when the React Compiler is explicitly enabled (and not in lintOnly mode). When the compiler is off, an empty config is used — users who need custom Babel transforms must wire them up directly in their Vite config.

--- a/.changesets/2150.md
+++ b/.changesets/2150.md
@@ -1,0 +1,3 @@
+- fix(vite): guard babel config behind reactCompiler flag (#2150)
+
+Babel config is now only passed to Vite's React plugin when the React Compiler is explicitly enabled (and not in lintOnly mode). When the compiler is off, an empty config is used — users who need custom Babel transforms must wire them up directly in their Vite config.

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -74,13 +74,16 @@ export function cedar({ mode }: PluginOptions = {}): PluginOption[] {
 
   const rscEnabled = cedarConfig.experimental?.rsc?.enabled
 
-  const webSideDefaultBabelConfig = getWebSideDefaultBabelConfig({
-    forVite: true,
-  })
+  // React compiler is only enabled if explicitly set AND lintOnly is false.
+  // Only provide the Babel config when the compiler is active; otherwise use
+  // an empty config so users must wire up Babel themselves in their Vite config.
+  const reactCompilerEnabled =
+    cedarConfig.experimental?.reactCompiler?.enabled &&
+    cedarConfig.experimental?.reactCompiler?.lintOnly === false
 
-  const babelConfig = {
-    ...webSideDefaultBabelConfig,
-  }
+  const babelConfig = reactCompilerEnabled
+    ? getWebSideDefaultBabelConfig({ forVite: true })
+    : {}
 
   return [
     tsconfigPaths(),

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react'
+import type { BabelOptions } from '@vitejs/plugin-react'
 import type { PluginOption } from 'vite'
 import { gqlPlugin as gqlTagPlugin } from 'vite-plugin-graphql-tag'
 import tsPathsMod from 'vite-tsconfig-paths'
@@ -12,7 +13,6 @@ const tsconfigPaths =
   // interop
   tsPathsMod.default?.default || tsPathsMod.default || tsPathsMod
 
-import { getWebSideDefaultBabelConfig } from '@cedarjs/babel-config'
 import { getConfig } from '@cedarjs/project-config'
 import {
   autoImportsPlugin,
@@ -64,26 +64,30 @@ export { cedarWaitForApiServer } from './plugins/vite-plugin-cedar-wait-for-api-
 
 type PluginOptions = {
   mode?: string | undefined
+  babel?: BabelOptions | undefined
 }
 
 /**
  * Pre-configured vite plugin, with required config for CedarJS apps.
  */
-export function cedar({ mode }: PluginOptions = {}): PluginOption[] {
+export function cedar({ mode, babel }: PluginOptions = {}): PluginOption[] {
   const cedarConfig = getConfig()
 
   const rscEnabled = cedarConfig.experimental?.rsc?.enabled
 
-  // React compiler is only enabled if explicitly set AND lintOnly is false.
-  // Only provide the Babel config when the compiler is active; otherwise use
-  // an empty config so users must wire up Babel themselves in their Vite config.
   const reactCompilerEnabled =
     cedarConfig.experimental?.reactCompiler?.enabled &&
     cedarConfig.experimental?.reactCompiler?.lintOnly === false
 
-  const babelConfig = reactCompilerEnabled
-    ? getWebSideDefaultBabelConfig({ forVite: true })
-    : {}
+  const babelConfig: BabelOptions | undefined =
+    reactCompilerEnabled || babel
+      ? {
+          ...(reactCompilerEnabled && {
+            plugins: [['babel-plugin-react-compiler', { target: '19' }]],
+          }),
+          ...babel,
+        }
+      : undefined
 
   return [
     tsconfigPaths(),


### PR DESCRIPTION
Fixes #2080.

Changes:
- Only include `babel-plugin-react-compiler` when the React Compiler is active (no longer pulls in the entire default Babel config)
- Exposes a `babel` option on `cedar()` so users can pass custom Babel config if needed:
  ```ts
  cedar({ babel: { plugins: ['my-babel-plugin'] } })
  ```
- User-provided `babel` config is merged with the compiler plugin (if active), so both can coexist