### PR TITLE
chore(ts): Remove stale @ts-ignore suppressions

### DIFF
--- a/packages/api-server/src/apiCLIConfigHandler.ts
+++ b/packages/api-server/src/apiCLIConfigHandler.ts
@@ -1,6 +1,3 @@
-// See https://github.com/webdiscus/ansis#troubleshooting
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import ansis from 'ansis'
 
 import { coerceRootPath } from '@cedarjs/fastify-web'

--- a/packages/api-server/src/bothCLIConfigHandler.ts
+++ b/packages/api-server/src/bothCLIConfigHandler.ts
@@ -1,6 +1,3 @@
-// See https://github.com/webdiscus/ansis#troubleshooting
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import ansis from 'ansis'
 
 import { redwoodFastifyWeb, coerceRootPath } from '@cedarjs/fastify-web'

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -2,9 +2,6 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-// See https://github.com/webdiscus/ansis#troubleshooting
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import ansis from 'ansis'
 import { config } from 'dotenv-defaults'
 import fg from 'fast-glob'

--- a/packages/api-server/src/logFormatter/formatters.ts
+++ b/packages/api-server/src/logFormatter/formatters.ts
@@ -1,6 +1,3 @@
-// See https://github.com/webdiscus/ansis#troubleshooting
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import ansis from 'ansis'
 import prettyBytes from 'pretty-bytes'
 import prettyMs from 'pretty-ms'

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -1,9 +1,6 @@
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-// See https://github.com/webdiscus/ansis#troubleshooting
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import ansis from 'ansis'
 import type { Handler } from 'aws-lambda'
 import fg from 'fast-glob'

--- a/packages/api-server/src/serverManager.ts
+++ b/packages/api-server/src/serverManager.ts
@@ -3,9 +3,6 @@ import { fork } from 'child_process'
 import fs from 'node:fs'
 import path from 'path'
 
-// See https://github.com/webdiscus/ansis#troubleshooting
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import ansis from 'ansis'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
@@ -77,9 +74,6 @@ export class ServerManager {
         forkOpts,
       )
     } else {
-      // An esbuild plugin will take care of import.meta.dirname
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       const dirname = import.meta.dirname
       const binPath = path.join(dirname, 'bin.js')
       const args = ['api', '--port', port.toString()]

--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -1,8 +1,5 @@
 import path from 'node:path'
 
-// See https://github.com/webdiscus/ansis#troubleshooting
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import ansis from 'ansis'
 import chokidar from 'chokidar'
 import { config } from 'dotenv-defaults'

--- a/packages/internal/src/ast.ts
+++ b/packages/internal/src/ast.ts
@@ -5,19 +5,12 @@ import { types } from '@babel/core'
 import type { ParserPlugin } from '@babel/parser'
 import { parse as babelParse } from '@babel/parser'
 import babelTraverse from '@babel/traverse'
-// Here's an explanation of why we do ts-ignore:
-// https://github.com/webdiscus/ansis#troubleshooting
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import ansis from 'ansis'
 
 import { getPaths } from '@cedarjs/project-config'
 
 import { isFileInsideFolder } from './files.js'
 
-// See https://github.com/babel/babel/discussions/13093
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 const traverse = babelTraverse.default || babelTraverse
 
 export const fileToAst = (filePath: string): types.Node => {

--- a/packages/internal/src/generate/graphqlSchema.ts
+++ b/packages/internal/src/generate/graphqlSchema.ts
@@ -6,10 +6,6 @@ import * as schemaAstPlugin from '@graphql-codegen/schema-ast'
 import { CodeFileLoader } from '@graphql-tools/code-file-loader'
 import type { LoadSchemaOptions } from '@graphql-tools/load'
 import { loadSchema } from '@graphql-tools/load'
-// Here's an explanation of why we do ts-ignore:
-// https://github.com/webdiscus/ansis#troubleshooting
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import ansis from 'ansis'
 import type { DocumentNode } from 'graphql'
 import { print } from 'graphql'

--- a/packages/internal/src/generate/templates.ts
+++ b/packages/internal/src/generate/templates.ts
@@ -1,11 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-const ___dirname =
-  // __dirname will work for CJS, and import.meta.dirname will work for ESM
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  typeof __dirname !== 'undefined' ? __dirname : import.meta?.dirname
+const ___dirname = import.meta.dirname
 
 /**
  * Write the contents of the template to the destination and interpolate the variables.

--- a/packages/internal/src/generate/watch.ts
+++ b/packages/internal/src/generate/watch.ts
@@ -3,8 +3,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import ansis from 'ansis'
 import chokidar from 'chokidar'
 

--- a/packages/internal/src/jsx.ts
+++ b/packages/internal/src/jsx.ts
@@ -3,9 +3,6 @@ import babelTraverse from '@babel/traverse'
 
 import { getJsxAttributeValue } from './jsxAttributeValue.js'
 
-// See https://github.com/babel/babel/discussions/13093
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 const traverse = babelTraverse.default || babelTraverse
 
 interface JsxElement {

--- a/packages/internal/src/routes.ts
+++ b/packages/internal/src/routes.ts
@@ -1,9 +1,5 @@
 import path from 'node:path'
 
-// Here's an explanation of why we do ts-ignore:
-// https://github.com/webdiscus/ansis#troubleshooting
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import ansis from 'ansis'
 
 import { getPaths, getRouteHookForPage } from '@cedarjs/project-config'

--- a/packages/prerender/src/babelPlugins/babel-plugin-redwood-prerender-media-imports.ts
+++ b/packages/prerender/src/babelPlugins/babel-plugin-redwood-prerender-media-imports.ts
@@ -1,9 +1,6 @@
 import { extname, join, relative, dirname } from 'path'
 
 import type { PluginObj, types, NodePath } from '@babel/core'
-// We need this for the CJS build
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import type { ManifestChunk as ViteManifestChunk } from 'vite'
 
 import { ensurePosixPath, getPaths } from '@cedarjs/project-config'

--- a/packages/testing/src/web/vitest/vite-plugin-cedarjs-router-import-transform.ts
+++ b/packages/testing/src/web/vitest/vite-plugin-cedarjs-router-import-transform.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore - Silence the TS error on this line for CJS builds
 import type { PluginOption } from 'vite'
 
 /**

--- a/packages/testing/src/web/vitest/vite-plugin-create-auth-import-transform.ts
+++ b/packages/testing/src/web/vitest/vite-plugin-create-auth-import-transform.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore - Silence the TS error on this line for CJS builds
 import type { PluginOption } from 'vite'
 
 export function createAuthImportTransformPlugin(): PluginOption {


### PR DESCRIPTION
## Summary

Started from a question about a CJS-related comment on a `@ts-ignore` in `packages/prerender/src/babelPlugins/babel-plugin-redwood-prerender-media-imports.ts`. That one turned out to be stale, which prompted a repo-wide search for similar patterns.

Every removal here was verified by actually deleting the suppression and running a real, forced `tsc --build` on the affected package before committing to the change — not just reading the comment and assuming.

**Removed (confirmed stale):**
- ansis default-import `@ts-ignore`s in `api-server` (6 files) and `internal` (3 files) — the linked [ansis troubleshooting workaround](https://github.com/webdiscus/ansis#troubleshooting) doesn't reproduce with the current `ansis`/TypeScript versions.
- `@babel/traverse` `.default`-unwrap `@ts-ignore`s in `internal/src/ast.ts` and `internal/src/jsx.ts` — same story.
- `vite` type-only import `@ts-ignore`s in `prerender` and `testing` (2 files) — `vite` ships ESM-only, which used to trip up a package's separate CJS declaration build; doesn't reproduce anymore.
- `api-server/src/serverManager.ts`'s `import.meta.dirname` `@ts-ignore` — the comment ("An esbuild plugin will take care of `import.meta.dirname`") referred to a plugin that was deleted when `api-server` went ESM-only in #2254, so it was stale on its own terms regardless of the type-check result.
- `internal/src/generate/templates.ts`'s CJS/ESM dual `___dirname` check — `internal` has been ESM-only since #2237, so the `typeof __dirname !== 'undefined'` branch is unreachable dead code. Simplified to `import.meta.dirname` directly.

**Tried and reverted (still genuinely needed):**
- `testing/src/config/jest/jest-serial-runner.ts` and `testing/src/web/globRoutesImporter.ts` both still produce real errors without the suppression (`TS2339`, `TS1470`) — kept as-is.
- The four `export = X` `@ts-ignore`s in `testing`'s Jest preset entry points (`jest-serial-runner.ts`, `config/jest/web/{index,resolver}.ts`, `config/jest/api/index.ts`) are a structurally different, still-live problem (TS disallows `export =` when targeting ES modules, but Jest's own CJS-only module loader requires it) — not staleness, left untouched.

No behavior change — these are all type-check-only suppressions; nothing here affects emitted JS.
