### PR TITLE
fix(eslint-plugin): Convert @cedarjs/eslint-plugin to ESM-only

### DIFF
--- a/packages/eslint-plugin/build.mts
+++ b/packages/eslint-plugin/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -7,16 +7,16 @@
     "directory": "packages/eslint-plugin"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-eslint-plugin.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "vitest run",

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,12 +1,14 @@
 import type { ESLintUtils } from '@typescript-eslint/utils'
 
+import pkgJson from '../package.json' with { type: 'json' }
+
 import { processEnvComputedRule } from './process-env-computed.js'
 import { serviceTypeAnnotations } from './service-type-annotations.js'
 import { unsupportedRouteComponents } from './unsupported-route-components.js'
 
 export const meta = {
   name: '@cedarjs/eslint-plugin',
-  version: require('../package.json').version,
+  version: pkgJson.version,
 }
 
 export const rules = {

--- a/packages/eslint-plugin/tsconfig.build.json
+++ b/packages/eslint-plugin/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "../../tsconfig.cjs-build-base.json",
+  "extends": "../../tsconfig.base.json",
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- Node 24 (the framework's minimum supported version) is required, and `@cedarjs/eslint-plugin` is only ever loaded via `import` in flat `eslint.config.mjs`/`.js` files (ESLint's flat-config loader always uses dynamic `import()`), so there's no reason for it to stay CommonJS.
- Flips `"type"` to `"module"`, switches the build to `buildEsm()` + `generateTypesEsm()`, and updates `tsconfig.json`/adds `tsconfig.build.json` to match the pattern used by other ESM-only packages.
- Replaces the one CJS-specific construct, `require('../package.json').version`, with a JSON import attribute (`import pkgJson from '../package.json' with { type: 'json' }`), matching the pattern already used elsewhere in the monorepo (e.g. `create-cedar-app`).
