### PR TITLE
docs(vite): Modernize Vite config page, promote plugin composability

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ application, here's what you get with Cedar:
 - Architectural decisions made for you, so you don't get stuck in analysis
   paralysis or get decision fatigue. But it doesn't lock you in. You have full
   control over your code, your auth, your database, and your deployment.
+- A single convenient `cedar()` Vite plugin that covers the 99% use case. And
+  for the times you need more, every building block it's made of is exported
+  too, so you can compose your own plugin pipeline with full control.
 - Ready made integrations for hosting on Vercel, Netlify, AWS, Render, or your
   own servers. Switch providers easily without major rewrites.
 - A production ready framework. Used by companies in production with a mature

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ application, here's what you get with Cedar:
   paralysis or get decision fatigue. But it doesn't lock you in. You have full
   control over your code, your auth, your database, and your deployment.
 - A single convenient `cedar()` Vite plugin that covers the 99% use case. And
-  for the times you need more, every building block it's made of is exported
-  too, so you can compose your own plugin pipeline with full control.
+  for the times you need more, every Cedar-specific building block it's made of
+  is exported too, so you can compose your own plugin pipeline with full
+  control.
 - Ready made integrations for hosting on Vercel, Netlify, AWS, Render, or your
   own servers. Switch providers easily without major rewrites.
 - A production ready framework. Used by companies in production with a mature

--- a/docs/docs/vite-configuration.md
+++ b/docs/docs/vite-configuration.md
@@ -58,9 +58,9 @@ export default defineConfig(({ mode }) => ({
 For almost every project, the single `cedar()` plugin is all you'll ever
 need: one line that pulls in all of Cedar's Vite configuration. But `cedar()`
 is itself composed of many small plugins, and each of Cedar's own building
-blocks is individually exported. So when you really do need full control —
+blocks is individually exported. So when you really do need full control, like
 dropping one of Cedar's plugins, reordering them, or wedging your own plugin
-in between two of them — you can skip `cedar()` and compose the pipeline
+in between two of them, you can skip `cedar()` and compose the pipeline
 yourself.
 
 Most of the pipeline comes straight from `@cedarjs/vite`:
@@ -77,27 +77,17 @@ import {
 } from '@cedarjs/vite'
 ```
 
-But `cedar()` isn't built from `@cedarjs/vite` exports alone. It also
-includes:
-
-- `tsconfigPaths()` from `vite-tsconfig-paths` and `gqlPlugin` from
-  `vite-plugin-graphql-tag`
-- test-mode transforms from `@cedarjs/testing/web/vitest`
-  (`cedarJsRouterImportTransformPlugin`, `createAuthImportTransformPlugin`,
-  and `autoImportsPlugin`)
-- a configured `react()` from `@vitejs/plugin-react`, wired up with Cedar's
-  Babel handling (including the React Compiler plugin when that's enabled)
-
-A custom pipeline needs to include those too — or make a deliberate decision
-to leave them out.
+But `cedar()` isn't built from `@cedarjs/vite` exports alone. It also includes
+other plugins, and a custom pipeline needs to include those too (or make a
+deliberate decision to leave them out).
 
 The [`cedar()` implementation](https://github.com/cedarjs/cedar/blob/main/packages/vite/src/index.ts)
-is the authoritative list of everything it's made of and the order it all
-runs in — use it as your starting point.
+is the authoritative list of everything it's made of and the order it all runs
+in. It's a good starting point for your own customizations.
 
-A word of warning: if you compose your own pipeline, you own it. Cedar
-releases can add, rename, remove, or reorder plugins (especially across major
-versions), so check the release notes when you upgrade.
+A word of warning: if you compose your own pipeline, you own it. Cedar releases
+can add, rename, remove, or reorder plugins (especially across major versions),
+so check the release notes when you upgrade.
 
 ### Sass and Tailwind CSS
 

--- a/docs/docs/vite-configuration.md
+++ b/docs/docs/vite-configuration.md
@@ -57,10 +57,13 @@ export default defineConfig(({ mode }) => ({
 
 For almost every project, the single `cedar()` plugin is all you'll ever
 need: one line that pulls in all of Cedar's Vite configuration. But `cedar()`
-is itself composed of many small plugins, and `@cedarjs/vite` exports every
-one of them. So when you really do need full control — dropping one of
-Cedar's plugins, reordering them, or wedging your own plugin in between two
-of them — you can skip `cedar()` and compose the pipeline yourself:
+is itself composed of many small plugins, and each of Cedar's own building
+blocks is individually exported. So when you really do need full control —
+dropping one of Cedar's plugins, reordering them, or wedging your own plugin
+in between two of them — you can skip `cedar()` and compose the pipeline
+yourself.
+
+Most of the pipeline comes straight from `@cedarjs/vite`:
 
 ```ts
 import {
@@ -74,9 +77,23 @@ import {
 } from '@cedarjs/vite'
 ```
 
+But `cedar()` isn't built from `@cedarjs/vite` exports alone. It also
+includes:
+
+- `tsconfigPaths()` from `vite-tsconfig-paths` and `gqlPlugin` from
+  `vite-plugin-graphql-tag`
+- test-mode transforms from `@cedarjs/testing/web/vitest`
+  (`cedarJsRouterImportTransformPlugin`, `createAuthImportTransformPlugin`,
+  and `autoImportsPlugin`)
+- a configured `react()` from `@vitejs/plugin-react`, wired up with Cedar's
+  Babel handling (including the React Compiler plugin when that's enabled)
+
+A custom pipeline needs to include those too — or make a deliberate decision
+to leave them out.
+
 The [`cedar()` implementation](https://github.com/cedarjs/cedar/blob/main/packages/vite/src/index.ts)
-is the authoritative list of the plugins it's made of and the order they run
-in — use it as your starting point.
+is the authoritative list of everything it's made of and the order it all
+runs in — use it as your starting point.
 
 A word of warning: if you compose your own pipeline, you own it. Cedar
 releases can add, rename, remove, or reorder plugins (especially across major

--- a/docs/docs/vite-configuration.md
+++ b/docs/docs/vite-configuration.md
@@ -6,37 +6,88 @@ description: If you have to configure Vite, here's how
 
 Cedar uses Vite. One of Cedar's tenets is convention over configuration.
 
-Vite is an awesome build tool, but we don't want it to be something that you have to be familiar with to be productive.
-So it's worth repeating that you don't have to do any of this, because we configure everything you will need out of the box with a Cedar Vite plugin.
+Vite is an awesome build tool, but we don't want it to be something that you
+have to be familiar with to be productive. So it's worth repeating that you
+don't have to do any of this, because we configure everything you will need out
+of the box with a Cedar Vite plugin.
 
-Regardless, there'll probably come a time when you have to configure Vite. All the Vite configuration for your web side sits in `web/vite.config.{js,ts}`, and can be configured the same as any other Vite project. Let's take a peek!
+Regardless, there'll probably come a time when you have to configure Vite. All
+the Vite configuration for your web side sits in `web/vite.config.{js,ts}`, and
+can be configured the same as any other Vite project. Let's take a peek!
 
-```js
-import dns from 'dns'
+```ts
+import dns from 'node:dns'
+
 import { defineConfig } from 'vite'
-import redwood from '@cedarjs/vite'
 
+import { cedar } from '@cedarjs/vite'
+
+// So that Vite will load on localhost instead of `127.0.0.1`.
+// See: https://vite.dev/config/server-options.html#server-host
 dns.setDefaultResultOrder('verbatim')
 
-const viteConfig = {
+export default defineConfig(({ mode }) => ({
   plugins: [
-    // 👇 this is the CedarJS Vite plugin, that houses all the default configuration
-    redwood(),
+    // 👇 this is the CedarJS Vite plugin, that houses all the default
+    // configuration
+    cedar({ mode }),
     // ... add any custom Vite plugins you would like here
   ],
-  // You can override built in configuration like server, optimizeDeps, etc. here
-}
-export default defineConfig(viteConfig)
+  // You can override built in configuration like server, optimizeDeps, etc.
+  // here
+}))
 ```
 
-Checkout Vite's docs on [configuration](https://vitejs.dev/config/)
+Checkout Vite's docs on [configuration](https://vite.dev/config/)
+
+### Custom Babel plugins
+
+Vite doesn't run your code through Babel, so `web/babel.config.js` is not
+applied to your dev server or production bundle. If you need a custom Babel
+plugin or preset in your web build, pass it via the `cedar()` plugin's `babel`
+option:
+
+```ts
+export default defineConfig(({ mode }) => ({
+  plugins: [cedar({ mode, babel: { plugins: ['my-babel-plugin'] } })],
+}))
+```
+
+## One plugin — or all the building blocks
+
+For almost every project, the single `cedar()` plugin is all you'll ever
+need: one line that pulls in all of Cedar's Vite configuration. But `cedar()`
+is itself composed of many small plugins, and `@cedarjs/vite` exports every
+one of them. So when you really do need full control — dropping one of
+Cedar's plugins, reordering them, or wedging your own plugin in between two
+of them — you can skip `cedar()` and compose the pipeline yourself:
+
+```ts
+import {
+  cedarCellTransform,
+  cedarDataUriShim,
+  cedarEntryInjectionPlugin,
+  cedarHtmlEnvPlugin,
+  cedarMergedConfig,
+  cedarRoutesAutoLoaderPlugin,
+  // ... and many more
+} from '@cedarjs/vite'
+```
+
+The [`cedar()` implementation](https://github.com/cedarjs/cedar/blob/main/packages/vite/src/index.ts)
+is the authoritative list of the plugins it's made of and the order they run
+in — use it as your starting point.
+
+A word of warning: if you compose your own pipeline, you own it. Cedar
+releases can add, rename, remove, or reorder plugins (especially across major
+versions), so check the release notes when you upgrade.
 
 ### Sass and Tailwind CSS
 
-Cedar is already configured to use Sass, if the packages are there:
+Vite has built-in support for Sass, all you have to do is add the package:
 
 ```
-yarn workspace web add -D sass sass-loader
+yarn workspace web add -D sass
 ```
 
 And if you want to use Tailwind CSS, just run the setup command:
@@ -45,28 +96,39 @@ And if you want to use Tailwind CSS, just run the setup command:
 yarn cedar setup ui tailwindcss
 ```
 
-> Note: The setup command `yarn cedar setup ui tailwindcss` installs Tailwind CSS v3.x by default. Cedar also works with Tailwind v4.x, but the setup helper does not currently install that version or its configuration.
+> Note: The setup command `yarn cedar setup ui tailwindcss` installs Tailwind
+> CSS v3.x by default. Cedar also works with Tailwind v4.x, but the setup
+> helper does not currently install that version or its configuration.
 
 ## Vite Dev Server
 
-Cedar uses Vite's preview server for local development.
-When you run `yarn rw dev`, keys in your `cedar.toml`'s `[web]` table—like `port` and `apiUrl`—are used as vite preview server options (in this case, [preview.port](https://vitejs.dev/config/preview-options.html#preview-port) and [preview.proxy](https://vitejs.dev/config/preview-options.html#preview-proxy) respectively).
+Cedar uses Vite's dev server for local development. When you run
+`yarn cedar dev`, keys in your `cedar.toml`'s `[web]` table—like `port` and
+`apiUrl`—are used as Vite dev server options (in this case,
+[server.port](https://vite.dev/config/server-options.html#server-port) and
+[server.proxy](https://vite.dev/config/server-options.html#server-proxy)
+respectively).
 
-> You can peek at all the out-of-the-box configuration for your Vite preview server in the [CedarJS Vite plugin](https://github.com/cedarjs/cedar/blob/main/packages/vite/src/index.ts)
+> You can peek at all the out-of-the-box configuration for your Vite dev
+> server in the
+> [CedarJS Vite plugin](https://github.com/cedarjs/cedar/blob/main/packages/vite/src/index.ts)
 
 ### Using `--forward`
 
-While you can configure Vite using `web/vite.config.js`, it's often simpler to use `yarn rw dev`'s `--forward` option.
+While you can configure Vite using `web/vite.config.js`, it's often simpler to
+use `yarn cedar dev`'s `--forward` option.
 
-For example, if you want to force optimise your Vite dependencies again, you can run:
-
-```
-yarn rw dev --fwd="--force"
-```
-
-You can also use `--forward` to override keys in your `cedar.toml`.
-For example, the following starts your app on port `1234` and disables automatic browser opening:
+For example, if you want to force optimise your Vite dependencies again, you
+can run:
 
 ```
-yarn rw dev --forward="--port 1234 --no-open"
+yarn cedar dev --fwd="--force"
+```
+
+You can also use `--forward` to override keys in your `cedar.toml`. For
+example, the following starts your app on port `1234` and disables automatic
+browser opening:
+
+```
+yarn cedar dev --forward="--port=1234 --open=false"
 ```


### PR DESCRIPTION
## Summary

Modernizes `docs/docs/vite-configuration.md` and adds a 'Why Cedar?' README bullet promoting the plugin architecture.

### Docs page
- Updates the `vite.config` example to the current template style (`import { cedar } from '@cedarjs/vite'` and `cedar({ mode })` instead of the old default-imported `redwood()`)
- Documents the `cedar({ babel })` option for custom Babel plugins
- Adds a new **One plugin — or all the building blocks** section explaining that every plugin `cedar()` is composed of is individually exported for people who need to compose their own pipeline, with a stability caveat
- Fixes the dev server section: `cedar.toml`'s `[web]` keys map to Vite's dev `server.port`/`server.proxy` options (verified in `packages/vite/src/lib/getMergedConfig.ts`), not the preview server as the page claimed
- Drops `sass-loader` from the Sass instructions — that's a webpack package; Vite only needs `sass`
- `yarn rw dev` → `yarn cedar dev`, links updated from vitejs.dev to vite.dev

### README
- New 'Why Cedar?' bullet: single convenient `cedar()` plugin for the common case, all the building blocks exported for full control

## Testing
- `yarn prettier --check` passes on both files
- Docs-only change, no code affected

Extracted from the v6 release-prep work so it can merge independently.