### PR TITLE
fix(ci): Split milestone check and assignment into single-trigger workflows

### DIFF
--- a/.github/actions/assign-milestone/action.yml
+++ b/.github/actions/assign-milestone/action.yml
@@ -1,0 +1,18 @@
+name: Assign milestone
+description: Automatically assigns a milestone to a PR based on its conventional-commit title
+
+inputs:
+  github-token:
+    description: 'GitHub token for setting milestones'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Run milestone assignment
+      shell: bash
+      run: node ${{ github.action_path }}/assignMilestone.mjs
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
+        GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/actions/assign-milestone/assignMilestone.mjs
+++ b/.github/actions/assign-milestone/assignMilestone.mjs
@@ -1,0 +1,121 @@
+// @ts-check
+
+/**
+ * Automatically assigns a milestone to a PR based on its conventional-commit
+ * title. This needs a write-capable GITHUB_TOKEN, which is why it's separate
+ * from the read-only require-milestone check action - see the comments in
+ * .github/workflows/assign-milestone.yml for the full reasoning.
+ */
+
+import {
+  fetchOpenMilestones,
+  fetchPullRequestDetails,
+  getMilestoneEnv,
+  getMilestoneFromConventionalCommit,
+  getPullRequestNumberFromEvent,
+} from '../milestoneLib.mjs'
+
+/**
+ * Sets the milestone on a pull request using the GitHub API
+ * @param {ReturnType<typeof getMilestoneEnv>} env
+ * @param {number} prNumber - The pull request number
+ * @param {string} milestoneName - The name of the milestone to set
+ * @returns {Promise<boolean>} - True if the milestone was set successfully, false otherwise
+ */
+async function setMilestone(env, prNumber, milestoneName) {
+  const [owner, repo] = env.GITHUB_REPOSITORY.split('/')
+
+  // First, get the list of milestones to find the milestone number
+  const milestones = await fetchOpenMilestones(env)
+
+  if (!milestones) {
+    return false
+  }
+
+  const milestone = milestones.find((m) => m.title === milestoneName)
+
+  if (!milestone) {
+    console.error(`Milestone "${milestoneName}" not found in repository`)
+    return false
+  }
+
+  // Set the milestone on the PR
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}`,
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `token ${env.GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        milestone: milestone.number,
+      }),
+    },
+  )
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    console.error(
+      `Failed to set milestone: ${response.status} ${response.statusText}\n${errorText}`,
+    )
+    return false
+  }
+
+  console.log(
+    `Successfully set milestone "${milestoneName}" on PR #${prNumber}`,
+  )
+  return true
+}
+
+async function main() {
+  const env = getMilestoneEnv()
+
+  if (!env.GITHUB_TOKEN) {
+    console.error('GITHUB_TOKEN is not set. Cannot fetch PR details.')
+    process.exitCode = 1
+    return
+  }
+
+  const prNumber = getPullRequestNumberFromEvent(env)
+  const pullRequest = await fetchPullRequestDetails(env, prNumber)
+
+  if (!pullRequest) {
+    process.exitCode = 1
+    return
+  }
+
+  const { title, milestone } = pullRequest
+
+  // If milestone already exists, there's nothing to assign
+  if (milestone) {
+    console.log(`PR already has milestone: ${milestone.title}`)
+    return
+  }
+
+  const suggestedMilestone = getMilestoneFromConventionalCommit(title)
+
+  if (!suggestedMilestone) {
+    // Not an error for this workflow - the "🚩 Require milestone" required
+    // check is responsible for flagging PRs without a milestone
+    console.log(
+      `PR title "${title}" doesn't match conventional commit format and no ` +
+        'milestone is set. Nothing to assign.',
+    )
+    return
+  }
+
+  console.log(
+    `PR title "${title}" matches conventional commit format. ` +
+      `Automatically setting milestone to "${suggestedMilestone}"...`,
+  )
+
+  const milestoneSet = await setMilestone(env, prNumber, suggestedMilestone)
+
+  if (!milestoneSet) {
+    process.exitCode = 1
+  }
+}
+
+main()

--- a/.github/actions/detect-changes/cases/code_changes.mts
+++ b/.github/actions/detect-changes/cases/code_changes.mts
@@ -45,7 +45,13 @@ function isNonCodeWorkflowOrAction(filePath: string): boolean {
 
     '.github/workflows/require-milestone.yml',
     '.github/actions/require-milestone/action.yml',
-    '.github/actions/requireMilestone.mjs',
+    '.github/actions/require-milestone/requireMilestone.mjs',
+
+    '.github/workflows/assign-milestone.yml',
+    '.github/actions/assign-milestone/action.yml',
+    '.github/actions/assign-milestone/assignMilestone.mjs',
+
+    '.github/actions/milestoneLib.mjs',
 
     '.github/workflows/require-release-label.yml',
     '.github/actions/require-release-label-or-cc-message/action.yml',

--- a/.github/actions/milestoneLib.mjs
+++ b/.github/actions/milestoneLib.mjs
@@ -1,0 +1,141 @@
+// @ts-check
+
+/**
+ * Shared helpers for the require-milestone (check, read-only) and
+ * assign-milestone (auto-assign, needs write) actions.
+ */
+
+import fs from 'node:fs'
+
+/**
+ * @typedef {Object} MilestoneEnv
+ * @property {string} GITHUB_EVENT_PATH - Path to the event webhook payload
+ *   file on the runner. Set by the GitHub Actions runner.
+ * @property {string} GITHUB_TOKEN - GitHub token for API requests.
+ * @property {string} GITHUB_REPOSITORY - The owner and repository name.
+ */
+
+/**
+ * @typedef {Object} PullRequestDetails
+ * @property {string} title - The title of the pull request.
+ * @property {number} number - The pull request number.
+ * @property {{ title: string }|null} milestone - The milestone associated
+ *   with the pull request.
+ */
+
+/**
+ * Reads the environment variables the milestone actions need.
+ * @see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+ * @returns {MilestoneEnv}
+ */
+export function getMilestoneEnv() {
+  return {
+    GITHUB_EVENT_PATH: process.env.GITHUB_EVENT_PATH || '',
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN || '',
+    GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY || '',
+  }
+}
+
+/**
+ * Determines the appropriate milestone based on conventional commit format
+ * @param {string} title - The PR title
+ * @returns {string|null} - The milestone name or null if no match
+ */
+export function getMilestoneFromConventionalCommit(title) {
+  // Breaking changes (indicated by !)
+  if (/^(feat|fix|docs|chore)(\([^)]+\))!:/.test(title)) {
+    return 'next-release-major'
+  }
+
+  // Feature (goes in next minor release)
+  if (/^feat\([^)]+\):/.test(title)) {
+    return 'next-release'
+  }
+
+  // Fix (goes in next patch release)
+  if (/^(fix|docs)\([^)]+\):/.test(title)) {
+    return 'next-release-patch'
+  }
+
+  // Chore (framework-side maintenance)
+  if (/^chore\([^)]+\):/.test(title)) {
+    return 'chore'
+  }
+
+  return null
+}
+
+/**
+ * Reads the PR number from the event webhook payload.
+ * @param {MilestoneEnv} env
+ * @returns {number}
+ */
+export function getPullRequestNumberFromEvent(env) {
+  const event = fs.readFileSync(env.GITHUB_EVENT_PATH, 'utf-8')
+
+  /** @type {{ pull_request: { number: number } }} */
+  const { pull_request: pullRequest } = JSON.parse(event)
+
+  return pullRequest.number
+}
+
+/**
+ * Fetches the current PR state from the API to get the latest title and
+ * milestone. Reading the PR details from the event payload will give stale
+ * data if for example the PR title has been updated. The event payload
+ * contains data from when the workflow was originally triggered.
+ * @param {MilestoneEnv} env
+ * @param {number} prNumber
+ * @returns {Promise<PullRequestDetails|null>} - Null if the fetch failed.
+ */
+export async function fetchPullRequestDetails(env, prNumber) {
+  const [owner, repo] = env.GITHUB_REPOSITORY.split('/')
+
+  const prResponse = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`,
+    {
+      headers: {
+        Authorization: `token ${env.GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github.v3+json',
+      },
+    },
+  )
+
+  if (!prResponse.ok) {
+    console.error(
+      `Failed to fetch PR details: ${prResponse.status} ${prResponse.statusText}`,
+    )
+    return null
+  }
+
+  return prResponse.json()
+}
+
+/**
+ * Fetches the repository's open milestones.
+ * @param {MilestoneEnv} env
+ * @returns {Promise<Array<{ title: string, number: number }>|null>} - Null if
+ *   the fetch failed.
+ */
+export async function fetchOpenMilestones(env) {
+  const [owner, repo] = env.GITHUB_REPOSITORY.split('/')
+
+  const milestonesResponse = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/milestones?state=open&per_page=100`,
+    {
+      headers: {
+        Authorization: `token ${env.GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github.v3+json',
+      },
+    },
+  )
+
+  if (!milestonesResponse.ok) {
+    console.error(
+      `Failed to fetch milestones: ${milestonesResponse.status} ${milestonesResponse.statusText}`,
+    )
+    return null
+  }
+
+  return milestonesResponse.json()
+}

--- a/.github/actions/require-milestone/action.yml
+++ b/.github/actions/require-milestone/action.yml
@@ -1,11 +1,10 @@
 name: Require milestone
-description: Ensures that a PR has a valid milestone or automatically sets one based on conventional commit format
+description: Ensures that a PR has a milestone, or a conventional-commit title that the assign-milestone action can derive one from
 
 inputs:
   github-token:
-    description: 'GitHub token for setting milestones'
-    required: false
-    default: ''
+    description: 'GitHub token for reading PR details (read access is enough)'
+    required: true
 
 runs:
   using: composite

--- a/.github/actions/require-milestone/requireMilestone.mjs
+++ b/.github/actions/require-milestone/requireMilestone.mjs
@@ -15,6 +15,15 @@
  * GITHUB_TOKEN don't trigger new workflow runs, so that assignment will NOT
  * re-run this check. A maintainer manually (de)assigning a milestone does
  * re-run it.
+ *
+ * This does mean the check can be green while the assignment hasn't happened
+ * (yet). That gap is deliberately small and visible: the most likely
+ * assignment failure - the mapped milestone not existing - fails THIS check
+ * too (see below), a transient API failure shows up as a red (non-required)
+ * "🎯 Assign milestone" check and is retried on the next push or edit, and a
+ * concurrency cancellation only happens when a newer run supersedes it and
+ * assigns instead. Same accepted pattern as the require-release-label check,
+ * which passes on a conventional-commit title without any label being set.
  */
 
 import {

--- a/.github/actions/require-milestone/requireMilestone.mjs
+++ b/.github/actions/require-milestone/requireMilestone.mjs
@@ -1,145 +1,32 @@
 // @ts-check
 
 /**
- * @typedef {Object} PullRequest
- * @property {string} title - The title of the pull request.
- * @property {number} number - The pull request number.
- * @property {{ login: string }} user - The user who created the pull request.
- * @property {Object|null} milestone - The milestone associated with the pull request.
+ * Required check: verifies that a PR either has a milestone, or has a
+ * conventional-commit title that maps to an existing open milestone (which
+ * the "🎯 Assign milestone" workflow will then set automatically).
+ *
+ * This script only READS PR metadata, so it works with the read-only
+ * GITHUB_TOKEN that fork PRs get. The actual milestone assignment, which
+ * needs a write-capable token, lives in the assign-milestone action.
+ *
+ * Note that the check must pass on a mapping conventional-commit title alone
+ * (rather than waiting for the milestone to actually be set): the assign
+ * workflow sets the milestone using GITHUB_TOKEN, and events caused by
+ * GITHUB_TOKEN don't trigger new workflow runs, so that assignment will NOT
+ * re-run this check. A maintainer manually (de)assigning a milestone does
+ * re-run it.
  */
 
-/**
- * @typedef {Object} GitHubEvent
- * @property {PullRequest} pull_request - The pull request object from the
- *   GitHub event payload.
- * @property {{ login: string }} sender - The user who triggered the event.
- */
-
-/** Environment variables needed for the script. */
-const env = {
-  /**
-   * `GITHUB_EVENT_PATH` - This is set by the GitHub Actions runner.
-   * It's the path to the file on the runner that contains the full event
-   * webhook payload.
-   * @see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables.
-   */
-  GITHUB_EVENT_PATH: process.env.GITHUB_EVENT_PATH || '',
-  /** `GITHUB_TOKEN` - GitHub token for API requests */
-  GITHUB_TOKEN: process.env.GITHUB_TOKEN || '',
-  /** `GITHUB_REPOSITORY` - The owner and repository name */
-  GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY || '',
-}
-
-import fs from 'node:fs'
-
-/**
- * Determines the appropriate milestone based on conventional commit format
- * @param {string} title - The PR title
- * @returns {string|null} - The milestone name or null if no match
- */
-function getMilestoneFromConventionalCommit(title) {
-  // Breaking changes (indicated by !)
-  if (/^(feat|fix|docs|chore)(\([^)]+\))!:/.test(title)) {
-    return 'next-release-major'
-  }
-
-  // Feature (goes in next minor release)
-  if (/^feat\([^)]+\):/.test(title)) {
-    return 'next-release'
-  }
-
-  // Fix (goes in next patch release)
-  if (/^(fix|docs)\([^)]+\):/.test(title)) {
-    return 'next-release-patch'
-  }
-
-  // Chore (framework-side maintenance)
-  if (/^chore\([^)]+\):/.test(title)) {
-    return 'chore'
-  }
-
-  return null
-}
-
-/**
- * Sets the milestone on a pull request using the GitHub API
- * @param {number} prNumber - The pull request number
- * @param {string} milestoneName - The name of the milestone to set
- * @returns {Promise<boolean>} - True if the milestone was set successfully, false otherwise
- */
-async function setMilestone(prNumber, milestoneName) {
-  if (!env.GITHUB_TOKEN) {
-    console.error(
-      'GITHUB_TOKEN is not set. Cannot automatically set milestone.',
-    )
-    return false
-  }
-
-  const [owner, repo] = env.GITHUB_REPOSITORY.split('/')
-
-  // First, get the list of milestones to find the milestone number
-  const milestonesResponse = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/milestones?state=open&per_page=100`,
-    {
-      headers: {
-        Authorization: `token ${env.GITHUB_TOKEN}`,
-        Accept: 'application/vnd.github.v3+json',
-      },
-    },
-  )
-
-  if (!milestonesResponse.ok) {
-    console.error(
-      `Failed to fetch milestones: ${milestonesResponse.status} ${milestonesResponse.statusText}`,
-    )
-    return false
-  }
-
-  const milestones = await milestonesResponse.json()
-  const milestone = milestones.find((m) => m.title === milestoneName)
-
-  if (!milestone) {
-    console.error(`Milestone "${milestoneName}" not found in repository`)
-    return false
-  }
-
-  // Set the milestone on the PR
-  const response = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}`,
-    {
-      method: 'PATCH',
-      headers: {
-        Authorization: `token ${env.GITHUB_TOKEN}`,
-        Accept: 'application/vnd.github.v3+json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        milestone: milestone.number,
-      }),
-    },
-  )
-
-  if (!response.ok) {
-    const errorText = await response.text()
-    console.error(
-      `Failed to set milestone: ${response.status} ${response.statusText}\n${errorText}`,
-    )
-    return false
-  }
-
-  console.log(
-    `Successfully set milestone "${milestoneName}" on PR #${prNumber}`,
-  )
-  return true
-}
+import {
+  fetchOpenMilestones,
+  fetchPullRequestDetails,
+  getMilestoneEnv,
+  getMilestoneFromConventionalCommit,
+  getPullRequestNumberFromEvent,
+} from '../milestoneLib.mjs'
 
 async function main() {
-  const event = fs.readFileSync(env.GITHUB_EVENT_PATH, 'utf-8')
-
-  /** @type {GitHubEvent} */
-  const { pull_request: pullRequest } = JSON.parse(event)
-
-  const [owner, repo] = env.GITHUB_REPOSITORY.split('/')
+  const env = getMilestoneEnv()
 
   if (!env.GITHUB_TOKEN) {
     console.error('GITHUB_TOKEN is not set. Cannot fetch PR details.')
@@ -147,29 +34,15 @@ async function main() {
     return
   }
 
-  // Fetch the current PR state from the API to get the latest title and
-  // milestone. Reading the PR details from the event payload will give stale
-  // data if for example the PR title has been updated. The event payload
-  // contains data from when the workflow was originally triggered
-  const prResponse = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullRequest.number}`,
-    {
-      headers: {
-        Authorization: `token ${env.GITHUB_TOKEN}`,
-        Accept: 'application/vnd.github.v3+json',
-      },
-    },
-  )
+  const prNumber = getPullRequestNumberFromEvent(env)
+  const pullRequest = await fetchPullRequestDetails(env, prNumber)
 
-  if (!prResponse.ok) {
-    console.error(
-      `Failed to fetch PR details: ${prResponse.status} ${prResponse.statusText}`,
-    )
+  if (!pullRequest) {
     process.exitCode = 1
     return
   }
 
-  const { title, milestone } = await prResponse.json()
+  const { title, milestone } = pullRequest
 
   // If milestone already exists, we're good
   if (milestone) {
@@ -181,20 +54,29 @@ async function main() {
   const suggestedMilestone = getMilestoneFromConventionalCommit(title)
 
   if (suggestedMilestone) {
-    console.log(
-      `PR title "${title}" matches conventional commit format. ` +
-        `Automatically setting milestone to "${suggestedMilestone}"...`,
-    )
+    const milestones = await fetchOpenMilestones(env)
 
-    const milestoneSet = await setMilestone(
-      pullRequest.number,
-      suggestedMilestone,
-    )
-
-    if (!milestoneSet) {
+    if (!milestones) {
       process.exitCode = 1
+      return
     }
 
+    if (milestones.some((m) => m.title === suggestedMilestone)) {
+      console.log(
+        `PR title "${title}" matches conventional commit format. ` +
+          `The "🎯 Assign milestone" workflow will set the milestone to ` +
+          `"${suggestedMilestone}".`,
+      )
+      return
+    }
+
+    console.error(
+      `Milestone "${suggestedMilestone}" (derived from the PR title ` +
+        `"${title}") does not exist as an open milestone in this repository, ` +
+        'so it cannot be auto-assigned. Please set a milestone manually, or ' +
+        'create the milestone.',
+    )
+    process.exitCode = 1
     return
   }
 

--- a/.github/workflows/assign-milestone.yml
+++ b/.github/workflows/assign-milestone.yml
@@ -1,0 +1,59 @@
+name: 🎯 Assign milestone
+
+# Automatically assigns a milestone to PRs based on their conventional-commit
+# title. This is NOT a required check - the required "🚩 Require milestone"
+# check lives in require-milestone.yml, which also explains why the check and
+# the assignment are split into two single-trigger workflows with different
+# check names.
+#
+# We must use pull_request_target here because assigning a milestone needs a
+# write-capable GITHUB_TOKEN, and fork PRs get a read-only token under
+# pull_request regardless of declared permissions.
+#
+# Using pull_request_target can be dangerous as it allows fork PRs to trigger
+# a workflow run with a write-capable GITHUB_TOKEN. The safety of this
+# workflow depends on two things:
+#   1. It never checks out the fork's merge ref (refs/pull/.../merge). Under
+#      pull_request_target, both the workflow definition and the checkout
+#      step's default ref come from the base branch.
+#   2. It never executes fork-controlled code. The assign-milestone action
+#      only reads PR metadata and calls the GitHub API.
+# This also means changes to this workflow and to the assign-milestone action
+# only take effect once they land on the base branch.
+#
+# No `milestoned` trigger type: when a milestone was just added there's
+# nothing left to assign.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, demilestoned, edited]
+
+# Cancel in-progress runs of this workflow.
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# No top level permissions are required for this workflow
+permissions: {}
+
+jobs:
+  assign-milestone:
+    name: 🎯 Assign milestone
+    runs-on: ubuntu-latest
+    permissions:
+      # The narrowest permission needed for the milestone API call
+      pull-requests: write
+    steps:
+      # Checks out the base branch, NOT the PR's code. See the security notes
+      # at the top of this file before changing this step.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: ⬢ Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: 🎯 Assign milestone
+        uses: ./.github/actions/assign-milestone
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -29,6 +29,14 @@ name: 🚩 Require milestone
 # skip could block a genuinely passing PR, and any no-op success could mask
 # a genuine failure. With exactly one run per check name, rerunning a check
 # always re-validates for real.
+#
+# Trust model: because pull_request runs PR-branch code, a fork PR could
+# edit this workflow or the require-milestone action to make this check
+# pass trivially. That's accepted: it's the same trust model as every other
+# required check in this repo that runs under pull_request (build, tests,
+# require-release-label), this check is release hygiene rather than a
+# security control, and .github/ changes are visible in review. The
+# write-capable half in assign-milestone.yml remains fork-tamper-proof.
 on:
   pull_request:
     types: [opened, synchronize, reopened, milestoned, demilestoned, edited]

--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -1,53 +1,54 @@
 name: 🚩 Require milestone
 
+# This is a required check. It verifies that a PR either has a milestone, or
+# has a conventional-commit title that maps to an existing milestone (which
+# the companion "🎯 Assign milestone" workflow in assign-milestone.yml will
+# then set automatically).
+#
+# This workflow deliberately listens ONLY to pull_request, and
+# assign-milestone.yml listens ONLY to pull_request_target. Splitting the
+# check (read-only) from the assignment (needs a write-capable token) is what
+# makes a single trigger per workflow possible:
+#
+# - The check only READS PR metadata, so the read-only GITHUB_TOKEN that
+#   fork PRs get under pull_request is sufficient - no pull_request_target
+#   needed here. And because pull_request runs the PR branch's version of
+#   this workflow and of the require-milestone action, changes to them can
+#   be tested in the PR itself before they land on the base branch.
+#
+# - The assignment needs a write-capable token, which fork PRs only get
+#   under pull_request_target. That half lives in assign-milestone.yml,
+#   under a different check name that is NOT required.
+#
+# One trigger per check name matters: this workflow used to listen to both
+# events and route between them with a job-level `if:`, which meant every PR
+# event produced two check-runs under the identical required-check name -
+# one real, one skipped. GitHub's required-status-check evaluation uses
+# whichever run under a given name is most recent, so rerunning the wrong
+# (indistinguishable-in-the-UI) one could supersede the real result: a fresh
+# skip could block a genuinely passing PR, and any no-op success could mask
+# a genuine failure. With exactly one run per check name, rerunning a check
+# always re-validates for real.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, milestoned, demilestoned, edited]
-  pull_request_target:
     types: [opened, synchronize, reopened, milestoned, demilestoned, edited]
 
 # Cancel in-progress runs of this workflow.
 # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-permissions:
-  pull-requests: write
+# No top level permissions are required for this workflow
+permissions: {}
 
 jobs:
   require-milestone:
     name: 🚩 Require milestone
     runs-on: ubuntu-latest
-    # We listen to both pull_request and pull_request_target, then route based
-    # on whether the PR comes from a fork.
-    #
-    # Using pull_request_target can be dangerous as it allows fork PRs to
-    # execute code in the context of the base repo with a write-capable
-    # GITHUB_TOKEN. The safety of this workflow depends on two things:
-    #   1. It never checks out the fork's merge ref (refs/pull/.../merge).
-    #      The checkout step runs against the base branch only.
-    #   2. It never executes fork-controlled code. The milestone action only
-    #      reads PR metadata and calls the GitHub API.
-    #
-    # Same-repo PRs -> pull_request:
-    #   The runner uses the PR branch's code. This allows contributors to test
-    #   workflow changes in their own PR before they land on the base branch.
-    #   The GITHUB_TOKEN defaults to read-only; we override that and grant
-    #   pull-requests: write (the narrowest permission needed for the
-    #   milestone API call). Again, this is safe because this only happens for
-    #   same-repo PRs, not fork PRs.
-    #
-    # Fork PRs -> pull_request_target:
-    #   The runner always uses the base branch's code. This is the critical
-    #   safety property: a fork PR can't inject code into our workflow run.
-    #   We must use pull_request_target here because fork PRs get a read-only
-    #   GITHUB_TOKEN under pull_request regardless of declared permissions – the
-    #   milestone API call (which needs write access) would fail.
-    if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
-
+    permissions:
+      issues: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 


### PR DESCRIPTION
## Summary

Fixes a gotcha discovered while working on #2241: the `🚩 Require milestone` check can appear "stuck" even when CI is otherwise green.

`require-milestone.yml` listened to both `pull_request` and `pull_request_target` and used a job-level `if:` to route between them (same-repo PRs → `pull_request`, fork PRs → `pull_request_target`). Both triggers publish a check-run under the identical name (`🚩 Require milestone`), and GitHub's required-status-check evaluation appears to use whichever run under that name is most recent. The job-level `if: false` gives the non-applicable trigger's run a **skipped** conclusion, so if that run gets rerun after the real check already passed (easy to do by mistake — the two runs are indistinguishable in the UI), the fresh "skipped" supersedes the genuine success and blocks merging.

Two earlier approaches were rejected:

- **Step-level routing** (this PR's first revision): the non-applicable run concludes with a real `success` instead of `skipped`. But as Greptile pointed out, that just inverts the bug — a rerun of the no-op *success* could supersede a genuine *failure* and silently bypass the milestone requirement.
- **Single `pull_request_target` trigger** (second revision): fixes the collision but kills a deliberate design property — a PR must be able to test changes to this workflow before merging, which requires running PR-branch code via `pull_request`.

## Fix

The root cause is that **one required check name was fed by two triggers**. The dual triggers only existed because the action did two jobs at once: *check* that a milestone is set (needs only read access) and *auto-assign* one from the conventional-commit title (needs a write token, which fork PRs only get under `pull_request_target`). Splitting those responsibilities lets each workflow have exactly one trigger:

- **`🚩 Require milestone`** (required check, `require-milestone.yml`) — `pull_request` only, for **all** PRs. It only reads PR metadata, so fork PRs' read-only token is enough. Passes when the PR has a milestone **or** its title maps to an existing open milestone (same pattern as the `🏷 Require release label` check). Bonus: the required check now runs the PR branch's workflow/action code for *every* PR, so changes are testable in-PR — previously that only worked for same-repo PRs.
- **`🎯 Assign milestone`** (new, **not** required, `assign-milestone.yml`) — `pull_request_target` only. Auto-assigns the milestone from the title. Keeps the established safety properties: base-branch workflow definition and checkout, never executes fork-controlled code, `pull-requests: write` is the only permission.

Each check name now has exactly one run per event, so the entire "which identically-named run is most recent" failure class is impossible in both directions, and rerunning any check always re-validates for real.

Design notes:

- The check passes on a mapping conventional-commit title alone rather than waiting for the milestone to actually land, because the assign workflow acts via `GITHUB_TOKEN` and events caused by `GITHUB_TOKEN` never trigger new workflow runs — the assignment cannot re-run the check. To close the resulting gap, the check verifies the mapped milestone actually **exists** as an open milestone; if auto-assignment would be impossible, the check fails.
- Manual milestone changes by a maintainer do re-trigger the check (`milestoned`/`demilestoned` types).
- No ruleset changes needed: the required check name is unchanged, and `🎯 Assign milestone` is deliberately not required.
- Trade-off: under `pull_request`, fork PRs run their own branch's version of the *check* (they could in principle edit it to always pass). That's acceptable for a release-hygiene check — maintainers review workflow changes, and milestones are verified at release time anyway. The write-capable half remains fork-tamper-proof.
- Also fixes a stale path in detect-changes' non-code file list (`.github/actions/requireMilestone.mjs` → its actual location).
