### PR TITLE
fix(vite): Resolve api/ bare specifiers without workspace symlinks

### DIFF
--- a/packages/vite/src/plugins/__tests__/__fixtures__/api-style-imports/api/db/generated/prisma/client.mts
+++ b/packages/vite/src/plugins/__tests__/__fixtures__/api-style-imports/api/db/generated/prisma/client.mts
@@ -1,0 +1,1 @@
+export const PrismaClient = { name: 'PrismaClient' }

--- a/packages/vite/src/plugins/__tests__/__fixtures__/api-style-imports/apiImport.ts
+++ b/packages/vite/src/plugins/__tests__/__fixtures__/api-style-imports/apiImport.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from 'api/db/generated/prisma/client.mts'
+
+console.log(PrismaClient)

--- a/packages/vite/src/plugins/__tests__/__fixtures__/api-style-imports/cedar.toml
+++ b/packages/vite/src/plugins/__tests__/__fixtures__/api-style-imports/cedar.toml
@@ -1,0 +1,4 @@
+[web]
+  port = 8910
+[api]
+  port = 8911

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedarjs-resolve-api-imports.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedarjs-resolve-api-imports.test.ts
@@ -1,0 +1,73 @@
+import path from 'node:path'
+
+import { build } from 'vite'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { cedarjsResolveCedarStyleImportsPlugin } from '../vite-plugin-cedarjs-resolve-cedar-style-imports.js'
+
+const rootDir = path.join(__dirname, '__fixtures__', 'api-style-imports')
+
+let originalCedarCwd: string | undefined
+
+beforeAll(() => {
+  // The api/ resolution needs getPaths() to find a project root
+  originalCedarCwd = process.env.CEDAR_CWD
+  process.env.CEDAR_CWD = rootDir
+})
+
+afterAll(() => {
+  if (originalCedarCwd === undefined) {
+    delete process.env.CEDAR_CWD
+  } else {
+    process.env.CEDAR_CWD = originalCedarCwd
+  }
+})
+
+async function testTransformation(fileName: string) {
+  const result = await build({
+    root: rootDir,
+    plugins: [cedarjsResolveCedarStyleImportsPlugin()],
+    build: {
+      lib: {
+        entry: fileName,
+        formats: ['es'],
+      },
+      write: false,
+      minify: false,
+    },
+    logLevel: 'silent',
+  })
+
+  const outputBundle = Array.isArray(result) ? result[0] : result
+
+  if (!('output' in outputBundle)) {
+    throw new Error('Build output is not in expected format')
+  }
+
+  const chunk = outputBundle.output.find(
+    (chunk) => chunk.type === 'chunk' && chunk.isEntry,
+  )
+
+  if (!chunk || !('code' in chunk)) {
+    throw new Error('Could not find entry chunk in build output')
+  }
+
+  return chunk.code
+}
+
+describe('api/ bare-specifier imports', () => {
+  it('resolves api/ imports to files under the api side', async () => {
+    // Under yarn and npm, imports like
+    // `import { PrismaClient } from 'api/db/generated/prisma/client.mts'`
+    // happen to resolve through the root node_modules workspace symlink.
+    // pnpm's strict isolation has no such link, so the plugin has to resolve
+    // them itself
+    const code = await testTransformation('apiImport.ts')
+
+    expect(code).toMatchInlineSnapshot(`
+      "const PrismaClient = { name: "PrismaClient" };
+      console.log(PrismaClient);
+      "
+    `)
+  })
+})

--- a/packages/vite/src/plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.ts
@@ -90,6 +90,20 @@ export function cedarjsResolveCedarStyleImportsPlugin(): Plugin {
         }
       }
 
+      // Handle api/ bare specifiers, like the ESM template's
+      // `import { PrismaClient } from 'api/db/generated/prisma/client.mts'`.
+      // Under yarn and npm these happen to resolve through the root
+      // node_modules workspace symlink, but pnpm's strict isolation creates
+      // no such link. Only resolves ids that match a file under the api side,
+      // so an actual `api` npm package would still resolve normally.
+      if (cedarPaths && id.startsWith('api/')) {
+        const resolved = resolveFromAbsolutePath(path.join(cedarPaths.base, id))
+
+        if (resolved) {
+          return normalizePath(resolved)
+        }
+      }
+
       // We only need this plugin when the module could not be found
       const resolvedPath = path.resolve(path.dirname(importer), id)
 


### PR DESCRIPTION
## Summary

The ESM template's `api/src/lib/db.ts` imports the generated Prisma client as `import { PrismaClient } from 'api/db/generated/prisma/client.mts'` — a bare specifier starting with `api/`. Under pnpm, loading any config or test that pulls in `db.ts` fails with `Cannot find package 'api/db/generated/prisma/client.mts'`. This PR teaches `cedarjsResolveCedarStyleImportsPlugin` to resolve `api/` specifiers to files under the api side, the same way it already handles `$api/`.

## Why this ever worked, and why pnpm breaks it

The reason this import resolves today under yarn and npm is a workspace symlink neither of us put much thought into: both package managers link every workspace package into the root `node_modules` under its package name. The api side's `package.json` is named `api`, so an installed project has `node_modules/api -> ../api`, and Node's ordinary bare-specifier resolution walks up from `api/src/lib/db.ts`, finds that link, and treats `api/db/generated/...` as a deep import into the "api package". I verified this empirically on freshly set-up test projects: the symlink exists in both the yarn and the npm project, and it does not exist under pnpm — pnpm only links workspace packages into the `node_modules` of packages that declare a dependency on them, and nothing depends on `api`. So under pnpm the specifier reaches Node's loader with nowhere to go.

I also went looking for any other plugin or Vite setting that might have been doing this resolution, and came up empty: `vite-tsconfig-paths` only maps what the api `tsconfig.json` declares (`src/*`, `types/*`, and a `@cedarjs/testing` alias — no `api/*` entry), `cedarVitestApiConfigPlugin` only aliases `src`, and `getMergedConfig`'s `resolve.alias` covers workspace packages plus a test-mode virtual module. `$api/` is handled by this same plugin. In other words, the root-`node_modules` symlink was the sole mechanism under yarn and npm, and it's an accident of hoisting rather than something Cedar set up deliberately.

To make sure yarn behavior doesn't change with the plugin now resolving these ids first: a fresh yarn ESM test project with this fix in place passes `cedar test api` (10 files / 23 tests) and `cedar test web` (17 files / 45 tests). Both resolution paths land on the same file; the plugin just gets there before the symlink would, and only claims ids that actually match a file under the api side — an app depending on the real `api` npm package still resolves normally through `node_modules`.

## Testing

- New unit test with an `api-style-imports` fixture proving the plugin resolves `api/db/generated/prisma/client.mts` to the fixture file
- Existing plugin test suite unchanged and passing (9 tests total)
- End to end: pnpm ESM test project passes `cedar build`, `cedar test web` and `cedar test api` with this fix (they fail at config load without it)