### PR TITLE
chore(deps): Drop dedent in favor of ts-dedent

### DIFF
--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -32,9 +32,9 @@
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
     "@types/yargs": "17.0.35",
-    "dedent": "1.7.2",
     "memfs": "4.64.0",
     "nodemon": "3.1.14",
+    "ts-dedent": "2.3.0",
     "typescript": "5.9.3",
     "vitest": "4.1.10"
   },

--- a/packages/auth-providers/dbAuth/setup/src/__tests__/setupDataMockDMMF.test.ts
+++ b/packages/auth-providers/dbAuth/setup/src/__tests__/setupDataMockDMMF.test.ts
@@ -1,9 +1,9 @@
 import type fs from 'node:fs'
 import path from 'node:path'
 
-import dedent from 'dedent'
 import { fs as memfs, vol } from 'memfs'
 import prompts from 'prompts'
+import dedent from 'ts-dedent'
 import {
   vi,
   beforeAll,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2455,11 +2455,11 @@ __metadata:
     "@cedarjs/project-config": "workspace:*"
     "@prisma/internals": "npm:7.8.0"
     "@types/yargs": "npm:17.0.35"
-    dedent: "npm:1.7.2"
     memfs: "npm:4.64.0"
     nodemon: "npm:3.1.14"
     prompts: "npm:2.4.2"
     termi-link: "npm:1.1.0"
+    ts-dedent: "npm:2.3.0"
     typescript: "npm:5.9.3"
     vitest: "npm:4.1.10"
   languageName: unknown
@@ -15418,7 +15418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dedent@npm:1.7.2, dedent@npm:^1.0.0":
+"dedent@npm:^1.0.0":
   version: 1.7.2
   resolution: "dedent@npm:1.7.2"
   peerDependencies:


### PR DESCRIPTION
We use ts-dedent everywhere else in the framework. 
Unfortunately dedent is still used by jest-circus, so it's still in node_modules. But that'll be cleaned up as soon as we remove jest support.