### PR TITLE
fix(ci): Make the create-cedar-rsc-app install retry actually retry

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -95,8 +95,12 @@ runs:
       run: |
         cd "$GITHUB_WORKSPACE/packages/create-cedar-rsc-app"
         for i in 1 2 3; do
-          yarn install --inline-builds
-          EXIT_CODE=$?
+          # `|| EXIT_CODE=$?` is load-bearing. GitHub runs `shell: bash` steps
+          # with `-e`, which aborts the step as soon as an untested command
+          # fails. Without it we never even reach the line below, and the loop
+          # gives up after the first attempt instead of retrying.
+          EXIT_CODE=0
+          yarn install --inline-builds || EXIT_CODE=$?
           if [ $EXIT_CODE -eq 0 ]; then
             break
           fi


### PR DESCRIPTION
## Problem

The `create-cedar-rsc-app` install retry loop in `.github/actions/set-up-job` has never retried. The step comment says the install "has been flaky on Windows (exit code 127)" and wraps it in a 3-attempt loop, but every one of those flakes has failed the job on the first try.

GitHub runs `shell: bash` steps with `--noprofile --norc -e -o pipefail`. Under `-e`, an untested command that fails aborts the whole script immediately — so:

```bash
for i in 1 2 3; do
  yarn install --inline-builds     # ← -e kills the step right here
  EXIT_CODE=$?                     # ← never reached on failure
```

Demonstrated with GitHub's exact flags:

```
--- with -e ---     (nothing printed)             exit: 1
--- without -e ---  Attempt 1 failed, retrying...
                    Attempt 2 failed, retrying... exit: 1
```

## Fix

Capture the exit code with `|| EXIT_CODE=$?`, which makes the command "tested" and therefore exempt from `-e`:

```bash
EXIT_CODE=0
yarn install --inline-builds || EXIT_CODE=$?
```

This is the same idiom already used in `e2e-vercel.yml:85`. I grepped the rest of `.github/` — that Vercel step and this one are the only places that capture a command's exit code, and Vercel's was already correct, so this is the only instance.

## Testing

Verified locally under `bash --noprofile --norc -e -o pipefail`, with the yarn call stubbed:

- persistent failure → retries twice, exits with the original code (127)
- fails once then succeeds → step continues, exit 0
- succeeds immediately → unchanged, exit 0

The real behaviour change only shows up when the install actually flakes, so CI here passing doesn't prove much beyond "not broken".
