### PR TITLE
feat(cca): Package manager specific lock files

### DIFF
--- a/.github/scripts/publish-release-candidate.mts
+++ b/.github/scripts/publish-release-candidate.mts
@@ -12,6 +12,11 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { setTimeout } from 'node:timers/promises'
 
+import {
+  generateNpmLockfile,
+  generatePnpmLockfile,
+} from '../../packages/create-cedar-app/scripts/generateLockfile.js'
+
 const REPO_ROOT = process.cwd()
 const CREATE_CEDAR_APP_DIR = path.join(REPO_ROOT, 'packages/create-cedar-app')
 const TEMPLATES_DIR = path.join(CREATE_CEDAR_APP_DIR, 'templates')
@@ -520,7 +525,37 @@ async function main() {
 
     updateJavaScriptTemplates()
 
-    log('Step 11: Generating yarn.lock files for templates')
+    log('Step 11: Generating lockfiles for overlays and templates')
+
+    // The npm and pnpm overlays replace the base template's root package.json
+    // wholesale, so their lockfiles are generated against the base template +
+    // overlay composition. The cjs overlays are used by both the ts and js
+    // templates, and the esm overlays by both esm-ts and esm-js, so ts and
+    // esm-ts act as representative bases.
+    // This runs before the base-template yarn.lock generation below so the
+    // base templates are still free of yarn install artifacts.
+    const overlayLockfileConfigs = [
+      { baseTemplateDir: 'ts', overlayBase: 'cjs' },
+      { baseTemplateDir: 'esm-ts', overlayBase: 'esm' },
+    ]
+
+    for (const { baseTemplateDir, overlayBase } of overlayLockfileConfigs) {
+      if (isDryRun) {
+        log(`Dry-run - skip overlay lockfile generation for ${overlayBase}`)
+        continue
+      }
+
+      const templatePath = path.join(TEMPLATES_DIR, baseTemplateDir)
+      const overlaysBaseDir = path.join(TEMPLATES_DIR, 'overlays', overlayBase)
+
+      await generateNpmLockfile(templatePath, path.join(overlaysBaseDir, 'npm'))
+      await generatePnpmLockfile(
+        templatePath,
+        path.join(overlaysBaseDir, 'pnpm'),
+      )
+    }
+
+    log('✅ Generated npm and pnpm lockfiles for overlays')
 
     for (const templateDir of TEMPLATE_DIRS) {
       if (isDryRun) {

--- a/.github/scripts/publish-release-candidate.mts
+++ b/.github/scripts/publish-release-candidate.mts
@@ -15,14 +15,12 @@ import { setTimeout } from 'node:timers/promises'
 import {
   generateNpmLockfile,
   generatePnpmLockfile,
+  generateYarnLockfile,
 } from '../../packages/create-cedar-app/scripts/generateLockfile.js'
 
 const REPO_ROOT = process.cwd()
 const CREATE_CEDAR_APP_DIR = path.join(REPO_ROOT, 'packages/create-cedar-app')
 const TEMPLATES_DIR = path.join(CREATE_CEDAR_APP_DIR, 'templates')
-
-// Template directories
-const TEMPLATE_DIRS = ['ts', 'js', 'esm-ts', 'esm-js']
 
 // Dependency fields whose in-monorepo entries get rewritten to the version
 // being published
@@ -298,51 +296,6 @@ async function removeCreateCedarAppFromWorkspaces(): Promise<() => void> {
   }
 }
 
-function generateYarnLockFile(templateDir: string) {
-  const templatePath = path.join(TEMPLATES_DIR, templateDir)
-  log(`Generating yarn.lock in ${templatePath}`)
-
-  // Remove any existing node_modules and lock files to ensure clean generation
-  fs.rmSync(path.join(templatePath, 'node_modules'), {
-    recursive: true,
-    force: true,
-  })
-  fs.rmSync(path.join(templatePath, 'yarn.lock'), { force: true })
-  fs.rmSync(path.join(templatePath, '.yarn'), { recursive: true, force: true })
-
-  // Create empty yarn.lock file (required for yarn to treat as separate
-  // project)
-  fs.writeFileSync(path.join(templatePath, 'yarn.lock'), '')
-  log(`Created empty yarn.lock for ${templateDir}`)
-
-  try {
-    // Set CI=false to disable immutable mode for yarn install
-    const originalCI = process.env.CI
-    process.env.CI = 'false'
-
-    execCommand('yarn install', templatePath)
-
-    // Restore original CI value
-    if (originalCI) {
-      process.env.CI = originalCI
-    } else {
-      delete process.env.CI
-    }
-
-    log(`✅ Generated yarn.lock for ${templateDir}`)
-  } catch (error) {
-    console.error(`❌ Failed to generate yarn.lock for ${templateDir}`)
-    throw error
-  }
-
-  // Clean up generated files except yarn.lock
-  fs.rmSync(path.join(templatePath, 'node_modules'), {
-    recursive: true,
-    force: true,
-  })
-  fs.rmSync(path.join(templatePath, '.yarn'), { recursive: true, force: true })
-}
-
 function updateJavaScriptTemplates() {
   log('Updating JavaScript templates using ts-to-js')
 
@@ -525,15 +478,14 @@ async function main() {
 
     updateJavaScriptTemplates()
 
-    log('Step 11: Generating lockfiles for overlays and templates')
+    log('Step 11: Generating lockfiles for the package-manager overlays')
 
-    // The npm and pnpm overlays replace the base template's root package.json
-    // wholesale, so their lockfiles are generated against the base template +
-    // overlay composition. The cjs overlays are used by both the ts and js
-    // templates, and the esm overlays by both esm-ts and esm-js, so ts and
-    // esm-ts act as representative bases.
-    // This runs before the base-template yarn.lock generation below so the
-    // base templates are still free of yarn install artifacts.
+    // The pm-specific overlays replace the base template's root package.json
+    // wholesale, so lockfiles are generated against the base template +
+    // overlay composition and shipped in the overlay dirs — the base
+    // templates themselves carry no lockfile. The cjs overlays are used by
+    // both the ts and js templates, and the esm overlays by both esm-ts and
+    // esm-js, so ts and esm-ts act as representative bases.
     const overlayLockfileConfigs = [
       { baseTemplateDir: 'ts', overlayBase: 'cjs' },
       { baseTemplateDir: 'esm-ts', overlayBase: 'esm' },
@@ -548,6 +500,10 @@ async function main() {
       const templatePath = path.join(TEMPLATES_DIR, baseTemplateDir)
       const overlaysBaseDir = path.join(TEMPLATES_DIR, 'overlays', overlayBase)
 
+      await generateYarnLockfile(
+        templatePath,
+        path.join(overlaysBaseDir, 'yarn'),
+      )
       await generateNpmLockfile(templatePath, path.join(overlaysBaseDir, 'npm'))
       await generatePnpmLockfile(
         templatePath,
@@ -555,18 +511,7 @@ async function main() {
       )
     }
 
-    log('✅ Generated npm and pnpm lockfiles for overlays')
-
-    for (const templateDir of TEMPLATE_DIRS) {
-      if (isDryRun) {
-        log(`Dry-run - skip generateYarnLockFile for ${templateDir}`)
-        continue
-      }
-
-      generateYarnLockFile(templateDir)
-    }
-
-    log('✅ Generated all yarn.lock files')
+    log('✅ Generated lockfiles for all package-manager overlays')
 
     if (isDryRun) {
       log('📝 Dry-run - skipping git commit and create-cedar-app publish')

--- a/packages/create-cedar-app/scripts/buildPack.js
+++ b/packages/create-cedar-app/scripts/buildPack.js
@@ -1,9 +1,14 @@
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { cd, within, $ } from 'zx'
+import { $ } from 'zx'
+
+import {
+  generateNpmLockfile,
+  generatePnpmLockfile,
+  generateYarnLockfile,
+} from './generateLockfile.js'
 
 const tsTemplatePath = fileURLToPath(
   new URL('../templates/ts', import.meta.url),
@@ -16,39 +21,6 @@ const esmTsTemplatePath = fileURLToPath(
 const overlaysPath = fileURLToPath(
   new URL('../templates/overlays', import.meta.url),
 )
-
-async function generateLockfile(
-  templatePath,
-  overlayDir,
-  lockfileName,
-  packageManager,
-  packageManagerArgs = [],
-) {
-  console.log(`Generating ${lockfileName}...`)
-  const tmpDir = fs.mkdtempSync(
-    path.join(os.tmpdir(), `cedar-${packageManager}-`),
-  )
-
-  try {
-    fs.cpSync(templatePath, tmpDir, { recursive: true })
-    fs.cpSync(overlayDir, tmpDir, { recursive: true, force: true })
-
-    await within(async () => {
-      cd(tmpDir)
-
-      await $`touch ${lockfileName}`
-      console.log(`Installing dependencies using ${packageManager}...`)
-      await $`${packageManager} ${packageManagerArgs}`
-    })
-
-    const lockDest = path.join(overlayDir, lockfileName)
-    fs.copyFileSync(path.join(tmpDir, lockfileName), lockDest)
-
-    return lockDest
-  } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true })
-  }
-}
 
 // For each (baseTemplate, overlayBase) pair we generate lockfiles for all
 // three package managers and store them in the PM-specific overlay dir.
@@ -66,29 +38,19 @@ const generatedFiles = []
 for (const { templatePath, overlayBase } of configs) {
   const overlaysBaseDir = path.join(overlaysPath, overlayBase)
 
-  const yarnLock = await generateLockfile(
+  const yarnLock = await generateYarnLockfile(
     templatePath,
     path.join(overlaysBaseDir, 'yarn'),
-    'yarn.lock',
-    'yarn',
   )
 
-  const npmLock = await generateLockfile(
+  const npmLock = await generateNpmLockfile(
     templatePath,
     path.join(overlaysBaseDir, 'npm'),
-    'package-lock.json',
-    'npm',
-    // TODO(PM): remove the `--force` and `--loglevel` flags when we're shipping
-    // React 19
-    ['install', '--force', '--loglevel', 'error'],
   )
 
-  const pnpmLock = await generateLockfile(
+  const pnpmLock = await generatePnpmLockfile(
     templatePath,
     path.join(overlaysBaseDir, 'pnpm'),
-    'pnpm-lock.yaml',
-    'pnpm',
-    ['install'],
   )
 
   generatedFiles.push(yarnLock, npmLock, pnpmLock)

--- a/packages/create-cedar-app/scripts/generateLockfile.js
+++ b/packages/create-cedar-app/scripts/generateLockfile.js
@@ -1,0 +1,84 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { cd, within, $ } from 'zx'
+
+// Entries that must never leak from the base template into the composed
+// project: install artifacts and lockfiles from other package managers would
+// influence (or end up next to) the lockfile we're generating
+const EXCLUDED_TEMPLATE_ENTRIES = [
+  'node_modules',
+  '.yarn',
+  'yarn.lock',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+]
+
+/**
+ * Composes a base template and a package-manager overlay in a temp dir, runs
+ * an install there, and copies the resulting lockfile into the overlay dir.
+ *
+ * The overlays replace the base template's root package.json wholesale, so
+ * lockfiles have to be generated against the base template + overlay
+ * composition rather than the base template alone.
+ *
+ * Returns the path to the generated lockfile.
+ */
+export async function generateLockfile(
+  templatePath,
+  overlayDir,
+  lockfileName,
+  packageManager,
+  packageManagerArgs = [],
+) {
+  console.log(`Generating ${lockfileName}...`)
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), `cedar-${packageManager}-`),
+  )
+
+  try {
+    fs.cpSync(templatePath, tmpDir, {
+      recursive: true,
+      filter: (src) => !EXCLUDED_TEMPLATE_ENTRIES.includes(path.basename(src)),
+    })
+    fs.cpSync(overlayDir, tmpDir, { recursive: true, force: true })
+
+    await within(async () => {
+      cd(tmpDir)
+
+      await $`touch ${lockfileName}`
+      console.log(`Installing dependencies using ${packageManager}...`)
+      await $`${packageManager} ${packageManagerArgs}`
+    })
+
+    const lockDest = path.join(overlayDir, lockfileName)
+    fs.copyFileSync(path.join(tmpDir, lockfileName), lockDest)
+
+    return lockDest
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+}
+
+export function generateYarnLockfile(templatePath, overlayDir) {
+  return generateLockfile(templatePath, overlayDir, 'yarn.lock', 'yarn')
+}
+
+export function generateNpmLockfile(templatePath, overlayDir) {
+  // TODO(PM): remove the `--force` and `--loglevel` flags when we're shipping
+  // React 19
+  return generateLockfile(
+    templatePath,
+    overlayDir,
+    'package-lock.json',
+    'npm',
+    ['install', '--force', '--loglevel', 'error'],
+  )
+}
+
+export function generatePnpmLockfile(templatePath, overlayDir) {
+  return generateLockfile(templatePath, overlayDir, 'pnpm-lock.yaml', 'pnpm', [
+    'install',
+  ])
+}

--- a/packages/create-cedar-app/scripts/generateLockfile.js
+++ b/packages/create-cedar-app/scripts/generateLockfile.js
@@ -79,7 +79,7 @@ export function generateNpmLockfile(templatePath, overlayDir) {
     overlayDir,
     'package-lock.json',
     'npm',
-    ['install', '--force', '--loglevel', 'error'],
+    ['install', '--no-audit', '--no-fund', '--force', '--loglevel', 'error'],
   )
 }
 

--- a/packages/create-cedar-app/scripts/generateLockfile.js
+++ b/packages/create-cedar-app/scripts/generateLockfile.js
@@ -31,6 +31,7 @@ export async function generateLockfile(
   lockfileName,
   packageManager,
   packageManagerArgs = [],
+  env = {},
 ) {
   console.log(`Generating ${lockfileName}...`)
   const tmpDir = fs.mkdtempSync(
@@ -46,6 +47,7 @@ export async function generateLockfile(
 
     await within(async () => {
       cd(tmpDir)
+      $.env = { ...process.env, ...env }
 
       await $`touch ${lockfileName}`
       console.log(`Installing dependencies using ${packageManager}...`)
@@ -62,7 +64,11 @@ export async function generateLockfile(
 }
 
 export function generateYarnLockfile(templatePath, overlayDir) {
-  return generateLockfile(templatePath, overlayDir, 'yarn.lock', 'yarn')
+  // Yarn defaults to immutable installs on CI, which would refuse to write
+  // the lockfile we're generating here
+  return generateLockfile(templatePath, overlayDir, 'yarn.lock', 'yarn', [], {
+    YARN_ENABLE_IMMUTABLE_INSTALLS: 'false',
+  })
 }
 
 export function generateNpmLockfile(templatePath, overlayDir) {

--- a/packages/create-cedar-app/src/project-files.ts
+++ b/packages/create-cedar-app/src/project-files.ts
@@ -63,22 +63,6 @@ export async function createProjectFiles(
   })
   await fs.promises.cp(overlayDir, newAppDir, { recursive: true, force: true })
 
-  // Published base templates ship a yarn.lock, and the pm-specific overlays
-  // can ship their own lockfile. Remove the lockfiles that don't belong to
-  // the selected package manager so the project ends up with exactly one,
-  // matching lockfile
-  const lockfilesByPackageManager: Record<PackageManager, string> = {
-    yarn: 'yarn.lock',
-    npm: 'package-lock.json',
-    pnpm: 'pnpm-lock.yaml',
-  }
-
-  for (const [pm, lockfile] of Object.entries(lockfilesByPackageManager)) {
-    if (pm !== packageManager) {
-      fs.rmSync(path.join(newAppDir, lockfile), { force: true })
-    }
-  }
-
   let databaseUrl = ''
   let directDatabaseUrl = ''
   let neonClaimExpiry = ''

--- a/packages/create-cedar-app/src/project-files.ts
+++ b/packages/create-cedar-app/src/project-files.ts
@@ -63,6 +63,22 @@ export async function createProjectFiles(
   })
   await fs.promises.cp(overlayDir, newAppDir, { recursive: true, force: true })
 
+  // Published base templates ship a yarn.lock, and the pm-specific overlays
+  // can ship their own lockfile. Remove the lockfiles that don't belong to
+  // the selected package manager so the project ends up with exactly one,
+  // matching lockfile
+  const lockfilesByPackageManager: Record<PackageManager, string> = {
+    yarn: 'yarn.lock',
+    npm: 'package-lock.json',
+    pnpm: 'pnpm-lock.yaml',
+  }
+
+  for (const [pm, lockfile] of Object.entries(lockfilesByPackageManager)) {
+    if (pm !== packageManager) {
+      fs.rmSync(path.join(newAppDir, lockfile), { force: true })
+    }
+  }
+
   let databaseUrl = ''
   let directDatabaseUrl = ''
   let neonClaimExpiry = ''


### PR DESCRIPTION
Don't put any lock file in the base template. Generate each of them into their respective overlay directory. This makes sure a project doesn't end up with two lockfiles (the (yarn) one from the base + whatever pm they selected (npm or pnpm))