### PR TITLE
Fix pnpm smoke tests by allowing msw transformation

### DIFF
--- a/.changesets/2151.md
+++ b/.changesets/2151.md
@@ -1,0 +1,3 @@
+- fix(testing): allow msw transformation in pnpm virtual store (#2151)
+
+Fixed pnpm smoke test failures by updating Jest's transformIgnorePatterns to allow msw (resolved to TypeScript source in pnpm virtual store) to be transformed by Babel.

--- a/packages/testing/src/config/jest/web/jest-preset.ts
+++ b/packages/testing/src/config/jest/web/jest-preset.ts
@@ -114,9 +114,14 @@ const config: Config = {
   },
   // Jest's default is to not transform anything in node_modules, but `.mjs`
   // files (and until-async) have to be compiled to CommonJS (see the
-  // transform above)
+  // transform above). With pnpm, msw is resolved to TypeScript source files
+  // in the virtual store, so we need to allow transformation for msw.
   transformIgnorePatterns: [
+    // Standard node_modules, but allow .mjs and until-async
     '[/\\\\]node_modules[/\\\\](?!.*\\.mjs$)(?!until-async[/\\\\])',
+    // pnpm virtual store, but allow msw (resolved to TS source)
+    '[/\\\\]node_modules[/\\\\]\\.pnpm[/\\\\](?!msw@)',
+    // yarn PnP
     '\\.pnp\\.[^\\\\/]+$',
   ],
   resolver: path.resolve(__dirname, './resolver.js'),


### PR DESCRIPTION
## Summary

Fixes #2148 — pnpm smoke tests failing due to Jest unable to parse msw's TypeScript source files.

## Problem

When pnpm installs msw, it resolves imports to TypeScript source files in the virtual store (`node_modules/.pnpm/msw@.../`), but Jest's `transformIgnorePatterns` was excluding these from Babel transformation. This caused Jest to fail with "Unexpected token 'export'" errors.

This issue has caused **30+ consecutive daily test failures** since at least June 22, 2026.

## Solution

Updated `transformIgnorePatterns` in the Jest web preset to allow msw to be transformed when found in pnpm's virtual store directory. The new pattern `[/\\]node_modules[/\\]\.pnpm[/\\](?!msw@)` specifically excludes packages in the virtual store from transformation **except** for msw.

## Testing

The fix should resolve all pnpm smoke test failures without affecting yarn smoke tests (which already pass).

Related issue: #2148

🤖 Generated with [Claude Code](https://claude.com/claude-code)