### PR TITLE
fix(web-server): Convert @cedarjs/web-server to ESM-only

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -358,8 +358,10 @@ export const builder = async (yargs: Argv) => {
         if (streamingEnabled) {
           await webSsrServerHandler(rscEnabled)
         } else {
-          // @cedarjs/web-server is still built as CJS only, so we don't need
-          // the same solution here as we do for the api side
+          // Unlike the api side, @cedarjs/web-server doesn't need to load a
+          // CJS build of the user's project (it only serves the already-built
+          // web dist), so it doesn't need the projectIsEsm() branching we do
+          // for the api side below
           await webServerCLIConfig.handler(argv)
         }
       },

--- a/packages/core/src/bins/cedar-web-server.ts
+++ b/packages/core/src/bins/cedar-web-server.ts
@@ -1,11 +1,17 @@
 #!/usr/bin/env node
 import { createRequire } from 'node:module'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 const require = createRequire(import.meta.url)
-const requireFromWebServer = createRequire(
-  require.resolve('@cedarjs/web-server/package.json'),
+const webServerPackageJsonPath =
+  require.resolve('@cedarjs/web-server/package.json')
+const webServerPackageJson = require(webServerPackageJsonPath)
+
+const bins = webServerPackageJson['bin']
+const binPath = path.join(
+  path.dirname(webServerPackageJsonPath),
+  bins['cedar-web-server'],
 )
 
-const bins = requireFromWebServer('./package.json')['bin']
-
-requireFromWebServer(bins['cedar-web-server'])
+await import(pathToFileURL(binPath).href)

--- a/packages/core/src/bins/rw-web-server.ts
+++ b/packages/core/src/bins/rw-web-server.ts
@@ -5,11 +5,13 @@
 // major release.
 
 import { createRequire } from 'node:module'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 const require = createRequire(import.meta.url)
-const requireFromWebServer = createRequire(
-  require.resolve('@cedarjs/web-server/package.json'),
-)
+const webServerPackageJsonPath =
+  require.resolve('@cedarjs/web-server/package.json')
+const webServerPackageJson = require(webServerPackageJsonPath)
 
 console.warn()
 console.warn(
@@ -17,6 +19,10 @@ console.warn(
 )
 console.warn()
 
-const bins = requireFromWebServer('./package.json')['bin']
+const bins = webServerPackageJson['bin']
+const binPath = path.join(
+  path.dirname(webServerPackageJsonPath),
+  bins['cedar-web-server'],
+)
 
-requireFromWebServer(bins['cedar-web-server'])
+await import(pathToFileURL(binPath).href)

--- a/packages/web-server/build.mts
+++ b/packages/web-server/build.mts
@@ -3,18 +3,27 @@ import {
   defaultBuildOptions,
   defaultIgnorePatterns,
 } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
 // Build the package
 await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    tsconfig: 'tsconfig.build.json',
+    format: 'esm',
+  },
   entryPointOptions: {
     ignore: [...defaultIgnorePatterns, './src/bin.ts', './src/types.ts'],
   },
 })
+await generateTypesEsm()
 
 // Build the bin
 await build({
   buildOptions: {
     ...defaultBuildOptions,
+    tsconfig: 'tsconfig.build.json',
+    format: 'esm',
     banner: {
       js: '#!/usr/bin/env node',
     },

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/web-server"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/cliConfig.js",
   "types": "./dist/cliConfig.d.ts",
   "bin": {
@@ -19,9 +19,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-web-server.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build && yarn fix:permissions\"",
     "fix:permissions": "chmod +x dist/index.js; chmod +x dist/watch.js",
     "prepublishOnly": "NODE_ENV=production yarn build"

--- a/packages/web-server/tsconfig.build.json
+++ b/packages/web-server/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src", "ambient.d.ts"],
+  "references": [
+    { "path": "../adapters/fastify/web" },
+    { "path": "../project-config" }
+  ]
+}

--- a/packages/web-server/tsconfig.json
+++ b/packages/web-server/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.cjs-build-base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "resolveJsonModule": true
   },


### PR DESCRIPTION
## Summary
- `@cedarjs/web-server` only serves the already-built web `dist` output — unlike `@cedarjs/api-server` it never needs to load a CJS build of the user's own project, so it doesn't need to stay CommonJS now that the framework requires Node >=24.
- Flips `"type"` to `"module"` and rebuilds both the package and its bundled `bin.js` as ESM, using the same `format: 'esm'` + shebang banner approach `api-server` already uses for its own ESM bin builds.
- Updates the two `core` bin shims, `cedar-web-server.ts` and `rw-web-server.ts`, from a synchronous `createRequire(...).require()` of web-server's bin to `await import()`, since the target is no longer requirable that way.
- Fixes a stale comment in `cli/serve.ts` that said web-server was "still built as CJS only" — it isn't anymore. The reason it still doesn't need `api-server`'s `projectIsEsm()` branching is unrelated to its own module format: it never loads the user's project code (only the prebuilt web `dist`), unlike `api-server`, which needs a CJS build to keep transpiling non-ESM Cedar projects' API code via Babel's require hook.

## Test plan
- [x] `yarn workspace @cedarjs/web-server build`
- [x] `yarn workspace @cedarjs/core build`
- [x] `yarn workspace @cedarjs/cli build`
- [x] `yarn workspace @cedarjs/cli test src/commands/__tests__/serve.test.ts`
- [x] `yarn eslint packages/web-server/src packages/core/src/bins/cedar-web-server.ts packages/core/src/bins/rw-web-server.ts packages/cli/src/commands/serve.ts`
- [x] Ran `node dist/bin.js --help` directly against `local-testing-project` (verified ESM bin bundle executes)
- [x] Ran the built `cedar-web-server` and `rw-web-server` bin shims from `core/dist/bins` against `local-testing-project` (verified the `await import()` dynamic-import replacement resolves and runs the web-server bin correctly)