### PR TITLE
chore(ci): tarsync and setup for pnpm and npm

### DIFF
--- a/.github/actions/set-up-test-project/setUpTestProject.mts
+++ b/.github/actions/set-up-test-project/setUpTestProject.mts
@@ -15,31 +15,6 @@ function cedarPrefix(pm: PackageManager): string {
   return 'yarn cedar'
 }
 
-function lockfileName(pm: PackageManager): string {
-  if (pm === 'npm') {
-    return 'package-lock.json'
-  }
-
-  if (pm === 'pnpm') {
-    return 'pnpm-lock.yaml'
-  }
-
-  return 'yarn.lock'
-}
-
-function isString(value: unknown): value is string {
-  return typeof value === 'string'
-}
-
-/**
- * In YAML single-quoted scalars, a literal single quote is escaped by doubling
- * it. Package names like @cedarjs/foo never contain quotes, but the tarball
- * path could on unusual runner configs.
- */
-function quotes(value: string) {
-  return value.replace(/'/g, "''")
-}
-
 interface Args {
   setOutput: (key: string, value: string) => void
   getInput: (key: string) => string
@@ -92,31 +67,36 @@ export async function setUpTestProject({
     recursive: true,
   })
 
-  // tarsync is yarn-based (the framework monorepo uses yarn). It copies
-  // framework packages into the project and runs `yarn install`, producing
-  // yarn.lock + node_modules. This works for all PMs because node_modules
-  // makes the `cedar` binary available regardless of which PM is configured.
-  await execInFramework('yarn project:tarsync --verbose', {
-    env: { CEDAR_CWD: testProjectPath },
-  })
-
-  // For npm/pnpm: run the project's own install to create the correct
-  // lockfile and node_modules layout. Before doing so, prepare the project
-  // so the install doesn't fail:
+  // Convert the project to the target package manager *before* tarsync runs.
   //
-  // 1. Update the packageManager field — pnpm reads it and refuses if it
-  //    says yarn.
-  // 2. Replace workspace:* protocols with file: references — npm doesn't
+  // tarsync detects the project's package manager and installs with it, so
+  // converting first means it does the one install we actually want. It used
+  // to run against a project that still looked like yarn's, which meant a
+  // wasted `yarn install` followed by a second install with the real package
+  // manager — and, worse, yarn's hoisted node_modules survived underneath the
+  // second one, hiding bugs that only appear in a nested layout.
+  //
+  // What needs preparing:
+  //
+  // 1. Set the packageManager field — this is what tarsync detects, and pnpm
+  //    refuses to run if it says yarn.
+  // 2. Remove yarn.lock, so nothing later mistakes the project for a yarn one.
+  // 3. Replace workspace:* protocols with file: references — npm doesn't
   //    understand workspace:*.
-  // 3. Pin dependency versions to what yarn resolved in yarn.lock so that
-  //    npm/pnpm don't pick up newer versions (which can change test output
-  //    like snapshot serialization).
+  // 4. Pin dependency versions to what the fixture resolved, so that npm/pnpm
+  //    don't pick up newer versions (which can change test output like
+  //    snapshot serialization).
+  //
+  // The tarball overrides themselves are tarsync's job — it writes
+  // `resolutions`, pnpm `overrides` or npm `overrides` as appropriate.
   if (packageManager !== 'yarn') {
     const pkgPath = path.join(testProjectPath, 'package.json')
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
 
-    // delete packageManager to let the `<pm> install` command set it
-    delete pkg.packageManager
+    // This is what tarsync detects, so it has to say the target package
+    // manager rather than the fixture's yarn
+    pkg.packageManager =
+      packageManager === 'pnpm' ? 'pnpm@11.8.0' : 'npm@11.8.0'
 
     // The fixture pins react-is via yarn's `resolutions`, but npm uses
     // `overrides` instead. Without this override, react-is resolves to 17.x
@@ -144,17 +124,22 @@ export async function setUpTestProject({
         },
       }
 
-      // Translate tarsync's yarn-style resolutions into pnpm overrides so
-      // pnpm install uses the local framework tarballs instead of fetching
-      // the published canary from the registry.
-      const tarsyncOverrideLines = Object.entries(
-        (pkg.resolutions as Record<string, string>) || {},
-      )
-        .filter(([, value]) => isString(value) && value.endsWith('.tgz'))
-        .map(([name, value]) => `  '${quotes(name)}': 'file:${quotes(value)}'`)
-        .join('\n')
-
+      // Note there are no tarball overrides here — tarsync appends those to
+      // this file's `overrides` block once it has built them
       const yaml = [
+        // The `overrides` below only redirect dependencies that are *declared*
+        // in a package.json. Peers that pnpm auto-installs are resolved
+        // straight from the registry, bypassing them — so `@cedarjs/auth`,
+        // `@cedarjs/graphql-server`, `@cedarjs/router` and `@cedarjs/web` were
+        // getting installed twice: once from the local tarball and once as the
+        // last published release. Framework packages that take those as peers
+        // (`@cedarjs/testing`, most importantly) then linked against the
+        // *published* copy, so the smoke test silently ran published code
+        // instead of the code being tested. Turning the auto-install off
+        // leaves the tarballs as the only copy. yarn/npm don't do this, which
+        // is why only pnpm was affected
+        'autoInstallPeers: false',
+        '',
         'packages:',
         '  - api',
         '  - web',
@@ -177,7 +162,6 @@ export async function setUpTestProject({
         '',
         'overrides:',
         "  'react-is': '19.2.3'",
-        tarsyncOverrideLines,
         '',
       ].join('\n')
 
@@ -229,15 +213,25 @@ export async function setUpTestProject({
       `Updated packageManager field to "${packageManager}"` +
         (packageManager === 'npm' ? ', replaced workspace:* → file:' : ''),
     )
-    console.log()
-    console.log(
-      `Running ${packageManager} install to create ${lockfileName(packageManager)}`,
-    )
 
-    await execInProject(`${packageManager} install`)
+    // The fixture ships a yarn.lock. Leaving it in place would both confuse
+    // tarsync's detection and let a yarn-shaped tree leak into the install
+    await fs.promises.rm(path.join(testProjectPath, 'yarn.lock'), {
+      force: true,
+    })
 
     console.log()
-  } else {
+  }
+
+  // tarsync builds the framework tarballs, copies them into the project,
+  // points the project's overrides at them (`resolutions` for yarn, `overrides`
+  // for npm and pnpm) and then installs with the project's own package
+  // manager — which the conversion above has already set
+  await execInFramework('yarn project:tarsync --verbose', {
+    env: { CEDAR_CWD: testProjectPath },
+  })
+
+  if (packageManager === 'yarn') {
     // Verify tarsync produced a yarn.lock. A missing lockfile means the
     // `yarn install` inside tarsync failed (possibly due to the V8 Maglev JIT
     // crash on Windows). Fail here with a clear message rather than letting

--- a/CI_SPEEDUP_PLAN.md
+++ b/CI_SPEEDUP_PLAN.md
@@ -144,6 +144,70 @@ cache-missing, that's a large chunk of its 12-minute runtime.
 `ci.yml` has it, but if `check-test-project-fixture(-esm)`, `codeql-analysis`,
 etc. don't, superseded runs keep eating queue slots after a new push.
 
+### 6. Cut the package-manager smoke tests' install cost (~75s per npm job)
+
+**Status: implemented 2026-07-21, not yet landed** (held for a follow-up PR to
+the jest preset resolution fix, #2155).
+
+Two independent wins, neither of which needs a cache:
+
+- **Stop installing twice.** `setUpTestProject` used to run tarsync against a
+  project that still looked like yarn's, so tarsync did a `yarn install`, and
+  then npm/pnpm installed again on top. Converting the project to the target
+  package manager _before_ tarsync means tarsync detects it and does the one
+  install we want. Saves a whole yarn install (~14s) per npm/pnpm job. It also
+  fixes a correctness problem: yarn's hoisted `node_modules` survived underneath
+  the second install and masked bugs that only appear in a nested layout.
+- **`npm install --no-audit --no-fund`.** npm runs a security audit and a
+  funding lookup after every install — network round trips over the whole
+  ~1800-package tree that tell us nothing about the framework build under test.
+
+Measured on the same project, warm `~/.npm`, lockfile deleted between runs:
+
+| install                                             | time    |
+| --------------------------------------------------- | ------- |
+| `npm install`                                       | **78s** |
+| `npm install --no-audit --no-fund --prefer-offline` | **17s** |
+| `npm install --no-audit --no-fund`                  | **18s** |
+
+`--prefer-offline` contributes nothing; the entire 60s is the audit. Install
+times through the new path, one install per job: yarn 13.6s, pnpm 18.2s, npm
+26.8s.
+
+#### On caching the npm cache directory
+
+Considered and **not** adopted, on the grounds that it's now attacking the
+_remaining_ ~18–27s rather than the 60s the audit flag already removed.
+
+You can pass a path to npm for it to use for storing its cache: `--cache <dir>`.
+By pointing at a **stable** path (like `<os.tmpdir()>/cedar-e2e/npm-cache`) you
+isolate it from the global `~/.npm` across concurrent installs, and so it can
+keep a cache warm across _many_ projects within a single run. Our smoke test
+does exactly one install per job, so there's no second install in the same run
+right now to benefit.
+
+The only version that would help us is persisting a cache across runs with
+`actions/cache`, since GitHub-hosted runners start with an empty `~/.npm`. The
+value of the `--cache` flag for us would be giving that cache a stable,
+predictable path to key on. Worth benchmarking before adopting: saving and
+restoring a cacache for ~1800 packages is itself tens of seconds of
+upload/download, plausibly a wash against an 18s install.
+
+Two things to know before anyone tries it:
+
+- **Stale tarballs are not a risk** (checked 2026-07-21). npm's cache key for a
+  local tarball is the relative path — `pacote:tarball:file:tarballs/cedarjs-web.tgz`
+  — with integrity only as metadata, and every run rebuilds tarballs under
+  identical names at the same version. But npm re-reads the file rather than
+  trusting the cache entry: repacking a tarball with a sentinel file, same name
+  and version, then reinstalling, installs the new contents.
+- **Caching `node_modules` or the lockfile would break**, because tarsync writes
+  **absolute** tarball paths into the project's overrides. A tree or lockfile
+  cached from one runner path carries paths that don't exist on the next. (This
+  is why projects deliberately uses relative `file:` specifiers.) Fix that
+  first if lockfile/tree caching is ever wanted — the npm cache directory itself
+  is unaffected.
+
 ## On flakiness specifically
 
 The definitive source here is

--- a/__fixtures__/test-project-pnpm/pnpm-workspace.yaml
+++ b/__fixtures__/test-project-pnpm/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+autoInstallPeers: false
+
 packages:
   - api
   - web

--- a/tasks/framework-tools/tarsync/lib.mts
+++ b/tasks/framework-tools/tarsync/lib.mts
@@ -117,14 +117,67 @@ export async function copyTarballs(projectPath: string) {
   )
 }
 
-export type PackageManager = 'yarn' | 'pnpm'
+export type PackageManager = 'yarn' | 'npm' | 'pnpm'
 
-export async function detectPackageManager(projectPath: string) {
-  const yarnLockExists = fs.existsSync(path.join(projectPath, 'yarn.lock'))
-  const pnpmLockExists = fs.existsSync(path.join(projectPath, 'pnpm-lock.yaml'))
+function isPackageManager(value: unknown): value is PackageManager {
+  return value === 'yarn' || value === 'npm' || value === 'pnpm'
+}
 
-  if (pnpmLockExists && !yarnLockExists) {
+/**
+ * Work out which package manager the *target project* uses.
+ *
+ * Deliberately reads the project rather than the ambient environment.
+ * `npm_config_user_agent` is no help here: tarsync is normally reached through
+ * `cfw`, which runs it as a script of the framework repo — a yarn workspace —
+ * so that variable always says "yarn" no matter what the target project uses.
+ *
+ * Lockfiles alone aren't enough either, because a lockfile is an *output* of
+ * the first install. A project being set up for pnpm or npm won't have one yet,
+ * so we also accept the markers that exist before install: pnpm's workspace
+ * file, and the `packageManager` field.
+ */
+export async function detectPackageManager(
+  projectPath: string,
+): Promise<PackageManager> {
+  const exists = (file: string) => fs.existsSync(path.join(projectPath, file))
+
+  // An explicit `packageManager` field wins — it's what corepack reads, so
+  // it's the closest thing to the project stating its own intent
+  try {
+    const packageJson: unknown = JSON.parse(
+      await fs.promises.readFile(
+        path.join(projectPath, 'package.json'),
+        'utf-8',
+      ),
+    )
+
+    if (
+      packageJson &&
+      typeof packageJson === 'object' &&
+      'packageManager' in packageJson &&
+      typeof packageJson.packageManager === 'string'
+    ) {
+      const name = packageJson.packageManager.split('@')[0]
+
+      if (isPackageManager(name)) {
+        return name
+      }
+    }
+  } catch {
+    // No package.json, or it isn't readable — fall through to the file checks
+  }
+
+  const yarnLockExists = exists('yarn.lock')
+
+  if (
+    (exists('pnpm-lock.yaml') || exists('pnpm-workspace.yaml')) &&
+    !yarnLockExists
+  ) {
     return 'pnpm'
+  }
+
+  if (exists('package-lock.json') && !yarnLockExists) {
+    return 'npm'
   }
 
   return 'yarn'
@@ -245,6 +298,75 @@ export async function updateResolutions(projectPath: string) {
 
     updatedPackageJson = { ...projectPackageJson }
     delete updatedPackageJson.pnpm
+  } else if (packageManager === 'npm') {
+    // npm has no `resolutions` — the equivalent is `overrides`, which lives in
+    // package.json like yarn's does.
+    //
+    // The tarball paths need an explicit `file:` prefix here. yarn and pnpm
+    // both accept a bare absolute path, but npm parses an override value as a
+    // version spec and won't recognise one.
+    const tarballOverrides = Object.fromEntries(
+      Object.entries(resolutions).map(([name, tarballPath]) => [
+        name,
+        `file:${tarballPath}`,
+      ]),
+    )
+
+    // npm rejects an override for a package that is also a direct dependency
+    // unless the two specs agree — `npm error code EOVERRIDE, Override for
+    // @cedarjs/core@5.0.1 conflicts with direct dependency`. So point the
+    // direct dependencies at the tarballs as well. The overrides are still
+    // needed: they're what redirects the framework packages that are pulled
+    // in transitively rather than declared
+    const pointDirectDepsAtTarballs = (packageJson: Record<string, any>) => {
+      for (const depsKey of ['dependencies', 'devDependencies']) {
+        const deps = packageJson[depsKey]
+
+        if (!deps) {
+          continue
+        }
+
+        for (const name of Object.keys(deps)) {
+          if (tarballOverrides[name]) {
+            deps[name] = tarballOverrides[name]
+          }
+        }
+      }
+    }
+
+    // Every workspace, not just the root — `@cedarjs/web` is a dependency of
+    // web, `@cedarjs/api` of api, and so on
+    for (const relativePath of ['api/package.json', 'web/package.json']) {
+      const workspacePkgPath = path.join(projectPath, relativePath)
+
+      if (!fs.existsSync(workspacePkgPath)) {
+        continue
+      }
+
+      const workspacePkg = JSON.parse(
+        await fs.promises.readFile(workspacePkgPath, 'utf-8'),
+      )
+
+      pointDirectDepsAtTarballs(workspacePkg)
+
+      await fs.promises.writeFile(
+        workspacePkgPath,
+        JSON.stringify(workspacePkg, null, 2),
+      )
+    }
+
+    pointDirectDepsAtTarballs(projectPackageJson)
+
+    // Merged rather than replaced so that overrides the project already set
+    // (react-is, for example) survive
+    updatedPackageJson = {
+      ...projectPackageJson,
+      overrides: {
+        ...projectPackageJson.overrides,
+        ...tarballOverrides,
+        ...reactResolutions,
+      },
+    }
   } else {
     updatedPackageJson = {
       ...projectPackageJson,
@@ -288,16 +410,25 @@ export async function getReactResolutions() {
 export async function pmInstall(projectPath: string, verbose = false) {
   const packageManager = await detectPackageManager(projectPath)
 
+  // npm runs a security audit and a funding lookup after every install. Both
+  // are network round trips over the whole dependency tree, and neither tells
+  // us anything about the framework build we're testing — skipping them takes
+  // the install from ~78s to ~18s. yarn and pnpm don't do this by default
+  const installArgs =
+    packageManager === 'npm'
+      ? ['install', '--no-audit', '--no-fund']
+      : ['install']
+
   if (verbose) {
     console.log(
-      `[tarsync] Running '${packageManager} install' in ${projectPath}`,
+      `[tarsync] Running '${packageManager} ${installArgs.join(' ')}' in ${projectPath}`,
     )
   }
   const start = Date.now()
 
   await within(async () => {
     cd(projectPath)
-    await $`${packageManager} install`
+    await $`${packageManager} ${installArgs}`
   })
 
   if (verbose) {
@@ -313,8 +444,14 @@ export async function pmInstall(projectPath: string, verbose = false) {
   // missing after install, fail loudly here rather than silently producing a
   // broken project that fails at a later, less obvious step.
   const lockfileName =
-    packageManager === 'pnpm' ? 'pnpm-lock.yaml' : 'yarn.lock'
+    packageManager === 'pnpm'
+      ? 'pnpm-lock.yaml'
+      : packageManager === 'npm'
+        ? 'package-lock.json'
+        : 'yarn.lock'
+
   const lockfilePath = path.join(projectPath, lockfileName)
+
   if (!fs.existsSync(lockfilePath)) {
     throw new Error(
       `[tarsync] '${packageManager} install' completed but ${lockfileName} was not created in ${projectPath}. ` +

--- a/tasks/framework-tools/tarsync/lib.mts
+++ b/tasks/framework-tools/tarsync/lib.mts
@@ -183,6 +183,50 @@ export async function detectPackageManager(
   return 'yarn'
 }
 
+/**
+ * Paths to every workspace's package.json, taken from the root manifest's
+ * `workspaces` field.
+ *
+ * Only the trailing `*` / `**` form is expanded — that covers what Cedar
+ * projects use (`["api", "web", "packages/*"]`) without pulling in a glob
+ * dependency. Anything fancier is left as a literal directory, which simply
+ * won't exist and gets filtered out.
+ */
+async function findWorkspaceManifests(
+  projectPath: string,
+  rootPackageJson: Record<string, any>,
+): Promise<string[]> {
+  const workspaces = rootPackageJson.workspaces
+  const patterns: string[] = Array.isArray(workspaces)
+    ? workspaces
+    : (workspaces?.packages ?? [])
+
+  const directories: string[] = []
+
+  for (const pattern of patterns) {
+    const wildcard = pattern.match(/^(.*)\/\*{1,2}$/)
+
+    if (wildcard) {
+      const parent = path.join(projectPath, wildcard[1])
+      const entries = await fs.promises
+        .readdir(parent, { withFileTypes: true })
+        .catch(() => [])
+
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          directories.push(path.join(parent, entry.name))
+        }
+      }
+    } else {
+      directories.push(path.join(projectPath, pattern))
+    }
+  }
+
+  return directories
+    .map((directory) => path.join(directory, 'package.json'))
+    .filter((manifestPath) => fs.existsSync(manifestPath))
+}
+
 export async function updateResolutions(projectPath: string) {
   const packageManager = await detectPackageManager(projectPath)
 
@@ -318,8 +362,16 @@ export async function updateResolutions(projectPath: string) {
     // direct dependencies at the tarballs as well. The overrides are still
     // needed: they're what redirects the framework packages that are pulled
     // in transitively rather than declared
+    // Every section npm treats as a direct dependency. `peerDependencies` is
+    // deliberately left alone: a peer is a range the project requires of its
+    // consumer, not something npm installs on its behalf, so rewriting one to
+    // a `file:` path would be wrong
     const pointDirectDepsAtTarballs = (packageJson: Record<string, any>) => {
-      for (const depsKey of ['dependencies', 'devDependencies']) {
+      for (const depsKey of [
+        'dependencies',
+        'devDependencies',
+        'optionalDependencies',
+      ]) {
         const deps = packageJson[depsKey]
 
         if (!deps) {
@@ -335,14 +387,13 @@ export async function updateResolutions(projectPath: string) {
     }
 
     // Every workspace, not just the root — `@cedarjs/web` is a dependency of
-    // web, `@cedarjs/api` of api, and so on
-    for (const relativePath of ['api/package.json', 'web/package.json']) {
-      const workspacePkgPath = path.join(projectPath, relativePath)
-
-      if (!fs.existsSync(workspacePkgPath)) {
-        continue
-      }
-
+    // web, `@cedarjs/api` of api, and so on. Derived from the root manifest
+    // rather than hard-coded, so a Cedar dependency added to any other
+    // workspace doesn't quietly keep a spec that conflicts with the overrides
+    for (const workspacePkgPath of await findWorkspaceManifests(
+      projectPath,
+      projectPackageJson,
+    )) {
       const workspacePkg = JSON.parse(
         await fs.promises.readFile(workspacePkgPath, 'utf-8'),
       )


### PR DESCRIPTION
Add pnpm and npm support to tarsync, and use it in CI for better coverage of those PMs