### PR TITLE
fix(cli): Skip update check for non-semver @cedarjs/core specs

### DIFF
--- a/packages/cli/src/lib/__tests__/updateCheck.test.ts
+++ b/packages/cli/src/lib/__tests__/updateCheck.test.ts
@@ -562,3 +562,76 @@ describe('Local version is not comparable (file: tarball or workspace spec)', ()
     expect(updateCheck.shouldShow()).toBe(false)
   })
 })
+
+describe('Project version changed while the cache is still fresh', () => {
+  beforeAll(async () => {
+    const actualProjectConfig = await vi.importActual<typeof ProjectConfig>(
+      '@cedarjs/project-config',
+    )
+
+    const config = actualProjectConfig.DEFAULT_CONFIG
+
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(TESTING_CURRENT_DATETIME))
+    vi.mocked(getConfig).mockReturnValue({
+      ...config,
+      notifications: {
+        ...config.notifications,
+        versionUpdates: ['latest'],
+      },
+    })
+
+    // @ts-expect-error - This is assignable in tests
+    fs.statSync = vi.fn((lockfilePath) => {
+      if (!vol.existsSync(lockfilePath as string)) {
+        const error = new Error(
+          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
+        ) as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }
+      return {
+        birthtimeMs: Date.now(),
+      }
+    })
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'time').mockImplementation(() => {})
+    vi.spyOn(console, 'timeEnd').mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    vol.reset()
+    vi.clearAllMocks()
+  })
+
+  it('Forces a fresh check and does not show a stale notification when the cached localVersion no longer matches the current spec', () => {
+    // The cache says the project is on 1.0.0 with a 2.0.0 update available,
+    // and checkedAt is fresh (well within CHECK_PERIOD). But the project has
+    // since been bumped to 2.0.0 itself. Without validating the spec against
+    // the cached localVersion, shouldShow() would tell a project already on
+    // 2.0.0 that it's on 1.0.0 and should upgrade to 2.0.0.
+    vol.fromJSON({
+      'package.json': JSON.stringify({
+        devDependencies: {
+          '@cedarjs/core': '^2.0.0',
+        },
+      }),
+      '.cedar/updateCheck/data.json': JSON.stringify({
+        localVersion: '1.0.0',
+        remoteVersions: { latest: '2.0.0' },
+        checkedAt: TESTING_CURRENT_DATETIME,
+        shownAt: updateCheck.DEFAULT_DATETIME_MS,
+      }),
+    })
+
+    // The mismatch should force a fresh check even though checkedAt is fresh
+    expect(updateCheck.shouldCheck()).toBe(true)
+    // And must not show the misleading 1.0.0 -> 2.0.0 notification
+    expect(updateCheck.shouldShow()).toBe(false)
+  })
+})

--- a/packages/cli/src/lib/__tests__/updateCheck.test.ts
+++ b/packages/cli/src/lib/__tests__/updateCheck.test.ts
@@ -59,50 +59,55 @@ import * as updateCheck from '../updateCheck.js'
 
 const TESTING_CURRENT_DATETIME = 1640995200000
 
-describe('Update is not available (1.0.0 -> 1.0.0)', () => {
-  beforeAll(async () => {
-    const actualProjectConfig = await vi.importActual<typeof ProjectConfig>(
-      '@cedarjs/project-config',
-    )
+function setVersionUpdates(tags: string[]) {
+  // @ts-expect-error - A partial config is enough for these tests
+  vi.mocked(getConfig).mockReturnValue({
+    notifications: {
+      versionUpdates: tags,
+    },
+  })
+}
 
-    const config = actualProjectConfig.DEFAULT_CONFIG
+beforeAll(() => {
+  // Use fake datetime
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(TESTING_CURRENT_DATETIME))
 
-    // Use fake datetime
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(TESTING_CURRENT_DATETIME))
-    vi.mocked(getConfig).mockReturnValue({
-      ...config,
-      notifications: {
-        ...config.notifications,
-        versionUpdates: ['latest'],
-      },
-    })
-
-    // Prevent the appearance of stale locks. Throw ENOENT when the underlying
-    // memfs filesystem doesn't have the path so `isLockSet` can distinguish
-    // a missing lock from a fresh one.
-    // @ts-expect-error - This is assignable in tests
-    fs.statSync = vi.fn((lockfilePath) => {
-      if (!vol.existsSync(lockfilePath as string)) {
-        const error = new Error(
-          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
-        ) as NodeJS.ErrnoException
-        error.code = 'ENOENT'
-        throw error
-      }
-      return {
-        birthtimeMs: Date.now(),
-      }
-    })
-
-    // Prevent console output during tests
-    vi.spyOn(console, 'log').mockImplementation(() => {})
-    vi.spyOn(console, 'time').mockImplementation(() => {})
-    vi.spyOn(console, 'timeEnd').mockImplementation(() => {})
+  // Prevent the appearance of stale locks. Throw ENOENT when the underlying
+  // memfs filesystem doesn't have the path so `isLockSet` can distinguish
+  // a missing lock from a fresh one.
+  // @ts-expect-error - This is assignable in tests
+  fs.statSync = vi.fn((lockfilePath) => {
+    if (!vol.existsSync(lockfilePath as string)) {
+      const error = new Error(
+        `ENOENT: no such file or directory, stat '${lockfilePath}'`,
+      ) as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      throw error
+    }
+    return {
+      birthtimeMs: Date.now(),
+    }
   })
 
-  afterAll(() => {
-    vi.useRealTimers()
+  // Prevent console output during tests
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'time').mockImplementation(() => {})
+  vi.spyOn(console, 'timeEnd').mockImplementation(() => {})
+})
+
+afterAll(() => {
+  vi.useRealTimers()
+})
+
+afterEach(() => {
+  vol.reset()
+  vi.clearAllMocks()
+})
+
+describe('Update is not available (1.0.0 -> 1.0.0)', () => {
+  beforeAll(() => {
+    setVersionUpdates(['latest'])
   })
 
   beforeEach(() => {
@@ -112,18 +117,13 @@ describe('Update is not available (1.0.0 -> 1.0.0)', () => {
     })
 
     vol.fromJSON({
-      // Users package.json containing the redwood version
+      // The user's package.json containing the pinned Cedar version
       'package.json': JSON.stringify({
         devDependencies: {
-          '@cedarjs/core': '^1.0.0',
+          '@cedarjs/core': '1.0.0',
         },
       }),
     })
-  })
-
-  afterEach(() => {
-    vol.reset()
-    vi.clearAllMocks()
   })
 
   it('Produces the correct updateData.json file', async () => {
@@ -164,36 +164,7 @@ describe('Update is not available (1.0.0 -> 1.0.0)', () => {
 
 describe('Update is available (1.0.0 -> 2.0.0)', () => {
   beforeAll(() => {
-    // Use fake datetime
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(TESTING_CURRENT_DATETIME))
-    // @ts-expect-error - Partial mock return
-    vi.mocked(getConfig).mockReturnValue({
-      notifications: {
-        versionUpdates: ['latest'],
-      },
-    })
-
-    // Prevent the appearance of stale locks. Throw ENOENT when the underlying
-    // memfs filesystem doesn't have the path so `isLockSet` can distinguish
-    // a missing lock from a fresh one.
-    // @ts-expect-error - This is assignable in tests
-    fs.statSync = vi.fn((lockfilePath) => {
-      if (!vol.existsSync(lockfilePath as string)) {
-        const error = new Error(
-          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
-        ) as NodeJS.ErrnoException
-        error.code = 'ENOENT'
-        throw error
-      }
-      return {
-        birthtimeMs: Date.now(),
-      }
-    })
-  })
-
-  afterAll(() => {
-    vi.useRealTimers()
+    setVersionUpdates(['latest'])
   })
 
   beforeEach(() => {
@@ -203,18 +174,13 @@ describe('Update is available (1.0.0 -> 2.0.0)', () => {
     })
 
     vol.fromJSON({
-      // Users package.json containing the redwood version
+      // The user's package.json containing the pinned Cedar version
       'package.json': JSON.stringify({
         devDependencies: {
-          '@cedarjs/core': '^1.0.0',
+          '@cedarjs/core': '1.0.0',
         },
       }),
     })
-  })
-
-  afterEach(() => {
-    vol.reset()
-    vi.clearAllMocks()
   })
 
   it('Produces the correct updateData.json file', async () => {
@@ -229,10 +195,6 @@ describe('Update is available (1.0.0 -> 2.0.0)', () => {
     })
   })
 
-  it('Should want to check before any check has run', () => {
-    expect(updateCheck.shouldCheck()).toBe(true)
-  })
-
   it('Should not want to check after a check has run', async () => {
     await updateCheck.check()
     expect(updateCheck.shouldCheck()).toBe(false)
@@ -246,52 +208,11 @@ describe('Update is available (1.0.0 -> 2.0.0)', () => {
     await updateCheck.check()
     expect(updateCheck.shouldShow()).toBe(true)
   })
-
-  it('Respects the lock', async () => {
-    setLock(updateCheck.CHECK_LOCK_IDENTIFIER)
-    expect(updateCheck.shouldCheck()).toBe(false)
-  })
 })
 
 describe('Update is available with rc tag (1.0.0-rc.1 -> 1.0.1-rc.58)', () => {
-  beforeAll(async () => {
-    const actualProjectConfig = await vi.importActual<typeof ProjectConfig>(
-      '@cedarjs/project-config',
-    )
-
-    const config = actualProjectConfig.DEFAULT_CONFIG
-
-    // Use fake datetime
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(TESTING_CURRENT_DATETIME))
-    vi.mocked(getConfig).mockReturnValue({
-      ...config,
-      notifications: {
-        ...config.notifications,
-        versionUpdates: ['latest', 'rc'],
-      },
-    })
-
-    // Prevent the appearance of stale locks. Throw ENOENT when the underlying
-    // memfs filesystem doesn't have the path so `isLockSet` can distinguish
-    // a missing lock from a fresh one.
-    // @ts-expect-error - This is assignable in tests
-    fs.statSync = vi.fn((lockfilePath) => {
-      if (!vol.existsSync(lockfilePath as string)) {
-        const error = new Error(
-          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
-        ) as NodeJS.ErrnoException
-        error.code = 'ENOENT'
-        throw error
-      }
-      return {
-        birthtimeMs: Date.now(),
-      }
-    })
-  })
-
-  afterAll(() => {
-    vi.useRealTimers()
+  beforeAll(() => {
+    setVersionUpdates(['latest', 'rc'])
   })
 
   beforeEach(() => {
@@ -301,18 +222,13 @@ describe('Update is available with rc tag (1.0.0-rc.1 -> 1.0.1-rc.58)', () => {
     })
 
     vol.fromJSON({
-      // Users package.json containing the redwood version
+      // The user's package.json containing the pinned Cedar version
       'package.json': JSON.stringify({
         devDependencies: {
-          '@cedarjs/core': '^1.0.0-rc.1',
+          '@cedarjs/core': '1.0.0-rc.1',
         },
       }),
     })
-  })
-
-  afterEach(() => {
-    vol.reset()
-    vi.clearAllMocks()
   })
 
   it('Produces the correct updateData.json file', async () => {
@@ -327,59 +243,24 @@ describe('Update is available with rc tag (1.0.0-rc.1 -> 1.0.1-rc.58)', () => {
     })
   })
 
-  it('Should want to check before any check has run', () => {
-    expect(updateCheck.shouldCheck()).toBe(true)
-  })
-
-  it('Should not want to check after a check has run', async () => {
-    await updateCheck.check()
-    expect(updateCheck.shouldCheck()).toBe(false)
-  })
-
-  it('Should not want to show before any check has run', () => {
-    expect(updateCheck.shouldShow()).toBe(false)
-  })
-
   it('Should want to show after a check has run', async () => {
     await updateCheck.check()
     expect(updateCheck.shouldShow()).toBe(true)
-  })
-
-  it('Respects the lock', async () => {
-    setLock(updateCheck.CHECK_LOCK_IDENTIFIER)
-    expect(updateCheck.shouldCheck()).toBe(false)
   })
 })
 
 describe('Update middleware', () => {
   beforeAll(() => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(TESTING_CURRENT_DATETIME))
-  })
-
-  afterAll(() => {
-    vi.useRealTimers()
+    setVersionUpdates(['latest'])
   })
 
   beforeEach(() => {
-    // Prevent the appearance of stale locks. Throw ENOENT when the underlying
-    // memfs filesystem doesn't have the path so `isLockSet` can distinguish
-    // a missing lock from a fresh one.
-    // @ts-expect-error - This is assignable in tests
-    fs.statSync = vi.fn((lockfilePath) => {
-      if (!vol.existsSync(lockfilePath as string)) {
-        const error = new Error(
-          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
-        ) as NodeJS.ErrnoException
-        error.code = 'ENOENT'
-        throw error
-      }
-      return {
-        birthtimeMs: Date.now(),
-      }
-    })
-
     vol.fromJSON({
+      'package.json': JSON.stringify({
+        devDependencies: {
+          '@cedarjs/core': '2.4.1',
+        },
+      }),
       '.cedar/updateCheck/data.json': JSON.stringify({
         localVersion: '2.4.1',
         remoteVersions: {
@@ -389,11 +270,6 @@ describe('Update middleware', () => {
         shownAt: updateCheck.DEFAULT_DATETIME_MS,
       }),
     })
-  })
-
-  afterEach(() => {
-    vol.reset()
-    vi.clearAllMocks()
   })
 
   it('does not show stale update info when a fresh check is due', () => {
@@ -406,45 +282,9 @@ describe('Update middleware', () => {
   })
 })
 
-describe('Local version is not comparable (file: tarball or workspace spec)', () => {
-  beforeAll(async () => {
-    const actualProjectConfig = await vi.importActual<typeof ProjectConfig>(
-      '@cedarjs/project-config',
-    )
-
-    const config = actualProjectConfig.DEFAULT_CONFIG
-
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(TESTING_CURRENT_DATETIME))
-    vi.mocked(getConfig).mockReturnValue({
-      ...config,
-      notifications: {
-        ...config.notifications,
-        versionUpdates: ['latest'],
-      },
-    })
-
-    // @ts-expect-error - This is assignable in tests
-    fs.statSync = vi.fn((lockfilePath) => {
-      if (!vol.existsSync(lockfilePath as string)) {
-        const error = new Error(
-          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
-        ) as NodeJS.ErrnoException
-        error.code = 'ENOENT'
-        throw error
-      }
-      return {
-        birthtimeMs: Date.now(),
-      }
-    })
-
-    vi.spyOn(console, 'log').mockImplementation(() => {})
-    vi.spyOn(console, 'time').mockImplementation(() => {})
-    vi.spyOn(console, 'timeEnd').mockImplementation(() => {})
-  })
-
-  afterAll(() => {
-    vi.useRealTimers()
+describe('@cedarjs/core version is not pinned', () => {
+  beforeAll(() => {
+    setVersionUpdates(['latest'])
   })
 
   beforeEach(() => {
@@ -453,41 +293,18 @@ describe('Local version is not comparable (file: tarball or workspace spec)', ()
     })
   })
 
-  afterEach(() => {
-    vol.reset()
-    vi.clearAllMocks()
-  })
-
-  it('Skips the check for a file: tarball spec without throwing', async () => {
+  it.each([
+    'file:/some/path/tarballs/cedarjs-core.tgz',
+    'workspace:*',
+    '^1.0.0',
+  ])('Skips the check and clears stored versions for %s', async (spec) => {
     vol.fromJSON({
       'package.json': JSON.stringify({
         devDependencies: {
-          '@cedarjs/core': 'file:/some/path/tarballs/cedarjs-core.tgz',
+          '@cedarjs/core': spec,
         },
       }),
-    })
-
-    await updateCheck.check()
-
-    const data = updateCheck.readUpdateDataFile()
-    // The raw spec is recorded as localVersion (failing shouldShow()'s
-    // semver guard), remote versions are cleared, and checkedAt is updated
-    // so the check isn't re-run on every command
-    expect(data.localVersion).toBe('file:/some/path/tarballs/cedarjs-core.tgz')
-    expect(data.remoteVersions.size).toBe(0)
-    expect(data.checkedAt).toBe(TESTING_CURRENT_DATETIME)
-    expect(updateCheck.shouldCheck()).toBe(false)
-  })
-
-  it('Clears stale version data when the spec becomes non-semver', async () => {
-    // A previously valid project state wanted to show an upgrade
-    // notification...
-    vol.fromJSON({
-      'package.json': JSON.stringify({
-        devDependencies: {
-          '@cedarjs/core': 'file:/some/path/tarballs/cedarjs-core.tgz',
-        },
-      }),
+      // Stale data from before the project switched to a non-pinned spec
       '.cedar/updateCheck/data.json': JSON.stringify({
         localVersion: '1.0.0',
         remoteVersions: { latest: '2.0.0' },
@@ -496,129 +313,34 @@ describe('Local version is not comparable (file: tarball or workspace spec)', ()
       }),
     })
 
-    // ...but the project has since switched to a tarball spec, so after the
-    // next (skipped) check the stale 1.0.0 -> 2.0.0 data must not survive
     await updateCheck.check()
 
-    expect(updateCheck.shouldShow()).toBe(false)
-  })
-
-  it('Skips the check for a workspace:* spec without hanging', async () => {
-    vol.fromJSON({
-      'package.json': JSON.stringify({
-        devDependencies: {
-          '@cedarjs/core': 'workspace:*',
-        },
-      }),
-    })
-
-    await updateCheck.check()
+    expect(latestVersion).not.toHaveBeenCalled()
 
     const data = updateCheck.readUpdateDataFile()
-    expect(data.localVersion).toBe('workspace:*')
+    expect(data.localVersion).toBe('0.0.0')
     expect(data.remoteVersions.size).toBe(0)
-  })
+    expect(data.checkedAt).toBe(TESTING_CURRENT_DATETIME)
 
-  it('Does not want to show for a persisted non-semver localVersion', () => {
-    vol.fromJSON({
-      // The current spec is comparable, so this specifically exercises the
-      // guard against previously persisted non-semver data
-      'package.json': JSON.stringify({
-        devDependencies: {
-          '@cedarjs/core': '^1.0.0',
-        },
-      }),
-      '.cedar/updateCheck/data.json': JSON.stringify({
-        localVersion: 'file:/some/path/tarballs/cedarjs-core.tgz',
-        remoteVersions: { latest: '2.0.0' },
-        checkedAt: TESTING_CURRENT_DATETIME,
-        shownAt: updateCheck.DEFAULT_DATETIME_MS,
-      }),
-    })
-
-    expect(updateCheck.shouldShow()).toBe(false)
-  })
-
-  it('Does not show stale data while the cache is still fresh', () => {
-    // The project was on a comparable version, a check ran recently (fresh
-    // checkedAt means shouldCheck() is false, so check() won't run and clear
-    // the data), and the project has since switched to a tarball spec. The
-    // stale 1.0.0 -> 2.0.0 notification must not show.
-    vol.fromJSON({
-      'package.json': JSON.stringify({
-        devDependencies: {
-          '@cedarjs/core': 'file:/some/path/tarballs/cedarjs-core.tgz',
-        },
-      }),
-      '.cedar/updateCheck/data.json': JSON.stringify({
-        localVersion: '1.0.0',
-        remoteVersions: { latest: '2.0.0' },
-        checkedAt: TESTING_CURRENT_DATETIME,
-        shownAt: updateCheck.DEFAULT_DATETIME_MS,
-      }),
-    })
-
+    // The recorded check prevents re-running on every command, and the
+    // cleared versions prevent showing the stale notification
     expect(updateCheck.shouldCheck()).toBe(false)
     expect(updateCheck.shouldShow()).toBe(false)
   })
 })
 
-describe('Project version changed while the cache is still fresh', () => {
-  beforeAll(async () => {
-    const actualProjectConfig = await vi.importActual<typeof ProjectConfig>(
-      '@cedarjs/project-config',
-    )
-
-    const config = actualProjectConfig.DEFAULT_CONFIG
-
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(TESTING_CURRENT_DATETIME))
-    vi.mocked(getConfig).mockReturnValue({
-      ...config,
-      notifications: {
-        ...config.notifications,
-        versionUpdates: ['latest'],
-      },
-    })
-
-    // @ts-expect-error - This is assignable in tests
-    fs.statSync = vi.fn((lockfilePath) => {
-      if (!vol.existsSync(lockfilePath as string)) {
-        const error = new Error(
-          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
-        ) as NodeJS.ErrnoException
-        error.code = 'ENOENT'
-        throw error
-      }
-      return {
-        birthtimeMs: Date.now(),
-      }
-    })
-
-    vi.spyOn(console, 'log').mockImplementation(() => {})
-    vi.spyOn(console, 'time').mockImplementation(() => {})
-    vi.spyOn(console, 'timeEnd').mockImplementation(() => {})
+describe('Project version changed while the cached data is still fresh', () => {
+  beforeAll(() => {
+    setVersionUpdates(['latest'])
   })
 
-  afterAll(() => {
-    vi.useRealTimers()
-  })
-
-  afterEach(() => {
-    vol.reset()
-    vi.clearAllMocks()
-  })
-
-  it('Forces a fresh check and does not show a stale notification when the cached localVersion no longer matches the current spec', () => {
+  it('Forces a fresh check and does not show a stale notification', () => {
     // The cache says the project is on 1.0.0 with a 2.0.0 update available,
-    // and checkedAt is fresh (well within CHECK_PERIOD). But the project has
-    // since been bumped to 2.0.0 itself. Without validating the spec against
-    // the cached localVersion, shouldShow() would tell a project already on
-    // 2.0.0 that it's on 1.0.0 and should upgrade to 2.0.0.
+    // but the project has since been upgraded to 2.0.0 itself
     vol.fromJSON({
       'package.json': JSON.stringify({
         devDependencies: {
-          '@cedarjs/core': '^2.0.0',
+          '@cedarjs/core': '2.0.0',
         },
       }),
       '.cedar/updateCheck/data.json': JSON.stringify({
@@ -629,9 +351,7 @@ describe('Project version changed while the cache is still fresh', () => {
       }),
     })
 
-    // The mismatch should force a fresh check even though checkedAt is fresh
     expect(updateCheck.shouldCheck()).toBe(true)
-    // And must not show the misleading 1.0.0 -> 2.0.0 notification
     expect(updateCheck.shouldShow()).toBe(false)
   })
 })

--- a/packages/cli/src/lib/__tests__/updateCheck.test.ts
+++ b/packages/cli/src/lib/__tests__/updateCheck.test.ts
@@ -405,3 +405,105 @@ describe('Update middleware', () => {
     expect(processOnSpy).not.toHaveBeenCalledWith('exit', expect.any(Function))
   })
 })
+
+describe('Local version is not comparable (file: tarball or workspace spec)', () => {
+  beforeAll(async () => {
+    const actualProjectConfig = await vi.importActual<typeof ProjectConfig>(
+      '@cedarjs/project-config',
+    )
+
+    const config = actualProjectConfig.DEFAULT_CONFIG
+
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(TESTING_CURRENT_DATETIME))
+    vi.mocked(getConfig).mockReturnValue({
+      ...config,
+      notifications: {
+        ...config.notifications,
+        versionUpdates: ['latest'],
+      },
+    })
+
+    // @ts-expect-error - This is assignable in tests
+    fs.statSync = vi.fn((lockfilePath) => {
+      if (!vol.existsSync(lockfilePath as string)) {
+        const error = new Error(
+          `ENOENT: no such file or directory, stat '${lockfilePath}'`,
+        ) as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }
+      return {
+        birthtimeMs: Date.now(),
+      }
+    })
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'time').mockImplementation(() => {})
+    vi.spyOn(console, 'timeEnd').mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    vi.useRealTimers()
+  })
+
+  beforeEach(() => {
+    vi.mocked(latestVersion).mockImplementation(async () => {
+      return '2.0.0'
+    })
+  })
+
+  afterEach(() => {
+    vol.reset()
+    vi.clearAllMocks()
+  })
+
+  it('Skips the check for a file: tarball spec without throwing', async () => {
+    vol.fromJSON({
+      'package.json': JSON.stringify({
+        devDependencies: {
+          '@cedarjs/core': 'file:/some/path/tarballs/cedarjs-core.tgz',
+        },
+      }),
+    })
+
+    await updateCheck.check()
+
+    const data = updateCheck.readUpdateDataFile()
+    // No version information recorded, but checkedAt is updated so the check
+    // isn't re-run on every command
+    expect(data.localVersion).toBe('0.0.0')
+    expect(data.remoteVersions.size).toBe(0)
+    expect(data.checkedAt).toBe(TESTING_CURRENT_DATETIME)
+    expect(updateCheck.shouldCheck()).toBe(false)
+  })
+
+  it('Skips the check for a workspace:* spec without hanging', async () => {
+    vol.fromJSON({
+      'package.json': JSON.stringify({
+        devDependencies: {
+          '@cedarjs/core': 'workspace:*',
+        },
+      }),
+    })
+
+    await updateCheck.check()
+
+    const data = updateCheck.readUpdateDataFile()
+    expect(data.localVersion).toBe('0.0.0')
+    expect(data.remoteVersions.size).toBe(0)
+  })
+
+  it('Does not want to show for a persisted non-semver localVersion', () => {
+    vol.fromJSON({
+      '.cedar/updateCheck/data.json': JSON.stringify({
+        localVersion: 'file:/some/path/tarballs/cedarjs-core.tgz',
+        remoteVersions: { latest: '2.0.0' },
+        checkedAt: TESTING_CURRENT_DATETIME,
+        shownAt: updateCheck.DEFAULT_DATETIME_MS,
+      }),
+    })
+
+    expect(updateCheck.shouldShow()).toBe(false)
+  })
+})

--- a/packages/cli/src/lib/__tests__/updateCheck.test.ts
+++ b/packages/cli/src/lib/__tests__/updateCheck.test.ts
@@ -470,12 +470,37 @@ describe('Local version is not comparable (file: tarball or workspace spec)', ()
     await updateCheck.check()
 
     const data = updateCheck.readUpdateDataFile()
-    // No version information recorded, but checkedAt is updated so the check
-    // isn't re-run on every command
-    expect(data.localVersion).toBe('0.0.0')
+    // The raw spec is recorded as localVersion (failing shouldShow()'s
+    // semver guard), remote versions are cleared, and checkedAt is updated
+    // so the check isn't re-run on every command
+    expect(data.localVersion).toBe('file:/some/path/tarballs/cedarjs-core.tgz')
     expect(data.remoteVersions.size).toBe(0)
     expect(data.checkedAt).toBe(TESTING_CURRENT_DATETIME)
     expect(updateCheck.shouldCheck()).toBe(false)
+  })
+
+  it('Clears stale version data when the spec becomes non-semver', async () => {
+    // A previously valid project state wanted to show an upgrade
+    // notification...
+    vol.fromJSON({
+      'package.json': JSON.stringify({
+        devDependencies: {
+          '@cedarjs/core': 'file:/some/path/tarballs/cedarjs-core.tgz',
+        },
+      }),
+      '.cedar/updateCheck/data.json': JSON.stringify({
+        localVersion: '1.0.0',
+        remoteVersions: { latest: '2.0.0' },
+        checkedAt: updateCheck.DEFAULT_DATETIME_MS,
+        shownAt: updateCheck.DEFAULT_DATETIME_MS,
+      }),
+    })
+
+    // ...but the project has since switched to a tarball spec, so after the
+    // next (skipped) check the stale 1.0.0 -> 2.0.0 data must not survive
+    await updateCheck.check()
+
+    expect(updateCheck.shouldShow()).toBe(false)
   })
 
   it('Skips the check for a workspace:* spec without hanging', async () => {
@@ -490,7 +515,7 @@ describe('Local version is not comparable (file: tarball or workspace spec)', ()
     await updateCheck.check()
 
     const data = updateCheck.readUpdateDataFile()
-    expect(data.localVersion).toBe('0.0.0')
+    expect(data.localVersion).toBe('workspace:*')
     expect(data.remoteVersions.size).toBe(0)
   })
 

--- a/packages/cli/src/lib/__tests__/updateCheck.test.ts
+++ b/packages/cli/src/lib/__tests__/updateCheck.test.ts
@@ -521,6 +521,13 @@ describe('Local version is not comparable (file: tarball or workspace spec)', ()
 
   it('Does not want to show for a persisted non-semver localVersion', () => {
     vol.fromJSON({
+      // The current spec is comparable, so this specifically exercises the
+      // guard against previously persisted non-semver data
+      'package.json': JSON.stringify({
+        devDependencies: {
+          '@cedarjs/core': '^1.0.0',
+        },
+      }),
       '.cedar/updateCheck/data.json': JSON.stringify({
         localVersion: 'file:/some/path/tarballs/cedarjs-core.tgz',
         remoteVersions: { latest: '2.0.0' },
@@ -529,6 +536,29 @@ describe('Local version is not comparable (file: tarball or workspace spec)', ()
       }),
     })
 
+    expect(updateCheck.shouldShow()).toBe(false)
+  })
+
+  it('Does not show stale data while the cache is still fresh', () => {
+    // The project was on a comparable version, a check ran recently (fresh
+    // checkedAt means shouldCheck() is false, so check() won't run and clear
+    // the data), and the project has since switched to a tarball spec. The
+    // stale 1.0.0 -> 2.0.0 notification must not show.
+    vol.fromJSON({
+      'package.json': JSON.stringify({
+        devDependencies: {
+          '@cedarjs/core': 'file:/some/path/tarballs/cedarjs-core.tgz',
+        },
+      }),
+      '.cedar/updateCheck/data.json': JSON.stringify({
+        localVersion: '1.0.0',
+        remoteVersions: { latest: '2.0.0' },
+        checkedAt: TESTING_CURRENT_DATETIME,
+        shownAt: updateCheck.DEFAULT_DATETIME_MS,
+      }),
+    })
+
+    expect(updateCheck.shouldCheck()).toBe(false)
     expect(updateCheck.shouldShow()).toBe(false)
   })
 })

--- a/packages/cli/src/lib/updateCheck.ts
+++ b/packages/cli/src/lib/updateCheck.ts
@@ -65,36 +65,28 @@ function getPersistenceDirectory() {
 }
 
 /**
- * Reads the @cedarjs/core spec from the project's package.json and strips
- * leading range characters (^ or ~). The result is only a comparable version
- * if it also passes semver.valid(). Returns undefined if the spec can't be
- * read at all.
+ * Reads the @cedarjs/core version from the project's package.json. Cedar
+ * projects pin an exact version, so anything that isn't a plain
+ * "1.2.3"-style semver version (ranges, `file:` tarballs, `workspace:*`,
+ * etc.) returns undefined — there's nothing meaningful to compare against.
  */
-function getLocalVersionSpec():
-  | { raw: string; normalized: string }
-  | undefined {
+function getLocalVersion(): string | undefined {
+  let version: unknown
+
   try {
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(getPaths().base, 'package.json'), 'utf-8'),
     )
-    const raw = packageJson.devDependencies['@cedarjs/core']
-
-    if (typeof raw !== 'string') {
-      return undefined
-    }
-
-    // Remove any leading non-digits, i.e. ^ or ~
-    // (The length guard matters: specs with no digit at all, like
-    // `workspace:*`, would otherwise loop forever)
-    let normalized = raw
-    while (normalized.length > 0 && !/\d/.test(normalized.charAt(0))) {
-      normalized = normalized.substring(1)
-    }
-
-    return { raw, normalized }
+    version = packageJson.devDependencies?.['@cedarjs/core']
   } catch {
     return undefined
   }
+
+  if (typeof version === 'string' && semver.valid(version)) {
+    return version
+  }
+
+  return undefined
 }
 
 /**
@@ -105,23 +97,16 @@ export async function check() {
   try {
     console.time('Update Check')
 
-    const spec = getLocalVersionSpec()
-    const localVersion = spec?.normalized ?? ''
+    const localVersion = getLocalVersion()
 
-    if (!spec || !semver.valid(localVersion)) {
-      // Specs like `file:../tarballs/cedarjs-core.tgz` (written by tarsync
-      // for npm projects) or `workspace:*` aren't versions — there's nothing
-      // meaningful to compare against, so skip the check
+    if (!localVersion) {
       console.log(
-        `Skipping update check: '${spec?.raw}' is not a comparable version`,
+        'Skipping update check: no pinned @cedarjs/core version found',
       )
-      // Record the check so we don't re-run it on every command, and replace
-      // any previously stored version data. Keeping stale data around would
-      // let shouldShow() display an upgrade notification that no longer
-      // reflects the project. Storing the raw spec as localVersion both
-      // documents what we saw and fails shouldShow()'s semver guard.
+      // Record the check so it isn't re-run on every command, and clear any
+      // previously stored versions so a stale notification can't show
       updateUpdateDataFile({
-        localVersion: spec?.raw ?? 'unknown',
+        localVersion: '0.0.0',
         remoteVersions: new Map(),
         checkedAt: new Date().getTime(),
       })
@@ -181,16 +166,10 @@ export function shouldCheck() {
 
   const data = readUpdateDataFile()
 
-  // The project's spec can change (e.g. a version bump) while the cache is
-  // still within CHECK_PERIOD. Comparing remote versions against a
-  // localVersion that no longer matches the current spec would misstate the
-  // current version, so force a fresh check whenever they disagree.
-  const spec = getLocalVersionSpec()
-  if (
-    spec &&
-    semver.valid(spec.normalized) &&
-    spec.normalized !== data.localVersion
-  ) {
+  // The project's version can change (e.g. an upgrade) while the cached data
+  // is still fresh, so force a new check whenever they disagree
+  const localVersion = getLocalVersion()
+  if (localVersion && localVersion !== data.localVersion) {
     return true
   }
 
@@ -209,38 +188,22 @@ export function shouldShow() {
     return false
   }
 
+  // Only projects with a pinned version get update notifications. Comparing
+  // against the current version (rather than the stored one) also means
+  // cached data that predates a version change can't produce a notification
+  // the project has already acted on.
+  const localVersion = getLocalVersion()
+
+  if (!localVersion) {
+    return false
+  }
+
   // Check there is a new version and we haven't shown the user recently
-  // The cached data may predate a switch to a non-comparable spec (e.g.
-  // tarsync converting the project to file: tarballs) and stay "fresh" for
-  // up to CHECK_PERIOD, so the *current* spec has to be validated too — not
-  // just the stored one
-  const spec = getLocalVersionSpec()
-
-  if (!spec || !semver.valid(spec.normalized)) {
-    return false
-  }
-
   const data = readUpdateDataFile()
-
-  // A data file written before we validated versions may contain a
-  // non-semver localVersion (e.g. a `file:` tarball spec) — nothing to
-  // compare against then
-  if (!semver.valid(data.localVersion)) {
-    return false
-  }
-
-  // The stored localVersion may be stale relative to the current spec (e.g.
-  // the project was bumped to a new version but the cache is still within
-  // CHECK_PERIOD). Comparing remote versions against a mismatched
-  // localVersion would misstate the current version, so bail until
-  // shouldCheck() has refreshed the cache to match the current spec.
-  if (spec.normalized !== data.localVersion) {
-    return false
-  }
 
   let newerVersion = false
   data.remoteVersions.forEach((version) => {
-    newerVersion ||= semver.gt(version, data.localVersion)
+    newerVersion ||= semver.gt(version, localVersion)
   })
   return data.shownAt < new Date().getTime() - SHOW_PERIOD && newerVersion
 }

--- a/packages/cli/src/lib/updateCheck.ts
+++ b/packages/cli/src/lib/updateCheck.ts
@@ -65,6 +65,39 @@ function getPersistenceDirectory() {
 }
 
 /**
+ * Reads the @cedarjs/core spec from the project's package.json and strips
+ * leading range characters (^ or ~). The result is only a comparable version
+ * if it also passes semver.valid(). Returns undefined if the spec can't be
+ * read at all.
+ */
+function getLocalVersionSpec():
+  | { raw: string; normalized: string }
+  | undefined {
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(getPaths().base, 'package.json'), 'utf-8'),
+    )
+    const raw = packageJson.devDependencies['@cedarjs/core']
+
+    if (typeof raw !== 'string') {
+      return undefined
+    }
+
+    // Remove any leading non-digits, i.e. ^ or ~
+    // (The length guard matters: specs with no digit at all, like
+    // `workspace:*`, would otherwise loop forever)
+    let normalized = raw
+    while (normalized.length > 0 && !/\d/.test(normalized.charAt(0))) {
+      normalized = normalized.substring(1)
+    }
+
+    return { raw, normalized }
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Performs an update check to detect if a newer version of Cedar is available
  * and records the result to a file within .cedar for persistence
  */
@@ -72,25 +105,15 @@ export async function check() {
   try {
     console.time('Update Check')
 
-    // Read package.json and extract the @cedarjs/core version
-    const packageJson = JSON.parse(
-      fs.readFileSync(path.join(getPaths().base, 'package.json'), 'utf-8'),
-    )
-    let localVersion = packageJson.devDependencies['@cedarjs/core']
+    const spec = getLocalVersionSpec()
+    const localVersion = spec?.normalized ?? ''
 
-    // Remove any leading non-digits, i.e. ^ or ~
-    // (The length guard matters: specs with no digit at all, like
-    // `workspace:*`, would otherwise loop forever)
-    while (localVersion.length > 0 && !/\d/.test(localVersion.charAt(0))) {
-      localVersion = localVersion.substring(1)
-    }
-
-    if (!semver.valid(localVersion)) {
+    if (!spec || !semver.valid(localVersion)) {
       // Specs like `file:../tarballs/cedarjs-core.tgz` (written by tarsync
       // for npm projects) or `workspace:*` aren't versions — there's nothing
       // meaningful to compare against, so skip the check
       console.log(
-        `Skipping update check: '${packageJson.devDependencies['@cedarjs/core']}' is not a comparable version`,
+        `Skipping update check: '${spec?.raw}' is not a comparable version`,
       )
       // Record the check so we don't re-run it on every command, and replace
       // any previously stored version data. Keeping stale data around would
@@ -98,7 +121,7 @@ export async function check() {
       // reflects the project. Storing the raw spec as localVersion both
       // documents what we saw and fails shouldShow()'s semver guard.
       updateUpdateDataFile({
-        localVersion: packageJson.devDependencies['@cedarjs/core'],
+        localVersion: spec?.raw ?? 'unknown',
         remoteVersions: new Map(),
         checkedAt: new Date().getTime(),
       })
@@ -173,6 +196,16 @@ export function shouldShow() {
   }
 
   // Check there is a new version and we haven't shown the user recently
+  // The cached data may predate a switch to a non-comparable spec (e.g.
+  // tarsync converting the project to file: tarballs) and stay "fresh" for
+  // up to CHECK_PERIOD, so the *current* spec has to be validated too — not
+  // just the stored one
+  const spec = getLocalVersionSpec()
+
+  if (!spec || !semver.valid(spec.normalized)) {
+    return false
+  }
+
   const data = readUpdateDataFile()
 
   // A data file written before we validated versions may contain a

--- a/packages/cli/src/lib/updateCheck.ts
+++ b/packages/cli/src/lib/updateCheck.ts
@@ -79,9 +79,24 @@ export async function check() {
     let localVersion = packageJson.devDependencies['@cedarjs/core']
 
     // Remove any leading non-digits, i.e. ^ or ~
-    while (!/\d/.test(localVersion.charAt(0))) {
+    // (The length guard matters: specs with no digit at all, like
+    // `workspace:*`, would otherwise loop forever)
+    while (localVersion.length > 0 && !/\d/.test(localVersion.charAt(0))) {
       localVersion = localVersion.substring(1)
     }
+
+    if (!semver.valid(localVersion)) {
+      // Specs like `file:../tarballs/cedarjs-core.tgz` (written by tarsync
+      // for npm projects) or `workspace:*` aren't versions — there's nothing
+      // meaningful to compare against, so skip the check
+      console.log(
+        `Skipping update check: '${packageJson.devDependencies['@cedarjs/core']}' is not a comparable version`,
+      )
+      // Still record the check so we don't re-run it on every command
+      updateUpdateDataFile({ checkedAt: new Date().getTime() })
+      return
+    }
+
     console.log(`Detected the current version of Cedar: '${localVersion}'`)
 
     const remoteVersions = new Map()
@@ -151,6 +166,14 @@ export function shouldShow() {
 
   // Check there is a new version and we haven't shown the user recently
   const data = readUpdateDataFile()
+
+  // A data file written before we validated versions may contain a
+  // non-semver localVersion (e.g. a `file:` tarball spec) — nothing to
+  // compare against then
+  if (!semver.valid(data.localVersion)) {
+    return false
+  }
+
   let newerVersion = false
   data.remoteVersions.forEach((version) => {
     newerVersion ||= semver.gt(version, data.localVersion)

--- a/packages/cli/src/lib/updateCheck.ts
+++ b/packages/cli/src/lib/updateCheck.ts
@@ -179,8 +179,22 @@ export function shouldCheck() {
     return false
   }
 
-  // Check if we haven't checked recently
   const data = readUpdateDataFile()
+
+  // The project's spec can change (e.g. a version bump) while the cache is
+  // still within CHECK_PERIOD. Comparing remote versions against a
+  // localVersion that no longer matches the current spec would misstate the
+  // current version, so force a fresh check whenever they disagree.
+  const spec = getLocalVersionSpec()
+  if (
+    spec &&
+    semver.valid(spec.normalized) &&
+    spec.normalized !== data.localVersion
+  ) {
+    return true
+  }
+
+  // Check if we haven't checked recently
   return data.checkedAt < new Date().getTime() - CHECK_PERIOD
 }
 
@@ -212,6 +226,15 @@ export function shouldShow() {
   // non-semver localVersion (e.g. a `file:` tarball spec) — nothing to
   // compare against then
   if (!semver.valid(data.localVersion)) {
+    return false
+  }
+
+  // The stored localVersion may be stale relative to the current spec (e.g.
+  // the project was bumped to a new version but the cache is still within
+  // CHECK_PERIOD). Comparing remote versions against a mismatched
+  // localVersion would misstate the current version, so bail until
+  // shouldCheck() has refreshed the cache to match the current spec.
+  if (spec.normalized !== data.localVersion) {
     return false
   }
 

--- a/packages/cli/src/lib/updateCheck.ts
+++ b/packages/cli/src/lib/updateCheck.ts
@@ -92,8 +92,16 @@ export async function check() {
       console.log(
         `Skipping update check: '${packageJson.devDependencies['@cedarjs/core']}' is not a comparable version`,
       )
-      // Still record the check so we don't re-run it on every command
-      updateUpdateDataFile({ checkedAt: new Date().getTime() })
+      // Record the check so we don't re-run it on every command, and replace
+      // any previously stored version data. Keeping stale data around would
+      // let shouldShow() display an upgrade notification that no longer
+      // reflects the project. Storing the raw spec as localVersion both
+      // documents what we saw and fails shouldShow()'s semver guard.
+      updateUpdateDataFile({
+        localVersion: packageJson.devDependencies['@cedarjs/core'],
+        remoteVersions: new Map(),
+        checkedAt: new Date().getTime(),
+      })
       return
     }
 


### PR DESCRIPTION
## Summary

The CLI's update check reads the `@cedarjs/core` spec from the project's root `package.json` and compares it against published versions with `semver.gt()`. Two specs break it:

- `file:` tarball paths (what tarsync writes for npm projects, since npm has no `resolutions`): the leading-non-digit strip turns `file:/private/tmp/cedar-501.../cedarjs-core.tgz` into garbage like `501/-Users-...`, and `semver.gt()` throws `Invalid Version`, crashing every `cedar` command in the project.
- `workspace:*` (no digits at all): the strip loop `while (!/\d/.test(...))` never terminates — the CLI hangs.

CI never saw this because `CEDAR_CI=1` disables the check; it surfaced running smoke-test verification locally.

## Fix

The update check now only supports the one spec real Cedar projects have: an exact pinned `"1.2.3"`-style semver version (prerelease versions like `1.0.0-rc.1` included). Everything else — `file:` tarballs, `workspace:*`, `^`/`~` ranges — bails early instead of being normalized:

- A single `getLocalVersion()` helper returns the pinned version, or `undefined` for anything that isn't valid semver. The strip loop is gone entirely.
- When there's no pinned version, `check()` skips the remote lookup, records `checkedAt` (so the check isn't re-attempted on every command), and clears any previously stored version data so a stale notification can't show.
- `shouldShow()` bails when there's no pinned version and compares cached remote versions against the *current* version rather than the stored one, so cached data that predates a version change can't produce a notification the project has already acted on.
- `shouldCheck()` forces a fresh check when the pinned version differs from the stored one (e.g. right after an upgrade, while the cache is still within the 24h window).
- The middleware prefers refreshing stale cached data over showing a notification based on it.

Note: projects that hand-edit `@cedarjs/core` to a `^`/`~` range no longer get update notifications at all. They fail safe — no check, no crash, no notification.

## Testing

`updateCheck.test.ts` was rewritten for the simplified behavior: the existing scenarios (no update, update available, rc-tag update) now use pinned versions, a parameterized case asserts that `file:`, `workspace:*`, and `^1.0.0` specs all skip cleanly and clear stored data, and a regression test covers the version-changed-while-cache-is-fresh case — 17 tests pass. Also verified end to end: an npm ESM test project converted by tarsync now runs `npx cedar` commands without crashing.
