### PR TITLE
chore(internal): Dedicated job path injection transform for api builds

### DIFF
--- a/packages/internal/src/build/__tests__/job-path-injector.test.ts
+++ b/packages/internal/src/build/__tests__/job-path-injector.test.ts
@@ -130,6 +130,19 @@ describe('applyJobPathInjector', () => {
     expect(result).toContain('name: "aliasedJob"')
   })
 
+  it('handles createJob on a later declarator in a multi-variable export', () => {
+    const code = `
+      export const notAJob = 1,
+        comboJob = jobs.createJob({ queue: 'combo' })
+    `
+
+    const result = applyJobPathInjector(code, jobFile('comboJob.js'), JOBS_DIR)
+
+    expect(result).toContain('path: "comboJob"')
+    expect(result).toContain('name: "comboJob"')
+    expect(result).not.toContain('name: "notAJob"')
+  })
+
   it('returns null for files without createJob calls', () => {
     const code = `
       export const someFunction = () => {

--- a/packages/internal/src/build/__tests__/job-path-injector.test.ts
+++ b/packages/internal/src/build/__tests__/job-path-injector.test.ts
@@ -1,0 +1,154 @@
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { applyJobPathInjector } from '../job-path-injector.js'
+
+const JOBS_DIR = '/test-app/api/src/jobs'
+
+function jobFile(...segments: string[]) {
+  return path.join(JOBS_DIR, ...segments)
+}
+
+describe('applyJobPathInjector', () => {
+  it('injects path and name into a createJob call with an empty object', () => {
+    const code = 'export const testJob = jobs.createJob({})'
+
+    const result = applyJobPathInjector(code, jobFile('testJob.js'), JOBS_DIR)
+
+    expect(result).toContain('path: "testJob"')
+    expect(result).toContain('name: "testJob"')
+  })
+
+  it('injects path and name into a createJob call with existing properties', () => {
+    const code = `
+      export const emailJob = jobs.createJob({
+        queue: 'email',
+        perform: async (data) => {
+          // send email
+        }
+      })
+    `
+
+    const result = applyJobPathInjector(code, jobFile('emailJob.js'), JOBS_DIR)
+
+    expect(result).toContain('path: "emailJob"')
+    expect(result).toContain('name: "emailJob"')
+    expect(result).toContain("queue: 'email'")
+    expect(result).toContain('perform: async (data)')
+  })
+
+  it('handles object literals with trailing commas', () => {
+    const code = `
+      export const sampleJob = jobs.createJob({
+        queue: 'default',
+        perform: async () => {
+          console.log('performing')
+        },
+      })
+    `
+
+    const result = applyJobPathInjector(code, jobFile('sampleJob.ts'), JOBS_DIR)
+
+    expect(result).toContain('path: "sampleJob"')
+    expect(result).toContain('name: "sampleJob"')
+    // The insert must not produce `,,` after the existing trailing comma
+    expect(result).not.toMatch(/,\s*,/)
+  })
+
+  it('handles nested directory paths', () => {
+    const code = `
+      export const cleanupJob = jobs.createJob({
+        queue: 'maintenance'
+      })
+    `
+
+    const result = applyJobPathInjector(
+      code,
+      jobFile('admin', 'cleanupJob.js'),
+      JOBS_DIR,
+    )
+
+    expect(result).toMatch(/path: "admin(\/|\\\\)cleanupJob"/)
+    expect(result).toContain('name: "cleanupJob"')
+  })
+
+  it('handles TypeScript files', () => {
+    const code = `
+      export const processJob = jobs.createJob({
+        queue: 'processing',
+        perform: async (data: JobData) => {
+          // process data
+        }
+      })
+    `
+
+    const result = applyJobPathInjector(
+      code,
+      jobFile('processJob.ts'),
+      JOBS_DIR,
+    )
+
+    expect(result).toContain('path: "processJob"')
+    expect(result).toContain('name: "processJob"')
+  })
+
+  it('handles multiple createJob calls in the same file', () => {
+    const code = `
+      export const firstJob = jobs.createJob({
+        queue: 'first'
+      })
+
+      export const secondJob = jobs.createJob({
+        queue: 'second'
+      })
+    `
+
+    const result = applyJobPathInjector(code, jobFile('multiJob.js'), JOBS_DIR)
+
+    expect(result).toContain('path: "multiJob"')
+    expect(result).toContain('name: "firstJob"')
+    expect(result).toContain('name: "secondJob"')
+  })
+
+  it('handles different member expression objects', () => {
+    const code = `
+      import { jobs as j } from '@cedarjs/api'
+
+      export const aliasedJob = j.createJob({
+        queue: 'aliased'
+      })
+    `
+
+    const result = applyJobPathInjector(
+      code,
+      jobFile('aliasedJob.js'),
+      JOBS_DIR,
+    )
+
+    expect(result).toContain('path: "aliasedJob"')
+    expect(result).toContain('name: "aliasedJob"')
+  })
+
+  it('returns null for files without createJob calls', () => {
+    const code = `
+      export const someFunction = () => {
+        return 'not a job'
+      }
+    `
+
+    const result = applyJobPathInjector(code, jobFile('noJob.js'), JOBS_DIR)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for createJob calls that are not exported consts', () => {
+    const code = `
+      const localJob = jobs.createJob({ queue: 'local' })
+    `
+
+    const result = applyJobPathInjector(code, jobFile('localJob.js'), JOBS_DIR)
+
+    expect(result).toBeNull()
+  })
+})

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -42,6 +42,7 @@ import { applyOtelWrapping } from './esbuild-plugin-cedar-otel-wrapping.js'
 import { applyHandlerAlsWrapping } from './esbuild-plugin-handler-als-wrapping.js'
 import { applyEsmExtensions } from './esm-extensions.js'
 import { applyImportDir } from './import-dir.js'
+import { applyJobPathInjector } from './job-path-injector.js'
 import { applySrcAlias } from './src-alias.js'
 import { applyTsconfigPaths } from './tsconfig-paths.js'
 
@@ -111,32 +112,34 @@ const runCedarBabelTransformsPlugin = {
       // running on the same file.
       fileContents =
         applyImportDir(fileContents, args.path)?.code ?? fileContents
+      // Inject `path` and `name` into createJob() definitions. This replaces
+      // the Babel job path injector override, which is disabled now that this
+      // pipeline calls transformWithBabel with forVite: true. It is the
+      // esbuild equivalent of the cedarjsJobPathInjectorPlugin used by the
+      // @cedarjs/vite pipelines.
+      fileContents =
+        applyJobPathInjector(fileContents, args.path, getPaths().api.jobs) ??
+        fileContents
 
       const normalizedPath = normalizePath(args.path)
       const cedarPaths = getPaths()
       const isEsm = projectSideIsEsm('api')
 
-      // The Babel pass is needed to apply a user's custom api/babel.config.js
-      // — getApiSideBabelPluginsForVite() is empty (the transforms above
-      // replace Cedar's api-side Babel plugins) and esbuild strips TypeScript
-      // itself when given the matching loader. Job files are the exception:
-      // they rely on the Babel job path injector override (see
-      // getApiSideBabelOverrides) to add `path` and `name` to createJob()
-      // definitions, because this pipeline has no equivalent of the
-      // cedarjsJobPathInjectorPlugin that the @cedarjs/vite pipelines use.
+      // The Babel pass is only needed to apply a user's custom
+      // api/babel.config.js: getApiSideBabelPluginsForVite() is empty (the
+      // transforms above replace Cedar's api-side Babel plugins) and esbuild
+      // strips TypeScript itself when given the matching loader.
       const apiBabelConfigPath = getApiSideBabelConfigPath()
-      const isJobsFile = normalizedPath.startsWith(
-        normalizePath(cedarPaths.api.jobs) + '/',
-      )
-      const useBabel = Boolean(apiBabelConfigPath) || isJobsFile
 
       let code = fileContents
 
-      if (useBabel) {
+      if (apiBabelConfigPath) {
         const transformedCode = await transformWithBabel(
           fileContents,
           args.path,
           getApiSideBabelPluginsForVite(),
+          'inline',
+          true,
         )
 
         if (!transformedCode?.code) {
@@ -180,7 +183,7 @@ const runCedarBabelTransformsPlugin = {
         // Babel output is always plain JS. Without Babel the contents are
         // still TypeScript/JSX, so pick the loader matching the file's
         // extension and let esbuild do the stripping.
-        loader: useBabel ? 'js' : getEsbuildLoader(args.path),
+        loader: apiBabelConfigPath ? 'js' : getEsbuildLoader(args.path),
       }
     })
   },
@@ -314,6 +317,13 @@ function createCedarViteApiPlugin(): Plugin {
         path.dirname(path.relative(cedarPaths.api.src, id)),
       )
       sourceCode = applyAutoImports(sourceCode)
+      // Inject `path` and `name` into createJob() definitions. This replaces
+      // the Babel job path injector override, which is disabled now that this
+      // pipeline calls transformWithBabel with forVite: true. It is the
+      // standalone-Vite equivalent of the cedarjsJobPathInjectorPlugin used
+      // by the @cedarjs/vite pipelines.
+      sourceCode =
+        applyJobPathInjector(sourceCode, id, cedarPaths.api.jobs) ?? sourceCode
 
       // Apply graphql-specific transforms on the raw TypeScript BEFORE
       // Babel CJS compilation. The ESM-pattern regexes in these
@@ -329,30 +339,23 @@ function createCedarViteApiPlugin(): Plugin {
         sourceCode = applyGqlormInject(sourceCode, id) ?? sourceCode
       }
 
-      // The Babel pass is needed to apply a user's custom api/babel.config.js
-      // — getApiSideBabelPluginsForVite() is empty (the transforms in this
-      // pipeline replace Cedar's api-side Babel plugins) and Vite strips
-      // TypeScript itself. Job files are the exception: they rely on the
-      // Babel job path injector override (see getApiSideBabelOverrides) to
-      // add `path` and `name` to createJob() definitions, because this
-      // pipeline has no equivalent of the cedarjsJobPathInjectorPlugin that
-      // the @cedarjs/vite pipelines use.
+      // The Babel pass is only needed to apply a user's custom
+      // api/babel.config.js: getApiSideBabelPluginsForVite() is empty (the
+      // transforms in this pipeline replace Cedar's api-side Babel plugins)
+      // and Vite strips TypeScript itself.
       const apiBabelConfigPath = getApiSideBabelConfigPath()
-      const isJobsFile = normalizedId.startsWith(
-        normalizePath(cedarPaths.api.jobs) + '/',
-      )
-      const useBabel = Boolean(apiBabelConfigPath) || isJobsFile
 
-      const transformedCode = useBabel
+      const transformedCode = apiBabelConfigPath
         ? await transformWithBabel(
             sourceCode,
             id,
             getApiSideBabelPluginsForVite(),
             true,
+            true,
           )
         : null
 
-      if (useBabel && !transformedCode?.code) {
+      if (apiBabelConfigPath && !transformedCode?.code) {
         throw new Error(`Could not transform file: ${id}`)
       }
 

--- a/packages/internal/src/build/esbuild-plugin-api-graphql.ts
+++ b/packages/internal/src/build/esbuild-plugin-api-graphql.ts
@@ -105,6 +105,8 @@ export const cedarApiGraphqlPlugin = {
           fileContents,
           args.path,
           getApiSideBabelPluginsForVite(),
+          'inline',
+          true,
         )
 
         if (!transformedCode?.code) {

--- a/packages/internal/src/build/job-path-injector.ts
+++ b/packages/internal/src/build/job-path-injector.ts
@@ -51,50 +51,55 @@ export function applyJobPathInjector(
     if (decl?.type !== 'VariableDeclaration') {
       continue
     }
-    const declarator = decl.declarations[0]
-    if (declarator?.id.type !== 'Identifier') {
-      continue
-    }
 
-    const init = declarator.init
-    if (init?.type !== 'CallExpression') {
-      continue
-    }
+    // Check every declarator: in
+    // `export const a = 1, myJob = jobs.createJob({})` the job is declared
+    // on the second one
+    for (const declarator of decl.declarations) {
+      if (declarator.id.type !== 'Identifier') {
+        continue
+      }
 
-    // Only match `<something>.createJob(...)`, mirroring the
-    // `$OBJ.createJob({ $$$PROPS })` pattern in the Vite plugin
-    const callee = init.callee
-    if (
-      callee.type !== 'MemberExpression' ||
-      callee.computed ||
-      callee.property.type !== 'Identifier' ||
-      callee.property.name !== 'createJob'
-    ) {
-      continue
-    }
+      const init = declarator.init
+      if (init?.type !== 'CallExpression') {
+        continue
+      }
 
-    const configArg = init.arguments[0]
-    if (configArg?.type !== 'ObjectExpression') {
-      continue
-    }
+      // Only match `<something>.createJob(...)`, mirroring the
+      // `$OBJ.createJob({ $$$PROPS })` pattern in the Vite plugin
+      const callee = init.callee
+      if (
+        callee.type !== 'MemberExpression' ||
+        callee.computed ||
+        callee.property.type !== 'Identifier' ||
+        callee.property.name !== 'createJob'
+      ) {
+        continue
+      }
 
-    const pathProperty = `path: ${JSON.stringify(importPathWithoutExtension)}`
-    const nameProperty = `name: ${JSON.stringify(declarator.id.name)}`
+      const configArg = init.arguments[0]
+      if (configArg?.type !== 'ObjectExpression') {
+        continue
+      }
 
-    const lastProperty = configArg.properties.at(-1)
-    if (lastProperty) {
-      // Insert right after the last property. This stays valid whether or
-      // not the object literal has a trailing comma.
-      insertions.push({
-        pos: lastProperty.end,
-        text: `, ${pathProperty}, ${nameProperty}`,
-      })
-    } else {
-      // Empty object: insert right after the opening brace
-      insertions.push({
-        pos: configArg.start + 1,
-        text: `${pathProperty}, ${nameProperty}`,
-      })
+      const pathProperty = `path: ${JSON.stringify(importPathWithoutExtension)}`
+      const nameProperty = `name: ${JSON.stringify(declarator.id.name)}`
+
+      const lastProperty = configArg.properties.at(-1)
+      if (lastProperty) {
+        // Insert right after the last property. This stays valid whether or
+        // not the object literal has a trailing comma.
+        insertions.push({
+          pos: lastProperty.end,
+          text: `, ${pathProperty}, ${nameProperty}`,
+        })
+      } else {
+        // Empty object: insert right after the opening brace
+        insertions.push({
+          pos: configArg.start + 1,
+          text: `${pathProperty}, ${nameProperty}`,
+        })
+      }
     }
   }
 

--- a/packages/internal/src/build/job-path-injector.ts
+++ b/packages/internal/src/build/job-path-injector.ts
@@ -1,0 +1,111 @@
+import path from 'node:path'
+
+import { parseSync } from 'oxc-parser'
+
+/**
+ * Injects `path` and `name` properties into `createJob()` definitions so the
+ * jobs runner can locate and identify the job's module at runtime.
+ *
+ * Standalone equivalent of the Vite cedarjsJobPathInjectorPlugin (used by
+ * buildApp and apiDevMiddleware) and the Babel pluginRedwoodJobPathInjector
+ * override they replaced. Applied inline in the esbuild API build and the
+ * standalone-Vite API build so neither path depends on Babel for job path
+ * injection.
+ *
+ * Keep this in sync with
+ * packages/vite/src/plugins/vite-plugin-cedarjs-job-path-injector.ts.
+ */
+export function applyJobPathInjector(
+  code: string,
+  filePath: string,
+  jobsDir: string,
+): string | null {
+  // Quick check to see if this might be a job file
+  if (!code.includes('createJob')) {
+    return null
+  }
+
+  let program
+  try {
+    program = parseSync(filePath, code, { sourceType: 'module' }).program
+  } catch (error) {
+    console.warn('Failed to parse file:', filePath)
+    console.warn(error)
+
+    // If we can't parse, just return the original code
+    return null
+  }
+
+  const importPath = path.relative(jobsDir, filePath)
+  const importPathWithoutExtension = importPath.replace(/\.[^/.]+$/, '')
+
+  // Collect insertions; they are applied in reverse order below so earlier
+  // positions stay valid while splicing
+  const insertions: { pos: number; text: string }[] = []
+
+  for (const node of program.body) {
+    if (node.type !== 'ExportNamedDeclaration') {
+      continue
+    }
+    const decl = node.declaration
+    if (decl?.type !== 'VariableDeclaration') {
+      continue
+    }
+    const declarator = decl.declarations[0]
+    if (declarator?.id.type !== 'Identifier') {
+      continue
+    }
+
+    const init = declarator.init
+    if (init?.type !== 'CallExpression') {
+      continue
+    }
+
+    // Only match `<something>.createJob(...)`, mirroring the
+    // `$OBJ.createJob({ $$$PROPS })` pattern in the Vite plugin
+    const callee = init.callee
+    if (
+      callee.type !== 'MemberExpression' ||
+      callee.computed ||
+      callee.property.type !== 'Identifier' ||
+      callee.property.name !== 'createJob'
+    ) {
+      continue
+    }
+
+    const configArg = init.arguments[0]
+    if (configArg?.type !== 'ObjectExpression') {
+      continue
+    }
+
+    const pathProperty = `path: ${JSON.stringify(importPathWithoutExtension)}`
+    const nameProperty = `name: ${JSON.stringify(declarator.id.name)}`
+
+    const lastProperty = configArg.properties.at(-1)
+    if (lastProperty) {
+      // Insert right after the last property. This stays valid whether or
+      // not the object literal has a trailing comma.
+      insertions.push({
+        pos: lastProperty.end,
+        text: `, ${pathProperty}, ${nameProperty}`,
+      })
+    } else {
+      // Empty object: insert right after the opening brace
+      insertions.push({
+        pos: configArg.start + 1,
+        text: `${pathProperty}, ${nameProperty}`,
+      })
+    }
+  }
+
+  if (insertions.length === 0) {
+    return null
+  }
+
+  let result = code
+  for (const { pos, text } of insertions.sort((a, b) => b.pos - a.pos)) {
+    result = result.slice(0, pos) + text + result.slice(pos)
+  }
+
+  return result
+}


### PR DESCRIPTION
Stacked on #2160.

## Summary

#2160 kept a Babel exception for job files: the esbuild (`buildApi`) and standalone-Vite (`buildApiWithVite`) api builds had no dedicated job path injector, so they relied on the `pluginRedwoodJobPathInjector` Babel override (implicitly enabled because those pipelines called `transformWithBabel` with `forVite: false`) to inject `path` and `name` into `createJob()` definitions.

This PR removes that last implicit Babel dependency:

- New `applyJobPathInjector()` string transform in `packages/internal/src/build/job-path-injector.ts`, implemented with `oxc-parser` (already a dependency) following the same pattern as the OTel/ALS transforms. It mirrors `cedarjsJobPathInjectorPlugin` from `@cedarjs/vite` (with a keep-in-sync note), and additionally handles object literals with trailing commas by inserting after the last property instead of before the closing brace.
- Both internal pipelines apply it unconditionally as a pre-Babel string transform, and now call `transformWithBabel` with `forVite: true` (matching the `@cedarjs/vite` pipelines), which disables the Babel injector override so jobs are never injected twice.
- The `useBabel`-for-jobs exception from #2160 is reverted: Babel now runs only when the project has an `api/babel.config.js`, for all files.

The `buildApp`/`apiDevMiddleware` pipelines are unchanged — they already use the dedicated Vite plugin. `registerApiSideBabelHook` (data-migrate/console/prerender) is unchanged and keeps the Babel override.

## Testing

- New unit tests for `applyJobPathInjector` ported from the Vite plugin's test suite, plus a trailing-comma case (`yarn workspace @cedarjs/internal test`, 266 passed).
- Verified end-to-end against a fixture project with a `createJob()` file: both `buildApi` and `buildApiWithVite` emit exactly one `path`/`name` pair, both with and without a user `api/babel.config.js`.
- ESM and CJS fixture build smoke checks pass (TS stripped, ALS wrapping, graphql options extract, ESM extension rewrites all intact).