### PR TITLE
chore(vite): remove dead getApiSideBabelPlugins calls

### DIFF
--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -21,10 +21,7 @@ const tsconfigPaths =
 
 import { buildCedarContext, wrapLegacyHandler } from '@cedarjs/api/runtime'
 import type { CedarHandler, LegacyHandler } from '@cedarjs/api/runtime'
-import {
-  getApiSideBabelPlugins,
-  transformWithBabel,
-} from '@cedarjs/babel-config'
+import { transformWithBabel } from '@cedarjs/babel-config'
 import { getAsyncStoreInstance } from '@cedarjs/context/dist/store'
 import { createGraphQLYoga } from '@cedarjs/graphql-server'
 import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
@@ -202,11 +199,6 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
   const isEsm = projectSideIsEsm('api')
   const normalizedBase = normalizePath(cedarPaths.base)
 
-  const babelPlugins = getApiSideBabelPlugins({
-    forVite: true,
-    projectIsEsm: isEsm,
-  })
-
   const workspacePkgSourceMap = Object.fromEntries(
     Object.entries(getWorkspacePackageAliases(cedarPaths, cedarConfig)).map(
       ([name, sourceFile]) => [name, normalizePath(sourceFile)],
@@ -314,7 +306,7 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
             const result = await transformWithBabel(
               sourceCode,
               id,
-              babelPlugins,
+              [],
               true,
               true,
             )

--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -17,10 +17,7 @@ const tsconfigPaths =
   // interop
   tsPathsMod.default?.default || tsPathsMod.default || tsPathsMod
 
-import {
-  getApiSideBabelPlugins,
-  transformWithBabel,
-} from '@cedarjs/babel-config'
+import { transformWithBabel } from '@cedarjs/babel-config'
 import {
   applyEsmExtensions,
   applySrcAlias,
@@ -158,13 +155,6 @@ export async function buildCedarApp({
       }
     }
   }
-
-  const babelPlugins = workspace.includes('api')
-    ? getApiSideBabelPlugins({
-        forVite: true,
-        projectIsEsm: projectSideIsEsm('api'),
-      })
-    : null
 
   const workspacePkgSourceMap = workspace.includes('api')
     ? Object.fromEntries(
@@ -382,7 +372,7 @@ export async function buildCedarApp({
 
   plugins.push(cedarMockCellDataPlugin())
 
-  if (babelPlugins) {
+  if (workspace.includes('api')) {
     plugins.push({
       name: 'cedar-vite-api-babel-transform',
       enforce: 'pre',
@@ -402,14 +392,13 @@ export async function buildCedarApp({
         const transformedCode = await transformWithBabel(
           code,
           id,
-          babelPlugins,
+          [],
           true,
           true,
         )
 
         if (transformedCode?.code) {
-          // babel-plugin-module-resolver is excluded for forVite:true builds
-          // (it is gated on !forVite in getApiSideBabelPlugins).  That plugin
+          // babel-plugin-module-resolver is not used in Vite builds. That plugin
           // previously rewrote `src/` bare specifiers to relative paths so
           // that Rollup's `external` function (which marks anything that is
           // not relative or absolute as external) would not capture them.


### PR DESCRIPTION
`getApiSideBabelPlugins({ forVite: true })` always returns `[]` — every plugin in that function is guarded by `!forVite`. The calls in `buildApp.ts` and `apiDevMiddleware.ts` were passing an empty array to `transformWithBabel`, which is a no-op.

Changes:
- Remove `getApiSideBabelPlugins` import and call from both files
- Replace `if (babelPlugins)` gate in `buildApp.ts` with `if (workspace.includes("api"))` (which was the only case that was truthy anyway)
- Pass `[]` directly to `transformWithBabel` (its internal `getApiSideDefaultBabelConfig` still provides TypeScript preset support)
- Update stale comment that referenced the removed function