### PR TITLE
fix(mailer-core): Convert @cedarjs/mailer-core to ESM-only

### DIFF
--- a/packages/mailer/core/build.mts
+++ b/packages/mailer/core/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/mailer/core/package.json
+++ b/packages/mailer/core/package.json
@@ -7,16 +7,16 @@
     "directory": "packages/mailer/core"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-mailer-core.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "vitest run",

--- a/packages/mailer/core/src/mailer.ts
+++ b/packages/mailer/core/src/mailer.ts
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module'
+
 import type { Logger } from '@cedarjs/api/logger'
 
 import type { AbstractMailHandler } from './handler.js'
@@ -12,6 +14,13 @@ import type {
   MailResult,
 } from './types.js'
 import { constructCompleteSendOptions, extractDefaults } from './utils.js'
+
+// The optional fallback handlers below are loaded with `require()` rather
+// than `import()` so that the constructor can stay synchronous. `require()`
+// isn't a global in ESM, so we need our own via `createRequire`. Node 24's
+// `require(esm)` support lets this keep working even though the handler
+// packages it loads are ESM.
+const require = createRequire(import.meta.url)
 
 export class Mailer<
   THandlers extends MailHandlers,

--- a/packages/mailer/core/tsconfig.build.json
+++ b/packages/mailer/core/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "erasableSyntaxOnly": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/packages/mailer/core/tsconfig.json
+++ b/packages/mailer/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "erasableSyntaxOnly": false
   },


### PR DESCRIPTION
## Summary
- Node 24 (the framework's minimum supported version) is required, and `@cedarjs/mailer-core` is only ever consumed via `import` from generated project API code and the other `mailer/*` sub-packages, so there's no reason for it to stay CommonJS.
- Flips `"type"` to `"module"`, switches the build to `buildEsm()` + `generateTypesEsm()`, and updates `tsconfig.json`/adds `tsconfig.build.json` to match the pattern used by other ESM-only packages (e.g. `tui`, `web-server`).
- Fixes the one CJS-specific construct: the two lazy, try/catch-wrapped `require()` calls used to feature-detect the optional `mailer-handler-in-memory`/`mailer-handler-studio` packages now go through `createRequire(import.meta.url)` instead of relying on a global `require`, which doesn't exist in ESM. This keeps working under Node 24's `require(esm)` support once those handler packages are converted to ESM-only too (see follow-up PRs).