### PR TITLE
chore(jobs): use `import ... with { ...`

### DIFF
--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -2,7 +2,7 @@
 // debug messages. CedarJS's Jobs will fallback to use `console` if no logger is
 // passed in to CedarJS or any adapter.
 
-import type { IntRange } from 'type-fest' assert { 'resolution-mode': 'import' }
+import type { IntRange } from 'type-fest' with { 'resolution-mode': 'import' }
 
 import type { BaseAdapter } from './adapters/BaseAdapter/BaseAdapter.js'
 


### PR DESCRIPTION
Fixes this build-time warning

```
❯ cd packages/jobs
❯ yarn build
▲ [WARNING] The "assert" keyword is not supported in the configured target environment ("node24") [assert-to-with]

    src/types.ts:5:42:
      5 │ import type { IntRange } from 'type-fest' assert { 'resolution-mode': 'import' }
        │                                           ~~~~~~
        ╵                                           with

  Did you mean to use "with" instead of "assert"?

1 warning

  dist/bins/cedar-jobs.js                       8.3kb
  dist/adapters/PrismaAdapter/PrismaAdapter.js  6.4kb
  dist/errors.js                                5.0kb
  dist/bins/cedar-jobs-worker.js                4.6kb
  dist/core/Worker.js                           4.6kb
  dist/core/Executor.js                         3.5kb
  dist/consts.js                                3.2kb
  dist/loaders.js                               2.8kb
  dist/core/Scheduler.js                        2.7kb
  dist/core/JobManager.js                       2.7kb
```