### PR TITLE
chore(deps): replace @ast-grep/napi with oxc-parser

### DIFF
--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -67,7 +67,6 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@ast-grep/napi": "0.45.0",
     "@babel/generator": "7.29.7",
     "@babel/parser": "7.29.7",
     "@babel/traverse": "7.29.7",
@@ -84,7 +83,9 @@
     "babel-plugin-ignore-html-and-css-imports": "0.1.0",
     "cheerio": "1.2.0",
     "graphql": "16.14.2",
+    "magic-string": "0.30.21",
     "mime-types": "2.1.35",
+    "oxc-parser": "0.141.0",
     "rollup": "4.60.4",
     "rollup-plugin-swc3": "0.12.1",
     "unimport": "5.7.0",

--- a/packages/prerender/src/graphql/vite-plugin-cedar-import-dir.ts
+++ b/packages/prerender/src/graphql/vite-plugin-cedar-import-dir.ts
@@ -1,7 +1,8 @@
 import path from 'node:path'
 
-import { parse, Lang } from '@ast-grep/napi'
 import fg from 'fast-glob'
+import MagicString from 'magic-string'
+import { parseSync } from 'oxc-parser'
 import type { Plugin } from 'vite'
 
 import { importStatementPath, getPaths } from '@cedarjs/project-config'
@@ -32,45 +33,38 @@ export function cedarImportDirPlugin(): Plugin {
         return null
       }
 
-      const ext = path.extname(id)
-      const language =
-        ext === '.ts' || ext === '.tsx' ? Lang.TypeScript : Lang.JavaScript
-
-      let ast
+      let program
       try {
-        ast = parse(language, code)
+        program = parseSync(id, code).program
       } catch (error) {
         console.warn('Failed to parse file:', id)
         console.warn(error)
         return null
       }
 
-      const root = ast.root()
       let hasTransformations = false
-      const edits = []
+      const s = new MagicString(code)
 
-      // Find all import statements with glob patterns
-      const globImports = root.findAll({
-        rule: {
-          pattern: 'import $DEFAULT_IMPORT from $SOURCE',
-        },
-      })
-
-      for (const importNode of globImports) {
-        const sourceNode = importNode.getMatch('SOURCE')
-        const defaultImportNode = importNode.getMatch('DEFAULT_IMPORT')
-
-        if (!sourceNode || !defaultImportNode) {
+      // Find all default-import statements with glob patterns
+      for (const node of program.body) {
+        if (node.type !== 'ImportDeclaration') {
           continue
         }
 
-        const sourceValue = sourceNode.text().slice(1, -1) // Remove quotes
+        const defaultSpecifier = node.specifiers.find(
+          (specifier) => specifier.type === 'ImportDefaultSpecifier',
+        )
+        if (!defaultSpecifier) {
+          continue
+        }
+
+        const sourceValue = node.source.value
         if (!sourceValue.includes('/**/')) {
           continue
         }
 
         hasTransformations = true
-        const importName = defaultImportNode.text()
+        const importName = defaultSpecifier.local.name
 
         const importGlob = importStatementPath(sourceValue)
         const cwd = importGlob.startsWith('src/')
@@ -113,8 +107,8 @@ export function cedarImportDirPlugin(): Plugin {
             replacement += `${importName}.${filePathVarName} = ${namespaceImportName};\n`
           }
 
-          // Create edit to replace the entire import statement
-          edits.push(importNode.replace(replacement.trim()))
+          // Overwrite the entire import statement with the replacement
+          s.overwrite(node.start, node.end, replacement.trim())
         } catch (error) {
           // If there's an error with glob matching, keep the original import
           console.warn(`Failed to process glob import: ${sourceValue}`, error)
@@ -122,11 +116,9 @@ export function cedarImportDirPlugin(): Plugin {
       }
 
       // Only return transformed code if we actually made changes
-      if (hasTransformations && edits.length > 0) {
-        const transformedCode = root.commitEdits(edits)
-
+      if (hasTransformations) {
         return {
-          code: transformedCode,
+          code: s.toString(),
           map: null, // For simplicity, not generating source maps
         }
       }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -48,7 +48,6 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@ast-grep/napi": "0.45.0",
     "@babel/generator": "7.29.7",
     "@babel/parser": "7.29.7",
     "@babel/traverse": "7.29.7",

--- a/packages/vite/src/plugins/vite-plugin-cedar-import-dir.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-import-dir.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { parse, Lang } from '@ast-grep/napi'
 import MagicString from 'magic-string'
+import { parseSync } from 'oxc-parser'
 import { normalizePath } from 'vite'
 import type { Plugin } from 'vite'
 
@@ -34,46 +34,38 @@ export function cedarImportDirPlugin(): Plugin {
         return null
       }
 
-      const ext = path.extname(id)
-      const language =
-        ext === '.ts' || ext === '.tsx' ? Lang.TypeScript : Lang.JavaScript
-
-      let ast
+      let program
       try {
-        ast = parse(language, code)
+        program = parseSync(id, code).program
       } catch (error) {
         console.warn('Failed to parse file:', id)
         console.warn(error)
         return null
       }
 
-      const root = ast.root()
       let hasTransformations = false
       const s = new MagicString(code)
 
-      // Find all import statements with glob patterns
-      const globImports = root.findAll({
-        rule: {
-          pattern: 'import $DEFAULT_IMPORT from $SOURCE',
-        },
-      })
-
-      for (const importNode of globImports) {
-        const sourceNode = importNode.getMatch('SOURCE')
-        const defaultImportNode = importNode.getMatch('DEFAULT_IMPORT')
-
-        if (!sourceNode || !defaultImportNode) {
+      // Find all default-import statements with glob patterns
+      for (const node of program.body) {
+        if (node.type !== 'ImportDeclaration') {
           continue
         }
 
-        // Remove quotes
-        const sourceValue = sourceNode.text().slice(1, -1)
+        const defaultSpecifier = node.specifiers.find(
+          (specifier) => specifier.type === 'ImportDefaultSpecifier',
+        )
+        if (!defaultSpecifier) {
+          continue
+        }
+
+        const sourceValue = node.source.value
         if (!sourceValue.includes('/**/')) {
           continue
         }
 
         hasTransformations = true
-        const importName = defaultImportNode.text()
+        const importName = defaultSpecifier.local.name
 
         const importGlob = importStatementPath(sourceValue)
         let cwd = path.dirname(id)
@@ -138,8 +130,7 @@ export function cedarImportDirPlugin(): Plugin {
           }
 
           // Overwrite the entire import statement with the replacement
-          const range = importNode.range()
-          s.overwrite(range.start.index, range.end.index, replacement.trim())
+          s.overwrite(node.start, node.end, replacement.trim())
         } catch (error) {
           // If there's an error with glob matching, keep the original import
           console.warn(`Failed to process glob import: ${sourceValue}`, error)

--- a/packages/vite/src/plugins/vite-plugin-cedarjs-job-path-injector.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedarjs-job-path-injector.ts
@@ -1,10 +1,27 @@
 import path from 'node:path'
 
-import { parse, Lang } from '@ast-grep/napi'
+import MagicString from 'magic-string'
+import type { SourceMap } from 'magic-string'
+import { parseSync } from 'oxc-parser'
 import type { Plugin } from 'vite'
 
 import { getPaths } from '@cedarjs/project-config'
 
+/**
+ * Vite plugin that injects `path` and `name` properties into `createJob()`
+ * definitions so the jobs runner can locate and identify the job's module at
+ * runtime.
+ *
+ * Transforms:
+ *   export const myJob = jobs.createJob({ perform: ... })
+ * into:
+ *   export const myJob = jobs.createJob({ perform: ..., path: "...", name: "myJob" })
+ *
+ * The extraction uses an oxc-parser AST walk so the transform is robust
+ * against nested object properties, aliased imports, and TypeScript syntax.
+ * The same logic is duplicated in `@cedarjs/internal`
+ * (`applyJobPathInjector`) for the standalone esbuild API build.
+ */
 export function cedarjsJobPathInjectorPlugin(): Plugin {
   return {
     name: 'cedarjs-job-path-injector',
@@ -14,112 +31,111 @@ export function cedarjsJobPathInjectorPlugin(): Plugin {
         return null
       }
 
-      const isTypescript = id.endsWith('.ts') || id.endsWith('.tsx')
-      const language = isTypescript ? Lang.TypeScript : Lang.JavaScript
-
-      let ast
-      try {
-        ast = parse(language, code)
-      } catch (error) {
-        console.warn('Failed to parse file:', id)
-        console.warn(error)
-
-        // If we can't parse, just return the original code
+      const result = applyJobPathInjector(code, id, getPaths().api.jobs)
+      if (!result) {
         return null
       }
-
-      const paths = getPaths()
-      const edits = []
-
-      const root = ast.root()
-
-      // Find all createJob calls with object literal configs
-      const createJobCalls = root.findAll({
-        rule: {
-          pattern: 'export const $VAR_NAME = $OBJ.createJob({ $$$PROPS })',
-        },
-      })
-
-      for (const callNode of createJobCalls) {
-        const varNameNode = callNode.getMatch('VAR_NAME')
-        const propsNodes = callNode.getMultipleMatches('PROPS')
-
-        if (!varNameNode) {
-          continue
-        }
-
-        const importName = varNameNode.text()
-        const importPath = path.relative(paths.api.jobs, id)
-        const importPathWithoutExtension = importPath.replace(/\.[^/.]+$/, '')
-
-        // Build the properties to insert
-        const pathProperty = `path: ${JSON.stringify(importPathWithoutExtension)}`
-        const nameProperty = `name: ${JSON.stringify(importName)}`
-
-        let insertText = ''
-        if (propsNodes.length > 0) {
-          // Insert after the last property - find the actual object literal
-          const objectLiteral = callNode.find({
-            rule: {
-              kind: 'object',
-              inside: {
-                kind: 'arguments',
-              },
-            },
-          })
-
-          if (objectLiteral) {
-            insertText = `, ${pathProperty}, ${nameProperty}`
-            // Find the position just before the closing brace
-            const objectText = objectLiteral.text()
-            const closeBraceIndex = objectText.lastIndexOf('}')
-            if (closeBraceIndex !== -1) {
-              const range = objectLiteral.range()
-              edits.push({
-                startPos: range.start.index + closeBraceIndex,
-                endPos: range.start.index + closeBraceIndex,
-                insertedText: insertText,
-              })
-            }
-          }
-        } else {
-          // Empty object - find the object literal and insert between braces
-          const objectLiteral = callNode.find({
-            rule: {
-              kind: 'object',
-              inside: {
-                kind: 'arguments',
-              },
-            },
-          })
-
-          if (objectLiteral) {
-            insertText = `${pathProperty}, ${nameProperty}`
-            const objectText = objectLiteral.text()
-            const openBraceIndex = objectText.indexOf('{')
-            if (openBraceIndex !== -1) {
-              const range = objectLiteral.range()
-              edits.push({
-                startPos: range.start.index + openBraceIndex + 1,
-                endPos: range.start.index + openBraceIndex + 1,
-                insertedText: insertText,
-              })
-            }
-          }
-        }
-      }
-
-      if (edits.length === 0) {
-        return null
-      }
-
-      // Apply modifications using ast-grep's commitEdits
-      const modifiedCode = root.commitEdits(edits)
 
       return {
-        code: modifiedCode,
-        map: null,
+        code: result.code,
+        map: result.map,
       }
     },
+  }
+}
+
+/**
+ * Injects `path` and `name` properties into `createJob()` definitions.
+ * Returns the transformed code with a sourcemap, or null if no
+ * transformation was needed.
+ *
+ * Duplicate of `@cedarjs/internal`'s `applyJobPathInjector` so this logic can
+ * run inside the Vite plugin pipeline without depending on internal's build
+ * output.
+ */
+export function applyJobPathInjector(
+  code: string,
+  filePath: string,
+  jobsDir: string,
+): { code: string; map: SourceMap } | null {
+  let program
+  try {
+    program = parseSync(filePath, code, { sourceType: 'module' }).program
+  } catch (error) {
+    console.warn('Failed to parse file:', filePath)
+    console.warn(error)
+
+    // If we can't parse, just return the original code
+    return null
+  }
+
+  const importPath = path.relative(jobsDir, filePath)
+  const importPathWithoutExtension = importPath.replace(/\.[^/.]+$/, '')
+
+  const s = new MagicString(code)
+  let hasTransformations = false
+
+  for (const node of program.body) {
+    if (node.type !== 'ExportNamedDeclaration') {
+      continue
+    }
+    const decl = node.declaration
+    if (decl?.type !== 'VariableDeclaration') {
+      continue
+    }
+
+    // Check every declarator: in
+    // `export const a = 1, myJob = jobs.createJob({})` the job is declared
+    // on the second one
+    for (const declarator of decl.declarations) {
+      if (declarator.id.type !== 'Identifier') {
+        continue
+      }
+
+      const init = declarator.init
+      if (init?.type !== 'CallExpression') {
+        continue
+      }
+
+      // Only match `<something>.createJob(...)`
+      const callee = init.callee
+      if (
+        callee.type !== 'MemberExpression' ||
+        callee.computed ||
+        callee.property.type !== 'Identifier' ||
+        callee.property.name !== 'createJob'
+      ) {
+        continue
+      }
+
+      const configArg = init.arguments[0]
+      if (configArg?.type !== 'ObjectExpression') {
+        continue
+      }
+
+      hasTransformations = true
+
+      const pathProperty = `path: ${JSON.stringify(importPathWithoutExtension)}`
+      const nameProperty = `name: ${JSON.stringify(declarator.id.name)}`
+
+      const lastProperty = configArg.properties.at(-1)
+      if (lastProperty) {
+        // Insert right after the last property. This stays valid whether or
+        // not the object literal has a trailing comma.
+        s.appendLeft(lastProperty.end, `, ${pathProperty}, ${nameProperty}`)
+      } else {
+        // Empty object: insert right after the opening brace
+        s.appendLeft(configArg.start + 1, `${pathProperty}, ${nameProperty}`)
+      }
+    }
+  }
+
+  if (!hasTransformations) {
+    return null
+  }
+
+  return {
+    code: s.toString(),
+    map: s.generateMap({ hires: true }),
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,105 +279,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ast-grep/napi-darwin-arm64@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@ast-grep/napi-darwin-arm64@npm:0.45.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@ast-grep/napi-darwin-x64@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@ast-grep/napi-darwin-x64@npm:0.45.0"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@ast-grep/napi-linux-arm64-gnu@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@ast-grep/napi-linux-arm64-gnu@npm:0.45.0"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@ast-grep/napi-linux-arm64-musl@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@ast-grep/napi-linux-arm64-musl@npm:0.45.0"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@ast-grep/napi-linux-x64-gnu@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@ast-grep/napi-linux-x64-gnu@npm:0.45.0"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@ast-grep/napi-linux-x64-musl@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@ast-grep/napi-linux-x64-musl@npm:0.45.0"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@ast-grep/napi-win32-arm64-msvc@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@ast-grep/napi-win32-arm64-msvc@npm:0.45.0"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@ast-grep/napi-win32-ia32-msvc@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@ast-grep/napi-win32-ia32-msvc@npm:0.45.0"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@ast-grep/napi-win32-x64-msvc@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@ast-grep/napi-win32-x64-msvc@npm:0.45.0"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@ast-grep/napi@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@ast-grep/napi@npm:0.45.0"
-  dependencies:
-    "@ast-grep/napi-darwin-arm64": "npm:0.45.0"
-    "@ast-grep/napi-darwin-x64": "npm:0.45.0"
-    "@ast-grep/napi-linux-arm64-gnu": "npm:0.45.0"
-    "@ast-grep/napi-linux-arm64-musl": "npm:0.45.0"
-    "@ast-grep/napi-linux-x64-gnu": "npm:0.45.0"
-    "@ast-grep/napi-linux-x64-musl": "npm:0.45.0"
-    "@ast-grep/napi-win32-arm64-msvc": "npm:0.45.0"
-    "@ast-grep/napi-win32-ia32-msvc": "npm:0.45.0"
-    "@ast-grep/napi-win32-x64-msvc": "npm:0.45.0"
-  dependenciesMeta:
-    "@ast-grep/napi-darwin-arm64":
-      optional: true
-    "@ast-grep/napi-darwin-x64":
-      optional: true
-    "@ast-grep/napi-linux-arm64-gnu":
-      optional: true
-    "@ast-grep/napi-linux-arm64-musl":
-      optional: true
-    "@ast-grep/napi-linux-x64-gnu":
-      optional: true
-    "@ast-grep/napi-linux-x64-musl":
-      optional: true
-    "@ast-grep/napi-win32-arm64-msvc":
-      optional: true
-    "@ast-grep/napi-win32-ia32-msvc":
-      optional: true
-    "@ast-grep/napi-win32-x64-msvc":
-      optional: true
-  checksum: 10c0/e0f429d50b62708b6dc09f35ee377b023ddab7fdbc677f1ecfa01e7a31b82d12c35ca15eeb4050db9529c69c7566d015674f29871af79889ebcecbc0600788e9
-  languageName: node
-  linkType: hard
-
 "@auth0/auth0-auth-js@npm:^1.10.0":
   version: 1.12.0
   resolution: "@auth0/auth0-auth-js@npm:1.12.0"
@@ -3396,7 +3297,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/prerender@workspace:packages/prerender"
   dependencies:
-    "@ast-grep/napi": "npm:0.45.0"
     "@babel/generator": "npm:7.29.7"
     "@babel/parser": "npm:7.29.7"
     "@babel/traverse": "npm:7.29.7"
@@ -3420,7 +3320,9 @@ __metadata:
     cheerio: "npm:1.2.0"
     concurrently: "npm:9.2.4"
     graphql: "npm:16.14.2"
+    magic-string: "npm:0.30.21"
     mime-types: "npm:2.1.35"
+    oxc-parser: "npm:0.141.0"
     publint: "npm:0.3.22"
     rollup: "npm:4.60.4"
     rollup-plugin-swc3: "npm:0.12.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3698,7 +3698,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/vite@workspace:packages/vite"
   dependencies:
-    "@ast-grep/napi": "npm:0.45.0"
     "@babel/generator": "npm:7.29.7"
     "@babel/parser": "npm:7.29.7"
     "@babel/traverse": "npm:7.29.7"


### PR DESCRIPTION
## Summary

`@ast-grep/napi` was used for declarative AST pattern-matching in three places across the monorepo, all doing the same kind of transform: expanding glob-star default imports and (in one case) injecting properties into `createJob()` calls. This PR ports all three to `oxc-parser` and removes `@ast-grep/napi` from the monorepo entirely.

**`packages/vite`** (two plugins):
- `cedarImportDirPlugin` (`vite-plugin-cedar-import-dir.ts`) — expands glob-star default imports like `import services from 'src/services/**/*.{js,ts}'`
- `cedarjsJobPathInjectorPlugin` (`vite-plugin-cedarjs-job-path-injector.ts`) — injects `path`/`name` properties into `createJob()` calls

**`packages/prerender`** (one plugin):
- Its own older, divergent copy of `cedarImportDirPlugin` (`src/graphql/vite-plugin-cedar-import-dir.ts`), used by the standalone Node prerender runner. Kept its existing behavioral differences from the `packages/vite` version intact: `fast-glob` instead of `fs.globSync`, simpler `cwd` resolution (no `web.base` branch), and no sourcemap generation.

`oxc-parser` is already used elsewhere in the codebase for equivalent AST-walk-based transforms (e.g. `cedarGraphqlOptionsExtractPlugin` in `packages/vite`), so this PR follows that same pattern rather than introducing something new.

- `cedarjsJobPathInjectorPlugin`'s new implementation mirrors the already-proven `oxc-parser` logic in `@cedarjs/internal`'s `applyJobPathInjector` (the esbuild-path equivalent for the standalone API build), duplicated locally per the existing convention already used by `cedarGraphqlOptionsExtractPlugin` — this avoids the Vite plugin depending on internal's build output, at the cost of intentional duplication (same tradeoff already made elsewhere in this package).
- Both `cedarImportDirPlugin` implementations walk `program.body` for `ImportDeclaration` nodes with a default specifier, replacing `ast-grep`'s `findAll({ rule: { pattern: 'import $DEFAULT_IMPORT from $SOURCE' } })` + `getMatch()` calls. Behavior (including glob resolution, exclusions, and generated replacement code) is unchanged.
- `@ast-grep/napi` is now removed from `yarn.lock` entirely, since `packages/prerender` was the last remaining consumer.
