### PR TITLE
fix(vite): merge user babel plugins with react-compiler plugin

### DIFF
--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -79,13 +79,15 @@ export function cedar({ mode, babel }: PluginOptions = {}): PluginOption[] {
     cedarConfig.experimental?.reactCompiler?.enabled &&
     cedarConfig.experimental?.reactCompiler?.lintOnly === false
 
+  const compilerPlugins: BabelOptions['plugins'] = reactCompilerEnabled
+    ? [['babel-plugin-react-compiler', { target: '19' }]]
+    : []
+
   const babelConfig: BabelOptions | undefined =
     reactCompilerEnabled || babel
       ? {
-          ...(reactCompilerEnabled && {
-            plugins: [['babel-plugin-react-compiler', { target: '19' }]],
-          }),
           ...babel,
+          plugins: [...compilerPlugins, ...(babel?.plugins ?? [])],
         }
       : undefined
 


### PR DESCRIPTION
Follow-up to #2150.

## Problem

The previous merge spread `...babel` after the compiler plugin config, so a user-provided `babel.plugins` array would silently *replace* the React Compiler plugin:

```ts
{
  ...(reactCompilerEnabled && {
    plugins: [['babel-plugin-react-compiler', { target: '19' }]],
  }),
  ...babel,  // babel.plugins overwrites the compiler plugin above ☝️
}
```

## Fix

Merge the plugin arrays explicitly so the compiler plugin (if enabled) is always prepended to any user-supplied plugins:

```ts
const compilerPlugins: BabelOptions['plugins'] = reactCompilerEnabled
  ? [['babel-plugin-react-compiler', { target: '19' }]]
  : []

const babelConfig: BabelOptions | undefined =
  reactCompilerEnabled || babel
    ? {
        ...babel,
        plugins: [...compilerPlugins, ...(babel?.plugins ?? [])],
      }
    : undefined
```

Both plugin sets now always run when the compiler is active.