### PR TITLE
chore(vite): Serialize virtual functions from real functions

### DIFF
--- a/.commandcode/taste/taste.md
+++ b/.commandcode/taste/taste.md
@@ -115,3 +115,7 @@ See [debugging/taste.md](debugging/taste.md)
 - When a workflow step uses `working-directory` and passes a path to the test project via an env var (e.g., `CEDAR_TEST_PROJECT_PATH`), use `${{ github.workspace }}/../path` rather than a relative path. The relative path resolves against the `working-directory`, not the workspace root. Confidence: 0.80
 - When a conditional job (`if:`) has no `strategy.matrix`, GitHub creates no job entry at all if the condition is false. Jobs referencing it in `needs` then fail. Always add a dummy matrix (e.g., `strategy.matrix: { os: [ubuntu-latest] }`) so skipped jobs appear as "skipped" entries that `ci-status-check` handles correctly. Confidence: 0.90
 - Do not use `inputs` expressions (e.g., `inputs.packageManager`) in job-level `if:` or `concurrency.group` of a `workflow_call` workflow that also has a `schedule` trigger. GitHub cannot resolve `inputs` at parse time for `schedule` triggers, causing the workflow to silently fail with 0 jobs. Remove `inputs` entirely or use a separate matrix approach. Confidence: 0.85
+
+# Vite Plugins
+
+- For Vite virtual modules (plugins with `load()` hooks that return template strings), prefer extracting logic into real exported functions at module scope that are serialized via `.toString()` rather than using side-effect imports solely for static analyzer visibility. Real functions are testable, give Knip a traceable dependency chain, and avoid dead-code `import` statements. Confidence: 0.65

--- a/.commandcode/taste/taste.md
+++ b/.commandcode/taste/taste.md
@@ -92,6 +92,23 @@ See [debugging/taste.md](debugging/taste.md)
 - When creating esbuild `onLoad` plugins with a `filter` regex, make the filter precise enough (include path separator) that a redundant inner path check (e.g., `args.path.endsWith(...)`) is unnecessary. A filter like `/\/graphql\.ts$/` avoids both false matches (e.g., `notgraphql.ts`) and redundant guards inside the callback. Confidence: 0.60
 - Keep each esbuild plugin in its own separate file, following the pattern of `esbuild-plugin-handler-als-wrapping.ts`. Do not define multiple plugins inline in the same file where the build options live — extract each into a dedicated file with a descriptive name. Confidence: 0.70
 
+# Migration / Porting
+
+- When porting Babel plugins to Vite/esbuild, the goal is to preserve existing behavior exactly — including existing bugs and shortcomings. Don't "fix" or improve behavior during migration; keep it identical to what Babel produced. Fixes and improvements belong in separate follow-up PRs. Confidence: 0.90
+
+# Package Management
+
+- Use exact version pinning (no caret `^` or tilde `~`) when specifying dependency versions. Confidence: 0.85
+
+# Code-Style
+
+- Avoid `for(;;)` infinite loops. Use a regular `while` loop with a clear exit condition in the `while` statement instead. Confidence: 0.80
+- Do not increment and assign on the same line (e.g., `const currentIndex = nextIndex++`). Separate the increment from the assignment for clarity. Confidence: 0.80
+
+# Configuration
+
+- Hard-code concurrency/parallelism values (e.g., `4`, `8`) rather than using environment variables for them. Explicit hard-coded values are easier to reason about and don't require documentation of env vars. Confidence: 0.75
+
 # Process Management
 
 - Never use `pkill` or `killall` to mass-kill processes by name (e.g., `pkill -9 node`). Only kill specific PIDs that you know are safe to terminate. Mass-killing can destroy the user's browser sessions, chat apps, and other work. Confidence: 0.85

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-log-formatter-dev.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-log-formatter-dev.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-import { cedarApiLogFormatterDevPlugin } from '../vite-plugin-cedar-log-formatter-dev'
+import {
+  cedarApiLogFormatterDevPlugin,
+  createFormattingDestination,
+} from '../vite-plugin-cedar-log-formatter-dev'
+
+vi.mock('@cedarjs/api-server/logFormatter', () => {
+  const LogFormatter = () => (line: string) => `[FORMATTED] ${line}`
+  return { LogFormatter }
+})
 
 const RESOLVED_VIRTUAL_MODULE_ID = '\0virtual:cedar-api-logger-dev'
 
@@ -61,10 +69,61 @@ describe('cedarApiLogFormatterDevPlugin', () => {
       expect(code).toContain("from '@cedarjs/api-server/logFormatter'")
       // Passes through every other export from the real module unchanged
       expect(code).toContain('export * from "@cedarjs/api/logger"')
-      // Only this one export is overridden
-      expect(code).toContain('export function createLogger(')
+      // Overrides createLogger (serialized from the exported function)
+      expect(code).toContain('function createLogger(')
       // Doesn't clobber a destination the caller already supplied
       expect(code).toContain('if (params.destination)')
     })
+  })
+})
+
+describe('createFormattingDestination', () => {
+  beforeEach(() => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('formats and writes a single complete log line', () => {
+    const dest = createFormattingDestination()
+    const writeSpy = vi.mocked(process.stdout.write)
+
+    dest.write('{"level":30,"msg":"hello"}\n')
+
+    expect(writeSpy).toHaveBeenCalledOnce()
+    expect(writeSpy.mock.calls[0][0]).toContain('{"level":30,"msg":"hello"}')
+  })
+
+  it('handles partial chunks buffered across multiple writes', () => {
+    const dest = createFormattingDestination()
+    const writeSpy = vi.mocked(process.stdout.write)
+
+    dest.write('{"level":30,"msg":"hello"}\n{"level":')
+    dest.write('40,"msg":"world"}\n')
+
+    expect(writeSpy).toHaveBeenCalledTimes(2)
+    expect(writeSpy.mock.calls[0][0]).toContain('{"level":30,"msg":"hello"}')
+    expect(writeSpy.mock.calls[1][0]).toContain('{"level":40,"msg":"world"}')
+  })
+
+  it('skips empty lines in the buffer', () => {
+    const dest = createFormattingDestination()
+    const writeSpy = vi.mocked(process.stdout.write)
+
+    dest.write('\n{"level":30,"msg":"hello"}\n\n\n')
+
+    expect(writeSpy).toHaveBeenCalledOnce()
+    expect(writeSpy.mock.calls[0][0]).toContain('{"level":30,"msg":"hello"}')
+  })
+
+  it('buffers a chunk with no newline', () => {
+    const dest = createFormattingDestination()
+    const writeSpy = vi.mocked(process.stdout.write)
+
+    dest.write('{"level":30,"msg":"partial"}')
+
+    expect(writeSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/vite/src/plugins/vite-plugin-cedar-log-formatter-dev.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-log-formatter-dev.ts
@@ -1,5 +1,12 @@
 import type { Plugin } from 'vite'
 
+// // Referenced at runtime by the virtual module in load() below, not from
+// // this file directly. Kept as a visible import so static analyzers (Knip) can
+// // see the dependency on @cedarjs/api-server.
+// import '@cedarjs/api-server'
+import type * as apiLogger from '@cedarjs/api/logger'
+import { LogFormatter } from '@cedarjs/api-server/logFormatter'
+
 const INTERCEPTED_SPECIFIER = '@cedarjs/api/logger'
 const VIRTUAL_MODULE_ID = 'virtual:cedar-api-logger-dev'
 const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID
@@ -46,19 +53,27 @@ export function cedarApiLogFormatterDevPlugin(): Plugin {
       }
 
       return `
-import * as realLogger from ${JSON.stringify(INTERCEPTED_SPECIFIER)}
-import { LogFormatter } from '@cedarjs/api-server/logFormatter'
+        import * as realLogger from ${JSON.stringify(INTERCEPTED_SPECIFIER)}
+        import { LogFormatter } from '@cedarjs/api-server/logFormatter'
 
-export * from ${JSON.stringify(INTERCEPTED_SPECIFIER)}
+        export * from ${JSON.stringify(INTERCEPTED_SPECIFIER)}
 
-function createFormattingDestination() {
+        ${createFormattingDestination.toString()}
+
+        ${createLogger.toString()}
+        `
+    },
+  }
+}
+
+export function createFormattingDestination() {
   const format = LogFormatter()
   let buffered = ''
 
   return {
-    write(chunk) {
+    write(chunk: string) {
       buffered += chunk
-      const lines = buffered.split('\\n')
+      const lines = buffered.split('\n')
       buffered = lines.pop() ?? ''
 
       for (const line of lines) {
@@ -70,7 +85,17 @@ function createFormattingDestination() {
   }
 }
 
-export function createLogger(params = {}) {
+type CreateLoggerParams = Parameters<typeof apiLogger.createLogger>[0]
+
+// This is only to make TS happy. The real `realLogger` that will be used when
+// the code actually runs is the one that `load()` above generates an import for
+const realLogger = {
+  createLogger: (_params: CreateLoggerParams) => {
+    return {} as apiLogger.Logger
+  },
+}
+
+export function createLogger(params: CreateLoggerParams = {}) {
   if (params.destination) {
     return realLogger.createLogger(params)
   }
@@ -79,8 +104,4 @@ export function createLogger(params = {}) {
     ...params,
     destination: createFormattingDestination(),
   })
-}
-`
-    },
-  }
 }

--- a/packages/vite/src/plugins/vite-plugin-cedar-log-formatter-dev.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-log-formatter-dev.ts
@@ -60,7 +60,8 @@ export function cedarApiLogFormatterDevPlugin(): Plugin {
 
         ${createFormattingDestination.toString()}
 
-        ${createLogger.toString()}
+        // toString() doesn't include the 'export' keyword
+        export ${createLogger.toString()}
         `
     },
   }


### PR DESCRIPTION
Extract real functions from the template string to make them testable, and to make their dependencies visible to static code analysis tools.