### PR TITLE
feat(api): Nudge users to use `request` instead of `event`

### DIFF
--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -98,11 +98,16 @@ export type AuthContextPayload = [
   // @MARK: Context is not passed when using middleware auth
   {
     /**
-     * @deprecated Use `request` instead — `event` is a legacy Lambda-style
-     *   object and will be removed in a future version.
+     * The Lambda-style event. On serverless deploys this is the canonical
+     * request object; on fetch-native paths a synthetic one is provided for
+     * backwards compatibility with existing `event.headers['key']` access.
      */
     event: APIGatewayProxyEvent | Request
-    /** The native fetch `Request`, when available. */
+    /**
+     * The native fetch `Request`, available on fetch-native paths. Prefer
+     * this when available.
+     * Do `request.headers.get('key')` to access headers
+     */
     request?: Request
     context?: LambdaContext
   },
@@ -112,7 +117,7 @@ export type Decoder = (
   token: string,
   type: string,
   req: {
-    /** @deprecated Use `request` instead. */
+    /** The Lambda-style request event */
     event: APIGatewayProxyEvent | Request
     request?: Request
     context?: LambdaContext

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -97,11 +97,12 @@ export type AuthContextPayload = [
   { type: string } & AuthorizationHeader,
   // @MARK: Context is not passed when using middleware auth
   {
-    event: APIGatewayProxyEvent | Request
     /**
-     * The native fetch `Request`, when available. This lets user code choose
-     * between `event.headers['key']` and `request.headers.get('key')`.
+     * @deprecated Use `request` instead — `event` is a legacy Lambda-style
+     *   object and will be removed in a future version.
      */
+    event: APIGatewayProxyEvent | Request
+    /** The native fetch `Request`, when available. */
     request?: Request
     context?: LambdaContext
   },
@@ -111,6 +112,7 @@ export type Decoder = (
   token: string,
   type: string,
   req: {
+    /** @deprecated Use `request` instead. */
     event: APIGatewayProxyEvent | Request
     request?: Request
     context?: LambdaContext


### PR DESCRIPTION
`event` was the older AWS Lambda Request shaped event.
`request` is the new web standards Request object.

`event`, and now `request`, is what you get on the third parameter to `getCurrentUser()`, and also in your `authDecoder`, if you have a custom one

```
⠶ request present (fetch-native paths):
  ┌───────────────────────────────────────────────────────┬──────────────────────────────────────────────────────┐
  │ Call site                                             │ Context                                              │
  ├───────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ runtime.ts → buildCedarContext →                      │ Fastify + vite dev middleware passes native Request. │
  │ getAuthenticationContext(request)                     │ requestToBaseEvent normalizes event, request gets    │
  │                                                       │ the raw Request                                      │
  ├───────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ useRedwoodAuthContext.ts →                            │ GraphQL Yoga — getAuthEvent() returns                │
  │ getAuthenticationContext(context.request)             │ context.request (web Request)                        │
  ├───────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ initDbAuthMiddleware → getCurrentUser(..., { event:   │ MiddlewareRequest (superset of Request)              │
  │ req, request: req })                                  │                                                      │
  ├───────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ initSupabaseAuthMiddleware → getCurrentUser(..., {    │ MiddlewareRequest                                    │
  │ event: req, request: req })                           │                                                      │
  └───────────────────────────────────────────────────────┴──────────────────────────────────────────────────────┘

⠶ request absent (Lambda-only paths):

  ┌───────────────────────────────────────────────────────┬──────────────────────────────────────────────────────┐
  │ Call site                                             │ Context                                              │
  ├───────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ graphql.ts → getAuthenticationContext(event, context) │ Lambda APIGatewayProxyEvent — no Request to pass.    │
  │                                                       │ isFetchApiRequest is false, event stays raw Lambda   │
  │                                                       │ event, request is undefined                          │
  ├───────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
  │ useRequireAuth.ts → getAuthenticationContext(event,   │ Lambda event from legacy requireAuth wrapper — same  │
  │ context)                                              │ as above                                             │
  └───────────────────────────────────────────────────────┴──────────────────────────────────────────────────────┘
```

  So request is populated on all modern fetch paths (buildCedarContext, GraphQL Yoga via web Request, middleware) but absent on the two true Lambda paths (the legacy graphql.ts handler and requireAuth).