### PR TITLE
chore(vite): Simplified Babel config for Vite projects

### DIFF
--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -131,11 +131,13 @@ cedar dev:
 cedar build:
   prisma gen → GraphQL types → validate SDLs →
   default: legacy separate builds
-    API (`buildApi()` esbuild → api/dist/, Babel plugin) →
+    API (`buildApi()` esbuild → api/dist/, string transforms; Babel pass only
+      when api/babel.config.js exists) →
     Web (`cedar-vite-build` → web/dist/) →
   --ud:
     unified Vite `buildApp({ ud: true })` with declared `client`, `api`, and `ssr`
-      environments (web/dist/ + api/dist/ + api/dist/ud/, preserveModules, Babel plugin,
+      environments (web/dist/ + api/dist/ + api/dist/ud/, preserveModules, dedicated
+      Vite plugins; Babel pass only when api/babel.config.js exists,
       adapter-free Fetchable at api/dist/ud/index.js) →
   prerender marked routes
 
@@ -351,18 +353,18 @@ It's GraphQL-only because:
      the cookie themselves. Preferrably with the help of the `useRequireAuth()`
      hook.
 
-| Path                                                      | Mechanism                  | ALS wrapping | `setContext()`  | `context.currentUser` |
-| --------------------------------------------------------- | -------------------------- | ------------ | --------------- | --------------------- |
-| **Non-UD dev** — GraphQL                                  | Fastify `onRequest` hook   | ✅           | ✅ plugin chain | ✅                    |
-| **Non-UD dev** — Functions                                | Fastify `onRequest` hook   | ✅           | ❌              | ❌ `undefined`        |
-| **Non-UD serve/deploy** (baremetal/docker) — GraphQL      | Fastify `onRequest` hook   | ✅           | ✅ plugin chain | ✅                    |
-| **Non-UD serve/deploy** (baremetal/docker) — Functions    | Fastify `onRequest` hook   | ✅           | ❌              | ❌ `undefined`        |
-| **Non-UD deploy** (Netlify/Vercel serverless) — GraphQL   | Babel safety net in output | ✅           | ✅ plugin chain | ✅                    |
-| **Non-UD deploy** (Netlify/Vercel serverless) — Functions | Babel safety net in output | ✅           | ❌              | ❌ `undefined`        |
-| **UD dev** — GraphQL                                      | Vite Babel transform       | ✅           | ✅ plugin chain | ✅                    |
-| **UD dev** — Functions                                    | Vite Babel transform       | ✅           | ❌              | ❌ `undefined`        |
-| **UD built/deploy** — GraphQL                             | Generated `store.run()`    | ✅           | ✅ plugin chain | ✅                    |
-| **UD built/deploy** — Functions                           | Generated `store.run()`    | ✅           | ❌              | ❌ `undefined`        |
+| Path                                                      | Mechanism                | ALS wrapping | `setContext()`  | `context.currentUser` |
+| --------------------------------------------------------- | ------------------------ | ------------ | --------------- | --------------------- |
+| **Non-UD dev** — GraphQL                                  | Fastify `onRequest` hook | ✅           | ✅ plugin chain | ✅                    |
+| **Non-UD dev** — Functions                                | Fastify `onRequest` hook | ✅           | ❌              | ❌ `undefined`        |
+| **Non-UD serve/deploy** (baremetal/docker) — GraphQL      | Fastify `onRequest` hook | ✅           | ✅ plugin chain | ✅                    |
+| **Non-UD serve/deploy** (baremetal/docker) — Functions    | Fastify `onRequest` hook | ✅           | ❌              | ❌ `undefined`        |
+| **Non-UD deploy** (Netlify/Vercel serverless) — GraphQL   | ALS wrapping in output   | ✅           | ✅ plugin chain | ✅                    |
+| **Non-UD deploy** (Netlify/Vercel serverless) — Functions | ALS wrapping in output   | ✅           | ❌              | ❌ `undefined`        |
+| **UD dev** — GraphQL                                      | Middleware `store.run()` | ✅           | ✅ plugin chain | ✅                    |
+| **UD dev** — Functions                                    | Middleware `store.run()` | ✅           | ❌              | ❌ `undefined`        |
+| **UD built/deploy** — GraphQL                             | Generated `store.run()`  | ✅           | ✅ plugin chain | ✅                    |
+| **UD built/deploy** — Functions                           | Generated `store.run()`  | ✅           | ❌              | ❌ `undefined`        |
 
 ## CONVENTIONS
 
@@ -378,7 +380,7 @@ It's GraphQL-only because:
   and `meta()` (SSR/RSC only: per-request meta tag injection)
 - Entry: `entry.client.tsx` (always). \*SSR/RSC: also `entry.server.tsx`
 - Routes in `Routes.tsx` as JSX (virtual, never rendered — auto-loaded by `cedar-routes-auto-loader` Vite/Babel plugin)
-- Build: default = esbuild (api) + Vite (web); `--ud` = unified Vite (`client` + `api` + `ssr` environments, `preserveModules: true`, Babel plugin)
+- Build: default = esbuild (api) + Vite (web); `--ud` = unified Vite (`client` + `api` + `ssr` environments, `preserveModules: true`; api Babel pass only when api/babel.config.js exists)
 - Server: API (Fastify by default; opt-in srvx via `cedar serve api --ud` or `cedar serve --ud`, which host the UD Fetchable from `api/dist/ud/index.js`). Web: Fastify (SPA). \*SSR/RSC: Web uses Express
 - Package mgr: Yarn 4 (+ experimental support for npm and pnpm); Framework: Yarn 4 + Nx (build orchestration).
 - Codegen: compile-time (Vite plugins) + on-demand (cedar-gen)

--- a/packages/babel-config/dist.test.ts
+++ b/packages/babel-config/dist.test.ts
@@ -11,6 +11,7 @@ describe('dist', () => {
         "TARGETS_NODE": "24",
         "getApiSideBabelConfigPath": [Function],
         "getApiSideBabelPlugins": [Function],
+        "getApiSideBabelPluginsForVite": [Function],
         "getApiSideBabelPresets": [Function],
         "getApiSideDefaultBabelConfig": [Function],
         "getCommonPlugins": [Function],

--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -58,28 +58,26 @@ export const getApiSideBabelPlugins = ({
   forVite = false,
   projectIsEsm = false,
 } = {}) => {
+  if (forVite) {
+    return getApiSideBabelPluginsForVite()
+  }
+
   const tsConfig = parseTypeScriptConfigFiles()
 
-  const plugins: (PluginShape | boolean)[] = [
+  const plugins: PluginList = [
     ...getCommonPlugins(),
     // Needed to support `/** @jsxImportSource custom-jsx-library */`
     // comments in JSX files
-    !forVite && ['@babel/plugin-transform-react-jsx', { runtime: 'automatic' }],
-    // For non-Vite consumers (Jest, registerApiSideBabelHook / Babel
-    // registerRequire paths such as data-migrate CJS and prerender CJS):
+    ['@babel/plugin-transform-react-jsx', { runtime: 'automatic' }],
+    // For the non-Vite consumers this function serves (Jest,
+    // registerApiSideBabelHook / Babel registerRequire paths such as
+    // data-migrate CJS and prerender CJS):
     //   • alias config: rewrites `src/` and tsconfig paths to relative paths
     //   • resolvePath: appends `.js`/`.jsx` to extensionless imports in ESM
     //     projects so Node's module resolver can find them, and strips `.js`
     //     suffixes in data-migrate / prerender contexts where the TypeScript
     //     source is `.ts` but callers write `.js` import specifiers.
-    //
-    // For Vite / esbuild (forVite: true):
-    //   • alias handling: covered by cedar-api-src-redirect + vite-tsconfig-paths
-    //     (Vite) or applySrcAlias + applyTsconfigPaths (esbuild)
-    //   • extension rewriting: covered by applyEsmExtensions in
-    //     runCedarBabelTransformsPlugin (esbuild); Vite / Rollup resolve
-    //     extensions themselves during bundling
-    !forVite && [
+    [
       'babel-plugin-module-resolver',
       {
         alias: {
@@ -135,14 +133,15 @@ export const getApiSideBabelPlugins = ({
     ],
     // Vite/esbuild use cedarDirectoryNamedImportPlugin / applyDirectoryNamedImport
     // instead of this babel plugin
-    !forVite && [
+    [
       pluginRedwoodDirectoryNamedImport,
       undefined,
       'rwjs-babel-directory-named-modules',
     ],
-    // Auto-import is handled by cedarAutoImportsPlugin for Vite; skip it in
-    // Vite contexts and keep it for non-Vite consumers (Jest, esbuild builds).
-    !forVite && [
+    // Auto-import is handled by cedarAutoImportsPlugin / applyAutoImports for
+    // Vite/esbuild; this Babel plugin serves the remaining non-Vite consumers
+    // (Jest, registerApiSideBabelHook).
+    [
       'babel-plugin-auto-import',
       {
         declarations: [
@@ -160,18 +159,44 @@ export const getApiSideBabelPlugins = ({
       },
       'rwjs-babel-auto-import',
     ],
-    !forVite && [
-      'babel-plugin-graphql-tag',
-      undefined,
-      'rwjs-babel-graphql-tag',
-    ],
+    ['babel-plugin-graphql-tag', undefined, 'rwjs-babel-graphql-tag'],
     // For Vite builds, glob imports are handled by cedarImportDirPlugin (Vite)
     // or applyImportDir (esbuild).  Keep the Babel plugin only for
     // non-Vite consumers: Jest, console, and data-migrate.
-    !forVite && [pluginRedwoodImportDir, {}, 'rwjs-babel-glob-import-dir'],
+    [pluginRedwoodImportDir, {}, 'rwjs-babel-glob-import-dir'],
   ]
 
-  return plugins.filter(<T>(n: T | boolean): n is T => Boolean(n))
+  return plugins
+}
+
+/**
+ * Purpose-built equivalent of `getApiSideBabelPlugins({ forVite: true })` for
+ * the Vite-driven api pipelines (buildCedarApp, the api dev middleware, and
+ * the esbuild/standalone-Vite api builds in @cedarjs/internal).
+ *
+ * Every Cedar-specific Babel plugin is gated behind `!forVite` in
+ * `getApiSideBabelPlugins` because these pipelines replace them with
+ * dedicated Vite/esbuild transforms:
+ *  - JSX/TypeScript compilation: handled natively by Vite/esbuild
+ *  - babel-plugin-module-resolver (`src/` and tsconfig `paths` aliases):
+ *    cedar-api-src-redirect + vite-tsconfig-paths (Vite) or applySrcAlias +
+ *    applyTsconfigPaths (esbuild); ESM extension rewriting is covered by
+ *    applyEsmExtensions
+ *  - directory-named imports: cedarDirectoryNamedImportPlugin /
+ *    applyDirectoryNamedImport
+ *  - auto-imports (gql, context): cedarAutoImportsPlugin / applyAutoImports
+ *  - graphql-tag: vite-plugin-graphql-tag
+ *  - glob imports: cedarImportDirPlugin / applyImportDir
+ *
+ * Only the common plugins remain — and that list is currently empty, which
+ * is why the Vite pipelines skip Babel entirely unless the project has a
+ * custom api/babel.config.js.
+ *
+ * The `projectIsEsm` option needs no equivalent here: it only affects the
+ * module-resolver `resolvePath` hook, which is a `!forVite` plugin.
+ */
+export const getApiSideBabelPluginsForVite = (): PluginList => {
+  return [...getCommonPlugins()]
 }
 
 export const getApiSideBabelConfigPath = () => {

--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -239,15 +239,18 @@ export const getApiSideBabelOverrides = ({
   return overrides as TransformOptions[]
 }
 
-export const getApiSideDefaultBabelConfig = ({
-  forVite = false,
-  projectIsEsm = false,
-  forJest = false,
-} = {}) => {
+/**
+ * The default api-side Babel config for Jest (@cedarjs/testing) and the
+ * Babel ESLint parser (@cedarjs/eslint-config). The Jest-only handler ALS
+ * wrapping override is always included: it only matches api/src/functions
+ * files, and for the parse-only ESLint consumer transform plugins have no
+ * effect.
+ */
+export const getApiSideDefaultBabelConfig = () => {
   return {
     presets: getApiSideBabelPresets(),
-    plugins: getApiSideBabelPlugins({ forVite, projectIsEsm }),
-    overrides: getApiSideBabelOverrides({ forVite, projectIsEsm, forJest }),
+    plugins: getApiSideBabelPlugins(),
+    overrides: getApiSideBabelOverrides({ forJest: true }),
     extends: getApiSideBabelConfigPath(),
     babelrc: false,
     ignore: ['node_modules'],
@@ -259,17 +262,18 @@ export const registerApiSideBabelHook = ({
   plugins = [],
   ...rest
 }: RegisterHookOptions = {}) => {
-  const defaultOptions = getApiSideDefaultBabelConfig({
-    projectIsEsm: projectSideIsEsm('api'),
-  })
+  const projectIsEsm = projectSideIsEsm('api')
 
   registerBabel({
-    ...defaultOptions,
     presets: getApiSideBabelPresets({
       presetEnv: true,
     }),
+    overrides: getApiSideBabelOverrides({ projectIsEsm }),
+    extends: getApiSideBabelConfigPath(),
+    babelrc: false,
+    ignore: ['node_modules'],
     extensions: ['.js', '.ts', '.jsx', '.tsx'],
-    plugins: [...defaultOptions.plugins, ...plugins],
+    plugins: [...getApiSideBabelPlugins({ projectIsEsm }), ...plugins],
     cache: false,
     ...rest,
   })
@@ -282,13 +286,15 @@ export const transformWithBabel = async (
   sourceMaps: TransformOptions['sourceMaps'] = 'inline',
   forVite = false,
 ) => {
-  const defaultOptions = getApiSideDefaultBabelConfig({
-    forVite,
-    projectIsEsm: projectSideIsEsm('api'),
-  })
-
   const result = transformAsync(sourceCode, {
-    ...defaultOptions,
+    presets: getApiSideBabelPresets(),
+    overrides: getApiSideBabelOverrides({
+      forVite,
+      projectIsEsm: projectSideIsEsm('api'),
+    }),
+    extends: getApiSideBabelConfigPath(),
+    babelrc: false,
+    ignore: ['node_modules'],
     cwd: getPaths().api.base,
     filename,
     // The default 'inline' embeds the map as a data URL in result.code,

--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -285,6 +285,10 @@ export const transformWithBabel = async (
   plugins: TransformOptions['plugins'],
   sourceMaps: TransformOptions['sourceMaps'] = 'inline',
   forVite = false,
+  // When sourceCode is itself the output of an earlier transform, pass that
+  // transform's map here and Babel will compose it into the map it emits, so
+  // the result maps all the way back to the original source.
+  inputSourceMap: TransformOptions['inputSourceMap'] = undefined,
 ) => {
   const result = transformAsync(sourceCode, {
     presets: getApiSideBabelPresets(),
@@ -303,6 +307,7 @@ export const transformWithBabel = async (
     // SSR source map chaining.
     sourceMaps,
     plugins,
+    inputSourceMap,
   })
 
   return result

--- a/packages/babel-config/src/index.ts
+++ b/packages/babel-config/src/index.ts
@@ -15,6 +15,8 @@ export {
   getApiSideBabelConfigPath,
   /** Used by @cedarjs/internal and @cedarjs/testing */
   getApiSideBabelPlugins,
+  /** Used by @cedarjs/internal and @cedarjs/vite */
+  getApiSideBabelPluginsForVite,
   /** Used by @cedarjs/testing */
   getApiSideBabelPresets,
   /** Used by @cedarjs/testing and @cedarjs/eslint-config */

--- a/packages/babel-config/src/index.ts
+++ b/packages/babel-config/src/index.ts
@@ -19,7 +19,7 @@ export {
   getApiSideBabelPresets,
   /** Used by @cedarjs/testing and @cedarjs/eslint-config */
   getApiSideDefaultBabelConfig,
-  /** Used by @cedarjs/cli, @remix/cli-helpers and @cedarjs/prerender */
+  /** Used by @cedarjs/cli, @cedarjs/cli-helpers and @cedarjs/prerender */
   registerApiSideBabelHook,
   /** Used by @cedarjs/internal and @cedarjs/vite */
   transformWithBabel,

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -11,6 +11,7 @@ const { getConfig, isTypeScriptProject } = require('@cedarjs/project-config')
 
 const config = getConfig()
 
+/** @returns {import('@babel/core').TransformOptions} */
 const getProjectBabelOptions = () => {
   // We can't nest the web overrides inside the overrides block
   // So we just take it out and put it as a separate item

--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -16,9 +16,11 @@ import { getConfig, isTypeScriptProject } from '@cedarjs/project-config'
 import sharedConfigs from './shared.mjs'
 
 // Note: This config is async to support getConfig()
+/** @returns {Promise<import('eslint').Linter.FlatConfig[]>} */
 export default async function createConfig() {
   const config = await getConfig()
 
+  /** @returns {import('@babel/core').TransformOptions} */
   const getProjectBabelOptions = () => {
     // We can't nest the web overrides inside the overrides block
     // So we just take it out and put it as a separate item

--- a/packages/eslint-config/shared.mjs
+++ b/packages/eslint-config/shared.mjs
@@ -26,7 +26,10 @@ import tseslint from 'typescript-eslint'
 
 import cedarjsPlugin from '@cedarjs/eslint-plugin'
 
-export default [
+// Using a const here rather than directly doing `export default [...]` becuase
+// otherwise the JSDoc below wouldn't attach it's type info properly
+/** @type {import('eslint').Linter.FlatConfig[]} */
+const sharedConfigs = [
   // Base recommended config
   js.configs.recommended,
 
@@ -270,3 +273,5 @@ export default [
     },
   },
 ]
+
+export default sharedConfigs

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -112,15 +112,27 @@ const runCedarBabelTransformsPlugin = {
       fileContents =
         applyImportDir(fileContents, args.path)?.code ?? fileContents
 
-      // The Babel pass is only needed to apply a user's custom
-      // api/babel.config.js: getApiSideBabelPluginsForVite() is empty (the
-      // transforms above replace Cedar's api-side Babel plugins) and esbuild
-      // strips TypeScript itself when given the matching loader.
+      const normalizedPath = normalizePath(args.path)
+      const cedarPaths = getPaths()
+      const isEsm = projectSideIsEsm('api')
+
+      // The Babel pass is needed to apply a user's custom api/babel.config.js
+      // — getApiSideBabelPluginsForVite() is empty (the transforms above
+      // replace Cedar's api-side Babel plugins) and esbuild strips TypeScript
+      // itself when given the matching loader. Job files are the exception:
+      // they rely on the Babel job path injector override (see
+      // getApiSideBabelOverrides) to add `path` and `name` to createJob()
+      // definitions, because this pipeline has no equivalent of the
+      // cedarjsJobPathInjectorPlugin that the @cedarjs/vite pipelines use.
       const apiBabelConfigPath = getApiSideBabelConfigPath()
+      const isJobsFile = normalizedPath.startsWith(
+        normalizePath(cedarPaths.api.jobs) + '/',
+      )
+      const useBabel = Boolean(apiBabelConfigPath) || isJobsFile
 
       let code = fileContents
 
-      if (apiBabelConfigPath) {
+      if (useBabel) {
         const transformedCode = await transformWithBabel(
           fileContents,
           args.path,
@@ -133,10 +145,6 @@ const runCedarBabelTransformsPlugin = {
 
         code = transformedCode.code
       }
-
-      const normalizedPath = normalizePath(args.path)
-      const cedarPaths = getPaths()
-      const isEsm = projectSideIsEsm('api')
 
       // For ESM projects, append .js/.jsx to extensionless relative imports
       // so Node's ESM resolver can locate the compiled output files at
@@ -172,7 +180,7 @@ const runCedarBabelTransformsPlugin = {
         // Babel output is always plain JS. Without Babel the contents are
         // still TypeScript/JSX, so pick the loader matching the file's
         // extension and let esbuild do the stripping.
-        loader: apiBabelConfigPath ? 'js' : getEsbuildLoader(args.path),
+        loader: useBabel ? 'js' : getEsbuildLoader(args.path),
       }
     })
   },
@@ -321,13 +329,21 @@ function createCedarViteApiPlugin(): Plugin {
         sourceCode = applyGqlormInject(sourceCode, id) ?? sourceCode
       }
 
-      // The Babel pass is only needed to apply a user's custom
-      // api/babel.config.js: getApiSideBabelPluginsForVite() is empty (the
-      // transforms in this pipeline replace Cedar's api-side Babel plugins)
-      // and Vite strips TypeScript itself.
+      // The Babel pass is needed to apply a user's custom api/babel.config.js
+      // — getApiSideBabelPluginsForVite() is empty (the transforms in this
+      // pipeline replace Cedar's api-side Babel plugins) and Vite strips
+      // TypeScript itself. Job files are the exception: they rely on the
+      // Babel job path injector override (see getApiSideBabelOverrides) to
+      // add `path` and `name` to createJob() definitions, because this
+      // pipeline has no equivalent of the cedarjsJobPathInjectorPlugin that
+      // the @cedarjs/vite pipelines use.
       const apiBabelConfigPath = getApiSideBabelConfigPath()
+      const isJobsFile = normalizedId.startsWith(
+        normalizePath(cedarPaths.api.jobs) + '/',
+      )
+      const useBabel = Boolean(apiBabelConfigPath) || isJobsFile
 
-      const transformedCode = apiBabelConfigPath
+      const transformedCode = useBabel
         ? await transformWithBabel(
             sourceCode,
             id,
@@ -336,7 +352,7 @@ function createCedarViteApiPlugin(): Plugin {
           )
         : null
 
-      if (apiBabelConfigPath && !transformedCode?.code) {
+      if (useBabel && !transformedCode?.code) {
         throw new Error(`Could not transform file: ${id}`)
       }
 

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -17,6 +17,7 @@ const tsconfigPaths =
   tsPathsMod.default?.default || tsPathsMod.default || tsPathsMod
 
 import {
+  getApiSideBabelConfigPath,
   getApiSideBabelPlugins,
   transformWithBabel,
 } from '@cedarjs/babel-config'
@@ -108,61 +109,92 @@ const runCedarBabelTransformsPlugin = {
       // running on the same file.
       fileContents =
         applyImportDir(fileContents, args.path)?.code ?? fileContents
-      const transformedCode = await transformWithBabel(
-        fileContents,
-        args.path,
-        getApiSideBabelPlugins({
-          forVite: true,
-          projectIsEsm: projectSideIsEsm('api'),
-        }),
-      )
 
-      if (transformedCode?.code) {
-        let code = transformedCode.code
-        const normalizedPath = normalizePath(args.path)
-        const cedarPaths = getPaths()
-        const isEsm = projectSideIsEsm('api')
+      // The Babel pass is only needed to apply a user's custom
+      // api/babel.config.js: getApiSideBabelPlugins({ forVite: true }) is
+      // empty (the transforms above replace Cedar's api-side Babel plugins)
+      // and esbuild strips TypeScript itself when given the matching loader.
+      const apiBabelConfigPath = getApiSideBabelConfigPath()
 
-        // For ESM projects, append .js/.jsx to extensionless relative imports
-        // so Node's ESM resolver can locate the compiled output files at
-        // runtime.  This replaces the resolvePath hook that
-        // babel-plugin-module-resolver previously provided; that plugin is now
-        // skipped for forVite:true builds.
-        if (isEsm) {
-          code = applyEsmExtensions(code, args.path)
+      let code = fileContents
+
+      if (apiBabelConfigPath) {
+        const transformedCode = await transformWithBabel(
+          fileContents,
+          args.path,
+          getApiSideBabelPlugins({
+            forVite: true,
+            projectIsEsm: projectSideIsEsm('api'),
+          }),
+        )
+
+        if (!transformedCode?.code) {
+          throw new Error(`Could not transform file: ${args.path}`)
         }
 
-        // Apply OTel wrapping and the handler ALS wrapping safeguard to API
-        // function handlers. These are the standalone-esbuild equivalents of
-        // the Vite cedarOtelWrappingPlugin and handlerAlsWrappingPlugin,
-        // replacing the Babel plugins for these builds. The ALS wrapping
-        // plugin replaces the (Jest-only) Babel plugin it succeeded.
-        // graphql.ts also lives in functions/ but is claimed by the dedicated
-        // cedarApiGraphqlPlugin, which is registered before this plugin, so it
-        // never reaches this branch.
-        const functionsDir = normalizePath(cedarPaths.api.functions)
-        if (normalizedPath.startsWith(functionsDir + '/')) {
-          code =
-            applyHandlerAlsWrapping(code, {
-              projectIsEsm: isEsm,
-            }) ?? code
-        }
-
-        if (
-          normalizedPath.startsWith(normalizePath(cedarPaths.api.src) + '/')
-        ) {
-          code = applyOtelWrapping(code, args.path, cedarPaths.api.src) ?? code
-        }
-
-        return {
-          contents: code,
-          loader: 'js',
-        }
+        code = transformedCode.code
       }
 
-      throw new Error(`Could not transform file: ${args.path}`)
+      const normalizedPath = normalizePath(args.path)
+      const cedarPaths = getPaths()
+      const isEsm = projectSideIsEsm('api')
+
+      // For ESM projects, append .js/.jsx to extensionless relative imports
+      // so Node's ESM resolver can locate the compiled output files at
+      // runtime.  This replaces the resolvePath hook that
+      // babel-plugin-module-resolver previously provided; that plugin is now
+      // skipped for forVite:true builds.
+      if (isEsm) {
+        code = applyEsmExtensions(code, args.path)
+      }
+
+      // Apply OTel wrapping and the handler ALS wrapping safeguard to API
+      // function handlers. These are the standalone-esbuild equivalents of
+      // the Vite cedarOtelWrappingPlugin and handlerAlsWrappingPlugin,
+      // replacing the Babel plugins for these builds. The ALS wrapping
+      // plugin replaces the (Jest-only) Babel plugin it succeeded.
+      // graphql.ts also lives in functions/ but is claimed by the dedicated
+      // cedarApiGraphqlPlugin, which is registered before this plugin, so it
+      // never reaches this branch.
+      const functionsDir = normalizePath(cedarPaths.api.functions)
+      if (normalizedPath.startsWith(functionsDir + '/')) {
+        code =
+          applyHandlerAlsWrapping(code, {
+            projectIsEsm: isEsm,
+          }) ?? code
+      }
+
+      if (normalizedPath.startsWith(normalizePath(cedarPaths.api.src) + '/')) {
+        code = applyOtelWrapping(code, args.path, cedarPaths.api.src) ?? code
+      }
+
+      return {
+        contents: code,
+        // Babel output is always plain JS. Without Babel the contents are
+        // still TypeScript/JSX, so pick the loader matching the file's
+        // extension and let esbuild do the stripping.
+        loader: apiBabelConfigPath ? 'js' : getEsbuildLoader(args.path),
+      }
     })
   },
+}
+
+/**
+ * Maps a source file's extension to the esbuild loader that can parse it.
+ * Used when the Babel pass is skipped and esbuild receives untranspiled
+ * TypeScript/JSX contents from an onLoad hook.
+ */
+function getEsbuildLoader(filePath: string): 'js' | 'jsx' | 'ts' | 'tsx' {
+  switch (path.extname(filePath)) {
+    case '.ts':
+      return 'ts'
+    case '.tsx':
+      return 'tsx'
+    case '.jsx':
+      return 'jsx'
+    default:
+      return 'js'
+  }
 }
 
 /**
@@ -290,56 +322,65 @@ function createCedarViteApiPlugin(): Plugin {
         sourceCode = applyGqlormInject(sourceCode, id) ?? sourceCode
       }
 
-      const transformedCode = await transformWithBabel(
-        sourceCode,
-        id,
-        getApiSideBabelPlugins({
-          forVite: true,
-          projectIsEsm: isEsm,
-        }),
-        true,
-      )
+      // The Babel pass is only needed to apply a user's custom
+      // api/babel.config.js: getApiSideBabelPlugins({ forVite: true }) is
+      // empty (the transforms in this pipeline replace Cedar's api-side Babel
+      // plugins) and Vite strips TypeScript itself.
+      const apiBabelConfigPath = getApiSideBabelConfigPath()
 
-      if (transformedCode?.code) {
-        let code = transformedCode.code
-
-        // Apply OTel wrapping to all API files.
-        if (
-          cedarConfig.experimental?.opentelemetry?.enabled &&
-          cedarConfig.experimental?.opentelemetry?.wrapApi
-        ) {
-          code = applyOtelWrapping(code, id, cedarPaths.api.src) ?? code
-        }
-
-        // Append .js/.jsx extensions to extensionless relative imports so that
-        // Node's ESM resolver can find them at runtime. This replaces the
-        // resolvePath hook in babel-plugin-module-resolver, which is disabled
-        // for forVite:true builds (babel-config/src/api.ts). With
-        // preserveModules:true Rollup preserves the import specifiers as-is
-        // in the output, so extensions must be present before bundling.
-        if (isEsm) {
-          code = applyEsmExtensions(code, id)
-        }
-
-        // Apply the handler ALS wrapping safeguard to API function handlers.
-        // This is the standalone-esbuild equivalent of the Vite
-        // handlerAlsWrappingPlugin and the (Jest-only) babel plugin it
-        // replaced.
-        const functionsDir = normalizePath(cedarPaths.api.functions)
-        if (normalizedId.startsWith(functionsDir + '/')) {
-          code =
-            applyHandlerAlsWrapping(code, {
+      const transformedCode = apiBabelConfigPath
+        ? await transformWithBabel(
+            sourceCode,
+            id,
+            getApiSideBabelPlugins({
+              forVite: true,
               projectIsEsm: isEsm,
-            }) ?? code
-        }
+            }),
+            true,
+          )
+        : null
 
-        return {
-          code,
-          map: transformedCode.map ?? null,
-        }
+      if (apiBabelConfigPath && !transformedCode?.code) {
+        throw new Error(`Could not transform file: ${id}`)
       }
 
-      throw new Error(`Could not transform file: ${id}`)
+      let outputCode = transformedCode?.code ?? sourceCode
+
+      // Apply OTel wrapping to all API files.
+      if (
+        cedarConfig.experimental?.opentelemetry?.enabled &&
+        cedarConfig.experimental?.opentelemetry?.wrapApi
+      ) {
+        outputCode =
+          applyOtelWrapping(outputCode, id, cedarPaths.api.src) ?? outputCode
+      }
+
+      // Append .js/.jsx extensions to extensionless relative imports so that
+      // Node's ESM resolver can find them at runtime. This replaces the
+      // resolvePath hook in babel-plugin-module-resolver, which is disabled
+      // for forVite:true builds (babel-config/src/api.ts). With
+      // preserveModules:true Rollup preserves the import specifiers as-is
+      // in the output, so extensions must be present before bundling.
+      if (isEsm) {
+        outputCode = applyEsmExtensions(outputCode, id)
+      }
+
+      // Apply the handler ALS wrapping safeguard to API function handlers.
+      // This is the standalone-esbuild equivalent of the Vite
+      // handlerAlsWrappingPlugin and the (Jest-only) babel plugin it
+      // replaced.
+      const functionsDir = normalizePath(cedarPaths.api.functions)
+      if (normalizedId.startsWith(functionsDir + '/')) {
+        outputCode =
+          applyHandlerAlsWrapping(outputCode, {
+            projectIsEsm: isEsm,
+          }) ?? outputCode
+      }
+
+      return {
+        code: outputCode,
+        map: transformedCode?.map ?? null,
+      }
     },
   }
 }

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import type { BuildContext, BuildOptions, PluginBuild } from 'esbuild'
 import { build, context } from 'esbuild'
+import MagicString from 'magic-string'
 import type { Plugin } from 'vite'
 import { build as viteBuild, normalizePath } from 'vite'
 import tsPathsMod from 'vite-tsconfig-paths'
@@ -372,9 +373,26 @@ function createCedarViteApiPlugin(): Plugin {
           }) ?? outputCode
       }
 
+      if (!transformedCode) {
+        // Without Babel there's no transform to report when the string
+        // rewrites didn't change anything.
+        if (outputCode === code) {
+          return null
+        }
+
+        // No Babel map to chain; a high-resolution identity map over the
+        // input keeps the sourcemap chain intact. This matches the fidelity
+        // of the Babel path, whose map also predates the post-Babel string
+        // transforms.
+        return {
+          code: outputCode,
+          map: new MagicString(code).generateMap({ hires: true }),
+        }
+      }
+
       return {
         code: outputCode,
-        map: transformedCode?.map ?? null,
+        map: transformedCode.map ?? null,
       }
     },
   }

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -18,7 +18,7 @@ const tsconfigPaths =
 
 import {
   getApiSideBabelConfigPath,
-  getApiSideBabelPlugins,
+  getApiSideBabelPluginsForVite,
   transformWithBabel,
 } from '@cedarjs/babel-config'
 import {
@@ -99,8 +99,9 @@ const runCedarBabelTransformsPlugin = {
       fileContents = applyDirectoryNamedImport(fileContents, args.path)
       fileContents = applyAutoImports(fileContents)
       // Expand glob imports (e.g. `import x from 'src/services/**/*.ts'`)
-      // before Babel runs.  The Babel import-dir plugin is disabled for these
-      // builds (forVite: true); applyImportDir is the esbuild equivalent.
+      // before Babel runs.  The Babel import-dir plugin is not part of
+      // getApiSideBabelPluginsForVite(); applyImportDir is the esbuild
+      // equivalent.
       //
       // This is intentionally applied inline rather than as a separate esbuild
       // plugin because esbuild 0.27 lacks onTransform chaining — onLoad
@@ -111,9 +112,9 @@ const runCedarBabelTransformsPlugin = {
         applyImportDir(fileContents, args.path)?.code ?? fileContents
 
       // The Babel pass is only needed to apply a user's custom
-      // api/babel.config.js: getApiSideBabelPlugins({ forVite: true }) is
-      // empty (the transforms above replace Cedar's api-side Babel plugins)
-      // and esbuild strips TypeScript itself when given the matching loader.
+      // api/babel.config.js: getApiSideBabelPluginsForVite() is empty (the
+      // transforms above replace Cedar's api-side Babel plugins) and esbuild
+      // strips TypeScript itself when given the matching loader.
       const apiBabelConfigPath = getApiSideBabelConfigPath()
 
       let code = fileContents
@@ -122,10 +123,7 @@ const runCedarBabelTransformsPlugin = {
         const transformedCode = await transformWithBabel(
           fileContents,
           args.path,
-          getApiSideBabelPlugins({
-            forVite: true,
-            projectIsEsm: projectSideIsEsm('api'),
-          }),
+          getApiSideBabelPluginsForVite(),
         )
 
         if (!transformedCode?.code) {
@@ -142,8 +140,8 @@ const runCedarBabelTransformsPlugin = {
       // For ESM projects, append .js/.jsx to extensionless relative imports
       // so Node's ESM resolver can locate the compiled output files at
       // runtime.  This replaces the resolvePath hook that
-      // babel-plugin-module-resolver previously provided; that plugin is now
-      // skipped for forVite:true builds.
+      // babel-plugin-module-resolver previously provided; that plugin is not
+      // part of getApiSideBabelPluginsForVite().
       if (isEsm) {
         code = applyEsmExtensions(code, args.path)
       }
@@ -323,19 +321,16 @@ function createCedarViteApiPlugin(): Plugin {
       }
 
       // The Babel pass is only needed to apply a user's custom
-      // api/babel.config.js: getApiSideBabelPlugins({ forVite: true }) is
-      // empty (the transforms in this pipeline replace Cedar's api-side Babel
-      // plugins) and Vite strips TypeScript itself.
+      // api/babel.config.js: getApiSideBabelPluginsForVite() is empty (the
+      // transforms in this pipeline replace Cedar's api-side Babel plugins)
+      // and Vite strips TypeScript itself.
       const apiBabelConfigPath = getApiSideBabelConfigPath()
 
       const transformedCode = apiBabelConfigPath
         ? await transformWithBabel(
             sourceCode,
             id,
-            getApiSideBabelPlugins({
-              forVite: true,
-              projectIsEsm: isEsm,
-            }),
+            getApiSideBabelPluginsForVite(),
             true,
           )
         : null
@@ -357,8 +352,8 @@ function createCedarViteApiPlugin(): Plugin {
 
       // Append .js/.jsx extensions to extensionless relative imports so that
       // Node's ESM resolver can find them at runtime. This replaces the
-      // resolvePath hook in babel-plugin-module-resolver, which is disabled
-      // for forVite:true builds (babel-config/src/api.ts). With
+      // resolvePath hook in babel-plugin-module-resolver, which is not part
+      // of getApiSideBabelPluginsForVite() (babel-config/src/api.ts). With
       // preserveModules:true Rollup preserves the import specifiers as-is
       // in the output, so extensions must be present before bundling.
       if (isEsm) {
@@ -438,8 +433,8 @@ export const buildApiWithVite = async () => {
     },
     // cedarImportDirPlugin must run before the Babel transform so glob imports
     // are expanded before Babel sees the code.  The Babel import-dir plugin is
-    // disabled for forVite:true builds; this inline Vite plugin is its
-    // replacement for this code path (both CJS and ESM output via Rollup).
+    // not part of getApiSideBabelPluginsForVite(); this inline Vite plugin is
+    // its replacement for this code path (both CJS and ESM output via Rollup).
     // tsconfigPaths resolves user-defined tsconfig.json `paths` aliases; it
     // replaces the Babel module-resolver's tsconfig-paths handling for this
     // code path.

--- a/packages/internal/src/build/esbuild-plugin-api-graphql.ts
+++ b/packages/internal/src/build/esbuild-plugin-api-graphql.ts
@@ -16,7 +16,7 @@ import type { PluginBuild } from 'esbuild'
 
 import {
   getApiSideBabelConfigPath,
-  getApiSideBabelPlugins,
+  getApiSideBabelPluginsForVite,
   transformWithBabel,
 } from '@cedarjs/babel-config'
 import { getConfig, getPaths, projectSideIsEsm } from '@cedarjs/project-config'
@@ -86,15 +86,16 @@ export const cedarApiGraphqlPlugin = {
       fileContents = applyAutoImports(fileContents)
 
       // Expand glob imports (e.g. `import x from 'src/services/**/*.ts'`)
-      // before Babel runs.  The Babel import-dir plugin is disabled for these
-      // builds (forVite: true); applyImportDir is the esbuild equivalent.
+      // before Babel runs.  The Babel import-dir plugin is not part of
+      // getApiSideBabelPluginsForVite(); applyImportDir is the esbuild
+      // equivalent.
       fileContents =
         applyImportDir(fileContents, args.path)?.code ?? fileContents
 
       // The Babel pass is only needed to apply a user's custom
-      // api/babel.config.js: getApiSideBabelPlugins({ forVite: true }) is
-      // empty (the transforms above replace Cedar's api-side Babel plugins)
-      // and esbuild strips TypeScript itself when given the 'ts' loader.
+      // api/babel.config.js: getApiSideBabelPluginsForVite() is empty (the
+      // transforms above replace Cedar's api-side Babel plugins) and esbuild
+      // strips TypeScript itself when given the 'ts' loader.
       const apiBabelConfigPath = getApiSideBabelConfigPath()
 
       let code = fileContents
@@ -103,10 +104,7 @@ export const cedarApiGraphqlPlugin = {
         const transformedCode = await transformWithBabel(
           fileContents,
           args.path,
-          getApiSideBabelPlugins({
-            forVite: true,
-            projectIsEsm: projectSideIsEsm('api'),
-          }),
+          getApiSideBabelPluginsForVite(),
         )
 
         if (!transformedCode?.code) {

--- a/packages/internal/src/build/esbuild-plugin-api-graphql.ts
+++ b/packages/internal/src/build/esbuild-plugin-api-graphql.ts
@@ -15,6 +15,7 @@ import path from 'node:path'
 import type { PluginBuild } from 'esbuild'
 
 import {
+  getApiSideBabelConfigPath,
   getApiSideBabelPlugins,
   transformWithBabel,
 } from '@cedarjs/babel-config'
@@ -90,20 +91,30 @@ export const cedarApiGraphqlPlugin = {
       fileContents =
         applyImportDir(fileContents, args.path)?.code ?? fileContents
 
-      const transformedCode = await transformWithBabel(
-        fileContents,
-        args.path,
-        getApiSideBabelPlugins({
-          forVite: true,
-          projectIsEsm: projectSideIsEsm('api'),
-        }),
-      )
+      // The Babel pass is only needed to apply a user's custom
+      // api/babel.config.js: getApiSideBabelPlugins({ forVite: true }) is
+      // empty (the transforms above replace Cedar's api-side Babel plugins)
+      // and esbuild strips TypeScript itself when given the 'ts' loader.
+      const apiBabelConfigPath = getApiSideBabelConfigPath()
 
-      if (!transformedCode?.code) {
-        throw new Error(`Could not transform file: ${args.path}`)
+      let code = fileContents
+
+      if (apiBabelConfigPath) {
+        const transformedCode = await transformWithBabel(
+          fileContents,
+          args.path,
+          getApiSideBabelPlugins({
+            forVite: true,
+            projectIsEsm: projectSideIsEsm('api'),
+          }),
+        )
+
+        if (!transformedCode?.code) {
+          throw new Error(`Could not transform file: ${args.path}`)
+        }
+
+        code = transformedCode.code
       }
-
-      let code = transformedCode.code
 
       // For ESM projects, append .js to extensionless relative imports so
       // Node's ESM resolver can find them at runtime. applyImportDir expands
@@ -130,7 +141,11 @@ export const cedarApiGraphqlPlugin = {
 
       return {
         contents: code,
-        loader: 'js',
+        // Babel output is always plain JS. Without Babel the contents are
+        // still TypeScript when the source file is graphql.ts, so pick the
+        // matching loader and let esbuild do the stripping. (The onLoad
+        // filter only matches .ts and .js files.)
+        loader: !apiBabelConfigPath && args.path.endsWith('.ts') ? 'ts' : 'js',
       }
     })
   },

--- a/packages/testing/src/config/jest/api/apiBabelConfig.ts
+++ b/packages/testing/src/config/jest/api/apiBabelConfig.ts
@@ -7,9 +7,7 @@ import {
 // Since configFile and babelrc is already passed a level up, cleaning up these keys here.
 // babelrc can not reside inside "extend"ed
 // Ref: packages/testing/config/jest/api/index.js
-const { babelrc: _b, ...defaultBabelConfig } = getApiSideDefaultBabelConfig({
-  forJest: true,
-})
+const { babelrc: _b, ...defaultBabelConfig } = getApiSideDefaultBabelConfig()
 
 type ConfigType = Omit<
   ReturnType<typeof getApiSideDefaultBabelConfig>,

--- a/packages/testing/src/config/jest/api/jest-preset.ts
+++ b/packages/testing/src/config/jest/api/jest-preset.ts
@@ -6,7 +6,7 @@ import { getApiSideDefaultBabelConfig } from '@cedarjs/babel-config'
 import { getPaths } from '@cedarjs/project-config'
 
 const rwjsPaths = getPaths()
-const { babelrc } = getApiSideDefaultBabelConfig({ forJest: true })
+const { babelrc } = getApiSideDefaultBabelConfig()
 
 /**
  * Resolve a specifier through the package's `exports` map.

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -23,14 +23,14 @@ import { buildCedarContext, wrapLegacyHandler } from '@cedarjs/api/runtime'
 import type { CedarHandler, LegacyHandler } from '@cedarjs/api/runtime'
 import {
   getApiSideBabelConfigPath,
-  getApiSideBabelPlugins,
+  getApiSideBabelPluginsForVite,
   transformWithBabel,
 } from '@cedarjs/babel-config'
 import { getAsyncStoreInstance } from '@cedarjs/context/dist/store'
 import { createGraphQLYoga } from '@cedarjs/graphql-server'
 import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
 import { applyGqlormInject } from '@cedarjs/internal/dist/build/api-graphql-transforms.js'
-import { getConfig, getPaths, projectSideIsEsm } from '@cedarjs/project-config'
+import { getConfig, getPaths } from '@cedarjs/project-config'
 
 import { getWorkspacePackageAliases } from './lib/workspacePackageAliases.js'
 import { cedarAutoImportsPlugin } from './plugins/vite-plugin-cedar-auto-import.js'
@@ -200,19 +200,15 @@ async function internalLoadApiFunctions(viteServer: ViteDevServer) {
 export async function createApiViteServer(): Promise<ViteDevServer> {
   const cedarPaths = getPaths()
   const cedarConfig = getConfig()
-  const isEsm = projectSideIsEsm('api')
   const normalizedBase = normalizePath(cedarPaths.base)
 
   // The Babel pass is only needed to apply a user's custom
-  // api/babel.config.js: getApiSideBabelPlugins({ forVite: true }) is empty
-  // (all of Cedar's api-side Babel transforms are handled by dedicated Vite
-  // plugins in this pipeline) and Vite strips TypeScript itself. Skip Babel
-  // entirely when the project has no such config file.
+  // api/babel.config.js: getApiSideBabelPluginsForVite() is empty (all of
+  // Cedar's api-side Babel transforms are handled by dedicated Vite plugins
+  // in this pipeline) and Vite strips TypeScript itself. Skip Babel entirely
+  // when the project has no such config file.
   const babelPlugins = getApiSideBabelConfigPath()
-    ? getApiSideBabelPlugins({
-        forVite: true,
-        projectIsEsm: isEsm,
-      })
+    ? getApiSideBabelPluginsForVite()
     : null
 
   const workspacePkgSourceMap = Object.fromEntries(

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -5,7 +5,6 @@ import { pathToFileURL } from 'node:url'
 
 import ansis from 'ansis'
 import type { Handler } from 'aws-lambda'
-import MagicString from 'magic-string'
 import type { SourceMap } from 'magic-string'
 import { normalizePath } from 'vite'
 import type { ModuleNode, Plugin, ViteDevServer } from 'vite'
@@ -34,6 +33,7 @@ import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
 import { applyGqlormInject } from '@cedarjs/internal/dist/build/api-graphql-transforms.js'
 import { getConfig, getPaths } from '@cedarjs/project-config'
 
+import { generateDiffSourceMap } from './lib/generateDiffSourceMap.js'
 import { getWorkspacePackageAliases } from './lib/workspacePackageAliases.js'
 import { cedarAutoImportsPlugin } from './plugins/vite-plugin-cedar-auto-import.js'
 import { cedarDirectoryNamedImportPlugin } from './plugins/vite-plugin-cedar-directory-named-import.js'
@@ -333,8 +333,10 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
             // Without a user Babel config there is nothing left for Babel to
             // do — Vite's own pipeline strips TypeScript — so only return the
             // string-transformed code (if it changed at all). When no exact
-            // map is available, fall back to a high-resolution identity map
-            // over the input so the sourcemap chain stays intact.
+            // map is available (gqlorm injection or OTel wrapping changed the
+            // code), derive one by diffing input and output so that line
+            // insertions still map every unchanged line — and therefore
+            // ssrFixStacktrace positions — correctly.
             if (!babelPlugins) {
               if (sourceCode === code) {
                 return null
@@ -342,9 +344,7 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
 
               return {
                 code: sourceCode,
-                map:
-                  sourceMap ??
-                  new MagicString(code).generateMap({ hires: true }),
+                map: sourceMap ?? generateDiffSourceMap(code, sourceCode),
               }
             }
 

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -5,6 +5,8 @@ import { pathToFileURL } from 'node:url'
 
 import ansis from 'ansis'
 import type { Handler } from 'aws-lambda'
+import MagicString from 'magic-string'
+import type { SourceMap } from 'magic-string'
 import { normalizePath } from 'vite'
 import type { ModuleNode, Plugin, ViteDevServer } from 'vite'
 import { gqlPlugin as gqlTagPlugin } from 'vite-plugin-graphql-tag'
@@ -291,13 +293,26 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
             // syntax; running them first ensures they always work regardless
             // of the project's module format.
             let sourceCode = code
+            // Exact sourcemap for the string transforms applied so far. Only
+            // the graphql options extract produces one; if a later transform
+            // changes the code again the map no longer matches and is
+            // cleared.
+            let sourceMap: SourceMap | null = null
             if (
               normalizePath(id).endsWith('/graphql.ts') ||
               normalizePath(id).endsWith('/graphql.js')
             ) {
               const extracted = applyGraphqlOptionsExtract(sourceCode)
-              sourceCode = extracted?.code ?? sourceCode
-              sourceCode = applyGqlormInject(sourceCode, id) ?? sourceCode
+              if (extracted) {
+                sourceCode = extracted.code
+                sourceMap = extracted.map
+              }
+
+              const injected = applyGqlormInject(sourceCode, id)
+              if (injected) {
+                sourceCode = injected
+                sourceMap = null
+              }
             }
 
             if (
@@ -308,19 +323,29 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
                 normalizedBase.length + '/api/src/'.length,
               )
               const apiFolder = relativePath.split('/')[0] ?? '?'
-              sourceCode =
-                applyOtelWrapping(sourceCode, id, apiFolder) ?? sourceCode
+              const wrapped = applyOtelWrapping(sourceCode, id, apiFolder)
+              if (wrapped) {
+                sourceCode = wrapped
+                sourceMap = null
+              }
             }
 
             // Without a user Babel config there is nothing left for Babel to
             // do — Vite's own pipeline strips TypeScript — so only return the
-            // string-transformed code (if it changed at all).
+            // string-transformed code (if it changed at all). When no exact
+            // map is available, fall back to a high-resolution identity map
+            // over the input so the sourcemap chain stays intact.
             if (!babelPlugins) {
               if (sourceCode === code) {
                 return null
               }
 
-              return { code: sourceCode, map: null }
+              return {
+                code: sourceCode,
+                map:
+                  sourceMap ??
+                  new MagicString(code).generateMap({ hires: true }),
+              }
             }
 
             // Use the code Vite already loaded instead of reading from disk, so

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -348,6 +348,22 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
               }
             }
 
+            // Babel maps its output back to `sourceCode`, but Vite needs a
+            // map back to `code` (this transform hook's input). Feed the
+            // string transforms' map (exact when available, diff-derived
+            // otherwise) as inputSourceMap so Babel emits the composed map.
+            const inputSourceMap =
+              sourceCode === code
+                ? null
+                : (sourceMap ?? generateDiffSourceMap(code, sourceCode))
+
+            // Babel can only compose the input map when its `sources` names
+            // the module — magic-string maps default to an empty source name,
+            // which makes the merged map's positions resolve to nothing.
+            if (inputSourceMap) {
+              inputSourceMap.sources = [id]
+            }
+
             // Use the code Vite already loaded instead of reading from disk, so
             // Vite's originalCode matches the Babel input. This ensures the SSR
             // transform's sourcesContent is consistent with the map.
@@ -357,6 +373,7 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
               babelPlugins,
               true,
               true,
+              inputSourceMap ?? undefined,
             )
 
             if (!result?.code) {

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -22,6 +22,7 @@ const tsconfigPaths =
 import { buildCedarContext, wrapLegacyHandler } from '@cedarjs/api/runtime'
 import type { CedarHandler, LegacyHandler } from '@cedarjs/api/runtime'
 import {
+  getApiSideBabelConfigPath,
   getApiSideBabelPlugins,
   transformWithBabel,
 } from '@cedarjs/babel-config'
@@ -202,10 +203,17 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
   const isEsm = projectSideIsEsm('api')
   const normalizedBase = normalizePath(cedarPaths.base)
 
-  const babelPlugins = getApiSideBabelPlugins({
-    forVite: true,
-    projectIsEsm: isEsm,
-  })
+  // The Babel pass is only needed to apply a user's custom
+  // api/babel.config.js: getApiSideBabelPlugins({ forVite: true }) is empty
+  // (all of Cedar's api-side Babel transforms are handled by dedicated Vite
+  // plugins in this pipeline) and Vite strips TypeScript itself. Skip Babel
+  // entirely when the project has no such config file.
+  const babelPlugins = getApiSideBabelConfigPath()
+    ? getApiSideBabelPlugins({
+        forVite: true,
+        projectIsEsm: isEsm,
+      })
+    : null
 
   const workspacePkgSourceMap = Object.fromEntries(
     Object.entries(getWorkspacePackageAliases(cedarPaths, cedarConfig)).map(
@@ -306,6 +314,17 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
               const apiFolder = relativePath.split('/')[0] ?? '?'
               sourceCode =
                 applyOtelWrapping(sourceCode, id, apiFolder) ?? sourceCode
+            }
+
+            // Without a user Babel config there is nothing left for Babel to
+            // do — Vite's own pipeline strips TypeScript — so only return the
+            // string-transformed code (if it changed at all).
+            if (!babelPlugins) {
+              if (sourceCode === code) {
+                return null
+              }
+
+              return { code: sourceCode, map: null }
             }
 
             // Use the code Vite already loaded instead of reading from disk, so

--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -403,14 +403,6 @@ export async function buildCedarApp({
           ? getApiSideBabelPluginsForVite()
           : null
 
-        const transformedCode = babelPlugins
-          ? await transformWithBabel(code, id, babelPlugins, true, true)
-          : null
-
-        if (babelPlugins && !transformedCode?.code) {
-          return null
-        }
-
         // babel-plugin-module-resolver is not part of
         // getApiSideBabelPluginsForVite().  That plugin
         // previously rewrote `src/` bare specifiers to relative paths so
@@ -423,25 +415,28 @@ export async function buildCedarApp({
           path.dirname(id),
         )
 
-        let outputCode = applySrcAlias(
-          transformedCode?.code ?? code,
-          fromDirRelativeToApiSrc,
-        )
+        const applyImportRewrites = (source: string) => {
+          let rewritten = applySrcAlias(source, fromDirRelativeToApiSrc)
 
-        // For ESM projects, append .js/.jsx extensions to extensionless
-        // relative imports so Node's ESM resolver can find them at runtime.
-        // This is needed because cedarImportDirPlugin expands glob imports
-        // (e.g. `src/directives/**/*.{js,ts}`) into individual extensionless
-        // import statements, and Rollup with preserveModules:true preserves
-        // those specifiers as-is in the output.
-        if (projectSideIsEsm('api')) {
-          outputCode = applyEsmExtensions(outputCode, id)
+          // For ESM projects, append .js/.jsx extensions to extensionless
+          // relative imports so Node's ESM resolver can find them at runtime.
+          // This is needed because cedarImportDirPlugin expands glob imports
+          // (e.g. `src/directives/**/*.{js,ts}`) into individual extensionless
+          // import statements, and Rollup with preserveModules:true preserves
+          // those specifiers as-is in the output.
+          if (projectSideIsEsm('api')) {
+            rewritten = applyEsmExtensions(rewritten, id)
+          }
+
+          return rewritten
         }
 
-        if (!transformedCode) {
+        const rewrittenCode = applyImportRewrites(code)
+
+        if (!babelPlugins) {
           // Without Babel there's no transform to report when the string
           // rewrites didn't change anything.
-          if (outputCode === code) {
+          if (rewrittenCode === code) {
             return null
           }
 
@@ -449,13 +444,47 @@ export async function buildCedarApp({
           // diff-derived map gives exact line and column mappings — including
           // the columns after a rewritten specifier on the same line.
           return {
-            code: outputCode,
-            map: generateDiffSourceMap(code, outputCode),
+            code: rewrittenCode,
+            map: generateDiffSourceMap(code, rewrittenCode),
           }
         }
 
+        // The rewrites run BEFORE Babel so their map can be handed to Babel
+        // as inputSourceMap — Babel then emits a map composed all the way
+        // back to this hook's input instead of one that stops at the
+        // rewritten intermediate.
+        const inputSourceMap =
+          rewrittenCode === code
+            ? null
+            : generateDiffSourceMap(code, rewrittenCode)
+
+        // Babel can only compose the input map when its `sources` names the
+        // module — magic-string maps default to an empty source name, which
+        // makes the merged map's positions resolve to nothing.
+        if (inputSourceMap) {
+          inputSourceMap.sources = [id]
+        }
+
+        const transformedCode = await transformWithBabel(
+          rewrittenCode,
+          id,
+          babelPlugins,
+          true,
+          true,
+          inputSourceMap ?? undefined,
+        )
+
+        if (!transformedCode?.code) {
+          return null
+        }
+
+        // Safety net: a user Babel plugin can itself emit `src/` imports or
+        // extensionless relative imports, which Rollup's `external` function
+        // would otherwise misclassify. In that rare case the returned map
+        // doesn't cover this final edit — matching the previous behavior,
+        // where every rewrite ran after Babel.
         return {
-          code: outputCode,
+          code: applyImportRewrites(transformedCode.code),
           map: transformedCode.map ?? null,
         }
       },

--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -18,6 +18,7 @@ const tsconfigPaths =
   tsPathsMod.default?.default || tsPathsMod.default || tsPathsMod
 
 import {
+  getApiSideBabelConfigPath,
   getApiSideBabelPlugins,
   transformWithBabel,
 } from '@cedarjs/babel-config'
@@ -159,12 +160,18 @@ export async function buildCedarApp({
     }
   }
 
-  const babelPlugins = workspace.includes('api')
-    ? getApiSideBabelPlugins({
-        forVite: true,
-        projectIsEsm: projectSideIsEsm('api'),
-      })
-    : null
+  // The Babel pass is only needed to apply a user's custom
+  // api/babel.config.js: getApiSideBabelPlugins({ forVite: true }) is empty
+  // (all of Cedar's api-side Babel transforms are handled by dedicated Vite
+  // plugins in this pipeline) and Vite strips TypeScript itself. Skip Babel
+  // entirely when the project has no such config file.
+  const babelPlugins =
+    workspace.includes('api') && getApiSideBabelConfigPath()
+      ? getApiSideBabelPlugins({
+          forVite: true,
+          projectIsEsm: projectSideIsEsm('api'),
+        })
+      : null
 
   const workspacePkgSourceMap = workspace.includes('api')
     ? Object.fromEntries(
@@ -382,7 +389,7 @@ export async function buildCedarApp({
 
   plugins.push(cedarMockCellDataPlugin())
 
-  if (babelPlugins) {
+  if (workspace.includes('api')) {
     plugins.push({
       name: 'cedar-vite-api-babel-transform',
       enforce: 'pre',
@@ -399,48 +406,44 @@ export async function buildCedarApp({
           return null
         }
 
-        const transformedCode = await transformWithBabel(
-          code,
-          id,
-          babelPlugins,
-          true,
-          true,
-        )
+        const transformedCode = babelPlugins
+          ? await transformWithBabel(code, id, babelPlugins, true, true)
+          : null
 
-        if (transformedCode?.code) {
-          // babel-plugin-module-resolver is excluded for forVite:true builds
-          // (it is gated on !forVite in getApiSideBabelPlugins).  That plugin
-          // previously rewrote `src/` bare specifiers to relative paths so
-          // that Rollup's `external` function (which marks anything that is
-          // not relative or absolute as external) would not capture them.
-          // Apply the same rewrite here so that `src/lib/logger` → `../../lib/logger`
-          // and the external function sees a relative path (starting with `.`).
-          const fromDirRelativeToApiSrc = path.relative(
-            cedarPaths.api.src,
-            path.dirname(id),
-          )
-          let outputCode = applySrcAlias(
-            transformedCode.code,
-            fromDirRelativeToApiSrc,
-          )
-
-          // For ESM projects, append .js/.jsx extensions to extensionless
-          // relative imports so Node's ESM resolver can find them at runtime.
-          // This is needed because cedarImportDirPlugin expands glob imports
-          // (e.g. `src/directives/**/*.{js,ts}`) into individual extensionless
-          // import statements, and Rollup with preserveModules:true preserves
-          // those specifiers as-is in the output.
-          if (projectSideIsEsm('api')) {
-            outputCode = applyEsmExtensions(outputCode, id)
-          }
-
-          return {
-            code: outputCode,
-            map: transformedCode.map ?? null,
-          }
+        if (babelPlugins && !transformedCode?.code) {
+          return null
         }
 
-        return null
+        // babel-plugin-module-resolver is excluded for forVite:true builds
+        // (it is gated on !forVite in getApiSideBabelPlugins).  That plugin
+        // previously rewrote `src/` bare specifiers to relative paths so
+        // that Rollup's `external` function (which marks anything that is
+        // not relative or absolute as external) would not capture them.
+        // Apply the same rewrite here so that `src/lib/logger` → `../../lib/logger`
+        // and the external function sees a relative path (starting with `.`).
+        const fromDirRelativeToApiSrc = path.relative(
+          cedarPaths.api.src,
+          path.dirname(id),
+        )
+        let outputCode = applySrcAlias(
+          transformedCode?.code ?? code,
+          fromDirRelativeToApiSrc,
+        )
+
+        // For ESM projects, append .js/.jsx extensions to extensionless
+        // relative imports so Node's ESM resolver can find them at runtime.
+        // This is needed because cedarImportDirPlugin expands glob imports
+        // (e.g. `src/directives/**/*.{js,ts}`) into individual extensionless
+        // import statements, and Rollup with preserveModules:true preserves
+        // those specifiers as-is in the output.
+        if (projectSideIsEsm('api')) {
+          outputCode = applyEsmExtensions(outputCode, id)
+        }
+
+        return {
+          code: outputCode,
+          map: transformedCode?.map ?? null,
+        }
       },
     })
   }

--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -19,7 +19,7 @@ const tsconfigPaths =
 
 import {
   getApiSideBabelConfigPath,
-  getApiSideBabelPlugins,
+  getApiSideBabelPluginsForVite,
   transformWithBabel,
 } from '@cedarjs/babel-config'
 import {
@@ -161,16 +161,13 @@ export async function buildCedarApp({
   }
 
   // The Babel pass is only needed to apply a user's custom
-  // api/babel.config.js: getApiSideBabelPlugins({ forVite: true }) is empty
-  // (all of Cedar's api-side Babel transforms are handled by dedicated Vite
-  // plugins in this pipeline) and Vite strips TypeScript itself. Skip Babel
-  // entirely when the project has no such config file.
+  // api/babel.config.js: getApiSideBabelPluginsForVite() is empty (all of
+  // Cedar's api-side Babel transforms are handled by dedicated Vite plugins
+  // in this pipeline) and Vite strips TypeScript itself. Skip Babel entirely
+  // when the project has no such config file.
   const babelPlugins =
     workspace.includes('api') && getApiSideBabelConfigPath()
-      ? getApiSideBabelPlugins({
-          forVite: true,
-          projectIsEsm: projectSideIsEsm('api'),
-        })
+      ? getApiSideBabelPluginsForVite()
       : null
 
   const workspacePkgSourceMap = workspace.includes('api')
@@ -414,8 +411,8 @@ export async function buildCedarApp({
           return null
         }
 
-        // babel-plugin-module-resolver is excluded for forVite:true builds
-        // (it is gated on !forVite in getApiSideBabelPlugins).  That plugin
+        // babel-plugin-module-resolver is not part of
+        // getApiSideBabelPluginsForVite().  That plugin
         // previously rewrote `src/` bare specifiers to relative paths so
         // that Rollup's `external` function (which marks anything that is
         // not relative or absolute as external) would not capture them.

--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -3,7 +3,6 @@ import path from 'node:path'
 
 import { catchAllEntry, getAllEntries } from '@universal-deploy/store'
 import { catchAll } from '@universal-deploy/vite'
-import MagicString from 'magic-string'
 import type { EnvironmentOptions, Plugin, PluginOption } from 'vite'
 import { createBuilder, normalizePath } from 'vite'
 import { gqlPlugin as gqlTagPlugin } from 'vite-plugin-graphql-tag'
@@ -30,6 +29,7 @@ import {
 import { findApiFiles } from '@cedarjs/internal/dist/files.js'
 import { getConfig, getPaths, projectSideIsEsm } from '@cedarjs/project-config'
 
+import { generateDiffSourceMap } from './lib/generateDiffSourceMap.js'
 import { getWorkspacePackageAliases } from './lib/workspacePackageAliases.js'
 import { cedarAutoImportsPlugin } from './plugins/vite-plugin-cedar-auto-import.js'
 import { cedarDirectoryNamedImportPlugin } from './plugins/vite-plugin-cedar-directory-named-import.js'
@@ -445,13 +445,12 @@ export async function buildCedarApp({
             return null
           }
 
-          // The rewrites only replace import specifiers in place and never
-          // add or remove lines, so a high-resolution identity map over the
-          // input keeps the sourcemap chain intact (columns can drift only
-          // within a rewritten import line).
+          // The rewrites only replace import specifiers in place, so the
+          // diff-derived map gives exact line and column mappings — including
+          // the columns after a rewritten specifier on the same line.
           return {
             code: outputCode,
-            map: new MagicString(code).generateMap({ hires: true }),
+            map: generateDiffSourceMap(code, outputCode),
           }
         }
 

--- a/packages/vite/src/buildApp.ts
+++ b/packages/vite/src/buildApp.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { catchAllEntry, getAllEntries } from '@universal-deploy/store'
 import { catchAll } from '@universal-deploy/vite'
+import MagicString from 'magic-string'
 import type { EnvironmentOptions, Plugin, PluginOption } from 'vite'
 import { createBuilder, normalizePath } from 'vite'
 import { gqlPlugin as gqlTagPlugin } from 'vite-plugin-graphql-tag'
@@ -159,16 +160,6 @@ export async function buildCedarApp({
       }
     }
   }
-
-  // The Babel pass is only needed to apply a user's custom
-  // api/babel.config.js: getApiSideBabelPluginsForVite() is empty (all of
-  // Cedar's api-side Babel transforms are handled by dedicated Vite plugins
-  // in this pipeline) and Vite strips TypeScript itself. Skip Babel entirely
-  // when the project has no such config file.
-  const babelPlugins =
-    workspace.includes('api') && getApiSideBabelConfigPath()
-      ? getApiSideBabelPluginsForVite()
-      : null
 
   const workspacePkgSourceMap = workspace.includes('api')
     ? Object.fromEntries(
@@ -403,6 +394,15 @@ export async function buildCedarApp({
           return null
         }
 
+        // The Babel pass is only needed to apply a user's custom
+        // api/babel.config.js: getApiSideBabelPluginsForVite() is empty (all of
+        // Cedar's api-side Babel transforms are handled by dedicated Vite
+        // plugins in this pipeline) and Vite strips TypeScript itself. Skip
+        // Babel entirely when the project has no such config file.
+        const babelPlugins = getApiSideBabelConfigPath()
+          ? getApiSideBabelPluginsForVite()
+          : null
+
         const transformedCode = babelPlugins
           ? await transformWithBabel(code, id, babelPlugins, true, true)
           : null
@@ -422,6 +422,7 @@ export async function buildCedarApp({
           cedarPaths.api.src,
           path.dirname(id),
         )
+
         let outputCode = applySrcAlias(
           transformedCode?.code ?? code,
           fromDirRelativeToApiSrc,
@@ -437,9 +438,26 @@ export async function buildCedarApp({
           outputCode = applyEsmExtensions(outputCode, id)
         }
 
+        if (!transformedCode) {
+          // Without Babel there's no transform to report when the string
+          // rewrites didn't change anything.
+          if (outputCode === code) {
+            return null
+          }
+
+          // The rewrites only replace import specifiers in place and never
+          // add or remove lines, so a high-resolution identity map over the
+          // input keeps the sourcemap chain intact (columns can drift only
+          // within a rewritten import line).
+          return {
+            code: outputCode,
+            map: new MagicString(code).generateMap({ hires: true }),
+          }
+        }
+
         return {
           code: outputCode,
-          map: transformedCode?.map ?? null,
+          map: transformedCode.map ?? null,
         }
       },
     })

--- a/packages/vite/src/lib/__tests__/generateDiffSourceMap.test.ts
+++ b/packages/vite/src/lib/__tests__/generateDiffSourceMap.test.ts
@@ -1,0 +1,130 @@
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping'
+import { describe, expect, it } from 'vitest'
+
+import { generateDiffSourceMap } from '../generateDiffSourceMap.js'
+
+function trace(original: string, transformed: string) {
+  const map = generateDiffSourceMap(original, transformed)
+
+  if (!map) {
+    throw new Error('Expected a sourcemap')
+  }
+
+  const tracer = new TraceMap(JSON.parse(map.toString()))
+
+  // `line` is 1-based, `column` is 0-based (trace-mapping conventions)
+  return (line: number, column: number) =>
+    originalPositionFor(tracer, { line, column })
+}
+
+describe('generateDiffSourceMap', () => {
+  it('returns null when nothing changed', () => {
+    const code = "import { db } from 'src/lib/db'\n"
+
+    expect(generateDiffSourceMap(code, code)).toBeNull()
+  })
+
+  it('maps columns exactly for an in-place specifier rewrite', () => {
+    const original = [
+      "import { db } from 'src/lib/db'",
+      '',
+      'export const getUser = () => db.user.findFirst()',
+    ].join('\n')
+    // `src/lib/db` (10 chars) → `../../lib/db` (12 chars): +2 columns
+    const transformed = original.replace('src/lib/db', '../../lib/db')
+
+    const pos = trace(original, transformed)
+
+    // The closing quote sits after the rewritten specifier: column 30 in the
+    // original, column 32 in the transformed code
+    expect(pos(1, 32)).toMatchObject({ line: 1, column: 30 })
+    // Unchanged lines map exactly
+    expect(pos(3, 13)).toMatchObject({ line: 3, column: 13 })
+  })
+
+  it('maps columns exactly when an extension is appended', () => {
+    const original = "import { logger } from '../lib/logger'\nlogger.info()"
+    const transformed =
+      "import { logger } from '../lib/logger.js'\nlogger.info()"
+
+    const pos = trace(original, transformed)
+
+    // The closing quote: column 37 originally, column 40 after `.js`
+    expect(pos(1, 40)).toMatchObject({ line: 1, column: 37 })
+    expect(pos(2, 7)).toMatchObject({ line: 2, column: 7 })
+  })
+
+  it('maps lines below a pure line insertion', () => {
+    const original = [
+      "import { logger } from 'src/lib/logger'",
+      '',
+      'export const handler = () => {',
+      '  logger.info("hi")',
+      '}',
+    ].join('\n')
+    const transformed = "import { db } from 'src/lib/db'\n" + original
+
+    const pos = trace(original, transformed)
+
+    // Every original line is shifted down by one in the transformed code
+    expect(pos(2, 0)).toMatchObject({ line: 1, column: 0 })
+    expect(pos(5, 2)).toMatchObject({ line: 4, column: 2 })
+    expect(pos(6, 0)).toMatchObject({ line: 5, column: 0 })
+  })
+
+  it('maps lines after a replaced block', () => {
+    const original = [
+      'const a = 1',
+      'export const fn = () => {',
+      '  return a',
+      '}',
+      'const b = 2',
+    ].join('\n')
+    const transformed = [
+      'const a = 1',
+      'export const fn = async () => {',
+      '  return wrap(() => {',
+      '    return a',
+      '  })',
+      '}',
+      'const b = 2',
+    ].join('\n')
+
+    const pos = trace(original, transformed)
+
+    // The anchored lines before and after the replaced block map exactly
+    expect(pos(1, 6)).toMatchObject({ line: 1, column: 6 })
+    expect(pos(7, 6)).toMatchObject({ line: 5, column: 6 })
+    // Positions inside the replaced block resolve to its start line
+    expect(pos(3, 2).line).toBe(2)
+  })
+
+  it('maps lines after a pure line deletion', () => {
+    const original = ['const a = 1', 'const gone = 0', 'const b = 2'].join('\n')
+    const transformed = ['const a = 1', 'const b = 2'].join('\n')
+
+    const pos = trace(original, transformed)
+
+    expect(pos(1, 6)).toMatchObject({ line: 1, column: 6 })
+    expect(pos(2, 6)).toMatchObject({ line: 3, column: 6 })
+  })
+
+  it('handles multiple rewritten import lines', () => {
+    const original = [
+      "import { db } from 'src/lib/db'",
+      "import { logger } from 'src/lib/logger'",
+      'db.user.findFirst()',
+    ].join('\n')
+    const transformed = [
+      "import { db } from '../lib/db.js'",
+      "import { logger } from '../lib/logger.js'",
+      'db.user.findFirst()',
+    ].join('\n')
+
+    const pos = trace(original, transformed)
+
+    expect(pos(1, 0)).toMatchObject({ line: 1, column: 0 })
+    expect(pos(2, 0)).toMatchObject({ line: 2, column: 0 })
+    expect(pos(3, 8)).toMatchObject({ line: 3, column: 8 })
+  })
+})

--- a/packages/vite/src/lib/__tests__/generateDiffSourceMap.test.ts
+++ b/packages/vite/src/lib/__tests__/generateDiffSourceMap.test.ts
@@ -109,6 +109,54 @@ describe('generateDiffSourceMap', () => {
     expect(pos(2, 6)).toMatchObject({ line: 3, column: 6 })
   })
 
+  it('maps unchanged lines inside a wrapped block (OTel-style)', () => {
+    const original = [
+      'const a = 1',
+      'export const getUser = async ({ id }) => {',
+      '  const user = await db.user.findUnique({ where: { id } })',
+      '  return user',
+      '}',
+      'const b = 2',
+    ].join('\n')
+    // OTel wrapping keeps the original statements verbatim inside the
+    // wrapper, shifted down by the inserted lines
+    const transformed = [
+      'const a = 1',
+      'export const getUser = async ({ id }) => {',
+      '  return tracer.startActiveSpan("getUser", async () => {',
+      '  const user = await db.user.findUnique({ where: { id } })',
+      '  return user',
+      '  })',
+      '}',
+      'const b = 2',
+    ].join('\n')
+
+    const pos = trace(original, transformed)
+
+    // The unchanged statements inside the wrapper map to their true original
+    // lines, not to the start of the wrapped block
+    expect(pos(4, 8)).toMatchObject({ line: 3, column: 8 })
+    expect(pos(5, 2)).toMatchObject({ line: 4, column: 2 })
+    expect(pos(8, 6)).toMatchObject({ line: 6, column: 6 })
+  })
+
+  it('maps anchored lines between two separate insertions', () => {
+    const original = ['const a = 1', 'const b = 2', 'const c = 3'].join('\n')
+    const transformed = [
+      'const inserted1 = 0',
+      'const a = 1',
+      'const b = 2',
+      'const inserted2 = 0',
+      'const c = 3',
+    ].join('\n')
+
+    const pos = trace(original, transformed)
+
+    expect(pos(2, 6)).toMatchObject({ line: 1, column: 6 })
+    expect(pos(3, 6)).toMatchObject({ line: 2, column: 6 })
+    expect(pos(5, 6)).toMatchObject({ line: 3, column: 6 })
+  })
+
   it('handles multiple rewritten import lines', () => {
     const original = [
       "import { db } from 'src/lib/db'",

--- a/packages/vite/src/lib/generateDiffSourceMap.ts
+++ b/packages/vite/src/lib/generateDiffSourceMap.ts
@@ -1,0 +1,145 @@
+import MagicString from 'magic-string'
+import type { SourceMap } from 'magic-string'
+
+/**
+ * Generates a sourcemap for a string transform by diffing its input and
+ * output. Used for transforms that don't produce a map themselves.
+ *
+ * The diff is anchored on the common prefix and suffix lines, so every
+ * unchanged line maps exactly. When the changed middle has the same number
+ * of lines on both sides, each changed line is refined with a per-line
+ * character prefix/suffix diff, which gives exact column mappings for
+ * in-place rewrites (e.g. import specifier rewrites) — including the
+ * columns after the rewritten span. When the line counts differ (inserted
+ * or removed lines), the whole middle block is mapped as a single edit:
+ * positions inside it resolve to its start, and every line before and after
+ * it still maps exactly.
+ *
+ * Returns null when the input and output are identical.
+ */
+export function generateDiffSourceMap(
+  original: string,
+  transformed: string,
+): SourceMap | null {
+  if (original === transformed) {
+    return null
+  }
+
+  const ms = new MagicString(original)
+
+  const origLines = original.split('\n')
+  const newLines = transformed.split('\n')
+
+  const offsetOfLine = (lines: string[], index: number) => {
+    let offset = 0
+    for (let i = 0; i < index; i++) {
+      offset += lines[i].length + 1
+    }
+    return offset
+  }
+
+  // Anchor on common prefix and suffix lines
+  let prefix = 0
+  const maxPrefix = Math.min(origLines.length, newLines.length)
+  while (prefix < maxPrefix && origLines[prefix] === newLines[prefix]) {
+    prefix++
+  }
+
+  let suffix = 0
+  const maxSuffix = Math.min(origLines.length, newLines.length) - prefix
+  while (
+    suffix < maxSuffix &&
+    origLines[origLines.length - 1 - suffix] ===
+      newLines[newLines.length - 1 - suffix]
+  ) {
+    suffix++
+  }
+
+  const origMiddle = origLines.slice(prefix, origLines.length - suffix)
+  const newMiddle = newLines.slice(prefix, newLines.length - suffix)
+
+  if (origMiddle.length === newMiddle.length) {
+    // Same line count: refine each changed line with a character-level
+    // prefix/suffix diff so columns map exactly, also after the edit
+    let lineStart = offsetOfLine(origLines, prefix)
+
+    for (let i = 0; i < origMiddle.length; i++) {
+      const origLine = origMiddle[i]
+      const newLine = newMiddle[i]
+
+      if (origLine !== newLine) {
+        let charPrefix = 0
+        const maxCharPrefix = Math.min(origLine.length, newLine.length)
+        while (
+          charPrefix < maxCharPrefix &&
+          origLine[charPrefix] === newLine[charPrefix]
+        ) {
+          charPrefix++
+        }
+
+        let charSuffix = 0
+        const maxCharSuffix =
+          Math.min(origLine.length, newLine.length) - charPrefix
+        while (
+          charSuffix < maxCharSuffix &&
+          origLine[origLine.length - 1 - charSuffix] ===
+            newLine[newLine.length - 1 - charSuffix]
+        ) {
+          charSuffix++
+        }
+
+        const start = lineStart + charPrefix
+        const end = lineStart + origLine.length - charSuffix
+        const replacement = newLine.slice(
+          charPrefix,
+          newLine.length - charSuffix,
+        )
+
+        if (start === end) {
+          ms.appendLeft(start, replacement)
+        } else if (replacement === '') {
+          ms.remove(start, end)
+        } else {
+          ms.overwrite(start, end, replacement)
+        }
+      }
+
+      lineStart += origLine.length + 1
+    }
+  } else {
+    const newMiddleText = newMiddle.join('\n')
+
+    if (origMiddle.length === 0) {
+      // Pure line insertion
+      if (suffix === 0) {
+        ms.appendLeft(original.length, '\n' + newMiddleText)
+      } else {
+        ms.appendLeft(offsetOfLine(origLines, prefix), newMiddleText + '\n')
+      }
+    } else {
+      const start = offsetOfLine(origLines, prefix)
+      const end = start + origMiddle.join('\n').length
+
+      if (newMiddle.length === 0) {
+        // Pure line deletion: also remove one of the bounding newlines
+        if (suffix === 0 && prefix > 0) {
+          ms.remove(start - 1, end)
+        } else {
+          ms.remove(start, Math.min(end + 1, original.length))
+        }
+      } else {
+        ms.overwrite(start, end, newMiddleText)
+      }
+    }
+  }
+
+  if (ms.toString() !== transformed) {
+    // Defensive: if the edit reconstruction doesn't reproduce the transformed
+    // code exactly, a mapping derived from it would be wrong. Fall back to a
+    // high-resolution identity map, which is line-accurate for
+    // line-preserving transforms and never worse than no map.
+    return new MagicString(original).generateMap({ hires: true })
+  }
+
+  return ms.generateMap({ hires: true })
+}

--- a/packages/vite/src/lib/generateDiffSourceMap.ts
+++ b/packages/vite/src/lib/generateDiffSourceMap.ts
@@ -1,19 +1,30 @@
 import MagicString from 'magic-string'
 import type { SourceMap } from 'magic-string'
 
+// The line alignment below is quadratic in the size of the changed region.
+// For pathologically large regions, skip the alignment and map the region as
+// a single edit instead of blowing up build time.
+const MAX_ALIGNMENT_CELLS = 1_000_000
+
+interface Hunk {
+  oStart: number
+  oEnd: number
+  nStart: number
+  nEnd: number
+}
+
 /**
  * Generates a sourcemap for a string transform by diffing its input and
  * output. Used for transforms that don't produce a map themselves.
  *
- * The diff is anchored on the common prefix and suffix lines, so every
- * unchanged line maps exactly. When the changed middle has the same number
- * of lines on both sides, each changed line is refined with a per-line
- * character prefix/suffix diff, which gives exact column mappings for
- * in-place rewrites (e.g. import specifier rewrites) — including the
- * columns after the rewritten span. When the line counts differ (inserted
- * or removed lines), the whole middle block is mapped as a single edit:
- * positions inside it resolve to its start, and every line before and after
- * it still maps exactly.
+ * The diff first anchors on the common prefix and suffix lines, then aligns
+ * the remaining lines with an LCS so that unchanged lines *inside* the
+ * changed region (e.g. statements inside a newly inserted wrapper) also map
+ * exactly. Aligned line pairs that differ are refined with a character-level
+ * prefix/suffix diff, which gives exact column mappings for in-place
+ * rewrites (e.g. import specifier rewrites) — including the columns after
+ * the rewritten span. Only lines with no counterpart at all map coarsely, to
+ * the start of their surrounding edit.
  *
  * Returns null when the input and output are identical.
  */
@@ -30,15 +41,16 @@ export function generateDiffSourceMap(
   const origLines = original.split('\n')
   const newLines = transformed.split('\n')
 
-  const offsetOfLine = (lines: string[], index: number) => {
-    let offset = 0
-    for (let i = 0; i < index; i++) {
-      offset += lines[i].length + 1
-    }
-    return offset
+  // lineOffsets[i] = character offset where original line i starts
+  const lineOffsets: number[] = new Array(origLines.length)
+  let offset = 0
+  for (let i = 0; i < origLines.length; i++) {
+    lineOffsets[i] = offset
+    offset += origLines[i].length + 1
   }
 
-  // Anchor on common prefix and suffix lines
+  // Anchor on common prefix and suffix lines. This is a fast path for the
+  // typical localized edit and bounds the alignment work below.
   let prefix = 0
   const maxPrefix = Math.min(origLines.length, newLines.length)
   while (prefix < maxPrefix && origLines[prefix] === newLines[prefix]) {
@@ -55,82 +67,17 @@ export function generateDiffSourceMap(
     suffix++
   }
 
-  const origMiddle = origLines.slice(prefix, origLines.length - suffix)
-  const newMiddle = newLines.slice(prefix, newLines.length - suffix)
+  const hunks = alignLines(
+    origLines,
+    prefix,
+    origLines.length - suffix,
+    newLines,
+    prefix,
+    newLines.length - suffix,
+  )
 
-  if (origMiddle.length === newMiddle.length) {
-    // Same line count: refine each changed line with a character-level
-    // prefix/suffix diff so columns map exactly, also after the edit
-    let lineStart = offsetOfLine(origLines, prefix)
-
-    for (let i = 0; i < origMiddle.length; i++) {
-      const origLine = origMiddle[i]
-      const newLine = newMiddle[i]
-
-      if (origLine !== newLine) {
-        let charPrefix = 0
-        const maxCharPrefix = Math.min(origLine.length, newLine.length)
-        while (
-          charPrefix < maxCharPrefix &&
-          origLine[charPrefix] === newLine[charPrefix]
-        ) {
-          charPrefix++
-        }
-
-        let charSuffix = 0
-        const maxCharSuffix =
-          Math.min(origLine.length, newLine.length) - charPrefix
-        while (
-          charSuffix < maxCharSuffix &&
-          origLine[origLine.length - 1 - charSuffix] ===
-            newLine[newLine.length - 1 - charSuffix]
-        ) {
-          charSuffix++
-        }
-
-        const start = lineStart + charPrefix
-        const end = lineStart + origLine.length - charSuffix
-        const replacement = newLine.slice(
-          charPrefix,
-          newLine.length - charSuffix,
-        )
-
-        if (start === end) {
-          ms.appendLeft(start, replacement)
-        } else if (replacement === '') {
-          ms.remove(start, end)
-        } else {
-          ms.overwrite(start, end, replacement)
-        }
-      }
-
-      lineStart += origLine.length + 1
-    }
-  } else {
-    const newMiddleText = newMiddle.join('\n')
-
-    if (origMiddle.length === 0) {
-      // Pure line insertion
-      if (suffix === 0) {
-        ms.appendLeft(original.length, '\n' + newMiddleText)
-      } else {
-        ms.appendLeft(offsetOfLine(origLines, prefix), newMiddleText + '\n')
-      }
-    } else {
-      const start = offsetOfLine(origLines, prefix)
-      const end = start + origMiddle.join('\n').length
-
-      if (newMiddle.length === 0) {
-        // Pure line deletion: also remove one of the bounding newlines
-        if (suffix === 0 && prefix > 0) {
-          ms.remove(start - 1, end)
-        } else {
-          ms.remove(start, Math.min(end + 1, original.length))
-        }
-      } else {
-        ms.overwrite(start, end, newMiddleText)
-      }
-    }
+  for (const hunk of hunks) {
+    applyHunk(ms, hunk, origLines, newLines, lineOffsets, original.length)
   }
 
   if (ms.toString() !== transformed) {
@@ -142,4 +89,168 @@ export function generateDiffSourceMap(
   }
 
   return ms.generateMap({ hires: true })
+}
+
+/**
+ * Aligns the changed regions' lines via a longest-common-subsequence walk
+ * and returns the unequal hunks between matched lines. Matched lines are
+ * left untouched so they map exactly.
+ */
+function alignLines(
+  origLines: string[],
+  oLo: number,
+  oHi: number,
+  newLines: string[],
+  nLo: number,
+  nHi: number,
+): Hunk[] {
+  const m = oHi - oLo
+  const n = nHi - nLo
+
+  if (m === 0 && n === 0) {
+    return []
+  }
+
+  if (m === 0 || n === 0 || m * n > MAX_ALIGNMENT_CELLS) {
+    return [{ oStart: oLo, oEnd: oHi, nStart: nLo, nEnd: nHi }]
+  }
+
+  // Standard LCS table, flattened: dp[i][j] = LCS length of
+  // origLines[oLo+i..] and newLines[nLo+j..]
+  const width = n + 1
+  const dp = new Int32Array((m + 1) * width)
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i * width + j] =
+        origLines[oLo + i] === newLines[nLo + j]
+          ? dp[(i + 1) * width + j + 1] + 1
+          : Math.max(dp[(i + 1) * width + j], dp[i * width + j + 1])
+    }
+  }
+
+  const hunks: Hunk[] = []
+  let i = 0
+  let j = 0
+  let hunkO = 0
+  let hunkN = 0
+
+  const flushHunk = () => {
+    if (i > hunkO || j > hunkN) {
+      hunks.push({
+        oStart: oLo + hunkO,
+        oEnd: oLo + i,
+        nStart: nLo + hunkN,
+        nEnd: nLo + j,
+      })
+    }
+  }
+
+  while (i < m && j < n) {
+    if (origLines[oLo + i] === newLines[nLo + j]) {
+      flushHunk()
+      i++
+      j++
+      hunkO = i
+      hunkN = j
+    } else if (dp[(i + 1) * width + j] >= dp[i * width + j + 1]) {
+      i++
+    } else {
+      j++
+    }
+  }
+  i = m
+  j = n
+  flushHunk()
+
+  return hunks
+}
+
+function applyHunk(
+  ms: MagicString,
+  { oStart, oEnd, nStart, nEnd }: Hunk,
+  origLines: string[],
+  newLines: string[],
+  lineOffsets: number[],
+  originalLength: number,
+): void {
+  const oCount = oEnd - oStart
+  const nCount = nEnd - nStart
+  const newSlice = newLines.slice(nStart, nEnd)
+
+  if (oCount === nCount) {
+    // Same line count: refine each line pair with a character-level
+    // prefix/suffix diff so columns map exactly, also after the edit
+    for (let k = 0; k < oCount; k++) {
+      diffLinePair(
+        ms,
+        lineOffsets[oStart + k],
+        origLines[oStart + k],
+        newLines[nStart + k],
+      )
+    }
+  } else if (oCount === 0) {
+    // Pure line insertion before original line oStart
+    const text = newSlice.join('\n')
+    if (oStart >= origLines.length) {
+      ms.appendLeft(originalLength, '\n' + text)
+    } else {
+      ms.appendLeft(lineOffsets[oStart], text + '\n')
+    }
+  } else if (nCount === 0) {
+    // Pure line deletion: also remove one of the bounding newlines
+    const start = lineOffsets[oStart]
+    if (oEnd >= origLines.length) {
+      ms.remove(oStart > 0 ? start - 1 : start, originalLength)
+    } else {
+      ms.remove(start, lineOffsets[oEnd])
+    }
+  } else {
+    // Replace the block, excluding the trailing newline (it is shared with
+    // whatever follows)
+    const start = lineOffsets[oStart]
+    const end = lineOffsets[oEnd - 1] + origLines[oEnd - 1].length
+    ms.overwrite(start, end, newSlice.join('\n'))
+  }
+}
+
+function diffLinePair(
+  ms: MagicString,
+  lineStart: number,
+  origLine: string,
+  newLine: string,
+): void {
+  if (origLine === newLine) {
+    return
+  }
+
+  let charPrefix = 0
+  const maxCharPrefix = Math.min(origLine.length, newLine.length)
+  while (
+    charPrefix < maxCharPrefix &&
+    origLine[charPrefix] === newLine[charPrefix]
+  ) {
+    charPrefix++
+  }
+
+  let charSuffix = 0
+  const maxCharSuffix = Math.min(origLine.length, newLine.length) - charPrefix
+  while (
+    charSuffix < maxCharSuffix &&
+    origLine[origLine.length - 1 - charSuffix] ===
+      newLine[newLine.length - 1 - charSuffix]
+  ) {
+    charSuffix++
+  }
+
+  const start = lineStart + charPrefix
+  const end = lineStart + origLine.length - charSuffix
+  const replacement = newLine.slice(charPrefix, newLine.length - charSuffix)
+
+  if (start === end) {
+    ms.appendLeft(start, replacement)
+  } else if (replacement === '') {
+    ms.remove(start, end)
+  } else {
+    ms.overwrite(start, end, replacement)
+  }
 }


### PR DESCRIPTION
Introduce `getApiSideBabelPluginsForVite()` and call that from all Vite-related callsites instead of the generic `getApiSideBabelPlugins({ ... })`