### PR TITLE
fix(vite): Make cedar dev --ud shut down promptly on SIGINT/SIGTERM

### DIFF
--- a/packages/vite/src/__tests__/cedar-unified-dev-shutdown.test.ts
+++ b/packages/vite/src/__tests__/cedar-unified-dev-shutdown.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { createShutdownHandler } from '../cedar-unified-dev.js'
+
+function makeLogger() {
+  return { warn: vi.fn(), error: vi.fn() }
+}
+
+function never() {
+  return new Promise<void>(() => {})
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe('createShutdownHandler', () => {
+  it('closes the servers and exits', async () => {
+    const close = vi.fn().mockResolvedValue(undefined)
+    const exit = vi.fn()
+
+    await createShutdownHandler({ close, exit, logger: makeLogger() })()
+
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(exit).toHaveBeenCalledWith(0)
+  })
+
+  it('exits even when close() never settles', async () => {
+    const exit = vi.fn()
+    const logger = makeLogger()
+
+    const shutdown = createShutdownHandler({
+      close: never,
+      timeoutMs: 50,
+      exit,
+      logger,
+    })
+
+    // Deliberately not awaited - the whole point is that it never resolves
+    shutdown()
+
+    expect(exit).not.toHaveBeenCalled()
+
+    await sleep(120)
+
+    expect(exit).toHaveBeenCalledWith(0)
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('did not shut down within 50ms'),
+    )
+  })
+
+  it('exits even when close() rejects', async () => {
+    const exit = vi.fn()
+    const logger = makeLogger()
+
+    await createShutdownHandler({
+      close: () => Promise.reject(new Error('server.close() blew up')),
+      exit,
+      logger,
+    })()
+
+    expect(exit).toHaveBeenCalledWith(0)
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('server.close() blew up'),
+    )
+  })
+
+  it('exits immediately on a second signal, without waiting for close()', async () => {
+    const exit = vi.fn()
+    const close = vi.fn(never)
+
+    const shutdown = createShutdownHandler({
+      close,
+      timeoutMs: 60_000,
+      exit,
+      logger: makeLogger(),
+    })
+
+    shutdown()
+    await shutdown()
+
+    expect(exit).toHaveBeenCalledWith(0)
+    // The hung close() from the first signal is never retried
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not close the servers twice', async () => {
+    const close = vi.fn().mockResolvedValue(undefined)
+    const exit = vi.fn()
+
+    const shutdown = createShutdownHandler({
+      close,
+      exit,
+      logger: makeLogger(),
+    })
+
+    await shutdown()
+    await shutdown()
+
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/vite/src/cedar-unified-dev.ts
+++ b/packages/vite/src/cedar-unified-dev.ts
@@ -8,6 +8,72 @@ import { getPaths, getConfig } from '@cedarjs/project-config'
 
 import { startApiDevMiddleware } from './apiDevMiddleware.js'
 
+/**
+ * How long to wait for the dev servers to close gracefully after a SIGINT or
+ * SIGTERM before forcing the process to exit.
+ */
+const SHUTDOWN_TIMEOUT_MS = 5_000
+
+interface ShutdownHandlerOptions {
+  /** Closes the running servers. Called once, on the first signal. */
+  close: () => Promise<void>
+  timeoutMs?: number
+  exit?: (code: number) => void
+  logger?: Pick<typeof console, 'warn' | 'error'>
+}
+
+/**
+ * Build the SIGINT/SIGTERM handler for the unified dev server.
+ *
+ * The handler always terminates the process, and does so promptly. Vite's
+ * `close()` waits for in-flight requests and open HMR websocket connections to
+ * drain, which is not guaranteed to finish, so the graceful path is bounded by
+ * a timeout. A second signal skips the wait entirely, which is what a user
+ * pressing Ctrl+C twice is asking for.
+ */
+export function createShutdownHandler({
+  close,
+  timeoutMs = SHUTDOWN_TIMEOUT_MS,
+  exit = (code) => process.exit(code),
+  logger = console,
+}: ShutdownHandlerOptions) {
+  let shuttingDown = false
+
+  return async function shutdown() {
+    // A second Ctrl+C means "stop waiting". Leave immediately.
+    if (shuttingDown) {
+      exit(0)
+      return
+    }
+
+    shuttingDown = true
+
+    const forceExitTimer = setTimeout(() => {
+      logger.warn(
+        `Dev server did not shut down within ${timeoutMs}ms. Forcing exit.`,
+      )
+      exit(0)
+    }, timeoutMs)
+
+    // Don't let the timer itself keep the process alive
+    forceExitTimer.unref()
+
+    try {
+      await close()
+    } catch (e) {
+      // Report, but still exit. A `close()` that rejects used to reject inside
+      // the signal handler, which skipped `process.exit()` entirely and left
+      // the server running and holding its ports.
+      const message = e instanceof Error ? e.message : String(e)
+      logger.error(`Error while shutting down the dev server: ${message}`)
+    } finally {
+      clearTimeout(forceExitTimer)
+    }
+
+    exit(0)
+  }
+}
+
 function isViteInternalRequest(url: string): boolean {
   const pathname = url.split('?')[0]
 
@@ -377,11 +443,12 @@ export async function startUnifiedDevServer() {
   }
 
   // Clean shutdown on signals – Ctrl+C sends SIGINT, process managers use SIGTERM
-  const shutdown = async () => {
-    await devServer.close()
-    await closeApi()
-    process.exit(0)
-  }
+  const shutdown = createShutdownHandler({
+    close: async () => {
+      await devServer.close()
+      await closeApi()
+    },
+  })
 
   process.on('SIGINT', shutdown)
   process.on('SIGTERM', shutdown)


### PR DESCRIPTION
## Problem

`cedar dev --ud` can ignore **Ctrl+C**. The signal handler was:

```ts
const shutdown = async () => {
  await devServer.close()
  await closeApi()
  process.exit(0)
}
```

Three ways this fails to terminate:

1. **`close()` hangs** → `process.exit()` is never reached.
2. **A second Ctrl+C doesn't help.** It re-entered the same handler and called
   `close()` again on an already-closing server, rather than doing what the user
   plainly meant.
3. **`close()` rejecting is fatal to the exit.** The rejection escaped the
   handler as an unhandled rejection, skipping `process.exit()` entirely and
   leaving the server up holding its ports.

## Why it's SIGINT specifically

Worth knowing before reviewing, because it corrects the original framing of this
PR: **SIGTERM was never the problem.** Vite registers its own SIGTERM handler
when it starts the server (`setupSIGTERMListener` → `closeServerAndExit`, see
`vite/dist/node/chunks/config.js`), and that handler wins the race — it closes
and exits with 143 regardless of what Cedar's handler is doing.

Measured at runtime by counting listeners in the running server:

```
PROBE sigterm_listeners=2 sigint_listeners=1
```

Two SIGTERM listeners (Vite's and Cedar's), but only **one** SIGINT listener —
Cedar's. Vite doesn't hook SIGINT. So Ctrl+C, the case a human actually hits, is
the one where these defects are reachable, and the one this PR fixes.

## Fix

Extract the handler into `createShutdownHandler()` and make it *always*
terminate:

- the graceful close is bounded by a 5s timeout, after which the process force
  exits with a warning
- a second signal exits immediately, without waiting
- `close()` is called at most once
- a rejecting `close()` is logged and still exits

Exit code stays `0` on every path, as before — this PR is about responsiveness,
not exit-code semantics.

## Verification

**End-to-end, A/B.** I ran the real server against the real fixture, sabotaging
only the graceful path (`await devServer.close()` replaced with a never-settling
promise in the built `dist`, nothing else changed), then sent SIGINT:

| Build | Result |
| --- | --- |
| `main` (before) | **STILL RUNNING after 30007ms** — unresponsive |
| this branch | **exited after 5054ms**, `code=0`, force-exit warning printed |

That is the failure mode and the fix, demonstrated in a live process rather than
argued from the code.

**Unit tests.** 5 tests over the handler, verified to fail against the previous
implementation by temporarily restoring the old body — 4 of 5 fail (hang on
non-settling close, hang on second signal, no exit on rejection, double close),
with the happy-path test still passing, which is correct since that path is
unchanged.

Without the sabotage the server exits in ~50ms on both builds, so there's no
regression in the healthy case. Full `@cedarjs/vite` suite passes (226 passed, 1
skipped, 4 todo).

*Note: an earlier version of this description said I couldn't verify this
end-to-end locally. That was wrong — an artifact of how I was launching the
server in a one-off probe, not a real limitation. Treat that caveat as retracted;
the table above supersedes it.*

## Relation to the CI flake

Loosely related, and less directly than I first claimed. The `ud-tests`
`EADDRINUSE` flake (documented in #2196, harness fixed in #2200) has the harness
sending SIGTERM — which, per the above, Vite already handles. So this PR is not
the fix for that flake, and #2200 does not depend on it. It's worth having on its
own merits: Ctrl+C should work.
