### PR TITLE
fix(e2e): record report files before jobsWorkoff, diff after

### DIFF
--- a/tasks/e2e-background-jobs/run.mts
+++ b/tasks/e2e-background-jobs/run.mts
@@ -113,12 +113,16 @@ async function main() {
   await scheduleCronJob(projectPath)
   await confirmJobDidNotRunSynchronously(projectPath, testFileName)
   const job = await confirmJobsWereScheduled(testFileLocation, testFileData)
+  const reportFilesBefore = fs
+    .readdirSync(projectPath)
+    .filter((file) => /^report-.*\.txt$/.test(file))
   await jobsWorkoff()
   await confirmJobsRan(
     projectPath,
     testFileName,
     testFileLocation,
     testFileData,
+    reportFilesBefore,
   )
   await confirmJobWasRemoved(job)
   await runCronJob(projectPath)
@@ -491,6 +495,7 @@ async function confirmJobsRan(
   testFileName: string,
   testFileLocation: string,
   testFileData: string,
+  reportFilesBefore: string[] = [],
 ) {
   console.log('\n❓ Testing: Confirming the jobs ran')
 
@@ -511,29 +516,29 @@ async function confirmJobsRan(
   }
   console.log('Confirmed: data job ran')
 
-  const reportFiles = fs
+  const reportFilesAfter = fs
     .readdirSync(projectPath)
     .filter((file) => /^report-.*\.txt$/.test(file))
 
-  const nbrOfReports = reportFiles.length
+  const newReportFiles = reportFilesAfter.filter(
+    (file) => !reportFilesBefore.includes(file),
+  )
+  const nbrOfReports = newReportFiles.length
 
   if (nbrOfReports !== 1) {
-    fs.readdirSync(projectPath).forEach((file) => {
-      console.log()
-      console.log('--- Cron job report files:')
-      console.log()
-      if (/^report-.*\.txt$/.test(file)) {
-        // Sometimes this e2e test fails in CI, and I'm not sure why. When I run
-        // it locally there's always just one cron job report file written, but
-        // in CI there's sometimes two.
-        // I want to know the timestamps in the report file names to see when
-        // they're created (if they're both created at the same time)
-        console.log(' - ' + file)
-      }
-      console.log()
-    })
-
-    console.error('💥 Expected 1 cron job report, but found', nbrOfReports)
+    console.log()
+    console.log('--- Cron job report files before workoff:')
+    console.log(
+      reportFilesBefore.map((f) => ' - ' + f).join('\n') || '  (none)',
+    )
+    console.log()
+    console.log('--- Cron job report files after workoff:')
+    console.log(reportFilesAfter.map((f) => ' - ' + f).join('\n') || '  (none)')
+    console.log()
+    console.error(
+      '💥 Expected 1 new cron job report after workoff, but found',
+      nbrOfReports,
+    )
     process.exit(1)
   }
   console.log('Confirmed: cron job ran')


### PR DESCRIPTION
## Problem

The e2e background jobs test was counting all `report-*.txt` files in the project directory after `jobsWorkoff()`, but some of those files may have existed before the workoff started (e.g. from a previous test run). This caused false positives where stale report files were counted as newly created.

## Fix

Snapshot the report files present **before** `jobsWorkoff()`, then diff against what's present **after** to get only the newly created files.

```typescript
const reportFilesBefore = fs
  .readdirSync(projectPath)
  .filter((file) => /^report-.*\.txt$/.test(file))
await jobsWorkoff()
await confirmJobsRan(..., reportFilesBefore)
```

`confirmJobsRan()` now accepts the before-snapshot and filters:
```typescript
const newReportFiles = reportFilesAfter.filter(
  (file) => !reportFilesBefore.includes(file),
)
```

The error output also now shows both before/after lists to make debugging easier.