### PR TITLE
chore(ci): Diagnostics for the silent Nx failures on Windows

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -145,11 +145,4 @@ runs:
       # everything the in-flight tasks printed is lost, and the step fails with
       # no error output at all. Streaming keeps the output even if we never get
       # a task summary.
-      run: |
-        set -o pipefail
-        yarn build --output-style=stream || {
-          echo "::group::package.json diagnostics"
-          node $GITHUB_WORKSPACE/.github/scripts/diagnose-package-json.mjs || true
-          echo "::endgroup::"
-          exit 1
-        }
+      run: bash "$GITHUB_WORKSPACE/.github/scripts/run-nx.sh" yarn build --output-style=stream

--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -139,9 +139,15 @@ runs:
     - name: 🏗️ Build
       if: inputs.build == 'true'
       shell: bash
+      # `--output-style=stream` is important. Nx's default CI output style
+      # buffers each task's output and only flushes it when that task finishes.
+      # When the Nx process itself dies mid-run (which has happened on Windows)
+      # everything the in-flight tasks printed is lost, and the step fails with
+      # no error output at all. Streaming keeps the output even if we never get
+      # a task summary.
       run: |
         set -o pipefail
-        yarn build || {
+        yarn build --output-style=stream || {
           echo "::group::package.json diagnostics"
           node $GITHUB_WORKSPACE/.github/scripts/diagnose-package-json.mjs || true
           echo "::endgroup::"

--- a/.github/scripts/run-nx.sh
+++ b/.github/scripts/run-nx.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Run an Nx command in CI, capturing enough on failure to tell an ordinary Nx
+# failure apart from the intermittent Windows one where Nx exits with code 1
+# and prints nothing at all.
+#
+# Usage:
+#   bash .github/scripts/run-nx.sh yarn build --output-style=stream
+#   bash .github/scripts/run-nx.sh yarn test-ci --maxWorkers=4
+#
+# On failure it always dumps the package.json diagnostics. If Nx also failed to
+# print its run summary it emits a warning annotation and retries once with Nx
+# Cloud disabled, to collect data on whether the cloud task runner is involved.
+
+set -uo pipefail
+
+if [ $# -eq 0 ]; then
+  echo "Usage: run-nx.sh <command> [args...]" >&2
+  exit 2
+fi
+
+WORKSPACE="${GITHUB_WORKSPACE:-$(pwd)}"
+LOG_DIR="${RUNNER_TEMP:-/tmp}"
+LOG_FILE="$LOG_DIR/nx-output.log"
+RETRY_LOG_FILE="$LOG_DIR/nx-output-retry.log"
+
+# Merge stderr into stdout before anything else gets a chance to drop it. The
+# failures we are chasing produce no output whatsoever, and we want to be sure
+# that is Nx being silent rather than the runner losing the stderr stream (the
+# steps that failed ran under both bash and pwsh, so neither is ruled out).
+"$@" 2>&1 | tee "$LOG_FILE"
+EXIT_CODE=$?
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+  exit 0
+fi
+
+echo "::group::package.json diagnostics"
+node "$WORKSPACE/.github/scripts/diagnose-package-json.mjs" || true
+echo "::endgroup::"
+
+# Nx prints a closing banner whenever it finishes a run - "Successfully ran
+# target <t> for N projects" or "Running target <t> for N projects failed",
+# followed by "Failed tasks:". A missing banner means Nx went away instead of
+# reporting, which is the bug we are characterising. Gating the retry on this
+# keeps ordinary red builds from paying for a second full run.
+NX_FINISHED='Successfully ran target|projects? failed|Failed tasks:'
+
+if grep -qE "$NX_FINISHED" "$LOG_FILE"; then
+  exit "$EXIT_CODE"
+fi
+
+echo "::warning::Nx exited with code $EXIT_CODE without printing a run summary. Retrying once with Nx Cloud disabled to see whether the cloud task runner is involved."
+
+NX_NO_CLOUD=true NX_VERBOSE_LOGGING=true "$@" 2>&1 | tee "$RETRY_LOG_FILE"
+RETRY_EXIT_CODE=$?
+
+if [ "$RETRY_EXIT_CODE" -eq 0 ]; then
+  echo "::warning::Retry with NX_NO_CLOUD=true passed where the cached run died silently. One data point for the Nx Cloud task runner theory - it takes several to mean anything, since this failure is intermittent."
+  exit 0
+fi
+
+if grep -qE "$NX_FINISHED" "$RETRY_LOG_FILE"; then
+  echo "::warning::Retry with NX_NO_CLOUD=true reported a normal Nx failure, so the silent first attempt is still unexplained."
+else
+  echo "::warning::Retry with NX_NO_CLOUD=true also died silently, so the Nx Cloud task runner is not the cause."
+fi
+
+exit "$RETRY_EXIT_CODE"

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -11,6 +11,13 @@ jobs:
   build-lint-test:
     runs-on: ${{ inputs.os }}
 
+    # Nx intermittently exits with code 1 and no output at all on Windows, at
+    # the point where it hands off to the task runner. Verbose logging costs us
+    # nothing but log noise and keeps the Nx Cloud cache, unlike disabling the
+    # cloud, so we can leave it on until we have caught the failure.
+    env:
+      NX_VERBOSE_LOGGING: ${{ inputs.os == 'windows-latest' && 'true' || '' }}
+
     steps:
       - name: Remove the tsc problem matcher if not ubuntu-latest
         if: inputs.os != 'ubuntu-latest'
@@ -28,7 +35,8 @@ jobs:
       #   run: yarn check:package
 
       - name: 🌡 Test Types
-        run: yarn test:types
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/run-nx.sh" yarn test:types
 
       - name: Get number of CPU cores
         if: always()
@@ -36,4 +44,5 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@97330871fe1b7d3529392ea000e3d2c4b357e403 # v3
 
       - name: 🧪 Test
-        run: yarn test-ci --maxWorkers=${{ steps.cpu-cores.outputs.count }}
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/run-nx.sh" yarn test-ci --maxWorkers=${{ steps.cpu-cores.outputs.count }}

--- a/.github/workflows/cli-smoke-tests.yml
+++ b/.github/workflows/cli-smoke-tests.yml
@@ -14,6 +14,8 @@ jobs:
     env:
       CEDAR_CI: 1
       CEDAR_VERBOSE_TELEMETRY: 1
+      # See the comment on the same variable in build-lint-test.yml
+      NX_VERBOSE_LOGGING: ${{ inputs.os == 'windows-latest' && 'true' || '' }}
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/smoke-tests-react-18-test.yml
+++ b/.github/workflows/smoke-tests-react-18-test.yml
@@ -41,14 +41,7 @@ jobs:
         shell: bash
         # See the comment on the same step in .github/actions/set-up-job for why
         # we pass `--output-style=stream`
-        run: |
-          set -o pipefail
-          yarn build --output-style=stream || {
-            echo "::group::package.json diagnostics"
-            node $GITHUB_WORKSPACE/.github/scripts/diagnose-package-json.mjs || true
-            echo "::endgroup::"
-            exit 1
-          }
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/run-nx.sh" yarn build --output-style=stream
 
       - name: 🌲 Set up test project for React 18
         id: set-up-test-project-react-18

--- a/.github/workflows/smoke-tests-react-18-test.yml
+++ b/.github/workflows/smoke-tests-react-18-test.yml
@@ -39,9 +39,11 @@ jobs:
 
       - name: 🏗️ Build
         shell: bash
+        # See the comment on the same step in .github/actions/set-up-job for why
+        # we pass `--output-style=stream`
         run: |
           set -o pipefail
-          yarn build || {
+          yarn build --output-style=stream || {
             echo "::group::package.json diagnostics"
             node $GITHUB_WORKSPACE/.github/scripts/diagnose-package-json.mjs || true
             echo "::endgroup::"


### PR DESCRIPTION
## Problem

Nx intermittently exits with **code 1 and no output at all** on Windows CI.
Three instances on [run 30150844400](https://github.com/cedarjs/cedar/actions/runs/30150844400):

| Job | Step | Time from Nx's banner to exit |
| --- | --- | --- |
| cli-smoke-tests / windows | `yarn build` | 31s, 7/73 tasks done |
| build-lint-test / windows | `yarn test:types` | ~3s, no output |
| build-lint-test / windows (re-run) | `yarn test-ci` | **0.57s**, no output |

No failing-task group, no closing banner, no Nx Cloud report — just
`##[error]Process completed with exit code 1.` Ubuntu passes every time.

The `test-ci` one is the informative one: it died 0.57s after printing
`Running target test for 60 projects`, before any task had started. That rules
out the first theory (that we were losing Nx's buffered per-task output when the
process died mid-run) — there was no task output to lose. Nx is dying at the
point where it hands off to the task runner, which puts the Nx Cloud task runner
under suspicion, since that is what it hands off to.

It also rules out the `packages/context` package.json race that the existing
diagnostics step caught on the first failure. That window can't be involved when
nothing has started running yet.

## Change

New `.github/scripts/run-nx.sh` wraps the Nx invocations in CI:

- **Merges stderr into stdout up front.** All three failures printed nothing at
  all, which is odd enough to want to rule out the runner losing the stderr
  stream rather than Nx being genuinely silent. The steps involved ran under
  both `bash` and `pwsh`, so neither shell is off the hook.
- **Always dumps the package.json diagnostics on failure**, as the build step
  did before.
- **If Nx also failed to print its closing banner, warns and retries once with
  `NX_NO_CLOUD=true`.**

The retry gate is the point of the design. Nx prints `Successfully ran target …`
or `Running target … for N projects failed` whenever it actually completes a
run, so its absence is a reliable marker for this bug. Ordinary red builds report
normally and are **never** retried — a genuinely failing PR doesn't pay for a
second uncached run. Only the silent failures retry, and each one tells us
whether disabling the cloud task runner changes the outcome. Cost when CI is
green: zero.

One retry passing proves nothing on its own, since the failure is intermittent.
Over a handful of collected failures the split is what matters: if the no-cloud
retry also dies silently, the cloud runner is cleared and we look elsewhere.

Also sets `NX_VERBOSE_LOGGING` on the Windows `build-lint-test` and
`cli-smoke-tests` jobs. Unlike disabling Nx Cloud outright, this keeps the remote
cache — worth roughly 4 minutes per Windows job (0/73 cache hits took 4m6s, 73/73
took 5.7s on the same job) — so it can stay on until we catch the failure.

Keeps `--output-style=stream` on the build steps, so a mid-run death like the
first failure doesn't swallow the output of tasks that were still going.

## Testing

The retry gate was exercised locally against **real Nx output replayed from the
CI logs** — a genuine task failure (`Running target build for 73 projects
failed`) correctly does not retry, the recorded silent death does, exit codes
propagate, and all four branches emit the intended annotations.

Note that `🌡 Test Types` and `🧪 Test` change from the default shell to `bash`
on Windows. The build step already ran under `bash` there, so this isn't new
ground, but it is the one thing in this PR worth watching in the Windows run.

## Not a fix

This is instrumentation. The root cause is still unknown, and this PR is how we
find it.
