### PR TITLE
chore(ci): Fix storybook-framework-cedarjs RC publishing

### DIFF
--- a/.github/scripts/publish-prerelease.mts
+++ b/.github/scripts/publish-prerelease.mts
@@ -19,12 +19,21 @@ import fs from 'node:fs'
 import path from 'node:path'
 import util from 'node:util'
 
+// Dependency fields whose in-monorepo entries get rewritten to the version
+// being published
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+] as const
+
 interface PackageJson {
   name?: string
   version?: string
   private?: boolean
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
   [key: string]: unknown
 }
 
@@ -244,25 +253,35 @@ function updatePackageVersions(workspaces: WorkspaceInfo[], version: string) {
   }
 }
 
+/**
+ * Rewrites every dependency that points at another package in this monorepo to
+ * `version`.
+ *
+ * Membership is decided by package *name*, not by the `workspace:*` spec or the
+ * `@cedarjs/` prefix, so already-pinned deps and unscoped packages (e.g.
+ * `storybook-framework-cedarjs`) get bumped too.
+ */
 function updateWorkspaceDependencies(
   workspaces: WorkspaceInfo[],
   version: string,
 ) {
-  log(`Updating workspace:* dependencies to ${version}`)
+  log(`Updating in-monorepo dependencies to ${version}`)
+
+  const workspaceNames = new Set(workspaces.map((ws) => ws.name))
 
   for (const workspace of workspaces) {
     const pkgJsonPath = path.join(REPO_ROOT, workspace.location, 'package.json')
     const pkgJson = readPackageJson(pkgJsonPath)
 
-    for (const depField of ['dependencies', 'devDependencies'] as const) {
+    for (const depField of DEPENDENCY_FIELDS) {
       const deps = pkgJson[depField]
 
       if (!deps) {
         continue
       }
 
-      for (const [depName, depVersion] of Object.entries(deps)) {
-        if (depVersion === 'workspace:*') {
+      for (const depName of Object.keys(deps)) {
+        if (workspaceNames.has(depName)) {
           deps[depName] = version
         }
       }

--- a/.github/scripts/publish-release-candidate.mts
+++ b/.github/scripts/publish-release-candidate.mts
@@ -19,9 +19,18 @@ const TEMPLATES_DIR = path.join(CREATE_CEDAR_APP_DIR, 'templates')
 // Template directories
 const TEMPLATE_DIRS = ['ts', 'js', 'esm-ts', 'esm-js']
 
+// Dependency fields whose in-monorepo entries get rewritten to the version
+// being published
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+] as const
+
 interface PackageJson {
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
   workspaces?: string[] | { packages: string[] }
   [key: string]: any
 }
@@ -64,82 +73,168 @@ function execCommand(
   }
 }
 
+/**
+ * Rewrites the deps of a package.json that lives outside the workspace graph
+ * (create-cedar-app itself and its templates) to `version`.
+ *
+ * `workspaceNames` covers packages published from this monorepo that aren't
+ * `@cedarjs/`-scoped, such as `storybook-framework-cedarjs`.
+ */
+function readPackageJson(pkgJsonPath: string): PackageJson {
+  return JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'))
+}
+
+function writePackageJson(pkgJsonPath: string, pkgJson: PackageJson) {
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')
+}
+
+/**
+ * Resolves a workspace's package.json path, failing loudly if it's missing.
+ *
+ * Yarn only reports a workspace because it found a package.json there, so a
+ * missing one means the checkout is corrupt — never something to skip past on
+ * the way to publishing.
+ */
+function workspacePackageJsonPath(workspace: WorkspaceInfo) {
+  const pkgJsonPath = path.join(REPO_ROOT, workspace.location, 'package.json')
+
+  if (!fs.existsSync(pkgJsonPath)) {
+    throw new Error(`No package.json at ${workspace.location}/package.json`)
+  }
+
+  return pkgJsonPath
+}
+
 function updatePackageJsonWithVersion(
   filePath: string,
   version: string,
+  workspaceNames: Set<string>,
   updateOwnVersion = false,
 ) {
   log(`Updating ${filePath}`)
 
-  const content = fs.readFileSync(filePath, 'utf-8')
-  const packageJson: PackageJson = JSON.parse(content)
+  const packageJson = readPackageJson(filePath)
 
   // Update the package's own version if requested
   if (updateOwnVersion) {
     packageJson.version = version
   }
 
-  // Update dependencies
-  if (packageJson.dependencies) {
-    for (const [pkg] of Object.entries(packageJson.dependencies)) {
-      if (pkg.startsWith('@cedarjs/')) {
-        packageJson.dependencies[pkg] = version
-      }
-    }
-  }
+  for (const depField of DEPENDENCY_FIELDS) {
+    const deps = packageJson[depField]
 
-  // Update devDependencies
-  if (packageJson.devDependencies) {
-    for (const [pkg] of Object.entries(packageJson.devDependencies)) {
-      if (pkg.startsWith('@cedarjs/')) {
-        packageJson.devDependencies[pkg] = version
-      }
-    }
-  }
-
-  fs.writeFileSync(filePath, JSON.stringify(packageJson, null, 2) + '\n')
-}
-
-function updateWorkspaceDependencies(version: string) {
-  log('Updating workspace dependencies across all packages')
-
-  // Get all workspace packages
-  const workspacesOutput = execCommand('yarn workspaces list --json')
-  const workspaces: WorkspaceInfo[] = workspacesOutput
-    .split('\n')
-    .filter((line) => line.trim())
-    .map((line) => JSON.parse(line))
-    .filter((ws) => ws.location !== '.')
-
-  for (const workspace of workspaces) {
-    const packageJsonPath = path.join(
-      REPO_ROOT,
-      workspace.location,
-      'package.json',
-    )
-
-    try {
-      const content = fs.readFileSync(packageJsonPath, 'utf-8')
-      let updatedContent = content.replace(/workspace:\*/g, version)
-
-      // Also update any @cedarjs dependencies to use the new version
-      updatedContent = updatedContent.replace(
-        /"@cedarjs\/([^"]+)":\s*"[^"]*"/g,
-        `"@cedarjs/$1": "${version}"`,
-      )
-
-      if (updatedContent !== content) {
-        fs.writeFileSync(packageJsonPath, updatedContent)
-        log(
-          'Updated workspace dependencies in ' +
-            `${workspace.location}/package.json`,
-        )
-      }
-    } catch {
-      // Skip if package.json doesn't exist or can't be read
+    if (!deps) {
       continue
     }
+
+    for (const depName of Object.keys(deps)) {
+      if (depName.startsWith('@cedarjs/') || workspaceNames.has(depName)) {
+        deps[depName] = version
+      }
+    }
   }
+
+  writePackageJson(filePath, packageJson)
+}
+
+/**
+ * Rewrites every dependency that points at another package in this monorepo to
+ * `version`.
+ *
+ * Membership is decided by package *name* (from `yarn workspaces list`), not by
+ * the `@cedarjs/` prefix or the `workspace:*` spec. Release branches carry a
+ * "update package versions to vX.Y.Z" commit that has already replaced
+ * `workspace:*` with a plain release version, and not every workspace package
+ * is `@cedarjs/`-scoped (e.g. `storybook-framework-cedarjs`), so both of those
+ * narrower checks miss deps that still need bumping.
+ */
+function updateWorkspaceDependencies(
+  workspaces: WorkspaceInfo[],
+  version: string,
+) {
+  log('Updating workspace dependencies across all packages')
+
+  const workspaceNames = new Set(workspaces.map((ws) => ws.name))
+
+  for (const workspace of workspaces) {
+    const packageJsonPath = workspacePackageJsonPath(workspace)
+    const packageJson = readPackageJson(packageJsonPath)
+    let changed = false
+
+    for (const depField of DEPENDENCY_FIELDS) {
+      const deps = packageJson[depField]
+
+      if (!deps) {
+        continue
+      }
+
+      for (const depName of Object.keys(deps)) {
+        if (workspaceNames.has(depName) && deps[depName] !== version) {
+          deps[depName] = version
+          changed = true
+        }
+      }
+    }
+
+    if (changed) {
+      writePackageJson(packageJsonPath, packageJson)
+      log(
+        'Updated workspace dependencies in ' +
+          `${workspace.location}/package.json`,
+      )
+    }
+  }
+}
+
+/**
+ * Fails the release before anything reaches npm if a package still points at a
+ * version of a sibling package that isn't the one being published.
+ *
+ * RC 5.0.2-rc.3 shipped `storybook-framework-cedarjs@5.0.2`, a version that
+ * never existed on npm, and nothing caught it until users hit
+ * "No candidates found" during install.
+ */
+function verifyWorkspaceDependencies(
+  workspaces: WorkspaceInfo[],
+  version: string,
+) {
+  log('Verifying in-monorepo dependencies all point at the version to publish')
+
+  const workspaceNames = new Set(workspaces.map((ws) => ws.name))
+  const problems: string[] = []
+
+  for (const workspace of workspaces) {
+    const packageJson = readPackageJson(workspacePackageJsonPath(workspace))
+
+    if (packageJson.version !== version) {
+      problems.push(`${workspace.name} has version ${packageJson.version}`)
+    }
+
+    for (const depField of DEPENDENCY_FIELDS) {
+      const deps = packageJson[depField]
+
+      if (!deps) {
+        continue
+      }
+
+      for (const [depName, depVersion] of Object.entries(deps)) {
+        if (workspaceNames.has(depName) && depVersion !== version) {
+          problems.push(
+            `${workspace.name} ${depField}.${depName} is ${depVersion}`,
+          )
+        }
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `Expected every in-monorepo dependency to be ${version}, but found:\n` +
+        problems.map((problem) => `  - ${problem}`).join('\n'),
+    )
+  }
+
+  log('✅ All in-monorepo dependencies point at ' + version)
 }
 
 async function removeCreateCedarAppFromWorkspaces(): Promise<() => void> {
@@ -335,31 +430,22 @@ async function main() {
       .filter((ws) => ws.location !== '.')
 
     for (const workspace of workspaces) {
-      const packageJsonPath = path.join(
-        REPO_ROOT,
-        workspace.location,
-        'package.json',
-      )
-      try {
-        const content = fs.readFileSync(packageJsonPath, 'utf-8')
-        const packageJson = JSON.parse(content)
+      const packageJsonPath = workspacePackageJsonPath(workspace)
+      const packageJson = readPackageJson(packageJsonPath)
 
-        // Update the version
-        packageJson.version = versionToPublish
+      // Update the version
+      packageJson.version = versionToPublish
 
-        fs.writeFileSync(
-          packageJsonPath,
-          JSON.stringify(packageJson, null, 2) + '\n',
-        )
-        log(`Updated version in ${workspace.location}/package.json`)
-      } catch {
-        // Skip if package.json doesn't exist or can't be read
-        continue
-      }
+      writePackageJson(packageJsonPath, packageJson)
+      log(`Updated version in ${workspace.location}/package.json`)
     }
 
     log('Step 5: Updating workspace dependencies')
-    updateWorkspaceDependencies(versionToPublish)
+    updateWorkspaceDependencies(workspaces, versionToPublish)
+
+    const workspaceNames = new Set(workspaces.map((ws) => ws.name))
+
+    verifyWorkspaceDependencies(workspaces, versionToPublish)
 
     log('Step 6: Committing version and dependency updates')
     execCommand('git add .')
@@ -426,6 +512,7 @@ async function main() {
       updatePackageJsonWithVersion(
         path.join(CREATE_CEDAR_APP_DIR, pkgJsonFile),
         versionToPublish,
+        workspaceNames,
       )
     }
 
@@ -503,6 +590,7 @@ async function main() {
     updatePackageJsonWithVersion(
       createCedarAppPackageJsonPath,
       versionToPublish,
+      workspaceNames,
       true,
     )
     log(`✅ Updated create-cedar-app version to ${versionToPublish}`)


### PR DESCRIPTION
A user reported this:
```
node ➜ /workspace (cedarjs-upgrade) $ yarn cedar upgrade -t 5.0.2-rc.3
↓ Skipping confirmation prompt because a specific tag is specified.
✔ Checking latest version
✔ Running pre-upgrade scripts
✔ Updating your CedarJS version
  ✔ Updating /workspace/package.json
  ✔ Updating /workspace/api/package.json
  ✔ Updating /workspace/web/package.json
✔ Removing CLI cache
✖ Could not finish installation. Please run `yarn install` and then `yarn dedupe`, before continuing
◼ Refreshing the Prisma client
◼ De-duplicating dependencies
◼ One more thing..
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Error: Could not finish installation. Please run `yarn install` and then `yarn dedupe`, before continuing
    at packageManagerInstall (file:///workspace/node_modules/@cedarjs/cli/dist/commands/upgrade/upgradeHandler.js:202:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async Task.run (file:///workspace/node_modules/listr2/dist/index.mjs:1908:5)

node ➜ /workspace (cedarjs-upgrade) $ yarn install
➤ YN0088: A new stable version of Yarn is available: 4.17.1!
➤ YN0088: Upgrade now by running yarn set version 4.17.1

➤ YN0000: · Yarn 4.12.0
➤ YN0000: ┌ Resolution step
➤ YN0082: │ storybook-framework-cedarjs@npm:5.0.2: No candidates found
➤ YN0000: └ Completed in 0s 554ms
➤ YN0000: · Failed with errors in 0s 576ms
node ➜ /workspace (cedarjs-upgrade) $ yarn dedupe 
➤ YN0000: ┌ Deduplication step
➤ YN0000: │ No packages can be deduped using the highest strategy
➤ YN0000: └ Completed
➤ YN0000: · Yarn 4.12.0
➤ YN0000: ┌ Resolution step
➤ YN0082: │ storybook-framework-cedarjs@npm:5.0.2: No candidates found
➤ YN0000: └ Completed in 0s 455ms
➤ YN0000: · Failed with errors in 0s 455ms
```

I reproduced, and when I tried to manually run `yarn install` I saw this

```
❯ yarn
➤ YN0000: · Yarn 4.14.1
➤ YN0000: ┌ Resolution step
➤ YN0082: │ storybook-framework-cedarjs@npm:5.0.2: No candidates found
➤ YN0000: └ Completed in 0s 227ms
➤ YN0000: · Failed with errors in 0s 234ms
```

This PR fixes the publishing bug that left those RC packages in a broken state