### PR TITLE
fix(testing): Start MSW for web-side tests in ESM/Vitest apps

### DIFF
--- a/__fixtures__/test-project-esm/web/src/pages/HomePage/HomePage.test.tsx
+++ b/__fixtures__/test-project-esm/web/src/pages/HomePage/HomePage.test.tsx
@@ -1,14 +1,13 @@
-import { render } from '@cedarjs/testing/web'
+import { render, screen } from '@cedarjs/testing/web'
 
 import HomePage from './HomePage'
 
-//   Improve this test with help from the CedarJS Testing Doc:
-//   https://cedarjs.com/docs/testing#testing-pages-layouts
-
 describe('HomePage', () => {
-  it('renders successfully', () => {
-    expect(() => {
-      render(<HomePage />)
-    }).not.toThrow()
+  it('renders the blog posts from the cell mock', async () => {
+    render(<HomePage />)
+
+    const titles = await screen.findAllByText('Mocked title')
+
+    expect(titles).toHaveLength(3)
   })
 })

--- a/__fixtures__/test-project/web/src/pages/HomePage/HomePage.test.tsx
+++ b/__fixtures__/test-project/web/src/pages/HomePage/HomePage.test.tsx
@@ -1,14 +1,13 @@
-import { render } from '@cedarjs/testing/web'
+import { render, screen } from '@cedarjs/testing/web'
 
 import HomePage from './HomePage'
 
-//   Improve this test with help from the CedarJS Testing Doc:
-//   https://cedarjs.com/docs/testing#testing-pages-layouts
-
 describe('HomePage', () => {
-  it('renders successfully', () => {
-    expect(() => {
-      render(<HomePage />)
-    }).not.toThrow()
+  it('renders the blog posts from the cell mock', async () => {
+    render(<HomePage />)
+
+    const titles = await screen.findAllByText('Mocked title')
+
+    expect(titles).toHaveLength(3)
   })
 })

--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -148,6 +148,10 @@ Vite plugins: cell transform | entry injection | html env | data-uri-to-buffer s
   auto-imports | import-dir | directory-named-import | js-as-jsx | merged config |
   api-babel-transform | cedar-routes-auto-loader | cedar-universal-deploy |
   cedar-wait-for-api-server | resolve-cedar-style-imports
+  *test mode (Vitest, mode === 'test'): adds router-import-transform |
+    create-auth-import-transform | test auto-imports (mockGraphQLQuery etc.) |
+    vitest-web-config (contributes a `test.setupFiles` entry that starts MSW,
+    imports cell mocks and resets handlers between tests)
   *SSR/RSC: adds RSC transforms
 ```
 

--- a/packages/testing/src/web/mockRequests.ts
+++ b/packages/testing/src/web/mockRequests.ts
@@ -90,6 +90,12 @@ export const closeServer = () => {
   } else {
     SERVER_INSTANCE.stop()
   }
+
+  // Clear the instance so that a later `startMSW()` call starts a fresh
+  // server instead of returning the closed one. This matters when the same
+  // module instance is reused across test files, like when running Vitest
+  // with `isolate: false`
+  SERVER_INSTANCE = undefined
 }
 
 export const registerHandler = (handler: RequestHandler) => {

--- a/packages/testing/src/web/mockRequests.ts
+++ b/packages/testing/src/web/mockRequests.ts
@@ -94,7 +94,13 @@ export const closeServer = () => {
   // Clear the instance so that a later `startMSW()` call starts a fresh
   // server instead of returning the closed one. This matters when the same
   // module instance is reused across test files, like when running Vitest
-  // with `isolate: false`
+  // with `isolate: false`.
+  // `REQUEST_HANDLER_QUEUE` is deliberately NOT cleared here: it holds the
+  // "global" handlers (cell mocks and `mockGraphQL*` calls made before the
+  // server started) that `setupRequestHandlers()` re-registers after every
+  // test. When the module instance is reused across test files, the module
+  // cache also prevents cell mock files from re-registering on re-import, so
+  // clearing the queue would permanently lose those global mocks
   SERVER_INSTANCE = undefined
 }
 

--- a/packages/testing/src/web/vitest/index.ts
+++ b/packages/testing/src/web/vitest/index.ts
@@ -1,3 +1,4 @@
 export { cedarJsRouterImportTransformPlugin } from './vite-plugin-cedarjs-router-import-transform.js'
+export { cedarVitestWebConfigPlugin } from './vite-plugin-cedar-vitest-web-config.js'
 export { createAuthImportTransformPlugin } from './vite-plugin-create-auth-import-transform.js'
 export { autoImportsPlugin } from './vite-plugin-auto-import.js'

--- a/packages/testing/src/web/vitest/vite-plugin-cedar-vitest-web-config.ts
+++ b/packages/testing/src/web/vitest/vite-plugin-cedar-vitest-web-config.ts
@@ -1,0 +1,28 @@
+import path from 'node:path'
+
+import type { Plugin } from 'vite'
+// Load Vitest's module augmentation of Vite's `UserConfig` so that the `test`
+// property returned from the `config` hook below typechecks
+import type {} from 'vitest/config'
+
+/**
+ * Contributes web-side Vitest config, most importantly a setup file that
+ * starts MSW so that `mockGraphQLQuery`/`mockGraphQLMutation` handlers (and
+ * cell mocks) actually intercept GraphQL requests during tests.
+ *
+ * Vitest resolves its `test` config from Vite plugins, so returning `test`
+ * from the `config` hook here merges with the user's own vitest config (the
+ * `setupFiles` arrays are concatenated).
+ */
+export function cedarVitestWebConfigPlugin(): Plugin {
+  return {
+    name: 'cedar-vitest-web-config',
+    config: () => {
+      return {
+        test: {
+          setupFiles: [path.join(import.meta.dirname, 'vitest-web.setup.js')],
+        },
+      }
+    },
+  }
+}

--- a/packages/testing/src/web/vitest/vitest-web.setup.ts
+++ b/packages/testing/src/web/vitest/vitest-web.setup.ts
@@ -1,0 +1,30 @@
+import { afterAll, afterEach, beforeAll } from 'vitest'
+
+import { getPaths } from '@cedarjs/project-config'
+
+import { findCellMocks } from '../findCellMocks.js'
+import { closeServer, setupRequestHandlers, startMSW } from '../mockRequests.js'
+
+beforeAll(async () => {
+  const cellMocks = findCellMocks(getPaths().web.src)
+
+  for (const m of cellMocks) {
+    // Importing the mock files registers the cell mock data as global MSW
+    // request handlers.
+    // See packages/vite/src/plugins/vite-plugin-cedar-mock-cell-data.ts
+    await import(m)
+  }
+
+  await startMSW('node')
+  // Register the handlers that were queued before the server started
+  setupRequestHandlers()
+})
+
+afterEach(() => {
+  // Reset the handlers in each test
+  setupRequestHandlers()
+})
+
+afterAll(() => {
+  closeServer()
+})

--- a/packages/testing/tsconfig.cjs.json
+++ b/packages/testing/tsconfig.cjs.json
@@ -11,6 +11,7 @@
     "**/__tests__",
     "**/__mocks__",
     "**/*.test.*",
-    "src/api/vitest"
+    "src/api/vitest",
+    "src/web/vitest"
   ]
 }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -17,6 +17,7 @@ import { getConfig } from '@cedarjs/project-config'
 import {
   autoImportsPlugin,
   cedarJsRouterImportTransformPlugin,
+  cedarVitestWebConfigPlugin,
   createAuthImportTransformPlugin,
 } from '@cedarjs/testing/web/vitest'
 
@@ -97,6 +98,7 @@ export function cedar({ mode, babel }: PluginOptions = {}): PluginOption[] {
     mode === 'test' && cedarJsRouterImportTransformPlugin(),
     mode === 'test' && createAuthImportTransformPlugin(),
     mode === 'test' && autoImportsPlugin(),
+    mode === 'test' && cedarVitestWebConfigPlugin(),
     cedarWaitForApiServer(),
     cedarDataUriShim(),
     cedarHtmlEnvPlugin(),

--- a/tasks/test-project/base-tasks.mts
+++ b/tasks/test-project/base-tasks.mts
@@ -39,6 +39,29 @@ function getPagesTasks(live = false, packageManager: PackageManager = 'yarn') {
           'homePage.js',
           fullPath('web/src/pages/HomePage/HomePage'),
         )
+
+        // The home page renders BlogPostsCell, so this test verifies that
+        // cell mock data is registered as MSW request handlers and that the
+        // cell's GraphQL request is intercepted
+        const testFileContent = `import { render, screen } from '@cedarjs/testing/web'
+
+      import HomePage from './HomePage'
+
+      describe('HomePage', () => {
+        it('renders the blog posts from the cell mock', async () => {
+          render(<HomePage />)
+
+          const titles = await screen.findAllByText('Mocked title')
+
+          expect(titles).toHaveLength(3)
+        })
+      })
+      `
+
+        fs.writeFileSync(
+          fullPath('web/src/pages/HomePage/HomePage.test'),
+          testFileContent,
+        )
       },
     },
     {

--- a/tasks/test-project/base-tasks.mts
+++ b/tasks/test-project/base-tasks.mts
@@ -40,23 +40,23 @@ function getPagesTasks(live = false, packageManager: PackageManager = 'yarn') {
           fullPath('web/src/pages/HomePage/HomePage'),
         )
 
-        // The home page renders BlogPostsCell, so this test verifies that
-        // cell mock data is registered as MSW request handlers and that the
-        // cell's GraphQL request is intercepted
+        // The home page renders BlogPostsCell, so this test verifies that cell
+        // mock data is registered as MSW request handlers and that the cell's
+        // GraphQL request is intercepted
         const testFileContent = `import { render, screen } from '@cedarjs/testing/web'
 
-      import HomePage from './HomePage'
+          import HomePage from './HomePage'
 
-      describe('HomePage', () => {
-        it('renders the blog posts from the cell mock', async () => {
-          render(<HomePage />)
+          describe('HomePage', () => {
+            it('renders the blog posts from the cell mock', async () => {
+              render(<HomePage />)
 
-          const titles = await screen.findAllByText('Mocked title')
+              const titles = await screen.findAllByText('Mocked title')
 
-          expect(titles).toHaveLength(3)
-        })
-      })
-      `
+              expect(titles).toHaveLength(3)
+            })
+          })
+        `
 
         fs.writeFileSync(
           fullPath('web/src/pages/HomePage/HomePage.test'),


### PR DESCRIPTION
Fixes #2134

## Problem

In ESM (Vitest) apps nothing ever started MSW for web-side tests. Handlers registered by `mockGraphQLQuery` / `mockGraphQLMutation` (and by cell mocks) were pushed onto the internal queue in `registerHandler()` and never drained, so GraphQL requests silently went out unmocked. See #2134 for the full analysis.

## Solution

Of the two options discussed in the issue, this PR goes with **the `cedar()` Vite plugin contributing a Cedar-provided setup file in test mode**. The mechanism was an open question in the issue, but it turns out we already use exactly this pattern on the API side: `cedarVitestApiConfigPlugin` returns `test.setupFiles` from its `config()` hook, and Vitest resolves its `test` config from Vite plugins (setup-file arrays from the user config and from plugins are concatenated by Vite's config merging). So the web side now mirrors the API side:

- **`@cedarjs/testing`**: new `cedarVitestWebConfigPlugin` (in `web/vitest`) contributes `test.setupFiles` pointing at a new `vitest-web.setup.js`. The setup file is the Vitest equivalent of `config/jest/web/jest.setup.ts`:
  - `beforeAll`: eagerly imports cell mock files (via `findCellMocks`) so global mocks register before tests run — matching the Jest semantics — then `await startMSW('node')` and `setupRequestHandlers()` to drain the queue
  - `afterEach`: `setupRequestHandlers()` to reset handlers between tests
  - `afterAll`: `closeServer()`
- **`@cedarjs/vite`**: `cedar()` adds the plugin when `mode === 'test'`, alongside the existing test-only plugins. Existing apps pick this up on upgrade with no changes to their `web/vitest.setup.ts`.
- **`mockRequests.ts`**: `closeServer()` now clears the module-level server instance so a later `startMSW()` starts a fresh server. This matters when the same module instance is reused across test files (e.g. Vitest with `isolate: false`); before, the second test file would get back the closed server.

The auto-imported `mockGraphQLQuery`/`mockGraphQLMutation`/`mockCurrentUser` in test files and the setup file resolve to the same (externalized) `@cedarjs/testing` module instance, so handlers registered from either side reach the same server.

## Regression test

The generated `HomePage` test (HomePage renders `BlogPostsCell`) now asserts on the cell mock data instead of just "renders successfully", in `tasks/test-project/base-tasks.mts` and both the `test-project` and `test-project-esm` fixtures. This covers the previously untested path from the issue: a component containing a cell whose GraphQL request must be intercepted, with the mock coming from the eagerly-imported `*Cell.mock.ts` file. It runs under both runners via the existing `cedar test web` smoke-test jobs.

## Testing notes

- `yarn workspace @cedarjs/testing build && yarn workspace @cedarjs/vite build` — clean (the CJS types build excludes `src/web/vitest` like it already excludes `src/api/vitest`; the vitest integration is ESM-only)
- `yarn workspace @cedarjs/testing test`, `yarn workspace @cedarjs/vite test` — pass
- Tarsynced into a copy of `__fixtures__/test-project-esm`: `yarn cedar test web --no-watch` — 17 files / 45 tests pass, including the new HomePage cell-mock test
- Negative check: with `cedarVitestWebConfigPlugin` disabled in the synced app, the new HomePage test fails (query never intercepted) — confirming it guards this exact regression
- Tarsynced into a copy of `__fixtures__/test-project` (Jest/CJS): `yarn cedar test web --no-watch` — 17 suites / 45 tests pass, so the updated test works identically under Jest
- `yarn lint` — pass
