### PR TITLE
fix(eslint-config): Update legacy config to use eslint-plugin-import-x

### DIFF
--- a/packages/eslint-config/shared.js
+++ b/packages/eslint-config/shared.js
@@ -25,7 +25,7 @@ module.exports = {
   plugins: [
     'prettier',
     '@babel',
-    'import',
+    'import-x',
     'jsx-a11y',
     'react',
     'react-hooks',
@@ -46,7 +46,7 @@ module.exports = {
     // See...
     // - https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#groups-array
     // - https://github.com/import-js/eslint-plugin-import/blob/main/README.md#importinternal-regex
-    'import/internal-regex': '^src/',
+    'import-x/internal-regex': '^src/',
   },
   rules: {
     '@cedarjs/process-env-computed': 'error',
@@ -70,7 +70,7 @@ module.exports = {
     'react/prop-types': 'off',
     'react/display-name': 'off',
     'react-hooks/exhaustive-deps': 'warn',
-    'import/order': [
+    'import-x/order': [
       'error',
       {
         'newlines-between': 'always',


### PR DESCRIPTION
## Summary

- `shared.mjs` (flat config) was migrated from `eslint-plugin-import` to `eslint-plugin-import-x` in #1650, but the legacy eslintrc-shaped `shared.js` was missed in that migration.
- `shared.js` still registered the plugin as `'import'` and used the `'import/order'` rule and `'import/internal-regex'` setting, which under legacy ESLint's plugin-name resolution requires the `eslint-plugin-import` package -- a dependency that was removed from `package.json` in that same PR.
- Any consumer loading this package's CJS/legacy export (e.g. an `.eslintrc.js` doing `extends: ['@cedarjs/eslint-config']`) would hit `Cannot find module 'eslint-plugin-import'`.
- This updates `shared.js` to use `'import-x'` / `'import-x/order'` / `'import-x/internal-regex'`, matching what `shared.mjs` already does.

## Who's affected

- `create-cedar-app` templates switched from the legacy config (wired via `package.json`'s `eslintConfig` field) to flat config (`eslint.config.mjs`) in #629, which shipped in **v2.1.0** (2025-12-04). Apps scaffolded from v2.1.0 onward never touch the legacy `index.js`/`shared.js` path at all.
- Apps scaffolded **before v2.1.0** that never migrated off the legacy config are the ones at risk -- but only if they've also bumped `@cedarjs/eslint-config` to **v5.0.0+** (2026-05-06, #1650, where `eslint-plugin-import` was dropped) without migrating to flat config in between.
- There's no codemod or upgrade-script that migrates a project's ESLint config automatically -- `upgrade-scripts/` and `packages/codemods/` have nothing ESLint-related. The only existing guidance is a soft, default-on deprecation warning added in #651 (also v2.1.0): `yarn cedar lint` detects legacy `.eslintrc.*` files / `package.json#eslintConfig` and prints manual migration steps, but doesn't touch any files or fail the run. So any project that kept ignoring that warning and updated its eslint-config dependency would have silently hit this crash with no automated fix path -- this patch closes that gap at the source.