### PR TITLE
chore(cli): Propagate cfw script failures instead of swallowing them

### DIFF
--- a/packages/cli/src/cfw.ts
+++ b/packages/cli/src/cfw.ts
@@ -58,6 +58,20 @@ try {
     // CEDAR_DISABLE_TELEMETRY
     env: { CEDAR_CWD: projectPath },
   })
-} catch {
+} catch (e) {
   console.log()
+
+  // With `stdio: 'inherit'` the failing command's output has already been
+  // shown, but the failure itself must still propagate — silently exiting 0
+  // here makes callers (like the test-project rebuild script) treat a failed
+  // framework sync as a success and continue against published packages
+  const exitCode =
+    e &&
+    typeof e === 'object' &&
+    'exitCode' in e &&
+    typeof e.exitCode === 'number'
+      ? e.exitCode
+      : 1
+
+  process.exit(exitCode)
 }


### PR DESCRIPTION
## Summary

`cfw` wrapped its script dispatch in `try { ... } catch { console.log() }` — every failure was swallowed and cfw exited 0.

In practice that meant the test-project rebuild script's tarsync step turned green while tarsync had actually failed, and the project silently continued against *published* framework packages instead of the local build. That produced very confusing downstream failures (builds failing on exports that exist locally but aren't published yet).

With `stdio: 'inherit'` the failing command's output is already visible; the catch now just propagates the child's exit code (defaulting to 1).

## Testing

Verified as part of the pnpm fixture-rebuild debugging for #2173 — with this fix (plus the rebuild-script changes in the companion PR), a failed framework sync fails the step instead of silently succeeding.