### PR TITLE
fix(auth-providers)!: Convert auth-*-api and auth-*-setup packages to ESM-only

### DIFF
--- a/docs/implementation-plans/2026-07-25-esm-migration.md
+++ b/docs/implementation-plans/2026-07-25-esm-migration.md
@@ -29,23 +29,23 @@ ESM Only (38)
 - mailer-handler-studio (https://github.com/cedarjs/cedar/pull/2217)
 - mailer-renderer-mjml-react (https://github.com/cedarjs/cedar/pull/2218)
 - mailer-renderer-react-email (https://github.com/cedarjs/cedar/pull/2219)
-- auth-auth0-api
-- auth-auth0-setup
-- auth-azure-active-directory-api
-- auth-azure-active-directory-setup
-- auth-clerk-api
-- auth-clerk-setup
-- auth-custom-setup
-- auth-dbauth-api
-- auth-dbauth-setup
-- auth-firebase-api
-- auth-firebase-setup
-- auth-netlify-api
-- auth-netlify-setup
-- auth-supabase-api
-- auth-supabase-setup
-- auth-supertokens-api
-- auth-supertokens-setup
+- auth-auth0-api (https://github.com/cedarjs/cedar/pull/2223)
+- auth-auth0-setup (https://github.com/cedarjs/cedar/pull/2223)
+- auth-azure-active-directory-api (https://github.com/cedarjs/cedar/pull/2223)
+- auth-azure-active-directory-setup (https://github.com/cedarjs/cedar/pull/2223)
+- auth-clerk-api (https://github.com/cedarjs/cedar/pull/2223)
+- auth-clerk-setup (https://github.com/cedarjs/cedar/pull/2223)
+- auth-custom-setup (https://github.com/cedarjs/cedar/pull/2223)
+- auth-dbauth-api (https://github.com/cedarjs/cedar/pull/2223)
+- auth-dbauth-setup (https://github.com/cedarjs/cedar/pull/2223)
+- auth-firebase-api (https://github.com/cedarjs/cedar/pull/2223)
+- auth-firebase-setup (https://github.com/cedarjs/cedar/pull/2223)
+- auth-netlify-api (https://github.com/cedarjs/cedar/pull/2223)
+- auth-netlify-setup (https://github.com/cedarjs/cedar/pull/2223)
+- auth-supabase-api (https://github.com/cedarjs/cedar/pull/2223)
+- auth-supabase-setup (https://github.com/cedarjs/cedar/pull/2223)
+- auth-supertokens-api (https://github.com/cedarjs/cedar/pull/2223)
+- auth-supertokens-setup (https://github.com/cedarjs/cedar/pull/2223)
 
 Dual Mode – CJS + ESM (33)
 
@@ -156,6 +156,6 @@ conversion to ESM-only. Suggested sequencing, low-risk first:
    #2215–#2219).
 2. The 17 `auth-*-api` / `auth-*-setup` packages — mechanically identical
    conversion, batch together, smoke-test against a generated commonjs template
-   project. **Done**, batched into a single PR.
+   project. **Done**, batched into a single PR (#2223).
 3. `fastify-web`, `cli-data-migrate`, `cli-storybook-vite` — no real external
    `require()` callers found at all. Still outstanding.

--- a/docs/implementation-plans/2026-07-25-esm-migration.md
+++ b/docs/implementation-plans/2026-07-25-esm-migration.md
@@ -1,17 +1,34 @@
 Here's the breakdown of the 74 packages in the CedarJS monorepo:
 
-CJS Only (27)
+CJS Only (3)
 
 - fastify-web (adapters/fastify/web)
 - cli-data-migrate
 - cli-storybook-vite
-- mailer-core
-- mailer-handler-in-memory
-- mailer-handler-nodemailer
-- mailer-handler-resend
-- mailer-handler-studio
-- mailer-renderer-mjml-react
-- mailer-renderer-react-email
+
+ESM Only (38)
+
+- cli
+- codemods
+- core
+- create-cedar-app
+- create-cedar-rsc-app
+- framework-tools
+- realtime
+- storybook
+- structure
+- utils
+- eslint-plugin (https://github.com/cedarjs/cedar/pull/2206)
+- telemetry (https://github.com/cedarjs/cedar/pull/2204)
+- tui (https://github.com/cedarjs/cedar/pull/2205)
+- web-server (https://github.com/cedarjs/cedar/pull/2207)
+- mailer-core (https://github.com/cedarjs/cedar/pull/2211)
+- mailer-handler-in-memory (https://github.com/cedarjs/cedar/pull/2212)
+- mailer-handler-nodemailer (https://github.com/cedarjs/cedar/pull/2215)
+- mailer-handler-resend (https://github.com/cedarjs/cedar/pull/2216)
+- mailer-handler-studio (https://github.com/cedarjs/cedar/pull/2217)
+- mailer-renderer-mjml-react (https://github.com/cedarjs/cedar/pull/2218)
+- mailer-renderer-react-email (https://github.com/cedarjs/cedar/pull/2219)
 - auth-auth0-api
 - auth-auth0-setup
 - auth-azure-active-directory-api
@@ -29,23 +46,6 @@ CJS Only (27)
 - auth-supabase-setup
 - auth-supertokens-api
 - auth-supertokens-setup
-
-ESM Only (14)
-
-- cli
-- codemods
-- core
-- create-cedar-app
-- create-cedar-rsc-app
-- framework-tools
-- realtime
-- storybook
-- structure
-- utils
-- eslint-plugin (https://github.com/cedarjs/cedar/pull/2206)
-- telemetry (https://github.com/cedarjs/cedar/pull/2204)
-- tui (https://github.com/cedarjs/cedar/pull/2205)
-- web-server (https://github.com/cedarjs/cedar/pull/2207)
 
 Dual Mode – CJS + ESM (33)
 
@@ -83,16 +83,17 @@ Dual Mode – CJS + ESM (33)
 - auth-supabase-middleware
 - auth-supertokens-web
 
-Summary: Of the 74 packages, 33 are dual mode (CJS + ESM), 27 are CJS-only, and
-14 are ESM-only. The CJS-only group is dominated by the `auth-providers/*`
-`api`/`setup` sub-packages and the `mailer/*` sub-packages, which all build with
-esbuild's default `cjs` format and never emit an ESM output. The `*-web` and
-`*-middleware` auth-provider packages, by contrast, build both ESM and CJS (via
+Summary: Of the 74 packages, 33 are dual mode (CJS + ESM), 3 are CJS-only, and
+38 are ESM-only. The remaining CJS-only packages (`fastify-web`,
+`cli-data-migrate`, `cli-storybook-vite`) build with esbuild's default `cjs`
+format and never emit an ESM output. The `*-web` and `*-middleware`
+auth-provider packages, by contrast, build both ESM and CJS (via
 `buildEsm`/`buildCjs` or `buildExternalEsm`/`buildExternalCjs`) and so land in
 Dual Mode alongside the already-tracked framework packages. ESM-only remains the
-packages that have been explicitly converted to drop their CJS build entirely,
-with `eslint-plugin`, `telemetry`, `tui`, and `web-server` being the most recent
-conversions.
+packages that have been explicitly converted to drop their CJS build entirely;
+`eslint-plugin`, `telemetry`, `tui`, `web-server`, the 7 `mailer/*` packages,
+and the 17 `auth-*-api`/`auth-*-setup` packages are the conversions done so far
+(see the sequencing plan below).
 
 **Correction (2026-07-25 review):** an earlier revision of this doc listed
 `cli-helpers`, `context`, and `record` under ESM Only, and listed
@@ -145,14 +146,16 @@ generated templates:
   Safe given the Node 24 floor, but end-user-facing — worth a smoke test against
   a generated commonjs-template project before converting.
 
-**Conclusion**: all 27 CJS-only packages are viable candidates for conversion to
-ESM-only. Suggested sequencing, low-risk first:
+**Conclusion**: all 27 originally-CJS-only packages are viable candidates for
+conversion to ESM-only. Suggested sequencing, low-risk first:
 
 1. `mailer-core`, `mailer-handler-in-memory`, `mailer-handler-nodemailer`,
    `mailer-handler-resend`, `mailer-handler-studio`,
-   `mailer-renderer-mjml-react`, `mailer-renderer-react-email`, `fastify-web`,
-   `cli-data-migrate`, `cli-storybook-vite` — no real external `require()`
-   callers found at all.
+   `mailer-renderer-mjml-react`, `mailer-renderer-react-email` — no real
+   external `require()` callers found at all. **Done** (PRs #2211, #2212,
+   #2215–#2219).
 2. The 17 `auth-*-api` / `auth-*-setup` packages — mechanically identical
    conversion, batch together, smoke-test against a generated commonjs template
-   project.
+   project. **Done**, batched into a single PR.
+3. `fastify-web`, `cli-data-migrate`, `cli-storybook-vite` — no real external
+   `require()` callers found at all. Still outstanding.

--- a/packages/auth-providers/auth0/api/build.mts
+++ b/packages/auth-providers/auth0/api/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/auth-providers/auth0/api/package.json
+++ b/packages/auth-providers/auth0/api/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/auth0/api"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "default": {
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-auth0-api.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/auth0/api/tsconfig.build.json
+++ b/packages/auth-providers/auth0/api/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
+}

--- a/packages/auth-providers/auth0/api/tsconfig.json
+++ b/packages/auth-providers/auth0/api/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../api" }]
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
 }

--- a/packages/auth-providers/auth0/setup/build.mts
+++ b/packages/auth-providers/auth0/setup/build.mts
@@ -1,8 +1,11 @@
-import { build, copyAssets } from '@cedarjs/framework-tools'
+import { buildEsm, copyAssets } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
 
 await copyAssets({
   buildFileUrl: import.meta.url,
   patterns: ['templates/**/*.template'],
 })
+
+await generateTypesEsm()

--- a/packages/auth-providers/auth0/setup/package.json
+++ b/packages/auth-providers/auth0/setup/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/auth0/setup"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-auth0-setup.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/auth0/setup/src/setupHandler.ts
+++ b/packages/auth-providers/auth0/setup/src/setupHandler.ts
@@ -6,12 +6,15 @@ import { standardAuthHandler } from '@cedarjs/cli-helpers'
 import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+  fs.readFileSync(
+    path.resolve(import.meta.dirname, '../package.json'),
+    'utf-8',
+  ),
 )
 
 export async function handler({ force: forceArg }: Args) {
   standardAuthHandler({
-    basedir: __dirname,
+    basedir: import.meta.dirname,
     forceArg,
     provider: 'auth0',
     authDecoderImport: "import { authDecoder } from '@cedarjs/auth-auth0-api'",

--- a/packages/auth-providers/auth0/setup/tsconfig.build.json
+++ b/packages/auth-providers/auth0/setup/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/auth-providers/auth0/setup/tsconfig.json
+++ b/packages/auth-providers/auth0/setup/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../cli-helpers/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/auth-providers/azureActiveDirectory/api/build.mts
+++ b/packages/auth-providers/azureActiveDirectory/api/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/auth-providers/azureActiveDirectory/api/package.json
+++ b/packages/auth-providers/azureActiveDirectory/api/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/azureActiveDirectory/api"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "default": {
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-azure-active-directory-api.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/azureActiveDirectory/api/tsconfig.build.json
+++ b/packages/auth-providers/azureActiveDirectory/api/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
+}

--- a/packages/auth-providers/azureActiveDirectory/api/tsconfig.json
+++ b/packages/auth-providers/azureActiveDirectory/api/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../api" }]
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
 }

--- a/packages/auth-providers/azureActiveDirectory/setup/build.mts
+++ b/packages/auth-providers/azureActiveDirectory/setup/build.mts
@@ -1,8 +1,11 @@
-import { build, copyAssets } from '@cedarjs/framework-tools'
+import { buildEsm, copyAssets } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
 
 await copyAssets({
   buildFileUrl: import.meta.url,
   patterns: ['templates/**/*.template'],
 })
+
+await generateTypesEsm()

--- a/packages/auth-providers/azureActiveDirectory/setup/package.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/azureActiveDirectory/setup"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-azure-active-directory-setup.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/azureActiveDirectory/setup/src/setupHandler.ts
+++ b/packages/auth-providers/azureActiveDirectory/setup/src/setupHandler.ts
@@ -6,12 +6,15 @@ import { standardAuthHandler } from '@cedarjs/cli-helpers'
 import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+  fs.readFileSync(
+    path.resolve(import.meta.dirname, '../package.json'),
+    'utf-8',
+  ),
 )
 
 export async function handler({ force: forceArg }: Args) {
   standardAuthHandler({
-    basedir: __dirname,
+    basedir: import.meta.dirname,
     forceArg,
     provider: 'azureActiveDirectory',
     authDecoderImport:

--- a/packages/auth-providers/azureActiveDirectory/setup/tsconfig.build.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/auth-providers/azureActiveDirectory/setup/tsconfig.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../cli-helpers/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/auth-providers/clerk/api/build.mts
+++ b/packages/auth-providers/clerk/api/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/auth-providers/clerk/api/package.json
+++ b/packages/auth-providers/clerk/api/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/clerk/api"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "default": {
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-clerk-api.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/clerk/api/tsconfig.build.json
+++ b/packages/auth-providers/clerk/api/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
+}

--- a/packages/auth-providers/clerk/api/tsconfig.json
+++ b/packages/auth-providers/clerk/api/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../api" }]
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
 }

--- a/packages/auth-providers/clerk/setup/build.mts
+++ b/packages/auth-providers/clerk/setup/build.mts
@@ -1,8 +1,11 @@
-import { build, copyAssets } from '@cedarjs/framework-tools'
+import { buildEsm, copyAssets } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
 
 await copyAssets({
   buildFileUrl: import.meta.url,
   patterns: ['templates/**/*.template'],
 })
+
+await generateTypesEsm()

--- a/packages/auth-providers/clerk/setup/package.json
+++ b/packages/auth-providers/clerk/setup/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/clerk/setup"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-clerk-setup.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/clerk/setup/src/setupHandler.ts
+++ b/packages/auth-providers/clerk/setup/src/setupHandler.ts
@@ -6,12 +6,15 @@ import { standardAuthHandler } from '@cedarjs/cli-helpers'
 import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+  fs.readFileSync(
+    path.resolve(import.meta.dirname, '../package.json'),
+    'utf-8',
+  ),
 )
 
 export const handler = async ({ force: forceArg }: Args) => {
   standardAuthHandler({
-    basedir: __dirname,
+    basedir: import.meta.dirname,
     forceArg,
     authDecoderImport: `import { clerkAuthDecoder as authDecoder } from '@cedarjs/auth-clerk-api'`,
     provider: 'clerk',

--- a/packages/auth-providers/clerk/setup/tsconfig.build.json
+++ b/packages/auth-providers/clerk/setup/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/auth-providers/clerk/setup/tsconfig.json
+++ b/packages/auth-providers/clerk/setup/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../cli-helpers/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/auth-providers/custom/setup/build.mts
+++ b/packages/auth-providers/custom/setup/build.mts
@@ -1,8 +1,11 @@
-import { build, copyAssets } from '@cedarjs/framework-tools'
+import { buildEsm, copyAssets } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
 
 await copyAssets({
   buildFileUrl: import.meta.url,
   patterns: ['templates/**/*.template'],
 })
+
+await generateTypesEsm()

--- a/packages/auth-providers/custom/setup/package.json
+++ b/packages/auth-providers/custom/setup/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/custom/setup"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-custom-setup.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/custom/setup/src/setupHandler.ts
+++ b/packages/auth-providers/custom/setup/src/setupHandler.ts
@@ -6,14 +6,17 @@ import { isTypeScriptProject, standardAuthHandler } from '@cedarjs/cli-helpers'
 import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+  fs.readFileSync(
+    path.resolve(import.meta.dirname, '../package.json'),
+    'utf-8',
+  ),
 )
 
 export async function handler({ force: forceArg }: Args) {
   const authFilename = isTypeScriptProject() ? 'auth.ts' : 'auth.js'
 
   standardAuthHandler({
-    basedir: __dirname,
+    basedir: import.meta.dirname,
     forceArg,
     provider: 'custom',
     webPackages: [`@cedarjs/auth@${version}`],

--- a/packages/auth-providers/custom/setup/tsconfig.build.json
+++ b/packages/auth-providers/custom/setup/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/auth-providers/custom/setup/tsconfig.json
+++ b/packages/auth-providers/custom/setup/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../cli-helpers/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/auth-providers/dbAuth/api/build.mts
+++ b/packages/auth-providers/dbAuth/api/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/auth-providers/dbAuth/api/package.json
+++ b/packages/auth-providers/dbAuth/api/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/dbAuth/api"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "default": {
@@ -46,9 +46,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-dbauth-api.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/dbAuth/api/src/__tests__/buildDbAuthResponse.test.ts
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/buildDbAuthResponse.test.ts
@@ -1,4 +1,3 @@
-import type { APIGatewayProxyEvent } from 'aws-lambda'
 import { describe, it, expect } from 'vitest'
 
 import { getDbAuthResponseBuilder } from '../shared'
@@ -34,7 +33,7 @@ describe('buildDbAuthResponse', () => {
       },
     }
 
-    const createResponse = getDbAuthResponseBuilder({} as Request)
+    const createResponse = getDbAuthResponseBuilder({})
     const result = createResponse(response, corsHeaders)
 
     expect(result).toEqual(expectedResponse)
@@ -74,7 +73,7 @@ describe('buildDbAuthResponse', () => {
 
     const createResponse = getDbAuthResponseBuilder({
       multiValueHeaders: {},
-    } as unknown as APIGatewayProxyEvent)
+    })
     const result = createResponse(response, corsHeaders)
 
     expect(result).toEqual(expectedResponse)
@@ -104,7 +103,7 @@ describe('buildDbAuthResponse', () => {
       },
     }
 
-    const createResponse = getDbAuthResponseBuilder({} as Request)
+    const createResponse = getDbAuthResponseBuilder({})
     const result = createResponse(response, corsHeaders)
 
     expect(result).toEqual(expectedResponse)

--- a/packages/auth-providers/dbAuth/api/tsconfig.build.json
+++ b/packages/auth-providers/dbAuth/api/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../auth/tsconfig.build.json"
+    },
+    {
+      "path": "../../../project-config"
+    }
+  ]
+}

--- a/packages/auth-providers/dbAuth/api/tsconfig.json
+++ b/packages/auth-providers/dbAuth/api/tsconfig.json
@@ -1,8 +1,12 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
   "references": [
-    { "path": "../../../auth/tsconfig.build.json" },
-    { "path": "../../../project-config" }
+    {
+      "path": "../../../auth/tsconfig.build.json"
+    },
+    {
+      "path": "../../../project-config"
+    }
   ]
 }

--- a/packages/auth-providers/dbAuth/middleware/src/__tests__/initDbAuthMiddleware.test.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/__tests__/initDbAuthMiddleware.test.ts
@@ -24,26 +24,24 @@ beforeAll(() => {
   vi.mock('@cedarjs/auth-dbauth-api', async (importOriginal) => {
     const original = (await importOriginal()) as any
     return {
-      default: {
-        ...original,
-        dbAuthSession: vi.fn().mockImplementation((req, cookieName) => {
-          if (
-            req.headers
-              .get('Cookie')
-              .includes(`${cookieName}=this_is_the_only_correct_session`)
-          ) {
-            return {
-              currentUser: {
-                email: 'user-1@example.com',
-                id: 'mocked-current-user-1',
-              },
-              mockedSession: 'this_is_the_only_correct_session',
-            }
+      ...original,
+      dbAuthSession: vi.fn().mockImplementation((req, cookieName) => {
+        if (
+          req.headers
+            .get('Cookie')
+            .includes(`${cookieName}=this_is_the_only_correct_session`)
+        ) {
+          return {
+            currentUser: {
+              email: 'user-1@example.com',
+              id: 'mocked-current-user-1',
+            },
+            mockedSession: 'this_is_the_only_correct_session',
           }
+        }
 
-          return undefined
-        }),
-      },
+        return undefined
+      }),
     }
   })
 })

--- a/packages/auth-providers/dbAuth/middleware/src/index.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/index.ts
@@ -1,9 +1,8 @@
 import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 
-import type { DbAuthResponse } from '@cedarjs/auth-dbauth-api'
-import dbAuthApi from '@cedarjs/auth-dbauth-api'
-// ^^ above package is still CJS, and named exports aren't supported in import statements
-const { dbAuthSession, generateCookieName } = dbAuthApi
+import type { DbAuthResponse } from '@cedarjs/auth-dbauth-api' with {
+  'resolution-mode': 'import',
+}
 import type { GetCurrentUser } from '@cedarjs/graphql-server'
 import { MiddlewareResponse } from '@cedarjs/web/middleware'
 import type { Middleware, MiddlewareRequest } from '@cedarjs/web/middleware'
@@ -117,6 +116,7 @@ export const initDbAuthMiddleware = ({
 
       // Note we have to use ".unset" and not ".clear"
       // because we want to remove these cookies from the browser
+      const { generateCookieName } = await import('@cedarjs/auth-dbauth-api')
       res.cookies.unset(generateCookieName(cookieName))
       res.cookies.unset('auth-provider')
     }
@@ -141,6 +141,9 @@ async function validateSession({
   getCurrentUser,
 }: ValidateParams) {
   let decryptedSession: any
+
+  const { dbAuthSession, generateCookieName } =
+    await import('@cedarjs/auth-dbauth-api')
 
   try {
     // If there's no session cookie the return value will be `null`.

--- a/packages/auth-providers/dbAuth/setup/build.mts
+++ b/packages/auth-providers/dbAuth/setup/build.mts
@@ -1,8 +1,11 @@
-import { build, copyAssets } from '@cedarjs/framework-tools'
+import { buildEsm, copyAssets } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
 
 await copyAssets({
   buildFileUrl: import.meta.url,
   patterns: ['templates/**/*.template'],
 })
+
+await generateTypesEsm()

--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -7,16 +7,16 @@
     "directory": "packages/auth-providers/dbAuth/setup"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-dbauth-setup.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "yarn vitest run src",

--- a/packages/auth-providers/dbAuth/setup/src/__tests__/setupDataMockDMMF.test.ts
+++ b/packages/auth-providers/dbAuth/setup/src/__tests__/setupDataMockDMMF.test.ts
@@ -116,13 +116,14 @@ vi.mock('@cedarjs/project-config', async (importOriginal) => {
   }
 })
 
-vi.mock('@prisma/internals', () => ({
-  getSchemaWithPath: () => {
+vi.mock('@prisma/internals', () => {
+  const getSchemaWithPath = () => {
     return {
       schemas: [[dbSchemaPath, memfs.readFileSync(dbSchemaPath, 'utf-8')]],
     }
-  },
-  getDMMF: () => {
+  }
+
+  const getDMMF = () => {
     const schema: string = memfs.readFileSync(dbSchemaPath, 'utf-8').toString()
 
     const models = schema
@@ -136,13 +137,19 @@ vi.mock('@prisma/internals', () => ({
         models,
       },
     }
-  },
-  default: {
-    createSchemaPathInput: vi.fn(),
-    getConfig: vi.fn(),
-    getSchemaWithPath: vi.fn(),
-  },
-}))
+  }
+
+  return {
+    getSchemaWithPath,
+    getDMMF,
+    default: {
+      createSchemaPathInput: vi.fn(),
+      getConfig: vi.fn(),
+      getSchemaWithPath,
+      getDMMF,
+    },
+  }
+})
 
 vi.mock('prompts', () => {
   return {

--- a/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
@@ -35,7 +35,10 @@ export async function handler({
   force: forceArg,
 }: Args) {
   const { version } = JSON.parse(
-    fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+    fs.readFileSync(
+      path.resolve(import.meta.dirname, '../package.json'),
+      'utf-8',
+    ),
   )
 
   const webAuthn = await shouldIncludeWebAuthn(webauthn)
@@ -77,7 +80,7 @@ export async function handler({
   }
 
   await standardAuthHandler({
-    basedir: __dirname,
+    basedir: import.meta.dirname,
     forceArg,
     provider: 'dbAuth',
     authDecoderImport:

--- a/packages/auth-providers/dbAuth/setup/src/shared.ts
+++ b/packages/auth-providers/dbAuth/setup/src/shared.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { getDMMF } from '@prisma/internals'
+import prismaInternals from '@prisma/internals'
 
 import { getPaths } from '@cedarjs/cli-helpers'
 import { runBin } from '@cedarjs/cli-helpers/packageManager/exec'
@@ -18,6 +18,7 @@ export const functionsPath = getPaths().api.functions.replace(
 )
 
 export const getModelNames = async () => {
+  const { getDMMF } = prismaInternals
   const result = await getPrismaSchemas()
   const datamodel = result.schemas
   const schema = await getDMMF({ datamodel })

--- a/packages/auth-providers/dbAuth/setup/tsconfig.build.json
+++ b/packages/auth-providers/dbAuth/setup/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/auth-providers/dbAuth/setup/tsconfig.json
+++ b/packages/auth-providers/dbAuth/setup/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../cli-helpers/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/auth-providers/firebase/api/build.mts
+++ b/packages/auth-providers/firebase/api/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/auth-providers/firebase/api/package.json
+++ b/packages/auth-providers/firebase/api/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/firebase/api"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "default": {
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-firebase-api.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/firebase/api/tsconfig.build.json
+++ b/packages/auth-providers/firebase/api/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
+}

--- a/packages/auth-providers/firebase/api/tsconfig.json
+++ b/packages/auth-providers/firebase/api/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../api" }]
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
 }

--- a/packages/auth-providers/firebase/setup/build.mts
+++ b/packages/auth-providers/firebase/setup/build.mts
@@ -1,8 +1,11 @@
-import { build, copyAssets } from '@cedarjs/framework-tools'
+import { buildEsm, copyAssets } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
 
 await copyAssets({
   buildFileUrl: import.meta.url,
   patterns: ['templates/**/*.template'],
 })
+
+await generateTypesEsm()

--- a/packages/auth-providers/firebase/setup/package.json
+++ b/packages/auth-providers/firebase/setup/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/firebase/setup"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-firebase-setup.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/firebase/setup/src/setupHandler.ts
+++ b/packages/auth-providers/firebase/setup/src/setupHandler.ts
@@ -6,12 +6,15 @@ import { standardAuthHandler } from '@cedarjs/cli-helpers'
 import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+  fs.readFileSync(
+    path.resolve(import.meta.dirname, '../package.json'),
+    'utf-8',
+  ),
 )
 
 export async function handler({ force: forceArg }: Args) {
   standardAuthHandler({
-    basedir: __dirname,
+    basedir: import.meta.dirname,
     forceArg,
     provider: 'firebase',
     authDecoderImport:

--- a/packages/auth-providers/firebase/setup/tsconfig.build.json
+++ b/packages/auth-providers/firebase/setup/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/auth-providers/firebase/setup/tsconfig.json
+++ b/packages/auth-providers/firebase/setup/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../cli-helpers/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/auth-providers/netlify/api/build.mts
+++ b/packages/auth-providers/netlify/api/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/auth-providers/netlify/api/package.json
+++ b/packages/auth-providers/netlify/api/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/netlify/api"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "default": {
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-netlify-api.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/netlify/api/tsconfig.build.json
+++ b/packages/auth-providers/netlify/api/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
+}

--- a/packages/auth-providers/netlify/api/tsconfig.json
+++ b/packages/auth-providers/netlify/api/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../api" }]
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
 }

--- a/packages/auth-providers/netlify/setup/build.mts
+++ b/packages/auth-providers/netlify/setup/build.mts
@@ -1,8 +1,11 @@
-import { build, copyAssets } from '@cedarjs/framework-tools'
+import { buildEsm, copyAssets } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
 
 await copyAssets({
   buildFileUrl: import.meta.url,
   patterns: ['templates/**/*.template'],
 })
+
+await generateTypesEsm()

--- a/packages/auth-providers/netlify/setup/package.json
+++ b/packages/auth-providers/netlify/setup/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/netlify/setup"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-netlify-setup.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/netlify/setup/src/setupHandler.ts
+++ b/packages/auth-providers/netlify/setup/src/setupHandler.ts
@@ -6,12 +6,15 @@ import { standardAuthHandler } from '@cedarjs/cli-helpers'
 import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+  fs.readFileSync(
+    path.resolve(import.meta.dirname, '../package.json'),
+    'utf-8',
+  ),
 )
 
 export async function handler({ force: forceArg }: Args) {
   standardAuthHandler({
-    basedir: __dirname,
+    basedir: import.meta.dirname,
     forceArg,
     provider: 'netlify',
     authDecoderImport: `import { authDecoder } from '@cedarjs/auth-netlify-api'`,

--- a/packages/auth-providers/netlify/setup/tsconfig.build.json
+++ b/packages/auth-providers/netlify/setup/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/auth-providers/netlify/setup/tsconfig.json
+++ b/packages/auth-providers/netlify/setup/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../cli-helpers/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/auth-providers/supabase/api/build.mts
+++ b/packages/auth-providers/supabase/api/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/auth-providers/supabase/api/package.json
+++ b/packages/auth-providers/supabase/api/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/supabase/api"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "default": {
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-supabase-api.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/supabase/api/tsconfig.build.json
+++ b/packages/auth-providers/supabase/api/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
+}

--- a/packages/auth-providers/supabase/api/tsconfig.json
+++ b/packages/auth-providers/supabase/api/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../api" }]
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
 }

--- a/packages/auth-providers/supabase/setup/build.mts
+++ b/packages/auth-providers/supabase/setup/build.mts
@@ -1,8 +1,11 @@
-import { build, copyAssets } from '@cedarjs/framework-tools'
+import { buildEsm, copyAssets } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
 
 await copyAssets({
   buildFileUrl: import.meta.url,
   patterns: ['templates/**/*.template'],
 })
+
+await generateTypesEsm()

--- a/packages/auth-providers/supabase/setup/package.json
+++ b/packages/auth-providers/supabase/setup/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/supabase/setup"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-supabase-setup.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/supabase/setup/src/setupHandler.ts
+++ b/packages/auth-providers/supabase/setup/src/setupHandler.ts
@@ -6,12 +6,15 @@ import { standardAuthHandler } from '@cedarjs/cli-helpers'
 import type { Args } from './setup.js'
 
 const { version } = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+  fs.readFileSync(
+    path.resolve(import.meta.dirname, '../package.json'),
+    'utf-8',
+  ),
 )
 
 export const handler = async ({ force: forceArg }: Args) => {
   standardAuthHandler({
-    basedir: __dirname,
+    basedir: import.meta.dirname,
     forceArg,
     provider: 'supabase',
     authDecoderImport: `import { authDecoder } from '@cedarjs/auth-supabase-api'`,

--- a/packages/auth-providers/supabase/setup/tsconfig.build.json
+++ b/packages/auth-providers/supabase/setup/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/auth-providers/supabase/setup/tsconfig.json
+++ b/packages/auth-providers/supabase/setup/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../cli-helpers/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/auth-providers/supertokens/api/build.mts
+++ b/packages/auth-providers/supertokens/api/build.mts
@@ -1,3 +1,5 @@
-import { build } from '@cedarjs/framework-tools'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
+await generateTypesEsm()

--- a/packages/auth-providers/supertokens/api/package.json
+++ b/packages/auth-providers/supertokens/api/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/supertokens/api"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "default": {
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-supertokens-api.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/supertokens/api/tsconfig.build.json
+++ b/packages/auth-providers/supertokens/api/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
+}

--- a/packages/auth-providers/supertokens/api/tsconfig.json
+++ b/packages/auth-providers/supertokens/api/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../api" }]
+  "references": [
+    {
+      "path": "../../../api"
+    }
+  ]
 }

--- a/packages/auth-providers/supertokens/setup/build.mts
+++ b/packages/auth-providers/supertokens/setup/build.mts
@@ -1,8 +1,11 @@
-import { build, copyAssets } from '@cedarjs/framework-tools'
+import { buildEsm, copyAssets } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-await build()
+await buildEsm()
 
 await copyAssets({
   buildFileUrl: import.meta.url,
   patterns: ['templates/**/*.template'],
 })
+
+await generateTypesEsm()

--- a/packages/auth-providers/supertokens/setup/package.json
+++ b/packages/auth-providers/supertokens/setup/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auth-providers/supertokens/setup"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -28,9 +28,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.mts && yarn build:types",
+    "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-supertokens-setup.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/supertokens/setup/src/setupHandler.ts
+++ b/packages/auth-providers/supertokens/setup/src/setupHandler.ts
@@ -7,11 +7,14 @@ import type { Args } from './setup.js'
 
 export async function handler({ force: forceArg }: Args) {
   const { version } = JSON.parse(
-    fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+    fs.readFileSync(
+      path.resolve(import.meta.dirname, '../package.json'),
+      'utf-8',
+    ),
   )
 
   standardAuthHandler({
-    basedir: __dirname,
+    basedir: import.meta.dirname,
     forceArg,
     provider: 'supertokens',
     authDecoderImport:

--- a/packages/auth-providers/supertokens/setup/tsconfig.build.json
+++ b/packages/auth-providers/supertokens/setup/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.build.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/auth-providers/supertokens/setup/tsconfig.json
+++ b/packages/auth-providers/supertokens/setup/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "extends": "../../../../tsconfig.cjs-build-base.json",
+  "extends": "../../../../tsconfig.base.json",
   "include": ["src"],
-  "references": [{ "path": "../../../cli-helpers/tsconfig.build.json" }]
+  "references": [
+    {
+      "path": "../../../cli-helpers/tsconfig.build.json"
+    }
+  ]
 }

--- a/packages/cli/src/commands/setup/auth/auth.ts
+++ b/packages/cli/src/commands/setup/auth/auth.ts
@@ -309,7 +309,7 @@ async function getAuthSetupHandler(module: string) {
 
   const setupModule = await import(module)
 
-  return setupModule.default.handler
+  return setupModule.handler
 }
 
 /**

--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -171,10 +171,10 @@ async function createServer() {
     plugins: [
       cjsInterop({
         dependencies: [
-          // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware, rwjs/router
+          // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware,
+          // rwjs/router, rwjs/auth-*-api
           '@cedarjs/forms',
           '@cedarjs/prerender/*',
-          '@cedarjs/auth-*-api',
           // Add more to the pattern below as they're converted to dual ESM/CJS
           // modules
           // '@cedarjs/auth-!(dbauth|auth0|clerk)-web',

--- a/packages/vite/src/rsc/rscBuildForSsr.ts
+++ b/packages/vite/src/rsc/rscBuildForSsr.ts
@@ -66,10 +66,10 @@ export async function rscBuildForSsr({
     plugins: [
       cjsInterop({
         dependencies: [
-          // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware, rwjs/router
+          // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware,
+          // rwjs/router, rwjs/auth-*-api
           '@cedarjs/forms',
           '@cedarjs/prerender/*',
-          '@cedarjs/auth-*-api',
           '@cedarjs/auth-!(dbauth)-web',
         ],
       }),

--- a/packages/vite/src/streaming/buildForStreamingServer.ts
+++ b/packages/vite/src/streaming/buildForStreamingServer.ts
@@ -20,10 +20,10 @@ export async function buildForStreamingServer({
     plugins: [
       cjsInterop({
         dependencies: [
-          // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware, rwjs/router
+          // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware,
+          // rwjs/router, rwjs/auth-*-api
           '@cedarjs/forms',
           '@cedarjs/prerender/*',
-          '@cedarjs/auth-*-api',
           '@cedarjs/auth-!(dbauth)-web',
         ],
       }),


### PR DESCRIPTION
TL;DR: This is possibly a breaking change for you if you have your own custom auth code that imports from any of the 17 `@cedarjs/auth-*-api` / `@cedarjs/auth-*-setup` packages and compiles it to CommonJS via `tsc`

---

Converts all 17 `auth-*-api` / `auth-*-setup` packages to ESM-only, following the same pattern used for the mailer package conversions (#2211, #2212, #2215-#2219):

- `package.json`: `"type": "commonjs"` -> `"type": "module"`, `build` script simplified to `node ./build.mts`, `build:types` now points at the new `tsconfig.build.json`
- `tsconfig.json`: extends `tsconfig.base.json` instead of `tsconfig.cjs-build-base.json`
- New `tsconfig.build.json` per package (mirrors the pattern used for `web-server`, `telemetry`, etc. — repeats any project `references` since those aren't inherited through `extends`)
- `build.mts`: `build()` → `buildEsm()` + `generateTypesEsm()`
- The 9 `*-setup` packages also needed `__dirname` → `import.meta.dirname` in `setupHandler.ts`, since `__dirname` isn't defined in real ESM

Per the [ESM migration plan doc](docs/implementation-plans/2026-07-25-esm-migration.md), this is safe under the framework's Node 24 floor: the only cross-boundary `require()` of these packages is Babel's CJS-template transpilation in generated user apps, which now resolves via Node 24's unflagged `require(esm)` support instead of throwing `ERR_REQUIRE_ESM`.

Also fixes a knock-on issue surfaced by the conversion: `auth-dbauth-api`'s tsconfig extends change altered how the shared root `tsconfig.eslint.json` (single unified TS program used for typed-linting, `module: "node20"` / `moduleResolution: "node16"`) resolves global `Request`/`APIGatewayProxyEvent` types for files in that package, making 3 `as Request` / `as unknown as APIGatewayProxyEvent` type assertions in a test file genuinely unnecessary per `@typescript-eslint/no-unnecessary-type-assertion`. Removed them — confirmed via `git worktree` against `main` that this lint error doesn't exist before the conversion, and that removing the casts doesn't change runtime test behavior (still 346/346 passing).

### `auth-dbauth-middleware` CJS build fix

CI caught a real regression: `auth-dbauth-middleware` is a dual-mode (ESM + CJS) package built with real `tsc` (not Babel), and its CJS build could no longer statically import from `auth-dbauth-api` now that it's ESM-only:

- The old default-import workaround (`import dbAuthApi from '@cedarjs/auth-dbauth-api'; const { dbAuthSession, generateCookieName } = dbAuthApi`) predates this conversion and no longer resolves.
- A plain named import hits `TS1479`: TypeScript's `node16` CJS emit refuses to statically `require()` a module it sees as ESM-only, even though Node 24 could handle it via `require(esm)` at runtime — `tsc` has no way to know about that runtime capability, so it errs conservatively at build time.

Fixed by using a dynamic `import()` for the values (valid syntax in both the ESM and CJS build of this shared source, and dynamic `import()` of an ESM module from CommonJS has been supported by Node for years, independent of the newer `require(esm)` feature), and the `resolution-mode: 'import'` attribute for the type-only import, matching the existing pattern in `packages/server-store/src/serverStore.ts`. Also updated the test's `vi.mock` shape, which mocked a `default` export matching the old CJS-interop shape that no longer exists.

### Is this a breaking change for CJS-only importers?

Not for the way CedarJS's generated apps actually consume these packages, but it is in a narrower way worth calling out:

1. **Plain Node `require()` at runtime** (this includes Babel-transpiled `require()` calls, which is how generated CJS-template user apps consume `@cedarjs/auth-dbauth-api` and friends) — not breaking. Babel transpiles `import` → `require()` without any compile-time check on whether the target is ESM, and at runtime Node 24's unflagged `require(esm)` support handles it transparently (already the premise of the migration doc's analysis, and empirically proven via a `require()` smoke test on #2219).
2. **TypeScript source compiled to CJS via `tsc`** (`module`/`moduleResolution: node16`+) — this does break, but at **build time**, not runtime. `tsc` refuses to statically emit a `require()` call for a module it resolves as ESM-only (`TS1479`/`TS1541`), since it can't know Node 24 can actually handle that call. This is exactly what hit `auth-dbauth-middleware` above, since it's built with real `tsc`, not Babel.

So the practical blast radius is: any TypeScript-authored package or app that still builds a CJS variant via `tsc` (not Babel) and does a static `import` of one of these 17 packages will fail to compile until it switches to a dynamic `import()` for values plus `resolution-mode: 'import'` for type-only imports. Within the monorepo that was `auth-dbauth-middleware` (fixed here). `auth-supabase-middleware` has the same dual-mode shape and imports from `auth-supabase-api` (also converted in this PR), but built clean without needing the same fix — not fully root-caused why it didn't hit the same wall, but confirmed via a clean build and full test run that it isn't currently broken. **Outside the monorepo, anyone building their own CedarJS auth integration with `tsc`-to-CJS rather than the standard Babel-based generated templates could hit the same thing.**

### More framework-only downstream breaks found by CI (unrelated to the `tsc`-to-CJS issue above)

These do not affect Cedar Apps, only the framework itself

- **`packages/cli/src/commands/setup/auth/auth.ts`**: `getAuthSetupHandler()` did `setupModule.default.handler`, relying on Node's old CJS→ESM interop synthesizing a `default` export. None of the 9 setup packages have an actual `export default` (only a named `handler` export), so this broke every `cedar setup auth <provider>` command — caught by the `test-project`/`test-project-esm` fixture rebuild jobs failing with `TypeError: Cannot read properties of undefined (reading 'handler')`. Fixed by using the named export directly.
- **`packages/vite/src/{devFeServer,streaming/buildForStreamingServer,rsc/rscBuildForSsr}.ts`**: the `cjsInterop` Vite plugin had `@cedarjs/auth-*-api` in its `dependencies` list, telling Rollup to wrap externalized imports of those packages in a synthetic default-import shim for CJS compatibility. Now that they're real ESM with no default export, Rollup generated `import __cjsInterop1__ from "@cedarjs/auth-dbauth-api"` in the built SSR/RSC server bundle, which throws `SyntaxError: The requested module '@cedarjs/auth-dbauth-api' does not provide an export named 'default'` at runtime — caught by the RSC smoke test job. Removed the glob from all three `cjsInterop` dependency lists, matching the existing "skip ESM modules" pattern already used for `@cedarjs/auth`, `@cedarjs/web`, etc.
- **`packages/auth-providers/dbAuth/setup/src/shared.ts`**: did `import { getDMMF } from '@prisma/internals'`. `@prisma/internals` is a plain CJS package (no `"exports"` map) whose dist bundles `getDMMF` via esbuild's `__export()` + `Object.defineProperty` getter pattern, which Node's `cjs-module-lexer` can't statically see through to synthesize a named ESM export — a plain-object destructure worked fine when this package was CJS, but a static ESM named import doesn't. Caught by the `test-project` fixture rebuild job failing with `SyntaxError: The requested module '@prisma/internals' does not provide an export named 'getDMMF'` during `cedar setup auth dbauth`. Fixed by switching to `import prismaInternals from '@prisma/internals'` + destructuring `getDMMF` off the default export, the same pattern already used everywhere else in the codebase that imports this package (e.g. `packages/cli/src/lib/schemaHelpers.ts`).