### PR TITLE
fix(vite): Reject $api imports from client-side code

### DIFF
--- a/docs/docs/prerender.md
+++ b/docs/docs/prerender.md
@@ -145,6 +145,12 @@ export async function routeParameters() {
 
 Take note of the special syntax for the import, with a dollar-sign in front of api. This lets our tooling (typescript and babel) know that you want to break out of the web side the page is in to access code on the api side. This only works in the routeHook scripts (and scripts in the root /scripts directory).
 
+:::warning `$api` imports are server-side only
+
+Importing `$api/...` from a page, component, or any other file that ends up in the browser bundle is an error. Those imports pull api-side code – like your Prisma client – into the web bundle, so Cedar fails the build with an explanatory message instead. If you need the data in the browser, fetch it through GraphQL.
+
+:::
+
 ---
 
 ## Prerender Utils

--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -148,7 +148,9 @@ cedar build:
 Vite plugins: cell transform | entry injection | html env | data-uri-to-buffer shim |
   auto-imports | import-dir | directory-named-import | js-as-jsx | merged config |
   api-babel-transform | cedar-routes-auto-loader | cedar-universal-deploy |
-  cedar-wait-for-api-server | resolve-cedar-style-imports
+  cedar-wait-for-api-server | resolve-cedar-style-imports |
+  cedar-api-import-guard (pre; errors on `$api/` imports in the client
+    environment, so api-side code can't be bundled into the browser)
   *test mode (Vitest, mode === 'test'): adds router-import-transform |
     create-auth-import-transform | test auto-imports (mockGraphQLQuery etc.) |
     vitest-web-config (contributes a `test.setupFiles` entry that starts MSW,

--- a/packages/cli/src/lib/exec.ts
+++ b/packages/cli/src/lib/exec.ts
@@ -80,18 +80,15 @@ export async function runScriptFunction({
       nodeRunnerEnv: {},
     },
     resolve: {
+      // `$api/` and `api/` imports are handled by
+      // cedarjsResolveCedarStyleImportsPlugin below, which also resolves
+      // Cedar's directory named modules (`$api/src/services/posts` ->
+      // posts/posts.ts) and leaves an actual `api` npm package alone. The web
+      // side equivalents have no plugin support, so they stay aliases
       alias: [
-        {
-          find: /^\$api\//,
-          replacement: getPaths().api.base + '/',
-        },
         {
           find: /^\$web\//,
           replacement: getPaths().web.base + '/',
-        },
-        {
-          find: /^api\//,
-          replacement: getPaths().api.base + '/',
         },
         {
           find: /^web\//,

--- a/packages/vite/src/__tests__/ud-build.test.ts
+++ b/packages/vite/src/__tests__/ud-build.test.ts
@@ -20,7 +20,10 @@ describe('UD build against fixture', () => {
     process.env.CEDAR_CWD = fixtureDir
     const { buildCedarApp } = await import('../buildApp.js')
     await buildCedarApp({ ud: true, verbose: false })
-  }, 30_000)
+    // A full UD build takes a couple of seconds locally, but Windows CI
+    // runners are slow enough, especially with other test files building in
+    // parallel, that 30s wasn't enough headroom
+  }, 90_000)
 
   it('produces api/dist/ud/index.js', () => {
     const outFile = join(fixtureDir, 'api', 'dist', 'ud', 'index.js')

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -21,6 +21,7 @@ import {
   createAuthImportTransformPlugin,
 } from '@cedarjs/testing/web/vitest'
 
+import { cedarApiImportGuardPlugin } from './plugins/vite-plugin-cedar-api-import-guard.js'
 import { cedarAutoImportsPlugin } from './plugins/vite-plugin-cedar-auto-import.js'
 import { cedarCellTransform } from './plugins/vite-plugin-cedar-cell.js'
 import { cedarDataUriShim } from './plugins/vite-plugin-cedar-data-uri-shim.js'
@@ -36,6 +37,7 @@ import { cedarTransformJsAsJsx } from './plugins/vite-plugin-jsx-loader.js'
 import { cedarMergedConfig } from './plugins/vite-plugin-merged-config.js'
 import { cedarSwapApolloProvider } from './plugins/vite-plugin-swap-apollo-provider.js'
 
+export { cedarApiImportGuardPlugin } from './plugins/vite-plugin-cedar-api-import-guard.js'
 export { cedarAutoImportsPlugin } from './plugins/vite-plugin-cedar-auto-import.js'
 export { cedarCjsCompatPlugin } from './plugins/vite-plugin-cedar-cjs-compat.js'
 export { cedarCellTransform } from './plugins/vite-plugin-cedar-cell.js'
@@ -93,6 +95,9 @@ export function cedar({ mode, babel }: PluginOptions = {}): PluginOption[] {
       : undefined
 
   return [
+    // Has to come before tsconfigPaths(), which would otherwise resolve
+    // `$api/*` imports using the project's web/tsconfig.json `paths` mapping
+    cedarApiImportGuardPlugin(),
     tsconfigPaths(),
     gqlTagPlugin(),
     mode === 'test' && cedarJsRouterImportTransformPlugin(),

--- a/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/api/src/lib/db.ts
+++ b/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/api/src/lib/db.ts
@@ -1,0 +1,1 @@
+export const db = { name: 'db' }

--- a/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/api/src/lib/mailer/index.ts
+++ b/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/api/src/lib/mailer/index.ts
@@ -1,0 +1,1 @@
+export const mailer = {}

--- a/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/api/src/services/posts/posts.ts
+++ b/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/api/src/services/posts/posts.ts
@@ -1,0 +1,1 @@
+export const posts = () => []

--- a/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/cedar.toml
+++ b/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/cedar.toml
@@ -1,0 +1,4 @@
+[web]
+  port = 8910
+[api]
+  port = 8911

--- a/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/web/src/pages/dollarApiImport.ts
+++ b/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/web/src/pages/dollarApiImport.ts
@@ -1,0 +1,3 @@
+import { db } from '$api/src/lib/db'
+
+console.log(db)

--- a/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/web/tsconfig.json
+++ b/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/web/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "src/*": ["./src/*"],
+      "$api/*": ["../api/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/web/vite.config.ts
+++ b/packages/vite/src/plugins/__tests__/__fixtures__/dollar-api-imports/web/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+
+import { cedarApiImportGuardPlugin } from '../../../../vite-plugin-cedar-api-import-guard.js'
+
+// Stands in for a Cedar project's web/vite.config.ts, which gets its plugins
+// from cedar()
+export default defineConfig({
+  plugins: [cedarApiImportGuardPlugin()],
+})

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-api-import-guard.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-api-import-guard.test.ts
@@ -21,6 +21,9 @@ const importer = path.join(webDir, 'src', 'pages', 'dollarApiImport.ts')
 // The plugin normalizes what it returns, so that Vite gets forward-slash paths
 // on Windows too
 const dbPath = normalizePath(path.join(rootDir, 'api', 'src', 'lib', 'db.ts'))
+const servicePath = normalizePath(
+  path.join(rootDir, 'api', 'src', 'services', 'posts', 'posts.ts'),
+)
 
 // Spinning up Vite dev servers is slow on Windows CI runners
 const TIMEOUT = 30_000
@@ -93,13 +96,11 @@ function getServer(setup: PluginSetup) {
 async function resolveInEnvironment(
   environmentName: 'client' | 'ssr',
   setup: PluginSetup,
+  id = '$api/src/lib/db',
 ) {
   const server = await getServer(setup)
   const environment = server.environments[environmentName]
-  const resolved = await environment.pluginContainer.resolveId(
-    '$api/src/lib/db',
-    importer,
-  )
+  const resolved = await environment.pluginContainer.resolveId(id, importer)
 
   return resolved?.id ?? null
 }
@@ -213,6 +214,26 @@ describe('$api imports in the ssr environment', () => {
       const resolved = await resolveInEnvironment('ssr', 'cedar')
 
       expect(resolved).toBe(dbPath)
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'resolves $api imports of directory named modules',
+    async () => {
+      // vite-tsconfig-paths resolves most $api imports on its own, through the
+      // web side's `$api/*` -> `../api/*` mapping, which is why it looks like
+      // cedarjsResolveCedarStyleImportsPlugin's $api handling is redundant.
+      // It isn't: plain path mapping doesn't know about Cedar's directory
+      // named modules, so `$api/src/services/posts` (posts/posts.ts) only
+      // resolves because of the Cedar plugin
+      const resolved = await resolveInEnvironment(
+        'ssr',
+        'cedar',
+        '$api/src/services/posts',
+      )
+
+      expect(resolved).toBe(servicePath)
     },
     TIMEOUT,
   )

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-api-import-guard.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-api-import-guard.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { build, createServer, normalizePath } from 'vite'
+import { build, createServer, normalizePath, resolveConfig } from 'vite'
 import type { PluginOption, ViteDevServer } from 'vite'
 import tsPathsMod from 'vite-tsconfig-paths'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -164,6 +164,37 @@ describe('$api imports in the client environment', () => {
       const resolved = await resolveInEnvironment('client', 'resolve')
 
       expect(resolved).toBe(null)
+    },
+    TIMEOUT,
+  )
+})
+
+describe('plugin ordering', () => {
+  it(
+    'runs before the plugins buildApp() adds on top of the project config',
+    async () => {
+      // buildApp() (`cedar build`, and `cedar build --ud`) starts its own
+      // plugin list with tsconfigPaths(), and passes it as inline config on
+      // top of the project's web/vite.config.ts – the one calling cedar().
+      // Vite puts config file plugins before inline ones, so the guard still
+      // gets to see $api imports first
+      const resolved = await resolveConfig(
+        {
+          root: webDir,
+          configFile: path.join(webDir, 'vite.config.ts'),
+          logLevel: 'silent',
+          plugins: [tsconfigPaths()],
+        },
+        'build',
+      )
+
+      const names = resolved.plugins.map((plugin) => plugin.name)
+      const guardIndex = names.indexOf('cedar-api-import-guard')
+      const tsconfigPathsIndex = names.indexOf('vite-tsconfig-paths')
+
+      expect(guardIndex).toBeGreaterThan(-1)
+      expect(tsconfigPathsIndex).toBeGreaterThan(-1)
+      expect(guardIndex).toBeLessThan(tsconfigPathsIndex)
     },
     TIMEOUT,
   )

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-api-import-guard.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-api-import-guard.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
 import { build, createServer, normalizePath } from 'vite'
-import type { PluginOption } from 'vite'
+import type { PluginOption, ViteDevServer } from 'vite'
 import tsPathsMod from 'vite-tsconfig-paths'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
@@ -22,6 +22,29 @@ const importer = path.join(webDir, 'src', 'pages', 'dollarApiImport.ts')
 // on Windows too
 const dbPath = normalizePath(path.join(rootDir, 'api', 'src', 'lib', 'db.ts'))
 
+// Spinning up Vite dev servers is slow on Windows CI runners
+const TIMEOUT = 30_000
+
+/** The plugin setups the tests resolve `$api/src/lib/db` through */
+const PLUGIN_SETUPS = {
+  /** Just the guard, to check what it does on its own */
+  guard: () => [cedarApiImportGuardPlugin()],
+  /** Just the resolve plugin, to check what it does on its own */
+  resolve: () => [cedarjsResolveCedarStyleImportsPlugin()],
+  /** What a Cedar project gets, in the order cedar() sets them up in */
+  cedar: () => [
+    cedarApiImportGuardPlugin(),
+    tsconfigPaths(),
+    cedarjsResolveCedarStyleImportsPlugin(),
+  ],
+} satisfies Record<string, () => PluginOption[]>
+
+type PluginSetup = keyof typeof PLUGIN_SETUPS
+
+// Starting a server per test is too slow, so they're started on demand and
+// shared between all tests that use the same plugin setup
+const servers = new Map<PluginSetup, Promise<ViteDevServer>>()
+
 let originalCedarCwd: string | undefined
 
 beforeAll(() => {
@@ -30,7 +53,11 @@ beforeAll(() => {
   process.env.CEDAR_CWD = rootDir
 })
 
-afterAll(() => {
+afterAll(async () => {
+  await Promise.all(
+    [...servers.values()].map(async (server) => (await server).close()),
+  )
+
   if (originalCedarCwd === undefined) {
     delete process.env.CEDAR_CWD
   } else {
@@ -38,111 +65,130 @@ afterAll(() => {
   }
 })
 
+function getServer(setup: PluginSetup) {
+  let server = servers.get(setup)
+
+  if (!server) {
+    server = createServer({
+      root: webDir,
+      configFile: false,
+      logLevel: 'silent',
+      server: { middlewareMode: true, hmr: false, watch: null },
+      plugins: PLUGIN_SETUPS[setup](),
+    })
+
+    servers.set(setup, server)
+  }
+
+  return server
+}
+
 /**
  * Resolves `$api/src/lib/db` in the given Vite environment, using the given
- * plugins in the order they're passed in
+ * plugin setup
  */
 async function resolveInEnvironment(
   environmentName: 'client' | 'ssr',
-  plugins: PluginOption[],
+  setup: PluginSetup,
 ) {
-  const server = await createServer({
-    root: webDir,
-    configFile: false,
-    logLevel: 'silent',
-    server: { middlewareMode: true, hmr: false, watch: null },
-    plugins,
-  })
+  const server = await getServer(setup)
+  const environment = server.environments[environmentName]
+  const resolved = await environment.pluginContainer.resolveId(
+    '$api/src/lib/db',
+    importer,
+  )
 
-  try {
-    const environment = server.environments[environmentName]
-    const resolved = await environment.pluginContainer.resolveId(
-      '$api/src/lib/db',
-      importer,
-    )
-
-    return resolved?.id ?? null
-  } finally {
-    await server.close()
-  }
+  return resolved?.id ?? null
 }
 
 describe('$api imports in the client environment', () => {
-  it('throws when a client module imports $api', async () => {
-    await expect(
-      resolveInEnvironment('client', [cedarApiImportGuardPlugin()]),
-    ).rejects.toThrow(/Cannot import "\$api\/src\/lib\/db" from client-side/)
-  })
+  it(
+    'throws when a client module imports $api',
+    async () => {
+      await expect(resolveInEnvironment('client', 'guard')).rejects.toThrow(
+        /Cannot import "\$api\/src\/lib\/db" from client-side/,
+      )
+    },
+    TIMEOUT,
+  )
 
-  it('mentions the importer in the error message', async () => {
-    await expect(
-      resolveInEnvironment('client', [cedarApiImportGuardPlugin()]),
-    ).rejects.toThrow(/dollarApiImport\.ts/)
-  })
+  it(
+    'mentions the importer in the error message',
+    async () => {
+      await expect(resolveInEnvironment('client', 'guard')).rejects.toThrow(
+        /dollarApiImport\.ts/,
+      )
+    },
+    TIMEOUT,
+  )
 
-  it('throws even though tsconfig paths would resolve $api', async () => {
-    // The web side's tsconfig.json maps `$api/*` to `../api/*`, so
-    // vite-tsconfig-paths resolves $api imports all on its own. The guard
-    // plugin has to run before it to be of any use
-    await expect(
-      resolveInEnvironment('client', [
-        cedarApiImportGuardPlugin(),
-        tsconfigPaths(),
-        cedarjsResolveCedarStyleImportsPlugin(),
-      ]),
-    ).rejects.toThrow(/Cannot import "\$api\/src\/lib\/db" from client-side/)
-  })
+  it(
+    'throws even though tsconfig paths would resolve $api',
+    async () => {
+      // The web side's tsconfig.json maps `$api/*` to `../api/*`, so
+      // vite-tsconfig-paths resolves $api imports all on its own. The guard
+      // plugin has to run before it to be of any use
+      await expect(resolveInEnvironment('client', 'cedar')).rejects.toThrow(
+        /Cannot import "\$api\/src\/lib\/db" from client-side/,
+      )
+    },
+    TIMEOUT,
+  )
 
-  it('fails the client build', async () => {
-    await expect(
-      build({
-        root: webDir,
-        configFile: false,
-        logLevel: 'silent',
-        plugins: [
-          cedarApiImportGuardPlugin(),
-          tsconfigPaths(),
-          cedarjsResolveCedarStyleImportsPlugin(),
-        ],
-        build: {
-          lib: { entry: importer, formats: ['es'] },
-          write: false,
-          minify: false,
-        },
-      }),
-    ).rejects.toThrow(/Cannot import "\$api\/src\/lib\/db" from client-side/)
-  })
+  it(
+    'fails the client build',
+    async () => {
+      await expect(
+        build({
+          root: webDir,
+          configFile: false,
+          logLevel: 'silent',
+          plugins: PLUGIN_SETUPS.cedar(),
+          build: {
+            lib: { entry: importer, formats: ['es'] },
+            write: false,
+            minify: false,
+          },
+        }),
+      ).rejects.toThrow(/Cannot import "\$api\/src\/lib\/db" from client-side/)
+    },
+    TIMEOUT,
+  )
 
-  it('does not resolve $api imports without the tsconfig paths mapping', async () => {
-    // Without the guard plugin, the import is left unresolved by
-    // cedarjsResolveCedarStyleImportsPlugin, and Vite reports its regular
-    // "Failed to resolve import" error
-    const resolved = await resolveInEnvironment('client', [
-      cedarjsResolveCedarStyleImportsPlugin(),
-    ])
+  it(
+    'does not resolve $api imports without the tsconfig paths mapping',
+    async () => {
+      // Without the guard plugin, the import is left unresolved by
+      // cedarjsResolveCedarStyleImportsPlugin, and Vite reports its regular
+      // "Failed to resolve import" error
+      const resolved = await resolveInEnvironment('client', 'resolve')
 
-    expect(resolved).toBe(null)
-  })
+      expect(resolved).toBe(null)
+    },
+    TIMEOUT,
+  )
 })
 
 describe('$api imports in the ssr environment', () => {
-  it('resolves $api imports', async () => {
-    // This is what `cedar dev` relies on when it runs a route hook's meta()
-    // function through ssrLoadModule()
-    const resolved = await resolveInEnvironment('ssr', [
-      cedarjsResolveCedarStyleImportsPlugin(),
-    ])
+  it(
+    'resolves $api imports',
+    async () => {
+      // This is what `cedar dev` relies on when it runs a route hook's meta()
+      // function through ssrLoadModule()
+      const resolved = await resolveInEnvironment('ssr', 'resolve')
 
-    expect(resolved).toBe(dbPath)
-  })
+      expect(resolved).toBe(dbPath)
+    },
+    TIMEOUT,
+  )
 
-  it('resolves $api imports with the guard plugin in place', async () => {
-    const resolved = await resolveInEnvironment('ssr', [
-      cedarApiImportGuardPlugin(),
-      tsconfigPaths(),
-      cedarjsResolveCedarStyleImportsPlugin(),
-    ])
+  it(
+    'resolves $api imports with the guard plugin in place',
+    async () => {
+      const resolved = await resolveInEnvironment('ssr', 'cedar')
 
-    expect(resolved).toBe(dbPath)
-  })
+      expect(resolved).toBe(dbPath)
+    },
+    TIMEOUT,
+  )
 })

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-api-import-guard.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-api-import-guard.test.ts
@@ -1,0 +1,148 @@
+import path from 'node:path'
+
+import { build, createServer, normalizePath } from 'vite'
+import type { PluginOption } from 'vite'
+import tsPathsMod from 'vite-tsconfig-paths'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { cedarApiImportGuardPlugin } from '../vite-plugin-cedar-api-import-guard.js'
+import { cedarjsResolveCedarStyleImportsPlugin } from '../vite-plugin-cedarjs-resolve-cedar-style-imports.js'
+
+// vite-tsconfig-paths is ESM-only, and CJS builds double-wrap its default
+// export. Same interop dance as in src/index.ts
+const tsconfigPaths =
+  // @ts-expect-error – .default only exists at runtime in CJS double-wrap
+  // interop
+  tsPathsMod.default?.default || tsPathsMod.default || tsPathsMod
+
+const rootDir = path.join(__dirname, '__fixtures__', 'dollar-api-imports')
+const webDir = path.join(rootDir, 'web')
+const importer = path.join(webDir, 'src', 'pages', 'dollarApiImport.ts')
+// The plugin normalizes what it returns, so that Vite gets forward-slash paths
+// on Windows too
+const dbPath = normalizePath(path.join(rootDir, 'api', 'src', 'lib', 'db.ts'))
+
+let originalCedarCwd: string | undefined
+
+beforeAll(() => {
+  // The $api/ resolution needs getPaths() to find a project root
+  originalCedarCwd = process.env.CEDAR_CWD
+  process.env.CEDAR_CWD = rootDir
+})
+
+afterAll(() => {
+  if (originalCedarCwd === undefined) {
+    delete process.env.CEDAR_CWD
+  } else {
+    process.env.CEDAR_CWD = originalCedarCwd
+  }
+})
+
+/**
+ * Resolves `$api/src/lib/db` in the given Vite environment, using the given
+ * plugins in the order they're passed in
+ */
+async function resolveInEnvironment(
+  environmentName: 'client' | 'ssr',
+  plugins: PluginOption[],
+) {
+  const server = await createServer({
+    root: webDir,
+    configFile: false,
+    logLevel: 'silent',
+    server: { middlewareMode: true, hmr: false, watch: null },
+    plugins,
+  })
+
+  try {
+    const environment = server.environments[environmentName]
+    const resolved = await environment.pluginContainer.resolveId(
+      '$api/src/lib/db',
+      importer,
+    )
+
+    return resolved?.id ?? null
+  } finally {
+    await server.close()
+  }
+}
+
+describe('$api imports in the client environment', () => {
+  it('throws when a client module imports $api', async () => {
+    await expect(
+      resolveInEnvironment('client', [cedarApiImportGuardPlugin()]),
+    ).rejects.toThrow(/Cannot import "\$api\/src\/lib\/db" from client-side/)
+  })
+
+  it('mentions the importer in the error message', async () => {
+    await expect(
+      resolveInEnvironment('client', [cedarApiImportGuardPlugin()]),
+    ).rejects.toThrow(/dollarApiImport\.ts/)
+  })
+
+  it('throws even though tsconfig paths would resolve $api', async () => {
+    // The web side's tsconfig.json maps `$api/*` to `../api/*`, so
+    // vite-tsconfig-paths resolves $api imports all on its own. The guard
+    // plugin has to run before it to be of any use
+    await expect(
+      resolveInEnvironment('client', [
+        cedarApiImportGuardPlugin(),
+        tsconfigPaths(),
+        cedarjsResolveCedarStyleImportsPlugin(),
+      ]),
+    ).rejects.toThrow(/Cannot import "\$api\/src\/lib\/db" from client-side/)
+  })
+
+  it('fails the client build', async () => {
+    await expect(
+      build({
+        root: webDir,
+        configFile: false,
+        logLevel: 'silent',
+        plugins: [
+          cedarApiImportGuardPlugin(),
+          tsconfigPaths(),
+          cedarjsResolveCedarStyleImportsPlugin(),
+        ],
+        build: {
+          lib: { entry: importer, formats: ['es'] },
+          write: false,
+          minify: false,
+        },
+      }),
+    ).rejects.toThrow(/Cannot import "\$api\/src\/lib\/db" from client-side/)
+  })
+
+  it('does not resolve $api imports without the tsconfig paths mapping', async () => {
+    // Without the guard plugin, the import is left unresolved by
+    // cedarjsResolveCedarStyleImportsPlugin, and Vite reports its regular
+    // "Failed to resolve import" error
+    const resolved = await resolveInEnvironment('client', [
+      cedarjsResolveCedarStyleImportsPlugin(),
+    ])
+
+    expect(resolved).toBe(null)
+  })
+})
+
+describe('$api imports in the ssr environment', () => {
+  it('resolves $api imports', async () => {
+    // This is what `cedar dev` relies on when it runs a route hook's meta()
+    // function through ssrLoadModule()
+    const resolved = await resolveInEnvironment('ssr', [
+      cedarjsResolveCedarStyleImportsPlugin(),
+    ])
+
+    expect(resolved).toBe(dbPath)
+  })
+
+  it('resolves $api imports with the guard plugin in place', async () => {
+    const resolved = await resolveInEnvironment('ssr', [
+      cedarApiImportGuardPlugin(),
+      tsconfigPaths(),
+      cedarjsResolveCedarStyleImportsPlugin(),
+    ])
+
+    expect(resolved).toBe(dbPath)
+  })
+})

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-api-import-guard.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-api-import-guard.test.ts
@@ -27,8 +27,6 @@ const TIMEOUT = 30_000
 
 /** The plugin setups the tests resolve `$api/src/lib/db` through */
 const PLUGIN_SETUPS = {
-  /** Just the guard, to check what it does on its own */
-  guard: () => [cedarApiImportGuardPlugin()],
   /** Just the resolve plugin, to check what it does on its own */
   resolve: () => [cedarjsResolveCedarStyleImportsPlugin()],
   /** What a Cedar project gets, in the order cedar() sets them up in */
@@ -38,6 +36,10 @@ const PLUGIN_SETUPS = {
     cedarjsResolveCedarStyleImportsPlugin(),
   ],
 } satisfies Record<string, () => PluginOption[]>
+
+// Dependency scanning is pure overhead here – the tests only ever resolve a
+// single id – and it's the slowest part of starting a server on CI
+const NO_DEP_SCAN = { noDiscovery: true, include: [] }
 
 type PluginSetup = keyof typeof PLUGIN_SETUPS
 
@@ -73,6 +75,7 @@ function getServer(setup: PluginSetup) {
       root: webDir,
       configFile: false,
       logLevel: 'silent',
+      optimizeDeps: NO_DEP_SCAN,
       server: { middlewareMode: true, hmr: false, watch: null },
       plugins: PLUGIN_SETUPS[setup](),
     })
@@ -105,7 +108,10 @@ describe('$api imports in the client environment', () => {
   it(
     'throws when a client module imports $api',
     async () => {
-      await expect(resolveInEnvironment('client', 'guard')).rejects.toThrow(
+      // The web side's tsconfig.json maps `$api/*` to `../api/*`, so
+      // vite-tsconfig-paths resolves $api imports all on its own. The guard
+      // plugin has to run before it to be of any use
+      await expect(resolveInEnvironment('client', 'cedar')).rejects.toThrow(
         /Cannot import "\$api\/src\/lib\/db" from client-side/,
       )
     },
@@ -115,21 +121,8 @@ describe('$api imports in the client environment', () => {
   it(
     'mentions the importer in the error message',
     async () => {
-      await expect(resolveInEnvironment('client', 'guard')).rejects.toThrow(
-        /dollarApiImport\.ts/,
-      )
-    },
-    TIMEOUT,
-  )
-
-  it(
-    'throws even though tsconfig paths would resolve $api',
-    async () => {
-      // The web side's tsconfig.json maps `$api/*` to `../api/*`, so
-      // vite-tsconfig-paths resolves $api imports all on its own. The guard
-      // plugin has to run before it to be of any use
       await expect(resolveInEnvironment('client', 'cedar')).rejects.toThrow(
-        /Cannot import "\$api\/src\/lib\/db" from client-side/,
+        /dollarApiImport\.ts/,
       )
     },
     TIMEOUT,
@@ -143,6 +136,7 @@ describe('$api imports in the client environment', () => {
           root: webDir,
           configFile: false,
           logLevel: 'silent',
+          optimizeDeps: NO_DEP_SCAN,
           plugins: PLUGIN_SETUPS.cedar(),
           build: {
             lib: { entry: importer, formats: ['es'] },

--- a/packages/vite/src/plugins/vite-plugin-cedar-api-import-guard.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-api-import-guard.ts
@@ -1,0 +1,39 @@
+import type { Plugin } from 'vite'
+
+/**
+ * `$api/` imports resolve to files on the api side. They're only supported in
+ * `*.routeHooks.{js,ts}` files and in scripts run with `yarn cedar exec` – both
+ * of which run on the server. This plugin makes a `$api/` import from code that
+ * ends up in the browser bundle fail with an explanatory error instead of
+ * silently bundling server-only code (like the Prisma client) into the browser.
+ *
+ * Has to run before `vite-tsconfig-paths`, which would otherwise resolve
+ * `$api/*` using the `paths` mapping in the project's `web/tsconfig.json`.
+ */
+export function cedarApiImportGuardPlugin(): Plugin {
+  return {
+    name: 'cedar-api-import-guard',
+    enforce: 'pre',
+
+    resolveId(id: string, importer?: string) {
+      // `this.environment` is undefined when the plugin is used outside of a
+      // Vite environment. Bailing there keeps the guard from firing in
+      // contexts where we can't tell client code from server code
+      if (this.environment?.name !== 'client' || !id.startsWith('$api/')) {
+        return null
+      }
+
+      throw new Error(
+        `Cannot import "${id}" from client-side code` +
+          (importer ? ` (imported by "${importer}")` : '') +
+          '.\n\n' +
+          '"$api/" imports resolve to your api side, which must never end up ' +
+          "in the browser bundle. They're only supported in server-side " +
+          'code, like *.routeHooks.{js,ts} files and scripts run with ' +
+          '`yarn cedar exec`.\n\n' +
+          'If you need this data in the browser, fetch it through GraphQL ' +
+          'instead.',
+      )
+    },
+  }
+}

--- a/packages/vite/src/plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.ts
@@ -80,7 +80,14 @@ export function cedarjsResolveCedarStyleImportsPlugin(): Plugin {
       }
 
       // Handle $api/ bare specifiers (web side only; used in routeHooks etc.)
-      if (cedarPaths && id.startsWith('$api/')) {
+      // Never resolve them for the client environment – that would bundle
+      // server-only code into the browser. See cedarApiImportGuardPlugin, which
+      // is what turns such an import into a helpful error message
+      if (
+        cedarPaths &&
+        id.startsWith('$api/') &&
+        this.environment?.name !== 'client'
+      ) {
         const resolved = resolveFromAbsolutePath(
           path.join(cedarPaths.api.base, id.slice('$api/'.length)),
         )

--- a/packages/vite/src/plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.ts
@@ -82,7 +82,13 @@ export function cedarjsResolveCedarStyleImportsPlugin(): Plugin {
       // Handle $api/ bare specifiers (web side only; used in routeHooks etc.)
       // Never resolve them for the client environment – that would bundle
       // server-only code into the browser. See cedarApiImportGuardPlugin, which
-      // is what turns such an import into a helpful error message
+      // is what turns such an import into a helpful error message.
+      // vite-tsconfig-paths resolves most $api imports through the web side's
+      // `$api/*` -> `../api/*` mapping, but it only does plain path mapping, so
+      // Cedar's directory named modules (`$api/src/services/posts` ->
+      // posts/posts.ts) still need this. Consumers without vite-tsconfig-paths
+      // (the Vitest api preset, dataMigrate, prerender's node runner) need all
+      // of it
       if (
         cedarPaths &&
         id.startsWith('$api/') &&


### PR DESCRIPTION
Fixes #2141

## Problem

`$api/` bare specifiers are documented as server-side only — `*.routeHooks.{js,ts}` files and scripts run with `yarn cedar exec`. But nothing scoped them, so a page or component could do

```tsx
import { db } from '$api/src/lib/db'
```

and silently bundle api-side code (the Prisma client setup, etc.) into the browser bundle.

## What I found while implementing

The issue proposed gating `cedarjsResolveCedarStyleImportsPlugin`'s `$api/` branch to the `ssr` environment. That alone isn't enough: **`vite-tsconfig-paths` resolves `$api/*` on its own**, via the `"$api/*": ["../api/*"]` mapping in every project's `web/tsconfig.json`. I verified this against a fixture project — with the Cedar plugin removed entirely, `$api/src/lib/db` still resolves in the `client` environment. And `vite-tsconfig-paths` is `enforce: 'pre'`, so it runs first anyway.

So making the Cedar plugin return `null` would not have made client-side `$api` imports fail.

## What this PR does

1. **New `cedarApiImportGuardPlugin`** (`enforce: 'pre'`, placed before `tsconfigPaths()` in `cedar()`): when `this.environment.name === 'client'`, any `$api/` specifier throws with an explanatory message naming the importer, instead of resolving.

   ```
   Cannot import "$api/src/lib/db" from client-side code (imported by ".../HomePage.tsx").

   "$api/" imports resolve to your api side, which must never end up in the browser bundle.
   They're only supported in server-side code, like *.routeHooks.{js,ts} files and scripts
   run with `yarn cedar exec`.

   If you need this data in the browser, fetch it through GraphQL instead.
   ```

2. **`cedarjsResolveCedarStyleImportsPlugin` no longer resolves `$api/` in the `client` environment**, so the plugin itself is no longer a source of client-side `$api` resolution.

3. Docs note in `docs/docs/prerender.md`.

### Why deny `client` rather than allow only `ssr`

The plugin is also used outside `cedar()` — `cli/src/lib/exec.ts`, `cli-packages/dataMigrate`, `prerender/src/graphql/node-runner.ts` and the Vitest api preset. Those create Vite servers with a custom environment named `nodeRunnerEnv`, so an `!== 'ssr'` allow-list would have changed behaviour for `yarn cedar exec`, data migrations and prerender. A `client` deny-list targets exactly the browser bundle and leaves every other consumer byte-for-byte as before.

## Unaffected paths (verified)

- **`cedar dev` streaming SSR route hooks** — `triggerRouteHooks.ts` uses `viteSsrDevServer.ssrLoadModule()`, i.e. the `ssr` environment. Covered by a test.
- **`cedar exec` / prerender's `routeParameters()`** — go through `exec.ts`, which resolves `$api` with a `resolve.alias`, not this plugin.
- **Prod route hooks** — built by a separate esbuild pass in `buildRouteHooks.ts`, not through `cedar()`.
- **Web tests** — Vitest 4 runs test files in the `ssr` environment (probed to confirm), so a test importing a routeHooks file keeps working.

## Behaviour change

Apps that today have an (undocumented, unsupported) `$api` import in web code will now fail the build with the message above instead of quietly shipping api code to the browser. That's the point of the issue, but worth calling out in release notes.

## Testing

New `packages/vite/src/plugins/__tests__/vite-plugin-cedar-api-import-guard.test.ts` (7 tests) against a small fixture project, resolving through real per-environment Vite plugin containers:

- client env: throws, and the message names the importer
- client env with `tsconfigPaths()` in the chain: still throws (guard ordering)
- a real `vite build` of a client entry importing `$api`: fails
- client env without the guard: `cedarjsResolveCedarStyleImportsPlugin` returns `null`
- ssr env: resolves to `api/src/lib/db.ts`, with and without the guard plugin present

```
yarn workspace @cedarjs/vite test   # 32 files, 233 passed
yarn workspace @cedarjs/vite build
yarn eslint <changed files> && yarn prettier --check <changed files>
```