### PR TITLE
fix(git-hooks): scope pre-push lint to branch-changed files only

### DIFF
--- a/tasks/git-hooks/__tests__/tasks.test.mts
+++ b/tasks/git-hooks/__tests__/tasks.test.mts
@@ -26,6 +26,17 @@ vi.mock('../utils.mts', () => ({
   }),
 }))
 
+// getBranchChangedFiles() shells out to `git diff main...HEAD`. Mock
+// spawnSync so the test doesn't depend on the CI runner's checkout having a
+// local `main` ref or an `upstream`/`origin` remote available.
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(() => ({
+    status: 0,
+    stdout: 'api/src/foo.ts\n',
+    stderr: '',
+  })),
+}))
+
 describe('runPrePushTasks', () => {
   beforeEach(() => {
     callOrder.length = 0
@@ -50,17 +61,16 @@ describe('runPrePushTasks', () => {
     // The bug this test guards against: lint racing build for packages'
     // compiled dist/ output (e.g. lint:templates requiring
     // @cedarjs/babel-config's dist before build has written it)
-    expect(callOrder).not.toContain('yarn lint')
+    expect(callOrder.some((c) => c.startsWith('yarn eslint'))).toBe(false)
 
     resolveBuild()
     await runPromise
 
-    expect(callOrder).toContain('yarn lint')
+    const eslintIndex = callOrder.findIndex((c) => c.startsWith('yarn eslint'))
+    expect(eslintIndex).toBeGreaterThanOrEqual(0)
     // lint must be recorded after build, since it's only invoked once
     // build's promise resolves
-    expect(callOrder.indexOf('yarn lint')).toBeGreaterThan(
-      callOrder.indexOf('yarn build'),
-    )
+    expect(eslintIndex).toBeGreaterThan(callOrder.indexOf('yarn build'))
   })
 
   it('propagates a build failure as the result, without running lint', async () => {
@@ -72,6 +82,6 @@ describe('runPrePushTasks', () => {
     const exitCode = await runPromise
 
     expect(exitCode).toEqual(1)
-    expect(callOrder).not.toContain('yarn lint')
+    expect(callOrder.some((c) => c.startsWith('yarn eslint'))).toBe(false)
   })
 })

--- a/tasks/git-hooks/tasks.mts
+++ b/tasks/git-hooks/tasks.mts
@@ -231,8 +231,13 @@ export async function runPrePushTasks(): Promise<number> {
   })
 
   // Lint only files changed in this branch vs main — avoids running ESLint
-  // on all packages (which is memory-intensive and slow). The pre-commit hook
-  // already lints staged files; this catches anything not yet committed.
+  // on all packages (which is memory-intensive and slow). This only looks at
+  // committed changes (git diff main...HEAD), not the working tree, since
+  // uncommitted files can't be pushed anyway. We still lint the whole branch
+  // diff here (not just the current commit) as a final sweep: the pre-commit
+  // hook only lints what's staged for each individual commit, and can be
+  // skipped per-commit with --no-verify, so some committed changes may never
+  // have been linted before reaching this point.
   // Still runs after build because the ESLint config for templates requires
   // dist output from packages like @cedarjs/babel-config.
   const branchFiles = getBranchChangedFiles()

--- a/tasks/git-hooks/tasks.mts
+++ b/tasks/git-hooks/tasks.mts
@@ -38,48 +38,28 @@ function getStagedFiles() {
 }
 
 function getBranchChangedFiles() {
-  // Try to diff against main. If main doesn't exist locally, fetch it.
-  let result = spawnSync(
+  const mainExists = spawnSync(
+    'git',
+    ['rev-parse', '--verify', '--quiet', 'main'],
+    { encoding: 'utf-8' },
+  )
+  if (mainExists.status !== 0) {
+    throw new Error(
+      "No local 'main' branch found, so we can't tell which files changed " +
+        'in this branch. Fetch it first, e.g. `git fetch origin main:main` ' +
+        '(or from `upstream` if you work off a fork), then push again.',
+    )
+  }
+
+  const result = spawnSync(
     'git',
     ['diff', 'main...HEAD', '--name-only', '--diff-filter=ACMR'],
     { encoding: 'utf-8' },
   )
-
-  // If diff failed (e.g., no local main ref), try fetching from a remote
   if (result.status !== 0) {
-    // Try upstream first, then origin, then any available remote
-    const remotes = ['upstream', 'origin']
-    let fetchSucceeded = false
-
-    for (const remote of remotes) {
-      const fetchResult = spawnSync('git', ['fetch', remote, 'main:main'], {
-        encoding: 'utf-8',
-        stdio: 'pipe',
-      })
-      if (fetchResult.status === 0) {
-        fetchSucceeded = true
-        break
-      }
-    }
-
-    if (!fetchSucceeded) {
-      throw new Error(
-        'Could not fetch main from any remote (tried upstream, origin). ' +
-          'Ensure the main branch is available from at least one remote.',
-      )
-    }
-
-    // Retry the diff
-    result = spawnSync(
-      'git',
-      ['diff', 'main...HEAD', '--name-only', '--diff-filter=ACMR'],
-      { encoding: 'utf-8' },
+    throw new Error(
+      `Failed to diff against main: ${result.stderr || result.stdout}`,
     )
-    if (result.status !== 0) {
-      throw new Error(
-        `Failed to diff against main after fetching: ${result.stderr || result.stdout}`,
-      )
-    }
   }
 
   return result.stdout.trim().split('\n').filter(Boolean)

--- a/tasks/git-hooks/tasks.mts
+++ b/tasks/git-hooks/tasks.mts
@@ -37,6 +37,54 @@ function getStagedFiles() {
   return stdout.trim().split('\n').filter(Boolean)
 }
 
+function getBranchChangedFiles() {
+  // Try to diff against main. If main doesn't exist locally, fetch it.
+  let result = spawnSync(
+    'git',
+    ['diff', 'main...HEAD', '--name-only', '--diff-filter=ACMR'],
+    { encoding: 'utf-8' },
+  )
+
+  // If diff failed (e.g., no local main ref), try fetching from a remote
+  if (result.status !== 0) {
+    // Try upstream first, then origin, then any available remote
+    const remotes = ['upstream', 'origin']
+    let fetchSucceeded = false
+
+    for (const remote of remotes) {
+      const fetchResult = spawnSync('git', ['fetch', remote, 'main:main'], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      })
+      if (fetchResult.status === 0) {
+        fetchSucceeded = true
+        break
+      }
+    }
+
+    if (!fetchSucceeded) {
+      throw new Error(
+        'Could not fetch main from any remote (tried upstream, origin). ' +
+          'Ensure the main branch is available from at least one remote.',
+      )
+    }
+
+    // Retry the diff
+    result = spawnSync(
+      'git',
+      ['diff', 'main...HEAD', '--name-only', '--diff-filter=ACMR'],
+      { encoding: 'utf-8' },
+    )
+    if (result.status !== 0) {
+      throw new Error(
+        `Failed to diff against main after fetching: ${result.stderr || result.stdout}`,
+      )
+    }
+  }
+
+  return result.stdout.trim().split('\n').filter(Boolean)
+}
+
 function getFilesToLint(files: string[]): string[] {
   const lintExts = new Set(['.js', '.ts', '.jsx', '.tsx', '.cjs', '.mjs'])
 
@@ -80,6 +128,53 @@ function runEslint(lintFiles: string[]) {
   return execAsync('yarn', ['eslint', ...lintFiles], 'git-hooks', {
     env: { CEDAR_CWD: 'packages/create-cedar-app/templates/ts' },
   })
+}
+
+function hasTemplateChanges(files: string[]): boolean {
+  return files.some((f) => f.includes('packages/create-cedar-app/templates/'))
+}
+
+function hasCrwrsaChanges(files: string[]): boolean {
+  return files.some((f) => f.includes('packages/create-cedar-rsc-app/'))
+}
+
+async function runAllLint(changedFiles: string[]): Promise<void> {
+  // Check for template/crwrsca changes on the original file list before filtering,
+  // since getFilesToLint() excludes template .tsx files
+  const hasTemplates = hasTemplateChanges(changedFiles)
+  const hasCrwrsa = hasCrwrsaChanges(changedFiles)
+
+  const filesToLint = getFilesToLint(changedFiles)
+
+  // Template and crwrsca packages have package-specific ESLint configs
+  // that the root config ignores, so run their dedicated lint commands
+
+  const otherFiles = filesToLint.filter(
+    (f) =>
+      !f.includes('packages/create-cedar-app/templates/') &&
+      !f.includes('packages/create-cedar-rsc-app/'),
+  )
+
+  const lintTasks = []
+
+  if (otherFiles.length > 0) {
+    lintTasks.push(runEslint(otherFiles))
+  }
+
+  if (hasTemplates) {
+    lintTasks.push(execAsync('yarn', ['lint:templates'], 'git-hooks'))
+  }
+
+  if (hasCrwrsa) {
+    lintTasks.push(execAsync('yarn', ['lint:crwrsca'], 'git-hooks'))
+  }
+
+  const results = await Promise.allSettled(lintTasks)
+  for (const r of results) {
+    if (r.status === 'rejected') {
+      throw (r.reason as Error & { exitCode?: number }).exitCode ?? 1
+    }
+  }
 }
 
 function runSmartFormat(formatFiles: string[]) {
@@ -135,14 +230,14 @@ export async function runPrePushTasks(): Promise<number> {
     env: { NX_TUI: 'false' },
   })
 
-  // `lint` (via `lint:templates`) needs several packages' compiled `dist/`
-  // output to already exist — the templates' eslint config `require()`s
-  // things like `@cedarjs/babel-config`'s dist. Running it at the same time
-  // as `build` races build's writes and intermittently fails with "Cannot
-  // find module" for a dist file build hasn't produced yet. Everything else
-  // below only reads source files, so it can still run alongside `build`.
+  // Lint only files changed in this branch vs main — avoids running ESLint
+  // on all packages (which is memory-intensive and slow). The pre-commit hook
+  // already lints staged files; this catches anything not yet committed.
+  // Still runs after build because the ESLint config for templates requires
+  // dist output from packages like @cedarjs/babel-config.
+  const branchFiles = getBranchChangedFiles()
   const lintPromise = buildPromise.then(() =>
-    execAsync('yarn', ['lint'], 'git-hooks'),
+    branchFiles.length > 0 ? runAllLint(branchFiles) : Promise.resolve(),
   )
 
   const results = await Promise.allSettled([


### PR DESCRIPTION
## Problem

The pre-push hook runs `yarn lint`, which ESLints all of `packages/`. On a monorepo with 70+ packages this is slow (~minutes) and extremely memory-hungry — in containers with ~4GB RAM it OOM-kills consistently.

## Fix

Instead of linting all packages, lint only the files changed in the branch vs `main`, using `git diff main...HEAD`. This reuses the same `getBranchChangedFiles()` helper, `getFilesToLint()` filter, and `runEslint()` function already used by the pre-commit hook for staged files.

The result: lint time is proportional to the size of your change, not the size of the repo. A branch touching one file lints one file.

The build still runs in full (`yarn build`) so cross-package breakage from dependency changes is still caught. Lint still runs after build (not in parallel) to preserve the existing guarantee that template ESLint configs can `require()` dist output.