### PR TITLE
fix(auth-providers): Convert auth-*-web and auth-*-middleware packages to ESM-only

### DIFF
--- a/docs/implementation-plans/2026-07-25-esm-migration.md
+++ b/docs/implementation-plans/2026-07-25-esm-migration.md
@@ -5,7 +5,7 @@ CJS Only (0)
 - None — all 27 originally-CJS-only packages have now been converted to
   ESM-only (see below).
 
-ESM Only (41)
+ESM Only (51)
 
 - cli
 - codemods
@@ -48,8 +48,18 @@ ESM Only (41)
 - fastify-web (adapters/fastify/web) (https://github.com/cedarjs/cedar/pull/2227)
 - cli-data-migrate (https://github.com/cedarjs/cedar/pull/2227)
 - cli-storybook-vite (https://github.com/cedarjs/cedar/pull/2227)
+- auth-auth0-web
+- auth-azure-active-directory-web
+- auth-clerk-web
+- auth-dbauth-web
+- auth-dbauth-middleware
+- auth-firebase-web
+- auth-netlify-web
+- auth-supabase-web
+- auth-supabase-middleware
+- auth-supertokens-web
 
-Dual Mode – CJS + ESM (33)
+Dual Mode – CJS + ESM (23)
 
 - api
 - api-server
@@ -74,28 +84,19 @@ Dual Mode – CJS + ESM (33)
 - testing
 - vite
 - web
-- auth-auth0-web
-- auth-azure-active-directory-web
-- auth-clerk-web
-- auth-dbauth-web
-- auth-dbauth-middleware
-- auth-firebase-web
-- auth-netlify-web
-- auth-supabase-web
-- auth-supabase-middleware
-- auth-supertokens-web
 
-Summary: Of the 74 packages, 33 are dual mode (CJS + ESM), 0 are CJS-only, and
-41 are ESM-only. Every package that was CJS-only as of the original inventory
-below has now been converted to ESM-only. The `*-web` and `*-middleware`
-auth-provider packages, by contrast, build both ESM and CJS (via
-`buildEsm`/`buildCjs` or `buildExternalEsm`/`buildExternalCjs`) and so land in
-Dual Mode alongside the already-tracked framework packages. ESM-only remains
-the packages that have been explicitly converted to drop their CJS build
-entirely; `eslint-plugin`, `telemetry`, `tui`, `web-server`, the 7 `mailer/*`
-packages, the 17 `auth-*-api`/`auth-*-setup` packages, and
-`fastify-web`/`cli-data-migrate`/`cli-storybook-vite` are the conversions done
-so far (see the sequencing plan below).
+Summary: Of the 74 packages, 23 are dual mode (CJS + ESM), 0 are CJS-only, and
+51 are ESM-only. Every package that was CJS-only as of the original inventory
+below has now been converted to ESM-only, and the 10 `auth-*-web` /
+`auth-*-middleware` packages that used to be Dual Mode have also been
+converted to ESM-only (see "Dual Mode -> ESM Only" below) — they were dual
+mode from a mechanical Babel-to-esbuild tooling migration, not because
+anything actually needed a CJS build of them. ESM-only remains the packages
+that have been explicitly converted to drop their CJS build entirely;
+`eslint-plugin`, `telemetry`, `tui`, `web-server`, the 7 `mailer/*` packages,
+the 17 `auth-*-api`/`auth-*-setup` packages,
+`fastify-web`/`cli-data-migrate`/`cli-storybook-vite`, and the 10
+`auth-*-web`/`auth-*-middleware` packages are the conversions done so far.
 
 **Correction (2026-07-25 review):** an earlier revision of this doc listed
 `cli-helpers`, `context`, and `record` under ESM Only, and listed
@@ -163,3 +164,44 @@ conversion to ESM-only. Suggested sequencing, low-risk first:
    project. **Done**, batched into a single PR (#2223).
 3. `fastify-web`, `cli-data-migrate`, `cli-storybook-vite` — no real external
    `require()` callers found at all. **Done** (#2227).
+
+## Dual Mode -> ESM Only: the auth-provider `-web`/`-middleware` packages
+
+With the CJS-only inventory fully converted, the next question was whether
+the remaining Dual Mode packages could also drop their CJS build. Framework
+packages like `cli-helpers`, `context`, `record`, `api`, `api-server`, etc.
+have real reasons to stay dual mode (they're consumed in contexts that
+genuinely need both formats). The 10 `auth-*-web` / `auth-*-middleware`
+packages turned out not to:
+
+- **`auth-*-web`** (8 packages): only ever consumed by generated project
+  templates (`web/src/auth.ts.template`) via a plain `import`, which Vite/
+  Rollup statically bundles into the client and SSR/streaming bundles.
+  Nothing `require()`s them — the `auth-*-setup` packages only ever reference
+  them by name in a `webPackages` string array passed to the installer, never
+  actually import them. Their `package.json` `exports` maps only ever exposed
+  an `import` condition plus a CJS `default` fallback — no external consumer
+  was ever expected to hit the CJS build.
+- **`auth-dbauth-middleware`, `auth-supabase-middleware`**: loaded server-side
+  via `viteDevServer.ssrLoadModule` in dev and dynamic `import()` of the built
+  `.mjs` entry in prod (`packages/vite/src/middleware/register.ts`), and
+  statically bundled by Rollup for the SSR/streaming builds same as the `-web`
+  packages. The CJS build's only real trigger was a _build-time_ TypeScript
+  constraint (`tsc`'s node16 CJS emit refusing to statically compile a
+  `require()` of an already-ESM-only dependency, the same `TS1479` class of
+  issue hit when `auth-dbauth-api` went ESM-only in #2223) — not a runtime
+  consumer.
+- Git history confirms the CJS build was mechanical, not driven by a
+  discovered caller: these packages picked up a dual ESM+CJS build as part of
+  a repo-wide Babel-to-esbuild tooling migration, and the
+  `vite-plugin-cjs-interop` config's `'@cedarjs/auth-!(dbauth)-web'` glob is
+  itself evidence of the pattern — narrowed once already (dropping `dbauth-web`
+  when it got a real ESM build with proper named exports), and now dropped
+  entirely as all of them have gone ESM-only.
+
+All 10 packages converted cleanly: `package.json` `exports` maps collapsed
+from `{import: ..., default/require: <cjs>}` to a single `default` condition,
+`build.ts`/`build.mts` dropped their `buildCjs()`/`buildExternalCjs()` +
+`generateTypesCjs()` + `insertCommonJsPackageJson()` calls, `tsconfig.cjs.json`
+files removed, and the stale `cjsInterop` glob entries removed from
+`packages/vite/src/{devFeServer,streaming/buildForStreamingServer,rsc/rscBuildForSsr}.ts`.

--- a/docs/implementation-plans/2026-07-25-esm-migration.md
+++ b/docs/implementation-plans/2026-07-25-esm-migration.md
@@ -48,16 +48,16 @@ ESM Only (51)
 - fastify-web (adapters/fastify/web) (https://github.com/cedarjs/cedar/pull/2227)
 - cli-data-migrate (https://github.com/cedarjs/cedar/pull/2227)
 - cli-storybook-vite (https://github.com/cedarjs/cedar/pull/2227)
-- auth-auth0-web
-- auth-azure-active-directory-web
-- auth-clerk-web
-- auth-dbauth-web
-- auth-dbauth-middleware
-- auth-firebase-web
-- auth-netlify-web
-- auth-supabase-web
-- auth-supabase-middleware
-- auth-supertokens-web
+- auth-auth0-web (https://github.com/cedarjs/cedar/pull/2234)
+- auth-azure-active-directory-web (https://github.com/cedarjs/cedar/pull/2234)
+- auth-clerk-web (https://github.com/cedarjs/cedar/pull/2234)
+- auth-dbauth-web (https://github.com/cedarjs/cedar/pull/2234)
+- auth-dbauth-middleware (https://github.com/cedarjs/cedar/pull/2234)
+- auth-firebase-web (https://github.com/cedarjs/cedar/pull/2234)
+- auth-netlify-web (https://github.com/cedarjs/cedar/pull/2234)
+- auth-supabase-web (https://github.com/cedarjs/cedar/pull/2234)
+- auth-supabase-middleware (https://github.com/cedarjs/cedar/pull/2234)
+- auth-supertokens-web (https://github.com/cedarjs/cedar/pull/2234)
 
 Dual Mode – CJS + ESM (23)
 

--- a/packages/auth-providers/auth0/web/build.ts
+++ b/packages/auth-providers/auth0/web/build.ts
@@ -1,17 +1,5 @@
-import { buildCjs, buildEsm } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-// ESM build and type generation
 await buildEsm()
 await generateTypesEsm()
-
-// CJS build, type generation, and package.json insert
-await buildCjs()
-await generateTypesCjs()
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-})

--- a/packages/auth-providers/auth0/web/package.json
+++ b/packages/auth-providers/auth0/web/package.json
@@ -10,28 +10,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "default": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     },
     "./dist/auth0": {
-      "import": {
+      "default": {
         "types": "./dist/auth0.d.ts",
         "default": "./dist/auth0.js"
-      },
-      "default": {
-        "types": "./dist/cjs/auth0.d.ts",
-        "default": "./dist/cjs/auth0.js"
       }
     }
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -40,7 +31,6 @@
     "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-auth0-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/auth0/web/tsconfig.cjs.json
+++ b/packages/auth-providers/auth0/web/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/auth-providers/azureActiveDirectory/web/build.mts
+++ b/packages/auth-providers/azureActiveDirectory/web/build.mts
@@ -1,17 +1,5 @@
-import { buildCjs, buildEsm } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-// ESM build and type generation
 await buildEsm()
 await generateTypesEsm()
-
-// CJS build, type generation, and package.json insert
-await buildCjs()
-await generateTypesCjs()
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-})

--- a/packages/auth-providers/azureActiveDirectory/web/package.json
+++ b/packages/auth-providers/azureActiveDirectory/web/package.json
@@ -10,28 +10,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "default": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     },
     "./dist/azureActiveDirectory": {
-      "import": {
+      "default": {
         "types": "./dist/azureActiveDirectory.d.ts",
         "default": "./dist/azureActiveDirectory.js"
-      },
-      "default": {
-        "types": "./dist/cjs/azureActiveDirectory.d.ts",
-        "default": "./dist/cjs/azureActiveDirectory.js"
       }
     }
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -40,7 +31,6 @@
     "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-azure-active-directory-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/azureActiveDirectory/web/tsconfig.cjs.json
+++ b/packages/auth-providers/azureActiveDirectory/web/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/auth-providers/clerk/web/build.ts
+++ b/packages/auth-providers/clerk/web/build.ts
@@ -1,17 +1,5 @@
-import { buildCjs, buildEsm } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-// ESM build and type generation
 await buildEsm()
 await generateTypesEsm()
-
-// CJS build, type generation, and package.json insert
-await buildCjs()
-await generateTypesCjs()
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-})

--- a/packages/auth-providers/clerk/web/package.json
+++ b/packages/auth-providers/clerk/web/package.json
@@ -10,28 +10,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "default": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     },
     "./dist/clerk": {
-      "import": {
+      "default": {
         "types": "./dist/clerk.d.ts",
         "default": "./dist/clerk.js"
-      },
-      "default": {
-        "types": "./dist/cjs/clerk.d.ts",
-        "default": "./dist/cjs/clerk.js"
       }
     }
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -40,7 +31,6 @@
     "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-clerk-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/clerk/web/tsconfig.cjs.json
+++ b/packages/auth-providers/clerk/web/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/auth-providers/dbAuth/middleware/build.mts
+++ b/packages/auth-providers/dbAuth/middleware/build.mts
@@ -1,14 +1,5 @@
-import { buildExternalCjs, buildExternalEsm } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildExternalEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
 await buildExternalEsm()
 await generateTypesEsm()
-
-await buildExternalCjs()
-await generateTypesCjs()
-
-await insertCommonJsPackageJson({ buildFileUrl: import.meta.url })

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -10,13 +10,9 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     }
   },
@@ -29,7 +25,6 @@
     "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-dbauth-middleware.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose tsconfig.cjs.json",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",
     "prepublishOnly": "NODE_ENV=production yarn build",

--- a/packages/auth-providers/dbAuth/middleware/tsconfig.cjs.json
+++ b/packages/auth-providers/dbAuth/middleware/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/auth-providers/dbAuth/web/build.ts
+++ b/packages/auth-providers/dbAuth/web/build.ts
@@ -1,17 +1,5 @@
-import { buildExternalEsm, buildExternalCjs } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildExternalEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-// ESM build and type generation
 await buildExternalEsm()
 await generateTypesEsm()
-
-// CJS build, type generation, and package.json insert
-await buildExternalCjs()
-await generateTypesCjs()
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-})

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -14,13 +14,18 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./webAuthn": {
+      "default": {
+        "types": "./dist/webAuthn.d.ts",
+        "default": "./dist/webAuthn.js"
+      }
     }
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist",
-    "webAuthn"
+    "dist"
   ],
   "scripts": {
     "build": "node ./build.ts",

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -10,18 +10,13 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "default": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     }
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
@@ -31,7 +26,6 @@
     "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-dbauth-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/dbAuth/web/tsconfig.cjs.json
+++ b/packages/auth-providers/dbAuth/web/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/auth-providers/dbAuth/web/webAuthn/index.js
+++ b/packages/auth-providers/dbAuth/web/webAuthn/index.js
@@ -1,2 +1,0 @@
-// For CommonJS environments, point to the CJS build
-module.exports = require('../dist/cjs/webAuthn')

--- a/packages/auth-providers/dbAuth/web/webAuthn/package.json
+++ b/packages/auth-providers/dbAuth/web/webAuthn/package.json
@@ -1,4 +1,0 @@
-{
-  "main": "./index.js",
-  "types": "../dist/cjs/webAuthn.d.ts"
-}

--- a/packages/auth-providers/firebase/web/build.ts
+++ b/packages/auth-providers/firebase/web/build.ts
@@ -1,17 +1,5 @@
-import { buildCjs, buildEsm } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-// ESM build and type generation
 await buildEsm()
 await generateTypesEsm()
-
-// CJS build, type generation, and package.json insert
-await buildCjs()
-await generateTypesCjs()
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-})

--- a/packages/auth-providers/firebase/web/package.json
+++ b/packages/auth-providers/firebase/web/package.json
@@ -10,28 +10,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "default": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     },
     "./dist/firebase": {
-      "import": {
+      "default": {
         "types": "./dist/firebase.d.ts",
         "default": "./dist/firebase.js"
-      },
-      "default": {
-        "types": "./dist/cjs/firebase.d.ts",
-        "default": "./dist/cjs/firebase.js"
       }
     }
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -40,7 +31,6 @@
     "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-firebase-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/firebase/web/tsconfig.cjs.json
+++ b/packages/auth-providers/firebase/web/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/auth-providers/netlify/web/build.ts
+++ b/packages/auth-providers/netlify/web/build.ts
@@ -1,17 +1,5 @@
-import { buildCjs, buildEsm } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-// ESM build and type generation
 await buildEsm()
 await generateTypesEsm()
-
-// CJS build, type generation, and package.json insert
-await buildCjs()
-await generateTypesCjs()
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-})

--- a/packages/auth-providers/netlify/web/package.json
+++ b/packages/auth-providers/netlify/web/package.json
@@ -10,28 +10,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "default": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     },
     "./dist/netlify": {
-      "import": {
+      "default": {
         "types": "./dist/netlify.d.ts",
         "default": "./dist/netlify.js"
-      },
-      "default": {
-        "types": "./dist/cjs/netlify.d.ts",
-        "default": "./dist/cjs/netlify.js"
       }
     }
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -40,7 +31,6 @@
     "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-netlify-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/netlify/web/tsconfig.cjs.json
+++ b/packages/auth-providers/netlify/web/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/auth-providers/supabase/middleware/build.mts
+++ b/packages/auth-providers/supabase/middleware/build.mts
@@ -1,14 +1,5 @@
-import { buildExternalCjs, buildExternalEsm } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildExternalEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
 await buildExternalEsm()
 await generateTypesEsm()
-
-await buildExternalCjs()
-await generateTypesCjs()
-
-await insertCommonJsPackageJson({ buildFileUrl: import.meta.url })

--- a/packages/auth-providers/supabase/middleware/package.json
+++ b/packages/auth-providers/supabase/middleware/package.json
@@ -10,27 +10,21 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     }
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist",
-    "cjsWrappers"
+    "dist"
   ],
   "scripts": {
     "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-auth-supabase-middleware.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",
     "prepublishOnly": "NODE_ENV=production yarn build",

--- a/packages/auth-providers/supabase/middleware/tsconfig.cjs.json
+++ b/packages/auth-providers/supabase/middleware/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/auth-providers/supabase/web/build.ts
+++ b/packages/auth-providers/supabase/web/build.ts
@@ -1,17 +1,5 @@
-import { buildCjs, buildEsm } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-// ESM build and type generation
 await buildEsm()
 await generateTypesEsm()
-
-// CJS build, type generation, and package.json insert
-await buildCjs()
-await generateTypesCjs()
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-})

--- a/packages/auth-providers/supabase/web/package.json
+++ b/packages/auth-providers/supabase/web/package.json
@@ -10,28 +10,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "default": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     },
     "./dist/supabase": {
-      "import": {
+      "default": {
         "types": "./dist/supabase.d.ts",
         "default": "./dist/supabase.js"
-      },
-      "default": {
-        "types": "./dist/cjs/supabase.d.ts",
-        "default": "./dist/cjs/supabase.js"
       }
     }
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -40,7 +31,6 @@
     "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-supabase-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/supabase/web/tsconfig.cjs.json
+++ b/packages/auth-providers/supabase/web/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/auth-providers/supertokens/web/build.ts
+++ b/packages/auth-providers/supertokens/web/build.ts
@@ -1,17 +1,5 @@
-import { buildCjs, buildEsm } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-// ESM build and type generation
 await buildEsm()
 await generateTypesEsm()
-
-// CJS build, type generation, and package.json insert
-await buildCjs()
-await generateTypesCjs()
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-})

--- a/packages/auth-providers/supertokens/web/package.json
+++ b/packages/auth-providers/supertokens/web/package.json
@@ -10,28 +10,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "default": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     },
     "./dist/supertokens": {
-      "import": {
+      "default": {
         "types": "./dist/supertokens.d.ts",
         "default": "./dist/supertokens.js"
-      },
-      "default": {
-        "types": "./dist/cjs/supertokens.d.ts",
-        "default": "./dist/cjs/supertokens.js"
       }
     }
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -40,7 +31,6 @@
     "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-auth-supertokens-web.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/supertokens/web/tsconfig.cjs.json
+++ b/packages/auth-providers/supertokens/web/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/testing/src/config/jest/web/jest-preset.ts
+++ b/packages/testing/src/config/jest/web/jest-preset.ts
@@ -215,16 +215,23 @@ const config: Config = {
     // node_modules (plus until-async) to CommonJS. This needs its own
     // transform entry (with the config inlined) because the web babel config
     // ignores node_modules
-    '[/\\\\]node_modules[/\\\\](?:.+\\.mjs|until-async[/\\\\].+\\.js)$': [
-      'babel-jest',
-      {
-        babelrc: false,
-        configFile: false,
-        presets: [
-          [require.resolve('@babel/preset-env'), { targets: { node: '20' } }],
-        ],
-      },
-    ],
+    //
+    // The `@cedarjs/auth-*-web` packages are ESM-only too, and (like
+    // until-async) ship plain `.js` files rather than `.mjs` since their
+    // package.json already declares `"type": "module"`. A generated
+    // project's `web/src/auth.ts` imports one of these, so they need the
+    // same carve-out.
+    '[/\\\\]node_modules[/\\\\](?:.+\\.mjs|(?:until-async|@cedarjs[/\\\\]auth-[a-z-]+-web)[/\\\\].+\\.js)$':
+      [
+        'babel-jest',
+        {
+          babelrc: false,
+          configFile: false,
+          presets: [
+            [require.resolve('@babel/preset-env'), { targets: { node: '20' } }],
+          ],
+        },
+      ],
     '\\.[jt]sx?$': [
       'babel-jest',
       // When jest runs tests in parallel, it serializes the config before passing down options to babel
@@ -235,8 +242,8 @@ const config: Config = {
     ],
   },
   // Jest's default is to not transform anything in node_modules, but `.mjs`
-  // files (and until-async) have to be compiled to CommonJS (see the
-  // transform above).
+  // files (and until-async, and @cedarjs/auth-*-web) have to be compiled to
+  // CommonJS (see the transform above).
   // The `.pnpm` lookahead is what makes this work with pnpm: its virtual store
   // puts packages at `node_modules/.pnpm/<pkg>@<version>/node_modules/<pkg>`,
   // so without it the pattern matches (and thereby ignores) at the *first*
@@ -245,7 +252,7 @@ const config: Config = {
   // Skipping that segment forces the match onto the inner `node_modules`,
   // which looks the same as a hoisted npm/yarn layout
   transformIgnorePatterns: [
-    '[/\\\\]node_modules[/\\\\](?!\\.pnpm[/\\\\])(?!.*\\.mjs$)(?!until-async[/\\\\])',
+    '[/\\\\]node_modules[/\\\\](?!\\.pnpm[/\\\\])(?!.*\\.mjs$)(?!until-async[/\\\\])(?!@cedarjs[/\\\\]auth-[a-z-]+-web[/\\\\])',
     '\\.pnp\\.[^\\\\/]+$',
   ],
   resolver: path.resolve(__dirname, './resolver.js'),

--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -172,13 +172,9 @@ async function createServer() {
       cjsInterop({
         dependencies: [
           // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware,
-          // rwjs/router, rwjs/auth-*-api
+          // rwjs/router, rwjs/auth-*-api, rwjs/auth-*-web
           '@cedarjs/forms',
           '@cedarjs/prerender/*',
-          // Add more to the pattern below as they're converted to dual ESM/CJS
-          // modules
-          // '@cedarjs/auth-!(dbauth|auth0|clerk)-web',
-          '@cedarjs/auth-!(dbauth)-web',
         ],
       }),
       rscEnabled && rscRoutesAutoLoader(),

--- a/packages/vite/src/rsc/rscBuildForSsr.ts
+++ b/packages/vite/src/rsc/rscBuildForSsr.ts
@@ -67,10 +67,9 @@ export async function rscBuildForSsr({
       cjsInterop({
         dependencies: [
           // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware,
-          // rwjs/router, rwjs/auth-*-api
+          // rwjs/router, rwjs/auth-*-api, rwjs/auth-*-web
           '@cedarjs/forms',
           '@cedarjs/prerender/*',
-          '@cedarjs/auth-!(dbauth)-web',
         ],
       }),
       rscRoutesAutoLoader(),

--- a/packages/vite/src/streaming/buildForStreamingServer.ts
+++ b/packages/vite/src/streaming/buildForStreamingServer.ts
@@ -21,10 +21,9 @@ export async function buildForStreamingServer({
       cjsInterop({
         dependencies: [
           // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware,
-          // rwjs/router, rwjs/auth-*-api
+          // rwjs/router, rwjs/auth-*-api, rwjs/auth-*-web
           '@cedarjs/forms',
           '@cedarjs/prerender/*',
-          '@cedarjs/auth-!(dbauth)-web',
         ],
       }),
     ],


### PR DESCRIPTION
## Summary

Converts the 10 Dual Mode auth-provider packages to ESM-only, completing the ESM migration for every `auth-providers/*` package: `auth-auth0-web`, `auth-azure-active-directory-web`, `auth-clerk-web`, `auth-dbauth-web`, `auth-firebase-web`, `auth-netlify-web`, `auth-supabase-web`, `auth-supertokens-web`, `auth-dbauth-middleware`, `auth-supabase-middleware`.

These are all safe to convert to ESM-only. Confirmed via research before starting:

- **`auth-*-web` packages**: only ever pulled into generated projects via a plain `import` in `web/src/auth.ts.template`, statically bundled by Vite/Rollup for the client and SSR/streaming builds. Nothing `require()`s them, and the `auth-*-setup` packages only ever reference them by name in a string array (`webPackages`) passed to the installer — never actually import them.
- **`auth-dbauth-middleware`, `auth-supabase-middleware`**: loaded via `viteDevServer.ssrLoadModule` in dev and dynamic `import()` of the built `.mjs` entry in prod (`packages/vite/src/middleware/register.ts`), same bundler-driven path as the `-web` packages.

## Changes

Mechanical conversion per package:
- `package.json` `exports` maps collapsed from `{import: ..., default/require: <cjs>}` to a single `default` condition
- Dropped the `main`/`module` split down to a single `main`
- `build.ts`/`build.mts` dropped `buildCjs()`/`buildExternalCjs()` + `generateTypesCjs()` + `insertCommonJsPackageJson()`, keeping only the ESM build + type generation
- Removed `tsconfig.cjs.json` from each package
- Removed the stale `"cjsWrappers"` entry from `auth-supabase-middleware`'s `files` array (referenced a directory that no longer exists)

Also removes the now-stale `'@cedarjs/auth-!(dbauth)-web'` `cjsInterop` glob from `packages/vite/src/{devFeServer,streaming/buildForStreamingServer,rsc/rscBuildForSsr}.ts` — Rollup no longer needs to wrap these packages in a CJS-interop default-import shim now that they're real ESM (matches the pattern of removing `@cedarjs/auth-*-api` from the same glob once those went ESM-only in #2223).

Updates the [ESM migration plan doc](docs/implementation-plans/2026-07-25-esm-migration.md): Dual Mode drops from 33 to 23 packages, ESM Only grows to 51, with a new section documenting the research and rationale for this conversion.

## Testing

- `yarn build` — all 73 projects build clean (100% cache hit on re-run)
- `yarn lint` — clean across the whole monorepo
- `yarn nx run-many -t test` — all 60 test projects passing
- `yarn test:types` — passing
- `yarn workspace <pkg> build`/`test` for all 10 converted packages individually — all passing
- Checked for downstream static-import risk (the `TS1479`/`tsc`-CJS-declaration class of break found in #2223): no real consumers exist outside the auth-providers packages themselves and their own tests

## Two more downstream breaks found by CI

- **`packages/testing/src/config/jest/web/jest-preset.ts`**: converting the `auth-*-web` packages to ESM-only broke every generated project's web-side Jest tests with `SyntaxError: Unexpected token 'export'` — Jest's CJS runtime can't parse the real ESM `export * from "./dbAuth.js"` now emitted by e.g. `auth-dbauth-web`'s `dist/index.js` when a project's `web/src/auth.ts` imports it. This is the exact same class of problem already solved here for `until-async` (an ESM-only MSW dependency that ships plain `.js` files instead of `.mjs`): extended the existing `transformIgnorePatterns`/`transform` carve-out to also cover `@cedarjs/auth-*-web`, so babel-jest compiles those files to CommonJS. Verified via a direct regex test (the carve-out applies without over-matching other `@cedarjs` packages, `until-async` behavior is unaffected) and by running babel directly against the real built output.

  This is likely the real reason these packages were dual-mode in the first place, rather than anything runtime-related: `auth-*-web` went dual-mode via #11334 (2024-08-21), and `dbauth-web` specifically via #245/#257 (2025-07-18/20) — all well before the `until-async` carve-out technique existed anywhere in this codebase (it was only introduced during the MSW v2 upgrade, #2133, 2026-07-20). Whoever converted these packages plausibly hit this exact Jest failure and had no known workaround at the time, so keeping a CJS build around was the pragmatic fix rather than anything at runtime genuinely requiring one.
- **Greptile caught this one**: `@cedarjs/auth-dbauth-web/webAuthn` (imported by generated projects' `auth.webAuthn.ts.template` when WebAuthn support is enabled) was exposed via a legacy nested-package.json wrapper directory (`webAuthn/package.json` + `webAuthn/index.js` doing `module.exports = require('../dist/cjs/webAuthn')`), pointing at the CJS build this PR removed. Confirmed via `git worktree` against `main` that this subpath was already unreachable through strict Node resolution even before this PR (the `exports` map never declared it), but it's real, live code referenced by generated templates — almost certainly reachable through bundler-mode (Vite/Rollup) resolution, which is more lenient about `exports` map enforcement. Fixed properly instead of patching the wrapper: added a real `"./webAuthn"` entry to the `exports` map pointing at the ESM build's `dist/webAuthn.js`/`dist/webAuthn.d.ts` (which already exist), removed the now-redundant wrapper directory. Verified via direct `require.resolve()`/`import()` checks that the subpath now resolves correctly.

Re-verified after both fixes: full clean `yarn build` (73 projects), `yarn lint`, and `yarn nx run-many -t test` (60 projects) all pass.

