### PR TITLE
fix(mailer-renderer-react-email): Convert @cedarjs/mailer-renderer-react-email to ESM-only

### DIFF
--- a/packages/mailer/renderers/react-email/build.mts
+++ b/packages/mailer/renderers/react-email/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/mailer/renderers/react-email/package.json
+++ b/packages/mailer/renderers/react-email/package.json
@@ -7,16 +7,16 @@
     "directory": "packages/mailer/renderers/react-email"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-mailer-renderer-react-email.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },

--- a/packages/mailer/renderers/react-email/tsconfig.build.json
+++ b/packages/mailer/renderers/react-email/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../../core" }]
+}

--- a/packages/mailer/renderers/react-email/tsconfig.json
+++ b/packages/mailer/renderers/react-email/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
   "references": [{ "path": "../../core" }]
 }


### PR DESCRIPTION
## Summary
- Node 24 (the framework's minimum supported version) is required, and `@cedarjs/mailer-renderer-react-email` is only ever consumed via `import` from generated project API code, so there's no reason for it to stay CommonJS.
- Flips `"type"` to `"module"`, switches the build to `buildEsm()` + `generateTypesEsm()`, and updates `tsconfig.json`/adds `tsconfig.build.json` to match the pattern used by other ESM-only packages.
- No source changes were needed — the package had no `require`/`__dirname`/CJS-specific constructs.