### PR TITLE
chore(core): Remove unused dependencies found by knip

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -42,6 +42,14 @@
       // eslint-plugin-react-compiler: optional peer dep, dynamically imported
       // in index.mjs only when experimental.reactCompiler is enabled.
       "ignoreDependencies": ["eslint-plugin-react-compiler"]
+    },
+    "packages/core": {
+      "entry": ["src/bins/*.ts"],
+      // graphql-tag: not imported by core's own source. It's a deliberate
+      // phantom dependency -- the js/ts create-cedar-app templates import it
+      // directly in generated code (api/src/directives/*) without declaring
+      // it themselves, relying on it hoisting in via @cedarjs/core.
+      "ignoreDependencies": ["graphql-tag"]
     }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,8 @@
     "@cedarjs/api-server": "workspace:*",
     "@cedarjs/cli": "workspace:*",
     "@cedarjs/internal": "workspace:*",
+    "@cedarjs/jobs": "workspace:*",
+    "@cedarjs/vite": "workspace:*",
     "@cedarjs/web-server": "workspace:*",
     "graphql-tag": "2.12.6",
     "nodemon": "3.1.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,13 +48,9 @@
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
   "dependencies": {
-    "@babel/cli": "7.29.7",
     "@cedarjs/api-server": "workspace:*",
     "@cedarjs/cli": "workspace:*",
-    "@cedarjs/eslint-config": "workspace:*",
     "@cedarjs/internal": "workspace:*",
-    "@cedarjs/project-config": "workspace:*",
-    "@cedarjs/testing": "workspace:*",
     "@cedarjs/web-server": "workspace:*",
     "graphql-tag": "2.12.6",
     "nodemon": "3.1.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3002,6 +3002,8 @@ __metadata:
     "@cedarjs/cli": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/internal": "workspace:*"
+    "@cedarjs/jobs": "workspace:*"
+    "@cedarjs/vite": "workspace:*"
     "@cedarjs/web-server": "workspace:*"
     graphql-tag: "npm:2.12.6"
     nodemon: "npm:3.1.14"
@@ -3289,7 +3291,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cedarjs/jobs@workspace:packages/jobs":
+"@cedarjs/jobs@workspace:*, @cedarjs/jobs@workspace:packages/jobs":
   version: 0.0.0-use.local
   resolution: "@cedarjs/jobs@workspace:packages/jobs"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,14 +2998,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/core@workspace:packages/core"
   dependencies:
-    "@babel/cli": "npm:7.29.7"
     "@cedarjs/api-server": "workspace:*"
     "@cedarjs/cli": "workspace:*"
-    "@cedarjs/eslint-config": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/internal": "workspace:*"
-    "@cedarjs/project-config": "workspace:*"
-    "@cedarjs/testing": "workspace:*"
     "@cedarjs/web-server": "workspace:*"
     graphql-tag: "npm:2.12.6"
     nodemon: "npm:3.1.14"
@@ -3042,7 +3038,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@cedarjs/eslint-config@workspace:*, @cedarjs/eslint-config@workspace:packages/eslint-config":
+"@cedarjs/eslint-config@workspace:packages/eslint-config":
   version: 0.0.0-use.local
   resolution: "@cedarjs/eslint-config@workspace:packages/eslint-config"
   dependencies:


### PR DESCRIPTION
## Summary

Third and last package from the original knip audit (`api-server` #2243/#2244/#2246 style cleanup, `eslint-config` #2246, now `core`).

`@cedarjs/core` is a meta-package ("configuration and common dependencies required by a CedarJS project") that deliberately declares some dependencies purely so they hoist into a scaffolded app's `node_modules`, even though core's own source never imports them -- a legitimate phantom-dependency pattern, not automatically a knip false positive. So each flagged dependency needed checking against actual `create-cedar-app` template usage before deciding to remove it, not just against `packages/core/src`.

**Removed** (redundant -- every template already declares and imports these directly itself; not used as phantom deps for anything):
- `@babel/cli` -- not declared, not imported, and the `babel` binary is never invoked anywhere in the framework or templates. Not a working phantom dependency at all, just dead weight.
- `@cedarjs/eslint-config` -- all four templates declare it directly (root `package.json`) and import it directly (`eslint.config.mjs`).
- `@cedarjs/project-config` -- declared directly at template root, imported directly in `api/src/lib/db.{js,ts}` and `graphql.config.cjs`.
- `@cedarjs/testing` -- declared directly at template root (and in `web/package.json` for the ESM templates); `cedar generate package` even self-declares it in the new workspace's own generated `package.json.template`.

**Kept** `graphql-tag` -- this one *is* a genuine, working phantom dependency: the `js`/`ts` templates import it directly in generated code (`api/src/directives/{skipAuth,requireAuth}/*`) without declaring it in their own `api/package.json`, relying on it hoisting in via `@cedarjs/core`. Documented and added to `knip.jsonc`'s `ignoreDependencies` for this workspace so knip stops flagging it.

**Added** `@cedarjs/vite` and `@cedarjs/jobs` as real dependencies -- unlike `graphql-tag`, these aren't phantom deps for consuming apps. They're directly used by core's *own* bin scripts (`cedar-dev-fe.ts`, `cedar-serve-fe.ts`, `cedar-jobs.ts`, `cedar-jobs-worker.ts`, `rw-jobs-worker.ts` all do `require.resolve('@cedarjs/{vite,jobs}/package.json')`, the same pattern already used for `nodemon`/`eslint`/`jest`/`vitest`/`cross-env`) and were simply missing from `package.json`.

**Also fixed the underlying entry-graph gap**: `packages/core` has no `index.ts`/`cli.ts`/`main.ts`, so knip's default entry pattern matched nothing and all 26 `src/bins/*.ts` scripts (every `bin` entry in `package.json`) were invisible to its reachability graph -- the same root cause fixed for `api-server` in #2243. This is why `@cedarjs/api-server`, `@cedarjs/cli`, `@cedarjs/internal`, `@cedarjs/web-server`, and `nodemon` were *also* being misreported as unused. Added `"entry": ["src/bins/*.ts"]` to `knip.jsonc` and all of these resolved correctly with no dependency changes needed.
