### PR TITLE
fix(mailer-handler-nodemailer): Convert @cedarjs/mailer-handler-nodemailer to ESM-only

### DIFF
--- a/packages/mailer/handlers/nodemailer/build.mts
+++ b/packages/mailer/handlers/nodemailer/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/mailer/handlers/nodemailer/package.json
+++ b/packages/mailer/handlers/nodemailer/package.json
@@ -7,16 +7,16 @@
     "directory": "packages/mailer/handlers/nodemailer"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-mailer-handler-nodemailer.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },

--- a/packages/mailer/handlers/nodemailer/src/index.ts
+++ b/packages/mailer/handlers/nodemailer/src/index.ts
@@ -1,7 +1,4 @@
 import nodemailer from 'nodemailer'
-// Under CJS the extensionless directory import resolved fine, but Node16/
-// NodeNext module resolution (which kicks in now that this package is
-// "type": "module") requires an explicit file extension for subpath imports.
 import type SMTPTransport from 'nodemailer/lib/smtp-transport/index.js'
 
 import { AbstractMailHandler } from '@cedarjs/mailer-core'

--- a/packages/mailer/handlers/nodemailer/src/index.ts
+++ b/packages/mailer/handlers/nodemailer/src/index.ts
@@ -1,5 +1,8 @@
 import nodemailer from 'nodemailer'
-import type SMTPTransport from 'nodemailer/lib/smtp-transport'
+// Under CJS the extensionless directory import resolved fine, but Node16/
+// NodeNext module resolution (which kicks in now that this package is
+// "type": "module") requires an explicit file extension for subpath imports.
+import type SMTPTransport from 'nodemailer/lib/smtp-transport/index.js'
 
 import { AbstractMailHandler } from '@cedarjs/mailer-core'
 import type {

--- a/packages/mailer/handlers/nodemailer/tsconfig.build.json
+++ b/packages/mailer/handlers/nodemailer/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "erasableSyntaxOnly": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/mailer/handlers/nodemailer/tsconfig.json
+++ b/packages/mailer/handlers/nodemailer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
     "erasableSyntaxOnly": false
   },


### PR DESCRIPTION
## Summary
- Node 24 (the framework's minimum supported version) is required, and `@cedarjs/mailer-handler-nodemailer` is only ever consumed via `import` from generated project API code, so there's no reason for it to stay CommonJS.
- Flips `"type"` to `"module"`, switches the build to `buildEsm()` + `generateTypesEsm()`, and updates `tsconfig.json`/adds `tsconfig.build.json` to match the pattern used by other ESM-only packages.
- Fixes the one CJS-specific construct: the extensionless directory import `nodemailer/lib/smtp-transport` resolved fine under CJS, but Node16/NodeNext module resolution (which kicks in now that this package is ESM) requires an explicit file extension for subpath imports, so it's now `nodemailer/lib/smtp-transport/index.js`.