### PR TITLE
fix(testing): resolve jest moduleNameMapper paths instead of assuming hoisting

### DIFF
--- a/packages/testing/src/config/jest/api/jest-preset.ts
+++ b/packages/testing/src/config/jest/api/jest-preset.ts
@@ -6,8 +6,33 @@ import { getApiSideDefaultBabelConfig } from '@cedarjs/babel-config'
 import { getPaths } from '@cedarjs/project-config'
 
 const rwjsPaths = getPaths()
-const NODE_MODULES_PATH = path.join(rwjsPaths.base, 'node_modules')
 const { babelrc } = getApiSideDefaultBabelConfig({ forJest: true })
+
+/**
+ * Resolve a specifier through the package's `exports` map.
+ *
+ * This mapping used to be built by joining onto `<project>/node_modules`, which
+ * assumes every package is hoisted to one directory at the project root. yarn
+ * and npm hoist, but pnpm nests, so that path often doesn't exist and the
+ * mapping pointed at nothing. Resolving works under all three, and doesn't
+ * require a `node_modules` directory to exist at all — which is what Yarn PnP
+ * needs.
+ *
+ * Returns undefined when the package isn't installed or doesn't export the
+ * subpath, in which case we drop the mapping and let Jest resolve the import
+ * normally. That beats pointing it at a path that isn't there.
+ */
+function resolveSubpath(specifier: string): string | undefined {
+  try {
+    return require.resolve(specifier, {
+      paths: [rwjsPaths.api.base, rwjsPaths.base],
+    })
+  } catch {
+    return undefined
+  }
+}
+
+const testingApiPath = resolveSubpath('@cedarjs/testing/api')
 
 const config: Config = {
   // To make sure other config option which depends on rootDir use
@@ -49,7 +74,7 @@ const config: Config = {
     '^src/(.*)$': path.join(rwjsPaths.api.src, '$1'),
     // @NOTE: Import @cedarjs/testing in api tests, and it automatically remaps to the api side only
     // This is to prevent web stuff leaking into api, and vice versa
-    '^@cedarjs/testing$': path.join(NODE_MODULES_PATH, '@cedarjs/testing/api'),
+    ...(testingApiPath ? { '^@cedarjs/testing$': testingApiPath } : {}),
     // Support for importing files with extensions (like you'd do in ESM projects)
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },

--- a/packages/testing/src/config/jest/web/jest-preset.ts
+++ b/packages/testing/src/config/jest/web/jest-preset.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import type { Config } from 'jest'
@@ -5,7 +6,129 @@ import type { Config } from 'jest'
 import { getPaths } from '@cedarjs/project-config'
 
 const cedarPaths = getPaths()
-const NODE_MODULES_PATH = path.join(cedarPaths.base, 'node_modules')
+
+// Where to resolve the packages below from. The web side first, because that's
+// where a web test's dependencies are declared, then the project root for
+// things only the root depends on (`@cedarjs/testing`). Node walks up from
+// each of these, so this covers yarn/npm's hoisted layout too
+const RESOLVE_FROM = [cedarPaths.web.base, cedarPaths.base]
+
+/**
+ * Find the directory a package was installed into.
+ *
+ * These mappings used to be built by joining paths onto
+ * `<project>/node_modules`, which assumes every package is hoisted to a single
+ * directory at the project root. yarn and npm do hoist, but pnpm nests: `react`
+ * lives in `web/node_modules/react`, and the project root only holds what the
+ * root package.json itself depends on. So those mappings pointed at paths that
+ * don't exist and every web test failed to run under pnpm.
+ *
+ * Resolving instead of assuming works under all three, and doesn't require a
+ * `node_modules` directory to exist at all — which is what Yarn PnP needs.
+ *
+ * Returns undefined if the package isn't installed, in which case the caller
+ * should drop the mapping and let Jest resolve the import normally. That's
+ * always better than mapping it to a path that isn't there.
+ */
+function resolvePackageDir(
+  packageName: string,
+  resolveFrom: string[] = RESOLVE_FROM,
+): string | undefined {
+  try {
+    // Most packages expose ./package.json, and it's the cheapest way to the
+    // package root
+    return path.dirname(
+      require.resolve(`${packageName}/package.json`, { paths: resolveFrom }),
+    )
+  } catch {
+    // Not exposed through the package's `exports` map — fall through
+  }
+
+  try {
+    let dir = path.dirname(require.resolve(packageName, { paths: resolveFrom }))
+
+    // Walk up from the entry point until we find the package's own manifest
+    for (;;) {
+      const manifestPath = path.join(dir, 'package.json')
+
+      if (fs.existsSync(manifestPath)) {
+        const manifest: unknown = JSON.parse(
+          fs.readFileSync(manifestPath, 'utf-8'),
+        )
+
+        if (
+          manifest &&
+          typeof manifest === 'object' &&
+          'name' in manifest &&
+          manifest.name === packageName
+        ) {
+          return dir
+        }
+      }
+
+      const parent = path.dirname(dir)
+
+      if (parent === dir) {
+        return undefined
+      }
+
+      dir = parent
+    }
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Path to a file (or subdirectory) inside an installed package. Deliberately
+ * resolves the package root and then joins, rather than resolving the subpath
+ * directly, so that an `exports` map can't block or redirect it — the mapping
+ * that uses this points at internal build output the package doesn't export.
+ */
+function packagePath(
+  packageName: string,
+  relativePath = '',
+  resolveFrom: string[] = RESOLVE_FROM,
+) {
+  const packageDir = resolvePackageDir(packageName, resolveFrom)
+
+  return packageDir && path.join(packageDir, relativePath)
+}
+
+/**
+ * Resolve a specifier through the package's `exports` map, which is how the
+ * rest of the world imports it. Preferred over `packagePath` wherever the
+ * package exports what we need: it doesn't hard-code the package's internal
+ * build layout, and the `require` condition gets us the CJS build Jest wants.
+ *
+ * Returns undefined when the package isn't installed or doesn't export the
+ * subpath, in which case the caller drops the mapping.
+ */
+function resolveSubpath(
+  specifier: string,
+  resolveFrom: string[] = RESOLVE_FROM,
+): string | undefined {
+  try {
+    return require.resolve(specifier, { paths: resolveFrom })
+  } catch {
+    return undefined
+  }
+}
+
+// `@cedarjs/web`'s own directory, so its dependencies can be resolved the way
+// it would resolve them. Falls back to the normal list if it isn't installed
+const cedarWebDir = resolvePackageDir('@cedarjs/web')
+const cedarWebResolveFrom = cedarWebDir
+  ? [cedarWebDir, ...RESOLVE_FROM]
+  : RESOLVE_FROM
+
+function definedEntries(mappings: Record<string, string | undefined>) {
+  return Object.fromEntries(
+    Object.entries(mappings).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  )
+}
 
 const config: Config = {
   // To make sure other config option which depends on rootDir always
@@ -43,45 +166,44 @@ const config: Config = {
   ],
   setupFilesAfterEnv: [path.resolve(__dirname, './jest.setup.js')],
   moduleNameMapper: {
-    /**
-     * Make sure modules that require different versions of these
-     * dependencies end up using the same one.
-     */
-    '^react$': path.join(NODE_MODULES_PATH, 'react'),
-    '^react-dom$': path.join(NODE_MODULES_PATH, 'react-dom'),
-    // Point straight at Apollo Client's CJS build. Mapping to the package
-    // directory would bypass its `exports` map and land on the ESM build,
-    // and `require.resolve` can't be used either because Node 22+ resolves
-    // it through the `module-sync` condition (also ESM) – both of which Jest
-    // can't parse
-    '^@apollo/client/react$': path.join(
-      NODE_MODULES_PATH,
-      '@apollo/client/__cjs/react/index.cjs',
-    ),
-    // We replace imports to "@cedarjs/router" with our own "mock" implementation.
-    '^@cedarjs/router$': path.join(
-      NODE_MODULES_PATH,
-      '@cedarjs/testing/dist/cjs/web/MockRouter.js',
-    ),
-    '^@cedarjs/web$': path.join(NODE_MODULES_PATH, '@cedarjs/web/dist/cjs'),
+    ...definedEntries({
+      /**
+       * Make sure modules that require different versions of these
+       * dependencies end up using the same one.
+       */
+      '^react$': resolveSubpath('react'),
+      '^react-dom$': resolveSubpath('react-dom'),
+      // Point straight at Apollo Client's CJS build. Resolving the subpath
+      // would go through its `exports` map and land on the ESM build (Node 22+
+      // picks the `module-sync` condition), which Jest can't parse.
+      // Resolved starting from `@cedarjs/web` because that's what depends on
+      // Apollo — a project doesn't declare it itself, so under pnpm it isn't
+      // reachable from the web side at all, and searching from there finds
+      // either nothing or some unrelated copy pulled in by another dependency
+      '^@apollo/client/react$': packagePath(
+        '@apollo/client',
+        '__cjs/react/index.cjs',
+        cedarWebResolveFrom,
+      ),
+      // We replace imports to "@cedarjs/router" with our own "mock" implementation.
+      '^@cedarjs/router$': resolveSubpath('@cedarjs/testing/web/MockRouter.js'),
+      '^@cedarjs/web$': resolveSubpath('@cedarjs/web'),
 
-    // This allows us to mock `createAuthentication` which is used by auth
-    // clients, which in turn lets us mock `useAuth` in tests
-    '^@cedarjs/auth$': path.join(
-      NODE_MODULES_PATH,
-      '@cedarjs/testing/dist/cjs/web/mockAuth.js',
-    ),
+      // This allows us to mock `createAuthentication` which is used by auth
+      // clients, which in turn lets us mock `useAuth` in tests
+      '^@cedarjs/auth$': resolveSubpath('@cedarjs/testing/auth'),
 
-    // @NOTE: Import @cedarjs/testing in web tests, and it automatically remaps to the web side only
-    // This is to prevent web stuff leaking into api, and vice versa
-    '^@cedarjs/testing$': path.join(NODE_MODULES_PATH, '@cedarjs/testing/web'),
+      // @NOTE: Import @cedarjs/testing in web tests, and it automatically remaps to the web side only
+      // This is to prevent web stuff leaking into api, and vice versa
+      '^@cedarjs/testing$': resolveSubpath('@cedarjs/testing/web'),
+      /**
+       * Mock out files that aren't particularly useful in tests. See fileMock.js for more info.
+       */
+      '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|css)$':
+        resolveSubpath('@cedarjs/testing/dist/cjs/web/fileMock.js'),
+    }),
     '~__CEDAR__USER_ROUTES_FOR_MOCK': cedarPaths.web.routes,
     '~__CEDAR__USER_AUTH_FOR_MOCK': path.join(cedarPaths.web.src, 'auth'),
-    /**
-     * Mock out files that aren't particularly useful in tests. See fileMock.js for more info.
-     */
-    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|css)$':
-      '@cedarjs/testing/dist/cjs/web/fileMock.js',
     // Support for importing files with extensions (like you'd do in ESM projects)
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },


### PR DESCRIPTION
## Problem

The web and api jest presets built their `moduleNameMapper` targets by joining onto `<projectRoot>/node_modules`:

```ts
const NODE_MODULES_PATH = path.join(cedarPaths.base, 'node_modules')
// ...
'^react$': path.join(NODE_MODULES_PATH, 'react'),
```

That assumes every package is hoisted into a single directory at the project root. yarn and npm hoist, so it worked there. **pnpm nests**: `react` lives in `web/node_modules/react`, and the project root only holds what the root `package.json` itself depends on.

Six of the web preset's seven mappings pointed at paths that don't exist, so `cedar test web` failed before running a single test in any pnpm Cedar app:

```
Configuration error:
  Could not locate module react mapped as: <project>/node_modules/react
```

This was invisible in CI because the smoke-test project is provisioned by tarsync, which runs `yarn install` and leaves a hoisted `node_modules` behind — fabricating exactly the layout the preset assumed. A follow-up PR fixes that provisioning.

## Fix

Resolve the specifiers instead of assuming where they live. Works under all three package managers, and no longer requires a `node_modules` directory to exist at all — a prerequisite for Yarn PnP.

- Most mappings go through the package's own `exports` map (`resolveSubpath`), which also stops us hard-coding other packages' internal build layout.
- **Apollo Client is the exception**: `__cjs/react/index.cjs` isn't exported, so its package root is resolved and joined (`packagePath`). This preserves the existing behaviour the old comment describes — resolving the subpath lands on the ESM build that Jest can't parse.
- Apollo is resolved **starting from `@cedarjs/web`**, because it's a transitive dependency of it. A project doesn't declare Apollo itself, so under pnpm it isn't reachable from the web side; searching from there found an unrelated `3.14.1` while the app uses `4.2.7`.
- A mapping whose target can't be resolved is **dropped** rather than pointed at a path that isn't there, so Jest falls back to normal resolution.

Note `@cedarjs/testing` has no `"."` export, so it must be resolved via its subpath exports (`./web`, `./auth`, `./web/MockRouter.js`, `./dist/cjs/web/fileMock.js`) — these point at exactly the files the old code hard-coded.

## Testing

| project | layout | web | api |
|---|---|---|---|
| local-testing-project | yarn, hoisted | 17 suites / 45 tests pass | 7 suites / 20 tests pass |
| test-project | real pnpm, nested | 17 suites / 45 tests pass | 7 suites / 20 tests pass |

Before this change the pnpm project ran **zero** web suites.

- `yarn workspace @cedarjs/testing test` — 4 files / 9 tests pass
- Verified the resolved mapper output under both layouts; every entry resolves, and to the correct copy (Apollo 4.2.7, local `@cedarjs/*` tarballs)

Not covered: yarn in pnpm mode, and PnP. The approach should suit both since it no longer assumes `node_modules`, but neither was tested.