### PR TITLE
fix(context,gqlorm,cli-helpers,internal,vite): Convert Tier 1 Dual Mode packages to ESM-only

### DIFF
--- a/docs/implementation-plans/2026-07-25-esm-migration.md
+++ b/docs/implementation-plans/2026-07-25-esm-migration.md
@@ -9,7 +9,7 @@ CJS Only (6)
 - ogimage-gen
 - server-store
 
-ESM Only (51)
+ESM Only (56)
 
 - cli
 - codemods
@@ -62,41 +62,44 @@ ESM Only (51)
 - auth-supabase-web (https://github.com/cedarjs/cedar/pull/2234)
 - auth-supabase-middleware (https://github.com/cedarjs/cedar/pull/2234)
 - auth-supertokens-web (https://github.com/cedarjs/cedar/pull/2234)
+- cli-helpers
+- context
+- gqlorm
+- internal
+- vite
 
-Dual Mode – CJS + ESM (17)
+Dual Mode – CJS + ESM (12)
 
 - api
 - api-server
 - auth
-- cli-helpers
-- context
 - eslint-config
-- gqlorm
 - graphql-server
-- internal
 - prerender
 - project-config
 - record
 - router
 - storage
 - testing
-- vite
 - web
 
-Summary: Of the 74 packages, 17 are dual mode (CJS + ESM), 6 are CJS-only, and
-51 are ESM-only. The 6 CJS-only packages (`babel-config`, `cookie-jar`,
+Summary: Of the 74 packages, 12 are dual mode (CJS + ESM), 6 are CJS-only, and
+56 are ESM-only. The 6 CJS-only packages (`babel-config`, `cookie-jar`,
 `forms`, `jobs`, `ogimage-gen`, `server-store`) were previously miscategorized
 as Dual Mode — see the correction below. Of the packages that were genuinely
 CJS-only in the original inventory, all 27 have now been converted to
-ESM-only, and the 10 `auth-*-web`/`auth-*-middleware` packages that used to be
-genuinely Dual Mode have also been converted to ESM-only (see "Dual Mode ->
-ESM Only" below) — they were dual mode from a mechanical Babel-to-esbuild
-tooling migration, not because anything actually needed a CJS build of them.
-ESM-only remains the packages that have been explicitly converted to drop
-their CJS build entirely; `eslint-plugin`, `telemetry`, `tui`, `web-server`,
-the 7 `mailer/*` packages, the 17 `auth-*-api`/`auth-*-setup` packages,
-`fastify-web`/`cli-data-migrate`/`cli-storybook-vite`, and the 10
-`auth-*-web`/`auth-*-middleware` packages are the conversions done so far.
+ESM-only, and 15 of the 17 packages that used to be genuinely Dual Mode have
+also been converted to ESM-only (see "Dual Mode -> ESM Only" below) — most
+were dual mode from a mechanical Babel-to-esbuild tooling migration, not
+because anything actually needed a CJS build of them. `prerender` is a
+deliberate exception, held back pending a decision (see below). ESM-only
+remains the packages that have been explicitly converted to drop their CJS
+build entirely; `eslint-plugin`, `telemetry`, `tui`, `web-server`, the 7
+`mailer/*` packages, the 17 `auth-*-api`/`auth-*-setup` packages,
+`fastify-web`/`cli-data-migrate`/`cli-storybook-vite`, the 10
+`auth-*-web`/`auth-*-middleware` packages, and
+`cli-helpers`/`context`/`gqlorm`/`internal`/`vite` are the conversions done so
+far.
 
 **Correction (2026-07-25 review):** an earlier revision of this doc listed
 `cli-helpers`, `context`, and `record` under ESM Only, and listed
@@ -232,3 +235,57 @@ from `{import: ..., default/require: <cjs>}` to a single `default` condition,
 `generateTypesCjs()` + `insertCommonJsPackageJson()` calls, `tsconfig.cjs.json`
 files removed, and the stale `cjsInterop` glob entries removed from
 `packages/vite/src/{devFeServer,streaming/buildForStreamingServer,rsc/rscBuildForSsr}.ts`.
+
+## Dual Mode -> ESM Only: the remaining framework packages
+
+With the auth-provider packages done, research into the rest of the Dual Mode
+list (`docs` research, not yet a PR at the time) sorted the remaining 17 into
+tiers by risk. Tier 1 — packages with no coupling to other Dual Mode packages
+and no real `require()` consumer found anywhere — converted cleanly:
+
+- **`context`, `gqlorm`, `internal`**: standard `buildEsm()`/`buildExternalEsm()`
+  conversions, no real consumers doing a synchronous `require()`.
+- **`cli-helpers`**: same pattern; also had one real `require('../../package.json')`
+  call (`src/lib/project.ts`) reading its own version — replaced with
+  `fs.readFileSync` + `JSON.parse`, since plain `require()` isn't a global in
+  real ESM.
+- **`vite`**: its `build.ts` already excluded several entry files
+  (`devFeServer.ts`, `runFeServer.ts`, etc.) from the CJS build with a comment
+  explaining they're only ever reached through ESM-only bins — direct evidence
+  the CJS build was already vestigial for part of the package. Also never
+  generated real CJS type declarations of its own; it manually wrote
+  `export type * from "../x.d.ts"` re-export stubs pointing at the ESM
+  declarations, meaning the "CJS" types were always just the ESM ones,
+  re-exported. Dropping the CJS build removes a documented workaround rather
+  than creating a new risk.
+
+**Real gotcha found and fixed**: `@cedarjs/context` going ESM-only broke
+generated projects' **api-side** Jest tests the same way the `-web` packages
+broke web-side tests in #2234 — `@cedarjs/testing`'s own api entry point does
+a top-level `require("@cedarjs/context")` in its CJS build (used by
+`packages/testing/src/api/directive.ts`, pulled in by virtually every
+api-side test via `@cedarjs/testing/api`), and Jest's CJS runtime can't parse
+the real ESM this now emits. Unlike the web preset, the **api-side** Jest
+preset (`packages/testing/src/config/jest/api/jest-preset.ts`) had **no**
+`transformIgnorePatterns` override at all before this — built one from
+scratch, mirroring the web-side pattern, carving out `@cedarjs/context`
+specifically (confirmed via `require("@cedarjs/...")` greps through
+`@cedarjs/testing`'s compiled CJS output that none of the other 4 packages in
+this batch are transitively required by it).
+
+**Held back: `prerender`.** Initial research called this "the cleanest of the
+batch," based on its consumer (`prerenderHandler.ts`) already branching
+between `import('@cedarjs/prerender/...')` and
+`import('@cedarjs/prerender/cjs/...')` at runtime. Closer inspection found
+that's true of the _consumer_, but not of the package itself:
+`src/runPrerender.tsx` (the CJS/`require` entry) and `src/runPrerenderEsm.tsx`
+(the ESM/`import` entry) are **not** the same source built twice — they're
+genuinely different implementations. The CJS version uses
+`registerApiSideBabelHook()`/`registerWebSideBabelHook()` (Babel-register
+hooks + `require()`) to transform and load the user's app; the ESM version
+uses a `NodeRunner` class and a `buildAndImport()` helper that writes a
+temporary combined entry file and loads it via Vite/Rollup instead. Dropping
+the CJS build here wouldn't just remove a redundant build target — it would
+retire an entire alternate prerendering implementation that classic CJS-mode
+projects may still depend on. That's a real product decision, not a
+mechanical cleanup, so it's out of scope for this round.

--- a/docs/implementation-plans/2026-07-25-esm-migration.md
+++ b/docs/implementation-plans/2026-07-25-esm-migration.md
@@ -1,9 +1,13 @@
 Here's the breakdown of the 74 packages in the CedarJS monorepo:
 
-CJS Only (0)
+CJS Only (6)
 
-- None — all 27 originally-CJS-only packages have now been converted to
-  ESM-only (see below).
+- babel-config
+- cookie-jar
+- forms
+- jobs
+- ogimage-gen
+- server-store
 
 ESM Only (51)
 
@@ -59,42 +63,38 @@ ESM Only (51)
 - auth-supabase-middleware (https://github.com/cedarjs/cedar/pull/2234)
 - auth-supertokens-web (https://github.com/cedarjs/cedar/pull/2234)
 
-Dual Mode – CJS + ESM (23)
+Dual Mode – CJS + ESM (17)
 
 - api
 - api-server
 - auth
-- babel-config
 - cli-helpers
 - context
-- cookie-jar
 - eslint-config
-- forms
 - gqlorm
 - graphql-server
 - internal
-- jobs
-- ogimage-gen
 - prerender
 - project-config
 - record
 - router
-- server-store
 - storage
 - testing
 - vite
 - web
 
-Summary: Of the 74 packages, 23 are dual mode (CJS + ESM), 0 are CJS-only, and
-51 are ESM-only. Every package that was CJS-only as of the original inventory
-below has now been converted to ESM-only, and the 10 `auth-*-web` /
-`auth-*-middleware` packages that used to be Dual Mode have also been
-converted to ESM-only (see "Dual Mode -> ESM Only" below) — they were dual
-mode from a mechanical Babel-to-esbuild tooling migration, not because
-anything actually needed a CJS build of them. ESM-only remains the packages
-that have been explicitly converted to drop their CJS build entirely;
-`eslint-plugin`, `telemetry`, `tui`, `web-server`, the 7 `mailer/*` packages,
-the 17 `auth-*-api`/`auth-*-setup` packages,
+Summary: Of the 74 packages, 17 are dual mode (CJS + ESM), 6 are CJS-only, and
+51 are ESM-only. The 6 CJS-only packages (`babel-config`, `cookie-jar`,
+`forms`, `jobs`, `ogimage-gen`, `server-store`) were previously miscategorized
+as Dual Mode — see the correction below. Of the packages that were genuinely
+CJS-only in the original inventory, all 27 have now been converted to
+ESM-only, and the 10 `auth-*-web`/`auth-*-middleware` packages that used to be
+genuinely Dual Mode have also been converted to ESM-only (see "Dual Mode ->
+ESM Only" below) — they were dual mode from a mechanical Babel-to-esbuild
+tooling migration, not because anything actually needed a CJS build of them.
+ESM-only remains the packages that have been explicitly converted to drop
+their CJS build entirely; `eslint-plugin`, `telemetry`, `tui`, `web-server`,
+the 7 `mailer/*` packages, the 17 `auth-*-api`/`auth-*-setup` packages,
 `fastify-web`/`cli-data-migrate`/`cli-storybook-vite`, and the 10
 `auth-*-web`/`auth-*-middleware` packages are the conversions done so far.
 
@@ -117,6 +117,33 @@ packages. Neither holds up:
   `require('@cedarjs/testing/config/jest/api')` resolves a subpath — not
   packages that could themselves be "converted" to ESM. They've been removed
   from the inventory.
+
+**Correction (2026-07-26 review):** research into which Dual Mode packages
+were good candidates to drop their CJS build turned up 6 packages that were
+never actually dual mode at all — they were CJS-only the whole time, just
+miscategorized:
+
+- `babel-config`: `package.json` `"type": "commonjs"`, `exports` only declares
+  `"." : "./dist/index.js"`, and `build.mts` calls the bare `build()` helper,
+  whose `defaultBuildOptions` default to `format: 'cjs'` — no ESM build is
+  ever produced.
+- `cookie-jar`: `build.mts` always builds `format: 'cjs'` only, and has done
+  so since the file was first added.
+- `forms`: same pattern — bare `build()` call, `exports["."]` has only a
+  `default` condition, no `import` condition.
+- `jobs`: bare `await build()` with no format override, root `"type":
+"commonjs"`, single flat `exports` condition.
+- `ogimage-gen`: same — `build.mts` is a bare `build()` call, `"type":
+"commonjs"`. It does have vestigial dual-mode-looking scaffolding (an
+  `exports["./middleware"].import` condition and a `cjsWrappers/` directory),
+  but both point at the same CJS output — leftover/unfinished work, not a
+  real ESM build.
+- `server-store`: `build.mts` explicitly sets `format: 'cjs'`, single output,
+  root `"type": "commonjs"`.
+
+Moved all 6 to CJS Only. This also means they're candidates for the
+CJS-only-to-ESM-only conversion described below, following the same Node
+24-`require(esm)` reasoning as the original 27 — not yet evaluated in detail.
 
 ## CJS Only -> ESM Only: candidates given the Node 24 requirement
 

--- a/docs/implementation-plans/2026-07-25-esm-migration.md
+++ b/docs/implementation-plans/2026-07-25-esm-migration.md
@@ -62,11 +62,11 @@ ESM Only (56)
 - auth-supabase-web (https://github.com/cedarjs/cedar/pull/2234)
 - auth-supabase-middleware (https://github.com/cedarjs/cedar/pull/2234)
 - auth-supertokens-web (https://github.com/cedarjs/cedar/pull/2234)
-- cli-helpers
-- context
-- gqlorm
-- internal
-- vite
+- cli-helpers (https://github.com/cedarjs/cedar/pull/2237)
+- context (https://github.com/cedarjs/cedar/pull/2237)
+- gqlorm (https://github.com/cedarjs/cedar/pull/2237)
+- internal (https://github.com/cedarjs/cedar/pull/2237)
+- vite (https://github.com/cedarjs/cedar/pull/2237)
 
 Dual Mode – CJS + ESM (12)
 

--- a/packages/cli-helpers/build.ts
+++ b/packages/cli-helpers/build.ts
@@ -1,29 +1,13 @@
-import { writeFileSync } from 'node:fs'
-
 import { build, defaultBuildOptions } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-// ESM build
 await build({
   buildOptions: {
     ...defaultBuildOptions,
+    tsconfig: 'tsconfig.build.json',
     format: 'esm',
     packages: 'external',
   },
 })
 
-// CJS build
-await build({
-  buildOptions: {
-    ...defaultBuildOptions,
-    outdir: 'dist/cjs',
-    packages: 'external',
-  },
-})
-
-// Place a package.json file with `type: commonjs` in the dist/cjs folder so
-// that all .js files are treated as CommonJS files.
-writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))
-
-// Place a package.json file with `type: module` in the dist folder so that
-// .js files are treated as ES Module files.
-writeFileSync('dist/package.json', JSON.stringify({ type: 'module' }))
+await generateTypesEsm()

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -10,83 +10,51 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "default": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     },
     "./loadEnvFiles": {
-      "import": {
+      "default": {
         "types": "./dist/lib/loadEnvFiles.d.ts",
         "default": "./dist/lib/loadEnvFiles.js"
-      },
-      "default": {
-        "types": "./dist/cjs/lib/loadEnvFiles.d.ts",
-        "default": "./dist/cjs/lib/loadEnvFiles.js"
       }
     },
     "./dist/lib/loadEnvFiles.js": {
-      "import": {
+      "default": {
         "types": "./dist/lib/loadEnvFiles.d.ts",
         "default": "./dist/lib/loadEnvFiles.js"
-      },
-      "default": {
-        "types": "./dist/cjs/lib/loadEnvFiles.d.ts",
-        "default": "./dist/cjs/lib/loadEnvFiles.js"
       }
     },
     "./packageManager": {
-      "import": {
+      "default": {
         "types": "./dist/packageManager/index.d.ts",
         "default": "./dist/packageManager/index.js"
-      },
-      "default": {
-        "types": "./dist/cjs/packageManager/index.d.ts",
-        "default": "./dist/cjs/packageManager/index.js"
       }
     },
     "./packageManager/exec": {
-      "import": {
+      "default": {
         "types": "./dist/packageManager/exec.d.ts",
         "default": "./dist/packageManager/exec.js"
-      },
-      "default": {
-        "types": "./dist/cjs/packageManager/exec.d.ts",
-        "default": "./dist/cjs/packageManager/exec.js"
       }
     },
     "./packageManager/packages": {
-      "import": {
+      "default": {
         "types": "./dist/packageManager/packages.d.ts",
         "default": "./dist/packageManager/packages.js"
-      },
-      "default": {
-        "types": "./dist/cjs/packageManager/packages.d.ts",
-        "default": "./dist/cjs/packageManager/packages.js"
       }
     },
     "./packageManager/display": {
-      "import": {
+      "default": {
         "types": "./dist/packageManager/display.d.ts",
         "default": "./dist/packageManager/display.js"
-      },
-      "default": {
-        "types": "./dist/cjs/packageManager/display.d.ts",
-        "default": "./dist/cjs/packageManager/display.js"
       }
     },
     "./packageManager/workspaces": {
-      "import": {
+      "default": {
         "types": "./dist/packageManager/workspaces.d.ts",
         "default": "./dist/packageManager/workspaces.js"
-      },
-      "default": {
-        "types": "./dist/cjs/packageManager/workspaces.d.ts",
-        "default": "./dist/cjs/packageManager/workspaces.js"
       }
     }
   },
@@ -95,9 +63,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "node ./build.ts && yarn build:types",
+    "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-cli-helpers.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.build.json ./tsconfig.cjs.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "vitest run",

--- a/packages/cli-helpers/src/lib/project.ts
+++ b/packages/cli-helpers/src/lib/project.ts
@@ -34,7 +34,8 @@ export const isTypeScriptProject = () => {
 
 export const getInstalledRedwoodVersion = () => {
   try {
-    const packageJson = require('../../package.json')
+    const packageJsonPath = path.join(import.meta.dirname, '../../package.json')
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
     return packageJson.version
   } catch {
     console.error(colors.error('Could not find installed Cedar version'))

--- a/packages/cli-helpers/tsconfig.cjs.json
+++ b/packages/cli-helpers/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/context/build.mts
+++ b/packages/context/build.mts
@@ -1,14 +1,5 @@
-import { buildCjs, buildEsm } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
 await buildEsm()
 await generateTypesEsm()
-
-await buildCjs()
-await generateTypesCjs()
-
-await insertCommonJsPackageJson({ buildFileUrl: import.meta.url })

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -10,38 +10,25 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "default": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     },
     "./dist/store": {
-      "import": {
+      "default": {
         "types": "./dist/store.d.ts",
         "default": "./dist/store.js"
-      },
-      "default": {
-        "types": "./dist/cjs/store.d.ts",
-        "default": "./dist/cjs/store.js"
       }
     },
     "./dist/store.js": {
-      "import": {
+      "default": {
         "types": "./dist/store.d.ts",
         "default": "./dist/store.js"
-      },
-      "default": {
-        "types": "./dist/cjs/store.d.ts",
-        "default": "./dist/cjs/store.js"
       }
     }
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -50,7 +37,6 @@
     "build": "node ./build.mts",
     "build:pack": "yarn pack -o cedarjs-context.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/context/tsconfig.cjs.json
+++ b/packages/context/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/gqlorm/build.ts
+++ b/packages/gqlorm/build.ts
@@ -1,14 +1,5 @@
-import { buildExternalCjs, buildExternalEsm } from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildExternalEsm } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
 await buildExternalEsm()
 await generateTypesEsm()
-
-await buildExternalCjs()
-await generateTypesCjs()
-
-await insertCommonJsPackageJson({ buildFileUrl: import.meta.url })

--- a/packages/gqlorm/package.json
+++ b/packages/gqlorm/package.json
@@ -76,7 +76,7 @@
       }
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/queryBuilder.js",
   "types": "dist/queryBuilder.d.ts",
   "files": [
     "dist"

--- a/packages/gqlorm/package.json
+++ b/packages/gqlorm/package.json
@@ -10,117 +10,73 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/queryBuilder.d.ts",
         "default": "./dist/queryBuilder.js"
-      },
-      "require": {
-        "types": "./dist/cjs/queryBuilder.d.ts",
-        "default": "./dist/cjs/queryBuilder.js"
       }
     },
     "./setup": {
-      "import": {
+      "default": {
         "types": "./dist/setup.d.ts",
         "default": "./dist/setup.js"
-      },
-      "require": {
-        "types": "./dist/cjs/setup.d.ts",
-        "default": "./dist/cjs/setup.js"
       }
     },
     "./queryBuilder": {
-      "import": {
+      "default": {
         "types": "./dist/queryBuilder.d.ts",
         "default": "./dist/queryBuilder.js"
-      },
-      "require": {
-        "types": "./dist/cjs/queryBuilder.d.ts",
-        "default": "./dist/cjs/queryBuilder.js"
       }
     },
     "./react/useLiveQuery": {
-      "import": {
+      "default": {
         "types": "./dist/react/useLiveQuery.d.ts",
         "default": "./dist/react/useLiveQuery.js"
-      },
-      "require": {
-        "types": "./dist/cjs/react/useLiveQuery.d.ts",
-        "default": "./dist/cjs/react/useLiveQuery.js"
       }
     },
     "./parser/queryParser": {
-      "import": {
+      "default": {
         "types": "./dist/parser/queryParser.d.ts",
         "default": "./dist/parser/queryParser.js"
-      },
-      "require": {
-        "types": "./dist/cjs/parser/queryParser.d.ts",
-        "default": "./dist/cjs/parser/queryParser.js"
       }
     },
     "./generator/graphqlGenerator": {
-      "import": {
+      "default": {
         "types": "./dist/generator/graphqlGenerator.d.ts",
         "default": "./dist/generator/graphqlGenerator.js"
-      },
-      "require": {
-        "types": "./dist/cjs/generator/graphqlGenerator.d.ts",
-        "default": "./dist/cjs/generator/graphqlGenerator.js"
       }
     },
     "./live/types": {
-      "import": {
+      "default": {
         "types": "./dist/live/types.d.ts",
         "default": "./dist/live/types.js"
-      },
-      "require": {
-        "types": "./dist/cjs/live/types.d.ts",
-        "default": "./dist/cjs/live/types.js"
       }
     },
     "./types/ast": {
-      "import": {
+      "default": {
         "types": "./dist/types/ast.d.ts",
         "default": "./dist/types/ast.js"
-      },
-      "require": {
-        "types": "./dist/cjs/types/ast.d.ts",
-        "default": "./dist/cjs/types/ast.js"
       }
     },
     "./types/orm": {
-      "import": {
+      "default": {
         "types": "./dist/types/orm.d.ts",
         "default": "./dist/types/orm.js"
-      },
-      "require": {
-        "types": "./dist/cjs/types/orm.d.ts",
-        "default": "./dist/cjs/types/orm.js"
       }
     },
     "./types/schema": {
-      "import": {
+      "default": {
         "types": "./dist/types/schema.d.ts",
         "default": "./dist/types/schema.js"
-      },
-      "require": {
-        "types": "./dist/cjs/types/schema.d.ts",
-        "default": "./dist/cjs/types/schema.js"
       }
     },
     "./types/typeUtils": {
-      "import": {
+      "default": {
         "types": "./dist/types/typeUtils.d.ts",
         "default": "./dist/types/typeUtils.js"
-      },
-      "require": {
-        "types": "./dist/cjs/types/typeUtils.d.ts",
-        "default": "./dist/cjs/types/typeUtils.js"
       }
     }
   },
-  "main": "dist/queryBuilder.js",
+  "main": "./dist/index.js",
   "types": "dist/queryBuilder.d.ts",
   "files": [
     "dist"
@@ -128,8 +84,7 @@
   "scripts": {
     "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-gqlorm.tgz",
-    "build:types": "tsc --build --verbose tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose tsconfig.cjs.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "check:attw": "node ./attw.ts",
     "check:package": "concurrently npm:check:attw yarn publint",

--- a/packages/gqlorm/tsconfig.cjs.json
+++ b/packages/gqlorm/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/internal/build.mts
+++ b/packages/internal/build.mts
@@ -1,40 +1,10 @@
-import {
-  buildEsm,
-  build,
-  copyAssets,
-  defaultBuildOptions,
-} from '@cedarjs/framework-tools'
-import {
-  generateTypesCjs,
-  generateTypesEsm,
-  insertCommonJsPackageJson,
-} from '@cedarjs/framework-tools/generateTypes'
+import { buildEsm, copyAssets } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
 await buildEsm()
 await generateTypesEsm()
 
-await build({
-  buildOptions: {
-    ...defaultBuildOptions,
-    tsconfig: 'tsconfig.cjs.json',
-    outdir: 'dist/cjs',
-    logOverride: {
-      // We need this for ./src/generate/templates.ts
-      'empty-import-meta': 'silent',
-    },
-  },
-})
-await generateTypesCjs()
-
-await insertCommonJsPackageJson({ buildFileUrl: import.meta.url })
-
 await copyAssets({
   buildFileUrl: import.meta.url,
   patterns: ['generate/templates/**/*.template'],
-})
-
-await copyAssets({
-  buildFileUrl: import.meta.url,
-  patterns: ['generate/templates/**/*.template'],
-  cjs: true,
 })

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -10,144 +10,88 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     },
     "./package.json": "./package.json",
     "./dist/dev": {
-      "import": {
+      "default": {
         "types": "./dist/dev.d.ts",
         "default": "./dist/dev.js"
-      },
-      "require": {
-        "types": "./dist/cjs/dev.d.ts",
-        "default": "./dist/cjs/dev.js"
       }
     },
     "./dist/files": {
-      "import": {
+      "default": {
         "types": "./dist/files.d.ts",
         "default": "./dist/files.js"
-      },
-      "require": {
-        "types": "./dist/cjs/files.d.ts",
-        "default": "./dist/cjs/files.js"
       }
     },
     "./dist/files.js": {
-      "import": {
+      "default": {
         "types": "./dist/files.d.ts",
         "default": "./dist/files.js"
-      },
-      "require": {
-        "types": "./dist/cjs/files.d.ts",
-        "default": "./dist/cjs/files.js"
       }
     },
     "./dist/gql": {
-      "import": {
+      "default": {
         "types": "./dist/gql.d.ts",
         "default": "./dist/gql.js"
-      },
-      "require": {
-        "types": "./dist/cjs/gql.d.ts",
-        "default": "./dist/cjs/gql.js"
       }
     },
     "./dist/project": {
-      "import": {
+      "default": {
         "types": "./dist/project.d.ts",
         "default": "./dist/project.js"
-      },
-      "require": {
-        "types": "./dist/cjs/project.d.ts",
-        "default": "./dist/cjs/project.js"
       }
     },
     "./dist/routes.js": {
-      "import": {
+      "default": {
         "types": "./dist/routes.d.ts",
         "default": "./dist/routes.js"
-      },
-      "require": {
-        "types": "./dist/cjs/routes.d.ts",
-        "default": "./dist/cjs/routes.js"
       }
     },
     "./dist/ts2js": {
-      "import": {
+      "default": {
         "types": "./dist/ts2js.d.ts",
         "default": "./dist/ts2js.js"
-      },
-      "require": {
-        "types": "./dist/cjs/ts2js.d.ts",
-        "default": "./dist/cjs/ts2js.js"
       }
     },
     "./dist/validateSchema": {
-      "import": {
+      "default": {
         "types": "./dist/validateSchema.d.ts",
         "default": "./dist/validateSchema.js"
-      },
-      "require": {
-        "types": "./dist/cjs/validateSchema.d.ts",
-        "default": "./dist/cjs/validateSchema.js"
       }
     },
     "./dist/build/api": {
-      "import": {
+      "default": {
         "types": "./dist/build/api.d.ts",
         "default": "./dist/build/api.js"
-      },
-      "require": {
-        "types": "./dist/cjs/build/api.d.ts",
-        "default": "./dist/cjs/build/api.js"
       }
     },
     "./dist/build/api.js": {
-      "import": {
+      "default": {
         "types": "./dist/build/api.d.ts",
         "default": "./dist/build/api.js"
-      },
-      "require": {
-        "types": "./dist/cjs/build/api.d.ts",
-        "default": "./dist/cjs/build/api.js"
       }
     },
     "./dist/build/api-graphql-transforms.js": {
-      "import": {
+      "default": {
         "types": "./dist/build/api-graphql-transforms.d.ts",
         "default": "./dist/build/api-graphql-transforms.js"
-      },
-      "require": {
-        "types": "./dist/cjs/build/api-graphql-transforms.d.ts",
-        "default": "./dist/cjs/build/api-graphql-transforms.js"
       }
     },
     "./dist/generate/generate": {
-      "import": {
+      "default": {
         "types": "./dist/generate/generate.d.ts",
         "default": "./dist/generate/generate.js"
-      },
-      "require": {
-        "types": "./dist/cjs/generate/generate.d.ts",
-        "default": "./dist/cjs/generate/generate.js"
       }
     },
     "./dist/generate/gqlormSchema": {
-      "import": {
+      "default": {
         "types": "./dist/generate/gqlormSchema.d.ts",
         "default": "./dist/generate/gqlormSchema.js"
-      },
-      "require": {
-        "types": "./dist/cjs/generate/gqlormSchema.d.ts",
-        "default": "./dist/cjs/generate/gqlormSchema.js"
       }
     }
   },
@@ -164,7 +108,6 @@
     "build:clean-dist": "rimraf 'dist/**/*/__tests__' --glob",
     "build:pack": "yarn pack -o cedarjs-internal.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn cedar-fwtools-attw",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/internal/tsconfig.cjs.json
+++ b/packages/internal/tsconfig.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo",
-    "verbatimModuleSyntax": false
-  }
-}

--- a/packages/testing/src/config/jest/api/jest-preset.ts
+++ b/packages/testing/src/config/jest/api/jest-preset.ts
@@ -79,6 +79,23 @@ const config: Config = {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   transform: {
+    // `@cedarjs/context` is ESM-only, and @cedarjs/testing's own api entry
+    // point (which virtually every generated project's api-side test
+    // imports, for scenario/mock helpers) requires it at the top level. Jest's
+    // CJS runtime can't parse the real ESM this now emits, so it needs the
+    // same babel-jest carve-out the web preset already uses for ESM-only
+    // node_modules packages (see jest-preset.ts on the web side for the
+    // fuller explanation of why this is necessary).
+    '[/\\\\]node_modules[/\\\\]@cedarjs[/\\\\]context[/\\\\].+\\.js$': [
+      'babel-jest',
+      {
+        babelrc: false,
+        configFile: false,
+        presets: [
+          [require.resolve('@babel/preset-env'), { targets: { node: '20' } }],
+        ],
+      },
+    ],
     '\\.[cm]?[jt]sx?$': [
       'babel-jest',
       // When jest runs tests in parallel, it serializes the config before passing down options to babel
@@ -91,6 +108,9 @@ const config: Config = {
       },
     ],
   },
+  transformIgnorePatterns: [
+    '[/\\\\]node_modules[/\\\\](?!@cedarjs[/\\\\]context[/\\\\])',
+  ],
   testPathIgnorePatterns: ['.scenarios.[jt]s$'],
 }
 

--- a/packages/vite/build.ts
+++ b/packages/vite/build.ts
@@ -1,5 +1,3 @@
-import { writeFileSync } from 'node:fs'
-
 import { commonjs } from '@hyrious/esbuild-plugin-commonjs'
 import * as esbuild from 'esbuild'
 
@@ -8,35 +6,8 @@ import {
   defaultBuildOptions,
   defaultIgnorePatterns,
 } from '@cedarjs/framework-tools'
+import { generateTypesEsm } from '@cedarjs/framework-tools/generateTypes'
 
-// CJS Build
-await build({
-  entryPointOptions: {
-    ignore: [
-      ...defaultIgnorePatterns,
-      '**/bundled',
-      // This whole chain is only ever reached through our ESM-only bins
-      // (`cedar-dev-fe`, `cedar-serve-fe`) - never `require()`d. Skip it here
-      // instead of emitting a CJS build with a broken `import.meta` (in
-      // devFeServer.ts, registerFwGlobalsAndShims.ts, streamHelpers.ts) or
-      // dangling requires of those files (in runFeServer.ts,
-      // createReactStreamingHandler.ts).
-      'src/devFeServer.ts',
-      'src/runFeServer.ts',
-      'src/lib/registerFwGlobalsAndShims.ts',
-      'src/streaming/streamHelpers.ts',
-      'src/streaming/createReactStreamingHandler.ts',
-    ],
-  },
-  buildOptions: {
-    ...defaultBuildOptions,
-    tsconfig: 'tsconfig.build.json',
-    outdir: 'dist/cjs',
-    packages: 'external',
-  },
-})
-
-// ESM Build
 await build({
   entryPointOptions: {
     ignore: [...defaultIgnorePatterns, '**/bundled'],
@@ -70,33 +41,4 @@ await esbuild.build({
   tsconfig: 'tsconfig.build.json',
 })
 
-// Place a package.json file with `type: commonjs` in the dist/cjs folder so
-// that all .js files are treated as CommonJS files.
-writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))
-
-// Place a package.json file with `type: module` in the dist folder so that
-// all .js files are treated as ES Module files.
-writeFileSync('dist/package.json', JSON.stringify({ type: 'module' }))
-
-// Add CommonJS types by creating common JS types. Using a .d.ts file, because
-// .d.cts files don't auto resolve
-// Notice I haven't specified the types in package.json for these - it's
-// following the naming conversion TSC wants.
-writeFileSync('dist/cjs/index.d.ts', 'export type * from "../index.d.ts"')
-writeFileSync(
-  'dist/cjs/buildFeServer.d.ts',
-  'export type * from "../buildFeServer.d.ts"',
-)
-writeFileSync('dist/cjs/client.d.ts', 'export type * from "../client.d.ts"')
-writeFileSync(
-  'dist/cjs/clientSsr.d.ts',
-  'export type * from "../clientSsr.d.ts"',
-)
-writeFileSync(
-  'dist/cjs/ClientRouter.d.ts',
-  'export type * from "../ClientRouter.d.ts"',
-)
-writeFileSync(
-  'dist/cjs/build/build.d.ts',
-  'export type * from "../../build/build.d.ts"',
-)
+await generateTypesEsm()

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -12,27 +12,17 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": {
+      "default": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
       }
     },
     "./api": {
       "types": "./dist/api/vite-plugin-cedar-vitest-api-preset.d.ts",
       "default": "./dist/api/vite-plugin-cedar-vitest-api-preset.js"
     },
-    "./buildFeServer": {
-      "require": "./dist/cjs/buildFeServer.js",
-      "import": "./dist/buildFeServer.js"
-    },
-    "./build": {
-      "import": "./dist/build/build.js",
-      "default": "./dist/cjs/build/build.js"
-    },
+    "./buildFeServer": "./dist/buildFeServer.js",
+    "./build": "./dist/build/build.js",
     "./bins/cedar-vite-build.mjs": "./bins/cedar-vite-build.mjs"
   },
   "bin": {
@@ -49,7 +39,7 @@
     "inject"
   ],
   "scripts": {
-    "build": "node ./build.ts && yarn build:types",
+    "build": "node ./build.ts",
     "build:pack": "yarn pack -o cedarjs-vite.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "check:attw": "node ./attw.ts",


### PR DESCRIPTION
## Summary

Converts 5 of the 6 "Tier 1" Dual Mode packages identified by research as good candidates for dropping their CJS build: `context`, `gqlorm`, `cli-helpers`, `internal`, `vite`. Also fixes a mislabeling in the [ESM migration plan doc](docs/implementation-plans/2026-07-25-esm-migration.md) — `babel-config`, `cookie-jar`, `forms`, `jobs`, `ogimage-gen`, and `server-store` were listed as Dual Mode but were actually CJS-only the whole time (moved to CJS Only, not touched otherwise in this PR).

**`prerender` (the 6th Tier 1 candidate) is deliberately held back.** Initial research called it "the cleanest of the batch" based on its consumer already branching between ESM/CJS import paths at runtime — but that's only true of the *consumer*. The package itself has `src/runPrerender.tsx` (the CJS entry, using `registerApiSideBabelHook()`/Babel-register + `require()`) and `src/runPrerenderEsm.tsx` (the ESM entry, using a `NodeRunner`/`buildAndImport()` approach that writes a temp combined entry file and loads it via Vite/Rollup) as **genuinely different implementations**, not the same source built twice. Dropping the CJS build here would retire an entire alternate prerendering path that classic CJS-mode projects may still depend on — a real product decision, not a mechanical cleanup. Full writeup in the doc.

## Changes

Mechanical conversion per package: `package.json` `exports` maps collapsed to a single `default` condition, dropped the `main`/`module` split, dropped `buildCjs()`/`buildExternalCjs()` + `generateTypesCjs()` + `insertCommonJsPackageJson()` from `build.ts`/`build.mts`, removed `tsconfig.cjs.json`.

## Fallout fixed

- **`cli-helpers/src/lib/project.ts`**: `require('../../package.json')` relied on `require` being a CJS global. Replaced with `fs.readFileSync` + `JSON.parse` via `import.meta.dirname`.
- **`vite/build.ts`**: dropped the CJS-only entry-point ignore list (`devFeServer.ts`, `runFeServer.ts`, etc. — these were already excluded from the CJS build with a comment explaining they're only reached through ESM-only bins) and the manual `dist/cjs/*.d.ts` re-export stubs — both existed solely to work around the CJS build, which no longer exists. `vite` never generated real CJS type declarations of its own; the stubs just pointed back at the ESM `.d.ts` files, so the "CJS types" were always just the ESM ones.
- **`packages/testing/src/config/jest/api/jest-preset.ts`**: converting `@cedarjs/context` to ESM-only broke every generated project's **api-side** Jest tests, the same class of bug found on the web side in #2234 — `@cedarjs/testing`'s own api entry point does a top-level `require()` of `context` (pulled in by virtually every api-side test via `@cedarjs/testing/api`), and Jest's CJS runtime can't parse the real ESM this now emits. Unlike the web preset, the api preset had **no** `transformIgnorePatterns` override at all before this — built one from scratch, mirroring the web-side pattern, carving out `@cedarjs/context` specifically (confirmed via grepping `@cedarjs/testing`'s compiled CJS output that no other package in this batch is transitively required by it).

## Downstream consumers checked

Every remaining Dual Mode package that does a static value import of one of these five (`api-server`, `testing`, `graphql-server`, `babel-config`, `ogimage-gen`, `prerender`) builds clean — none of them hit the `TS1479` class of break found for `auth-dbauth-middleware` in #2223, since their own CJS output is esbuild-bundled rather than `tsc`-emitted (or, for `prerender`, doesn't statically import into a `tsc`-CJS-compiled file).

## `@cedarjs/context` dual package hazard — verified, not just asserted

`@cedarjs/context` holds a module-level singleton (`CONTEXT_STORAGE`, an `AsyncLocalStorage`, in `src/store.ts`) that all of `context`/`setContext`/`getAsyncStoreInstance` read and write through. This package has historically been the source of "dual package hazard" bugs: when it built separate ESM and CJS files, an app that reached it via both `require()` (e.g. a CJS-compiled api side) and `import` (e.g. an ESM-only dependency) could get **two separate module instances** with two separate `AsyncLocalStorage`s — context set on one is silently invisible on the other. No error, just auth/context state that mysteriously doesn't propagate.

Converting to ESM-only removes the second file entirely, so there's structurally only one module for Node's `require(esm)` and `import` to both resolve to — but "should fix it" isn't the same as "verified it fixed it," so I built both sides (`main` and this branch) with `git worktree` and ran the same test against each:

- **`main` (dual-mode, before)**: loading `@cedarjs/context` via `require()` and via `import()` in the same process returned **different** `setContext`/`getAsyncStoreInstance` function references and a **different** `AsyncLocalStorage` instance. Context set through one was `undefined` when read through the other — the hazard, reproduced.
- **this branch (ESM-only, after)**: `require()` and `import()` of the same package return **identical** function references and the identical `AsyncLocalStorage` instance. Context set via `require()` inside a `store.run()` is correctly visible via `import()`, and vice versa.

To be precise about what this does and doesn't claim: whether a given app actually hits dual-instantiation depends on its dependency-resolution graph (hoisting layout, which packages reach `context` via `require()` vs `import`, etc.) — that's exactly why this has been a recurring bug rather than a permanent one. Each prior fix patched one graph shape that triggered it; the two-file (ESM+CJS) structure stayed in place, so a later dependency bump or hoisting change could reintroduce it elsewhere. This PR doesn't just patch another instance — it removes the two-file structure itself, the only thing that ever made dual-instantiation possible. There's no longer a second module for any future graph shape to accidentally resolve to.

## Testing

- `yarn build` — all 73 projects build clean (100% cache hit on re-run)
- `yarn lint` — clean across the whole monorepo
- `yarn nx run-many -t test` — all 60 test projects passing
- `yarn test:types` — passing
- `yarn workspace <pkg> build`/`test` for all 5 converted packages individually — all passing
- Verified the api-side Jest preset fix via direct regex tests (mirroring the web-side verification approach) and by running babel directly against the real built `@cedarjs/context` output
- Verified `@cedarjs/prerender` (untouched, still dual-mode) still builds clean after `vite`/`context`/`cli-helpers`/`internal` went ESM-only, since it depends on `vite` via `src/graphql/node-runner.ts`

