### PR TITLE
feat(babel-config): skip TypeScript preset and user babel.config for Vite API builds

### DIFF
--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -21,9 +21,15 @@ import pluginRedwoodJobPathInjector from './plugins/babel-plugin-redwood-job-pat
 
 export const TARGETS_NODE = '24'
 
-export const getApiSideBabelPresets = (
-  { presetEnv } = { presetEnv: false },
-) => {
+export const getApiSideBabelPresets = ({
+  presetEnv = false,
+  forVite = false,
+}: { presetEnv?: boolean; forVite?: boolean } = {}) => {
+  // Vite and esbuild handle TypeScript natively — no preset needed
+  if (forVite) {
+    return [] as TransformOptions['presets']
+  }
+
   return [
     [
       '@babel/preset-typescript',
@@ -220,10 +226,13 @@ export const getApiSideDefaultBabelConfig = ({
   forJest = false,
 } = {}) => {
   return {
-    presets: getApiSideBabelPresets(),
+    presets: getApiSideBabelPresets({ forVite }),
     plugins: getApiSideBabelPlugins({ forVite, projectIsEsm }),
     overrides: getApiSideBabelOverrides({ forVite, projectIsEsm, forJest }),
-    extends: getApiSideBabelConfigPath(),
+    // Don't pick up the user's babel.config.js for Vite builds — Vite handles
+    // transformation itself; user config is only meaningful for non-Vite paths
+    // (Jest, data-migrate, prerender).
+    extends: forVite ? undefined : getApiSideBabelConfigPath(),
     babelrc: false,
     ignore: ['node_modules'],
   }


### PR DESCRIPTION
## Summary

When `forVite: true`, `getApiSideDefaultBabelConfig` now returns a true no-op config:

- **`getApiSideBabelPresets`** gains a `forVite` parameter. When `true`, returns `[]` — Vite and esbuild handle TypeScript natively, so `@babel/preset-typescript` is redundant.
- **`getApiSideDefaultBabelConfig`** skips `extends: getApiSideBabelConfigPath()` when `forVite: true` — user babel.config.js is only relevant for non-Vite paths (Jest, data-migrate, prerender).

## Why

Before this change, calling `getApiSideDefaultBabelConfig({ forVite: true })` — which happens inside `transformWithBabel` in both `buildApp.ts` and `apiDevMiddleware.ts` — still loaded `@babel/preset-typescript` and potentially the user's `babel.config.js`. Plugins and overrides were already empty when `forVite: true`, but the TypeScript preset had no such guard.

With `forVite: true` the result is now a near no-op:
```ts
{
  presets: [],
  plugins: [],
  overrides: [],
  extends: undefined,
  babelrc: false,
  ignore: ['node_modules'],
}
```

Babel still runs in the Vite pipeline (via `transformWithBabel`), but it's a near no-op — only the explicitly-passed `plugins` argument does any work (decorators, etc.).

Fixes #2080 (incrementally moving away from Babel for Vite).