### PR TITLE
chore(ud-tests): Per-test ports and per-test process ownership

### DIFF
--- a/tasks/ud-tests/harness.test.mts
+++ b/tasks/ud-tests/harness.test.mts
@@ -75,10 +75,14 @@ describe('stopProcess', () => {
     const p = spawnUnkillableBySigterm()
     await new Promise((resolve) => setTimeout(resolve, 500))
 
-    // The server itself is a grandchild - zx spawns through a shell - and it is
-    // the one holding the ports, so it is the one that has to die.
+    // zx spawns through a shell, but whether the command becomes a separate
+    // grandchild is platform-dependent: macOS forks, while Linux's dash execs a
+    // simple command and so replaces the shell outright. Either way the set that
+    // has to die is the one stopProcess uses - descendants plus the top-level
+    // pid - so assert against that rather than assuming a grandchild exists.
     const descendants = await ps.tree({ pid: p.pid, recursive: true })
-    expect(descendants.length).toBeGreaterThan(0)
+    const pids = [p.pid!, ...descendants.map((d) => Number(d.pid))]
+    expect(pids.every((pid) => isAlive(pid))).toBe(true)
 
     const start = Date.now()
     // A short grace period keeps the test quick; the escalation is the point
@@ -92,7 +96,6 @@ describe('stopProcess', () => {
     // Assert the processes are really gone rather than trusting zx's promise,
     // which settles on stdio close and can lag behind the actual exits.
     // Polled, because reaping a SIGKILLed process isn't instantaneous.
-    const pids = [...descendants.map((d) => Number(d.pid)), p.pid]
     await waitFor(() => pids.every((pid) => !isAlive(pid)))
 
     for (const pid of pids) {

--- a/tasks/ud-tests/harness.test.mts
+++ b/tasks/ud-tests/harness.test.mts
@@ -1,0 +1,109 @@
+import net from 'node:net'
+
+import { describe, expect, it } from 'vitest'
+import { $, ps } from 'zx'
+
+import { reservePort, stopProcess } from './vitest.setup.mjs'
+
+/** `signal 0` checks for the process's existence without touching it */
+function isAlive(pid: number) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function waitFor(condition: () => boolean, timeout = 5_000) {
+  const start = Date.now()
+
+  while (!condition() && Date.now() - start < timeout) {
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+}
+
+/**
+ * Covers the bits of the harness the UD server tests rely on but can't
+ * demonstrate themselves - a real server that hangs on SIGTERM is exactly the
+ * situation we don't want to have to reproduce to know this works.
+ */
+
+/** A process that installs a SIGTERM handler doing nothing, so SIGTERM is ignored */
+function spawnUnkillableBySigterm() {
+  return $`node -e ${"process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"}`
+}
+
+function spawnNormal() {
+  return $`node -e ${'setInterval(() => {}, 1000)'}`
+}
+
+describe('reservePort', () => {
+  it('hands out distinct, bindable ports', async () => {
+    const ports = await Promise.all([
+      reservePort(),
+      reservePort(),
+      reservePort(),
+    ])
+
+    expect(new Set(ports).size).toBe(3)
+
+    // Each one should actually be free right now
+    for (const port of ports) {
+      await new Promise<void>((resolve, reject) => {
+        const server = net.createServer()
+        server.on('error', reject)
+        server.listen(port, '127.0.0.1', () => server.close(() => resolve()))
+      })
+    }
+  })
+})
+
+describe('stopProcess', () => {
+  it('stops a process that honours SIGTERM', async () => {
+    const p = spawnNormal()
+    // Give the child time to actually start before signalling it
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    const start = Date.now()
+    await stopProcess(p)
+
+    expect(Date.now() - start).toBeLessThan(4_000)
+  }, 15_000)
+
+  it('escalates to SIGKILL for a process that ignores SIGTERM', async () => {
+    const p = spawnUnkillableBySigterm()
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    // The server itself is a grandchild - zx spawns through a shell - and it is
+    // the one holding the ports, so it is the one that has to die.
+    const descendants = await ps.tree({ pid: p.pid, recursive: true })
+    expect(descendants.length).toBeGreaterThan(0)
+
+    const start = Date.now()
+    // A short grace period keeps the test quick; the escalation is the point
+    await stopProcess(p, 750)
+    const elapsed = Date.now() - start
+
+    // It had to wait out the grace period before escalating
+    expect(elapsed).toBeGreaterThanOrEqual(700)
+    expect(elapsed).toBeLessThan(10_000)
+
+    // Assert the processes are really gone rather than trusting zx's promise,
+    // which settles on stdio close and can lag behind the actual exits.
+    // Polled, because reaping a SIGKILLed process isn't instantaneous.
+    const pids = [...descendants.map((d) => Number(d.pid)), p.pid]
+    await waitFor(() => pids.every((pid) => !isAlive(pid)))
+
+    for (const pid of pids) {
+      expect(isAlive(pid)).toBe(false)
+    }
+  }, 20_000)
+
+  it('is a no-op for a process that has already exited', async () => {
+    const p = $`node -e ${'process.exit(0)'}`
+    await p.catch(() => undefined)
+
+    await expect(stopProcess(p)).resolves.toBeUndefined()
+  }, 15_000)
+})

--- a/tasks/ud-tests/udDev.test.mts
+++ b/tasks/ud-tests/udDev.test.mts
@@ -3,14 +3,12 @@ import WebSocket from 'ws'
 import { fs, path, $ } from 'zx'
 
 import {
+  autoStop,
   FIXTURE_PATH,
   pollForReady,
+  reservePort,
   sleep,
-  testContext,
 } from './vitest.setup.mjs'
-
-const WEB_PORT = 18910
-const BASE_URL = `http://localhost:${WEB_PORT}`
 
 async function fetchJson(url: string, init?: RequestInit) {
   const res = await fetch(url, init)
@@ -44,10 +42,17 @@ function resolveUnifiedDevBin() {
 
 describe('cedar dev --ud', () => {
   it('serves the web SPA shell and API routes with HMR', async () => {
+    // Ports are reserved per test rather than hardcoded, so a server that
+    // outlives another test can't stop this one from binding.
+    const WEB_PORT = await reservePort()
+    const API_PORT = await reservePort()
+    const BASE_URL = `http://localhost:${WEB_PORT}`
+
     // 1. Start the unified dev server directly
     const unifiedDevBin = resolveUnifiedDevBin()
-    const devProcess = $`yarn node ${unifiedDevBin} --port ${WEB_PORT} --apiPort 18911 --no-open`
-    testContext.processes.push(devProcess)
+    autoStop(
+      $`yarn node ${unifiedDevBin} --port ${WEB_PORT} --apiPort ${API_PORT} --no-open`,
+    )
 
     // 2. Wait for the web server to be ready
     await pollForReady(`${BASE_URL}/`)
@@ -112,15 +117,20 @@ describe('cedar dev --ud', () => {
   }, 60_000)
 
   it('pretty-prints the api logger output instead of printing raw pino NDJSON', async () => {
+    const WEB_PORT = await reservePort()
+    const API_PORT = await reservePort()
+    const BASE_URL = `http://localhost:${WEB_PORT}`
+
     const unifiedDevBin = resolveUnifiedDevBin()
     // The api logger defaults to `silent` when NODE_ENV=test (see
     // packages/api/src/logger/index.ts), which vitest sets and this
     // process inherits — force a level that actually emits the
     // graphql-server plugin's debug-level request logs this test checks for.
-    const devProcess = $({
-      env: { ...process.env, LOG_LEVEL: 'debug' },
-    })`yarn node ${unifiedDevBin} --port ${WEB_PORT} --apiPort 18911 --no-open`
-    testContext.processes.push(devProcess)
+    const devProcess = autoStop(
+      $({
+        env: { ...process.env, LOG_LEVEL: 'debug' },
+      })`yarn node ${unifiedDevBin} --port ${WEB_PORT} --apiPort ${API_PORT} --no-open`,
+    )
 
     let stdoutBuffer = ''
     devProcess.stdout.on('data', (data: Buffer) => {
@@ -291,10 +301,9 @@ function createCdpSession(
 
 describe('cedar dev --ud --debug-port', () => {
   it('opens the inspector on the given port, allows CDP interaction, and can pause/resume execution', async () => {
-    // Use distinct ports to avoid accidental overlap if tests ever parallelise
-    const WEB_PORT = 18920
-    const API_PORT = 18921
-    const DEBUG_PORT = 38911
+    const WEB_PORT = await reservePort()
+    const API_PORT = await reservePort()
+    const DEBUG_PORT = await reservePort()
     const BASE_URL = `http://localhost:${WEB_PORT}`
 
     // 1. Start the unified dev server with --debug-port. We pass the flag
@@ -309,7 +318,7 @@ describe('cedar dev --ud --debug-port', () => {
     devProcess.stderr.on('data', (data: Buffer) => {
       stderrBuffer += data.toString()
     })
-    testContext.processes.push(devProcess)
+    autoStop(devProcess)
 
     // 2. Wait for the inspector message on stderr and verify the port.
     //    inspector.open() logs:  Debugger listening on ws://127.0.0.1:<port>/<uuid>
@@ -421,10 +430,9 @@ describe('cedar dev --ud --debug-port', () => {
 
 describe('cedar dev --ud --debug-brk', () => {
   it('blocks the server until a debugger connects, then serves requests normally', async () => {
-    // Use distinct ports — no overlap with the other two test blocks
-    const WEB_PORT = 18930
-    const API_PORT = 18931
-    const DEBUG_PORT = 38912
+    const WEB_PORT = await reservePort()
+    const API_PORT = await reservePort()
+    const DEBUG_PORT = await reservePort()
     const BASE_URL = `http://localhost:${WEB_PORT}`
 
     // 1. Start the unified dev server with --debug-brk.
@@ -437,7 +445,7 @@ describe('cedar dev --ud --debug-brk', () => {
     devProcess.stderr.on('data', (data: Buffer) => {
       stderrBuffer += data.toString()
     })
-    testContext.processes.push(devProcess)
+    autoStop(devProcess)
 
     // 2. Wait for the inspector message on stderr.
     const inspectorUrl = await new Promise<string>((resolve, reject) => {

--- a/tasks/ud-tests/udServe.test.mts
+++ b/tasks/ud-tests/udServe.test.mts
@@ -2,14 +2,12 @@ import { beforeAll, describe, expect, it } from 'vitest'
 import { $ } from 'zx'
 
 import {
+  autoStop,
   cedar,
   buildFixture,
   pollForReady,
-  testContext,
+  reservePort,
 } from './vitest.setup.mjs'
-
-const WEB_PORT = 18910
-const API_PORT = 18911
 
 async function fetchJson(url: string, init?: RequestInit) {
   const res = await fetch(url, init)
@@ -30,16 +28,19 @@ describe('cedar serve api --ud', () => {
   }, 180_000)
 
   it('serves API functions, legacy handlers, and GraphQL', async () => {
+    // Ports are reserved per test rather than hardcoded, so a server that
+    // outlives another test can't stop this one from binding.
+    const API_PORT = await reservePort()
+    const WEB_PORT = await reservePort()
+
     // NOTE: `cedar serve --ud` does not exist yet, so we start the API and
     // web servers separately. When both-side UD serving lands, simplify this
     // to a single command.
     // 1. Start the UD API server
-    const apiProcess = $`yarn node ${cedar} serve api --ud --port ${API_PORT}`
-    testContext.processes.push(apiProcess)
+    autoStop($`yarn node ${cedar} serve api --ud --port ${API_PORT}`)
 
     // 2. Start the web server
-    const webProcess = $`yarn node ${cedar} serve web --port ${WEB_PORT}`
-    testContext.processes.push(webProcess)
+    autoStop($`yarn node ${cedar} serve web --port ${WEB_PORT}`)
 
     // 3. Wait for both servers to be ready
     await pollForReady(`http://localhost:${API_PORT}/hello`)

--- a/tasks/ud-tests/vitest.config.mts
+++ b/tasks/ud-tests/vitest.config.mts
@@ -4,8 +4,12 @@ export default defineConfig({
   test: {
     logHeapUsage: true,
     setupFiles: ['./vitest.setup.mts'],
-    // Run test suites in series because we start and stop servers
-    // on the same host and port between test cases.
+    // Still serial, but no longer because of ports - those are reserved per
+    // test now (see reservePort in vitest.setup.mts). The remaining reason is
+    // the shared fixture directory: the HMR test edits
+    // __fixtures__/cedar-ud-app/api/src/functions/hello.ts and restores it
+    // afterwards, and udServe's beforeAll builds the same fixture. Isolate the
+    // fixture per suite and this can go.
     pool: 'threads',
     fileParallelism: false,
   },

--- a/tasks/ud-tests/vitest.setup.mts
+++ b/tasks/ud-tests/vitest.setup.mts
@@ -1,7 +1,8 @@
+import net from 'node:net'
 import { fileURLToPath } from 'node:url'
 
-import { afterAll, afterEach, beforeAll } from 'vitest'
-import { fs, path, $ } from 'zx'
+import { afterAll, beforeAll, onTestFinished } from 'vitest'
+import { fs, path, ps, $ } from 'zx'
 import type { ProcessPromise } from 'zx'
 
 import { getConfig } from '@cedarjs/project-config'
@@ -10,6 +11,9 @@ $.verbose = !!process.env.VERBOSE
 
 const fixtureUrl = new URL('../../__fixtures__/cedar-ud-app', import.meta.url)
 export const FIXTURE_PATH = fileURLToPath(fixtureUrl)
+
+/** How long a server gets to exit on SIGTERM before we escalate to SIGKILL */
+const STOP_GRACE_MS = 5_000
 
 /** Resolve the cedar CLI binary from the monorepo */
 function resolveCedarBin() {
@@ -23,7 +27,6 @@ function resolveCedarBin() {
 export const cedar = resolveCedarBin()
 
 export const testContext = {
-  processes: [] as ProcessPromise[],
   projectConfig: {} as ReturnType<typeof getConfig>,
 }
 
@@ -43,19 +46,147 @@ afterAll(() => {
   }
 })
 
-afterEach(async () => {
-  for (const p of testContext.processes) {
-    p.kill()
+const reservedPorts = new Set<number>()
 
-    try {
-      await p
-    } catch {
-      // ignore
+/**
+ * Reserve a free TCP port.
+ *
+ * The servers under test run as child processes, so we can't hand them a socket
+ * we already hold - we have to pick a number and trust it is still free a
+ * moment later. Letting the OS pick an ephemeral port is far safer than
+ * hardcoding one, and `reservedPorts` stops us handing the same number to two
+ * tests in the same run.
+ */
+export async function reservePort() {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const port = await new Promise<number>((resolve, reject) => {
+      const probe = net.createServer()
+      probe.unref()
+      probe.on('error', reject)
+      probe.listen(0, '127.0.0.1', () => {
+        const address = probe.address()
+        const found = typeof address === 'object' && address ? address.port : 0
+        probe.close(() => resolve(found))
+      })
+    })
+
+    if (port && !reservedPorts.has(port)) {
+      reservedPorts.add(port)
+      return port
     }
   }
 
-  testContext.processes = []
-})
+  throw new Error('Could not reserve a free port')
+}
+
+/**
+ * Every pid we may need to signal, the server itself first.
+ *
+ * This has to be captured *before* anything is signalled. zx spawns through a
+ * shell, so the server is a grandchild; the shell dies on the first SIGTERM,
+ * the server gets reparented to init, and from then on walking down from the
+ * shell's pid finds nothing. Which means zx can no longer kill the one process
+ * that actually holds the ports - so we remember the pids ourselves.
+ *
+ * ud-tests are Ubuntu-only (see .github/workflows/ud-tests.yml), so plain POSIX
+ * signals are enough here - no Windows taskkill path needed.
+ */
+async function collectPids(p: ProcessPromise) {
+  const pids: number[] = []
+
+  try {
+    const tree = await ps.tree({ pid: p.pid, recursive: true })
+    pids.push(...tree.map((entry) => Number(entry.pid)))
+  } catch {
+    // Best effort. Without `ps` we can still signal the shell itself.
+  }
+
+  if (p.pid) {
+    pids.push(p.pid)
+  }
+
+  return pids.filter((pid) => Number.isInteger(pid) && pid > 0)
+}
+
+function signalAll(pids: number[], signal: 'SIGTERM' | 'SIGKILL') {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal)
+    } catch {
+      // Already gone
+    }
+  }
+}
+
+function isAlive(pid: number) {
+  try {
+    // Signal 0 tests for existence without delivering anything
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Stop a server child process, escalating to SIGKILL if it doesn't go quietly.
+ *
+ * SIGTERM alone isn't enough in every case. The --debug-brk test deliberately
+ * leaves the process blocked in `inspector.waitForDebugger()`, and a blocked
+ * event loop can never run a JS signal handler - so if that test fails before
+ * it resumes the process, SIGTERM is ignored forever. Escalating stops a
+ * process like that from outliving its test and sitting on its ports.
+ */
+export async function stopProcess(p: ProcessPromise, graceMs = STOP_GRACE_MS) {
+  // Attach this first. Killing a process makes zx reject, and an unhandled
+  // rejection would take down the test run.
+  const exited = p.catch(() => undefined)
+
+  const pids = await collectPids(p)
+
+  signalAll(pids, 'SIGTERM')
+
+  if (await settledWithin(exited, graceMs)) {
+    return
+  }
+
+  signalAll(pids.filter(isAlive), 'SIGKILL')
+
+  // Bounded on purpose. zx settles on stdio close, and the grandchild inherits
+  // those pipes, so the promise can stay pending after everything is dead. What
+  // we need is the processes gone, not zx noticing.
+  await settledWithin(exited, graceMs)
+}
+
+const timedOut = Symbol('timedOut')
+
+/** Resolves true if `promise` settled within `ms`, false if it timed out */
+async function settledWithin(promise: Promise<unknown>, ms: number) {
+  let timer: NodeJS.Timeout | undefined
+
+  const deadline = new Promise<typeof timedOut>((resolve) => {
+    timer = setTimeout(() => resolve(timedOut), ms)
+  })
+
+  try {
+    return (await Promise.race([promise, deadline])) !== timedOut
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Register a server child process for teardown when the current test ends.
+ *
+ * `onTestFinished` runs even when the test throws, and it keeps ownership next
+ * to the code that started the process - rather than in a shared array drained
+ * by a global hook, where one test's leaked process became the next test's
+ * failure.
+ */
+export function autoStop(p: ProcessPromise) {
+  onTestFinished(() => stopProcess(p))
+  return p
+}
 
 export function sleep(time = 1_000) {
   return new Promise((resolve) => setTimeout(resolve, time))

--- a/tasks/ud-tests/vitest.setup.mts
+++ b/tasks/ud-tests/vitest.setup.mts
@@ -94,15 +94,18 @@ export async function reservePort() {
 async function collectPids(p: ProcessPromise) {
   const pids: number[] = []
 
+  // Top-level pid first, so the server is signalled before the children it
+  // owns. Signalling its esbuild child first makes the server crash on a
+  // "service was stopped: write EPIPE" mid-transform instead of shutting down.
+  if (p.pid) {
+    pids.push(p.pid)
+  }
+
   try {
     const tree = await ps.tree({ pid: p.pid, recursive: true })
     pids.push(...tree.map((entry) => Number(entry.pid)))
   } catch {
-    // Best effort. Without `ps` we can still signal the shell itself.
-  }
-
-  if (p.pid) {
-    pids.push(p.pid)
+    // Best effort. Without `ps` we can still signal the top-level process.
   }
 
   return pids.filter((pid) => Number.isInteger(pid) && pid > 0)


### PR DESCRIPTION
Restructures the UD test harness so a leaked server can't fail an unrelated test.

## Before

Every test started servers on hardcoded ports and pushed the processes into a
shared `testContext.processes` array, drained by a global `afterEach` that sent
SIGTERM once and swallowed every error. `udDev` and `udServe` both hardcoded
`18910` — which is why `fileParallelism: false` was needed, and why one test's
leaked server became the next suite's `EADDRINUSE` (see the 2026-07-25 entry in
the flaky-tests doc, #2196).

## After

- **Ports reserved per test** from the OS (`reservePort`), so a straggler can't
  stop another test from binding.
- **Ownership via `autoStop()` / `onTestFinished`**, registered where the process
  is started rather than in a shared array drained by a global hook.
- **`stopProcess()` escalates SIGTERM → SIGKILL.** Still necessary even with a
  well-behaved server: the `--debug-brk` test deliberately leaves the process
  blocked in `inspector.waitForDebugger()`, and a blocked event loop can never
  run a JS signal handler. Escalation is the safety net for that case rather than
  the mechanism for the normal one.

`fileParallelism: false` stays, but the comment now gives the real reason. It
isn't ports any more — it's the shared fixture directory: the HMR test edits
`__fixtures__/cedar-ud-app/api/src/functions/hello.ts` and restores it, and
`udServe`'s `beforeAll` builds the same fixture. Isolate the fixture per suite
and it can go.

## Two things the kill path needs, both found by the tests rather than by reading

I wrote the obvious version first and the new tests failed three times. Worth
knowing, because both are invisible until a server actually misbehaves:

1. **zx's `kill()` must be awaited, and even then can't be relied on here.** It
   walks the process tree via `ps` *at call time*, but the server is a
   grandchild — zx spawns through a shell. The shell dies on the first SIGTERM,
   the grandchild is reparented to init, and from then on walking down from the
   shell's pid finds nothing. zx can no longer reach the one process holding the
   ports. Verified directly:

   ```
   shell=18054 child=18055
   after SIGTERM: shell alive=false child alive=true
   ps.tree from shell pid now: 0 entries   <-- zx has lost the child
   child ppid now: 1
   ```

   So the pids are snapshotted *before* anything is signalled.

2. **zx settles on stdio close, not on exit.** The grandchild inherits those
   pipes, so the promise can stay pending long after everything is dead. Awaiting
   it unbounded hangs; every wait on it is now bounded.

## Testing

New `harness.test.mts` covers port reservation and the kill path, including a
process that ignores SIGTERM. It asserts the pids are *actually gone* via
`process.kill(pid, 0)` rather than trusting zx's promise — which is exactly the
assertion that caught both bugs above.

Full ud-tests suite passes locally, 9 tests, ~18s. Run twice: against a
`@cedarjs/vite` build **with** the shutdown fix from #2197 and against one
**without** it, so this change stands on its own and doesn't depend on that PR
landing. No leaked processes after either run, and the fixture is left clean.

## Note on #2197

While doing this I found that the ud-tests suite runs fine on my machine — so the
"could not verify end-to-end locally" caveat in #2197's description is wrong. It
was an artifact of how I was launching the server in a one-off probe, not a real
limitation. That PR's fix can and should be verified end-to-end; I'd treat its
stated caveat as retracted.


## Update (second commit, `ddd3cea51b`)

Two refinements after running the harness tests on both platforms:

1. **The grandchild shape is platform-dependent.** macOS's `bash` forks (server
   is a grandchild of zx's pid); Ubuntu's `dash` execs a simple command,
   replacing the shell, so the top-level pid *is* the server. `stopProcess`
   targets "top-level pid plus descendants" and the harness test now asserts
   against that set instead of assuming a grandchild exists.
2. **Signal order: top-level process before its descendants.** Signalling the
   server's esbuild child first makes the server crash mid-transform on
   `The service was stopped: write EPIPE` instead of shutting down — so
   `collectPids` puts the top-level pid first. (Corollary for log-reading:
   EPIPE during teardown is a kill-ordering artifact, not the signature-D
   startup esbuild crash.)
