### PR TITLE
chore(eslint-config): Remove unused dependencies found by knip

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -37,6 +37,11 @@
       // @cedarjs/graphql-server: optional peer dep, dynamically imported in
       // src/plugins/graphql.ts only when a project has a GraphQL function.
       "ignoreDependencies": ["publint", "@cedarjs/graphql-server"]
+    },
+    "packages/eslint-config": {
+      // eslint-plugin-react-compiler: optional peer dep, dynamically imported
+      // in index.mjs only when experimental.reactCompiler is enabled.
+      "ignoreDependencies": ["eslint-plugin-react-compiler"]
     }
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -34,15 +34,10 @@
     "@babel/eslint-plugin": "7.29.7",
     "@cedarjs/babel-config": "workspace:*",
     "@cedarjs/eslint-plugin": "workspace:*",
-    "@cedarjs/internal": "workspace:*",
     "@cedarjs/project-config": "workspace:*",
     "@eslint/js": "8.57.1",
-    "@typescript-eslint/eslint-plugin": "8.60.1",
-    "@typescript-eslint/parser": "8.60.1",
     "eslint": "8.57.1",
     "eslint-config-prettier": "10.1.8",
-    "eslint-import-resolver-babel-module": "5.3.2",
-    "eslint-plugin-babel": "5.3.1",
     "eslint-plugin-import-x": "4.17.1",
     "eslint-plugin-jest-dom": "5.5.0",
     "eslint-plugin-jsx-a11y": "6.10.2",
@@ -53,7 +48,6 @@
     "typescript-eslint": "8.60.1"
   },
   "devDependencies": {
-    "@babel/cli": "7.29.7",
     "typescript": "5.9.3"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3046,21 +3046,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@babel/cli": "npm:7.29.7"
     "@babel/core": "npm:^7.26.10"
     "@babel/eslint-parser": "npm:7.29.7"
     "@babel/eslint-plugin": "npm:7.29.7"
     "@cedarjs/babel-config": "workspace:*"
     "@cedarjs/eslint-plugin": "workspace:*"
-    "@cedarjs/internal": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
     "@eslint/js": "npm:8.57.1"
-    "@typescript-eslint/eslint-plugin": "npm:8.60.1"
-    "@typescript-eslint/parser": "npm:8.60.1"
     eslint: "npm:8.57.1"
     eslint-config-prettier: "npm:10.1.8"
-    eslint-import-resolver-babel-module: "npm:5.3.2"
-    eslint-plugin-babel: "npm:5.3.1"
     eslint-plugin-import-x: "npm:4.17.1"
     eslint-plugin-jest-dom: "npm:5.5.0"
     eslint-plugin-jsx-a11y: "npm:6.10.2"
@@ -16521,30 +16515,6 @@ __metadata:
     unrs-resolver:
       optional: true
   checksum: 10c0/07851103443b70af681c5988e2702e681ff9b956e055e11d4bd9b2322847fa0d9e8da50c18fc7cb1165106b043f34fbd0384d7011c239465c4645c52132e56f3
-  languageName: node
-  linkType: hard
-
-"eslint-import-resolver-babel-module@npm:5.3.2":
-  version: 5.3.2
-  resolution: "eslint-import-resolver-babel-module@npm:5.3.2"
-  dependencies:
-    pkg-up: "npm:^3.1.0"
-    resolve: "npm:^1.20.0"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-    babel-plugin-module-resolver: ^3.0.0 || ^4.0.0 || ^5.0.0
-  checksum: 10c0/168fc793cc565cb8c27eb69c67872420980a6fcaac4a5b6951bdaa2700c0745c997d282b3c8cce313c423a12933a0f6fcc347a799398f3cf7f91e9e8a35d2d69
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-babel@npm:5.3.1":
-  version: 5.3.1
-  resolution: "eslint-plugin-babel@npm:5.3.1"
-  dependencies:
-    eslint-rule-composer: "npm:^0.3.0"
-  peerDependencies:
-    eslint: ">=4.0.0"
-  checksum: 10c0/c73e054c3cf3c5392e8ea7e56f41db3859b9d7c0dd347c28a5f08ae87889cc4879fcddfe227ee1ec075a9ab62e34e245d7e6e723180dfa36d07397c2cbb2c1a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Follow-up to the `packages/api-server` knip cleanup, picking up `packages/eslint-config` (the original goal before #2243/#2244 became their own side quests).

- Removed `@cedarjs/internal`, `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint-import-resolver-babel-module`, and `eslint-plugin-babel` from `dependencies` -- genuinely unused now that `shared.js`/`index.js` (the legacy CJS config) are gone (#2244). `shared.mjs` gets its TypeScript-ESLint support via the bundled `typescript-eslint` package's `tseslint` export, not the standalone plugin/parser packages.
- Removed `@babel/cli` from `devDependencies` -- unused.
- Added `packages/eslint-config` to `knip.jsonc`'s `workspaces`, ignoring `eslint-plugin-react-compiler` -- it's a real usage knip can't statically see (optional peer dep, dynamically imported in `index.mjs` only when `experimental.reactCompiler` is enabled in a project's `cedar.toml`).

`yarn knip --workspace packages/eslint-config` is now fully clean (exit 0).