### PR TITLE
fix(mailer-renderer-mjml-react): Convert @cedarjs/mailer-renderer-mjml-react to ESM-only

### DIFF
--- a/packages/mailer/renderers/mjml-react/build.mts
+++ b/packages/mailer/renderers/mjml-react/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/mailer/renderers/mjml-react/package.json
+++ b/packages/mailer/renderers/mjml-react/package.json
@@ -7,16 +7,16 @@
     "directory": "packages/mailer/renderers/mjml-react"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-mailer-renderer-mjml-react.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },

--- a/packages/mailer/renderers/mjml-react/src/index.ts
+++ b/packages/mailer/renderers/mjml-react/src/index.ts
@@ -1,6 +1,3 @@
-// Under CJS the extensionless subpath import resolved fine, but Node16/
-// NodeNext module resolution (which kicks in now that this package is
-// "type": "module") requires an explicit file extension for subpath imports.
 import { renderToMjml } from '@faire/mjml-react/utils/renderToMjml.js'
 import mjml2html from 'mjml'
 

--- a/packages/mailer/renderers/mjml-react/src/index.ts
+++ b/packages/mailer/renderers/mjml-react/src/index.ts
@@ -1,4 +1,7 @@
-import { renderToMjml } from '@faire/mjml-react/utils/renderToMjml'
+// Under CJS the extensionless subpath import resolved fine, but Node16/
+// NodeNext module resolution (which kicks in now that this package is
+// "type": "module") requires an explicit file extension for subpath imports.
+import { renderToMjml } from '@faire/mjml-react/utils/renderToMjml.js'
 import mjml2html from 'mjml'
 
 import type {

--- a/packages/mailer/renderers/mjml-react/tsconfig.build.json
+++ b/packages/mailer/renderers/mjml-react/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/mailer/renderers/mjml-react/tsconfig.json
+++ b/packages/mailer/renderers/mjml-react/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
   "references": [{ "path": "../../core" }]
 }


### PR DESCRIPTION
## Summary
- Node 24 (the framework's minimum supported version) is required, and `@cedarjs/mailer-renderer-mjml-react` is only ever consumed via `import` from generated project API code, so there's no reason for it to stay CommonJS.
- Flips `"type"` to `"module"`, switches the build to `buildEsm()` + `generateTypesEsm()`, and updates `tsconfig.json`/adds `tsconfig.build.json` to match the pattern used by other ESM-only packages.
- Fixes the one CJS-specific construct: the extensionless subpath import `@faire/mjml-react/utils/renderToMjml` resolved fine under CJS, but Node16/NodeNext module resolution (which kicks in now that this package is ESM) requires an explicit file extension for subpath imports, so it's now `@faire/mjml-react/utils/renderToMjml.js`.