### PR TITLE
feat(pm): Explicit deps and Vite pin for ESM projects on pnpm and npm

### DIFF
--- a/__fixtures__/test-project-esm/api/package.json
+++ b/__fixtures__/test-project-esm/api/package.json
@@ -6,10 +6,16 @@
   "dependencies": {
     "@cedarjs/api": "5.0.2",
     "@cedarjs/auth-dbauth-api": "5.0.2",
+    "@cedarjs/context": "5.0.2",
     "@cedarjs/graphql-server": "5.0.2",
     "@my-org/validators": "workspace:*",
     "@prisma/adapter-better-sqlite3": "7.8.0",
     "@prisma/client": "7.8.0",
-    "better-sqlite3": "12.9.0"
+    "better-sqlite3": "12.9.0",
+    "graphql-tag": "2.12.6"
+  },
+  "devDependencies": {
+    "@cedarjs/vite": "5.0.2",
+    "vitest": "4.1.10"
   }
 }

--- a/__fixtures__/test-project-esm/web/package.json
+++ b/__fixtures__/test-project-esm/web/package.json
@@ -22,12 +22,16 @@
     "react-dom": "19.2.3"
   },
   "devDependencies": {
+    "@cedarjs/testing": "5.0.2",
     "@cedarjs/vite": "5.0.2",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10.5.4",
-    "postcss": "^8.5.20",
+    "postcss": "^8.5.22",
     "postcss-loader": "^8.2.1",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "vite": "7.3.5"
   }
 }

--- a/packages/create-cedar-app/templates/esm-js/api/package.json
+++ b/packages/create-cedar-app/templates/esm-js/api/package.json
@@ -8,6 +8,12 @@
     "@cedarjs/graphql-server": "5.0.2",
     "@prisma/adapter-better-sqlite3": "7.8.0",
     "@prisma/client": "7.8.0",
-    "better-sqlite3": "12.9.0"
+    "better-sqlite3": "12.9.0",
+    "@cedarjs/context": "5.0.2",
+    "graphql-tag": "2.12.6"
+  },
+  "devDependencies": {
+    "@cedarjs/vite": "5.0.2",
+    "vitest": "4.1.10"
   }
 }

--- a/packages/create-cedar-app/templates/esm-js/web/package.json
+++ b/packages/create-cedar-app/templates/esm-js/web/package.json
@@ -21,6 +21,10 @@
   "devDependencies": {
     "@cedarjs/vite": "5.0.2",
     "@types/react": "^18.2.55",
-    "@types/react-dom": "^18.2.19"
+    "@types/react-dom": "^18.2.19",
+    "@cedarjs/testing": "5.0.2",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
+    "vite": "7.3.5"
   }
 }

--- a/packages/create-cedar-app/templates/esm-ts/api/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/api/package.json
@@ -8,6 +8,12 @@
     "@cedarjs/graphql-server": "5.0.2",
     "@prisma/adapter-better-sqlite3": "7.8.0",
     "@prisma/client": "7.8.0",
-    "better-sqlite3": "12.9.0"
+    "better-sqlite3": "12.9.0",
+    "@cedarjs/context": "5.0.2",
+    "graphql-tag": "2.12.6"
+  },
+  "devDependencies": {
+    "@cedarjs/vite": "5.0.2",
+    "vitest": "4.1.10"
   }
 }

--- a/packages/create-cedar-app/templates/esm-ts/web/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/web/package.json
@@ -21,6 +21,10 @@
   "devDependencies": {
     "@cedarjs/vite": "5.0.2",
     "@types/react": "^18.2.55",
-    "@types/react-dom": "^18.2.19"
+    "@types/react-dom": "^18.2.19",
+    "@cedarjs/testing": "5.0.2",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
+    "vite": "7.3.5"
   }
 }

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/pnpm-workspace.yaml
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+autoInstallPeers: false
+
 packages:
   - api
   - web

--- a/packages/create-cedar-app/templates/overlays/esm/npm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/npm/package.json
@@ -10,12 +10,14 @@
     "@cedarjs/eslint-config": "5.0.2",
     "@cedarjs/project-config": "5.0.2",
     "@cedarjs/testing": "5.0.2",
-    "prisma": "7.8.0"
+    "prisma": "7.8.0",
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": "=24.x"
   },
   "overrides": {
-    "react-is": "19.2.3"
+    "react-is": "19.2.3",
+    "vite": "7.3.5"
   }
 }

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -6,7 +6,8 @@
     "@cedarjs/eslint-config": "5.0.2",
     "@cedarjs/project-config": "5.0.2",
     "@cedarjs/testing": "5.0.2",
-    "prisma": "7.8.0"
+    "prisma": "7.8.0",
+    "vitest": "4.1.10"
   },
   "engines": {
     "node": "=24.x",

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/pnpm-workspace.yaml
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+autoInstallPeers: false
+
 packages:
   - api
   - web
@@ -19,3 +21,4 @@ allowBuilds:
 
 overrides:
   'react-is': '19.2.3'
+  'vite': '7.3.5'


### PR DESCRIPTION
## Summary

Makes ESM projects work under pnpm and npm by declaring dependencies that were previously reachable only through yarn hoisting, and by giving the pnpm/npm overlays the vitest devDependency and Vite 7 pin the yarn overlay already has.

## What pnpm's strict isolation surfaced

Config, setup, and test files import packages the workspace packages never declared:

- `web/vite.config.ts` imports `vite`
- `api/vitest.config.mts` imports `vitest/config` and `@cedarjs/vite/api`
- `web/vitest.setup.ts` imports `@testing-library/jest-dom` and `@testing-library/react`
- test files import `@cedarjs/testing/web`
- api code imports `graphql-tag`, and the auto-imports transform injects `import { context } from '@cedarjs/context'`

Under yarn (and npm's flat hoisting) these resolve from the root `node_modules`; under pnpm each workspace package only sees what it declares. All of the above are now explicit in the ESM templates (`esm-ts` and `esm-js`), which is equally correct under yarn — one shared template for all package managers. The ESM fixture is regenerated to match (the diff is exactly these additions plus a caret-range refresh the codemods picked up).

## Overlay changes

- npm overlay: `vitest` devDependency and `"vite": "7.3.5"` in `overrides`
- pnpm overlay: `vitest` devDependency and `vite: '7.3.5'` in `pnpm-workspace.yaml` `overrides`
- This matches the yarn overlay, which already ships `vitest` plus the pin via `resolutions` — all three package managers are now consistent. The pin is what stops Vitest 4 from resolving its own nested Vite 8 (verified under pnpm: exactly one vite@7.3.5 in the store, vitest@4.1.10 resolves against it)
- pnpm overlays (cjs and esm) also set `autoInstallPeers: false`, matching what CI's package-manager conversion already required: auto-installed peers resolve from the registry, bypassing overrides, which let published packages shadow tarball-synced framework packages during framework testing

## Testing

With this plus #2177: fresh pnpm and npm ESM test projects pass `cedar build --no-prerender`, `cedar test web` (17 files / 45 tests) and `cedar test api` (10 files / 23 tests) end to end. A fresh yarn ESM project passes the same suites, confirming no yarn regression.