### PR TITLE
chore(rsc): Set up from sources in CI

### DIFF
--- a/.github/actions/set-up-rsc-project/README.md
+++ b/.github/actions/set-up-rsc-project/README.md
@@ -3,12 +3,12 @@
 This action creates a CidarJS project with Streaming SSR and RSC support set up.
 It's used for RSC smoke tests.
 
-It runs `yarn create cedar-app -y ...` to set up the project, and then upgrades
-it to the latest canary release of Cedar. After that it runs
-`experimental setup-streaming-ssr` and `experimental setup-rsc` followed by
-a build of the CidarJS app. Finally it runs `project:copy` to get the latest
-changes to the framework (i.e. the changes introduced by the PR triggering this
-action) into the project.
+It scaffolds the project with the `create-cedar-app` built from the current
+commit (`packages/create-cedar-app/dist/create-cedar-app.js`), then runs
+`experimental setup-streaming-ssr` and `experimental setup-rsc` using the
+locally built CLI. Finally it runs `project:tarsync` to get the changes
+introduced by the PR triggering this action into the project, and builds the
+CedarJS app.
 
 ## Testing/running locally
 

--- a/.github/actions/set-up-rsc-project/setUpRscProject.mts
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mts
@@ -1,4 +1,3 @@
-import fs from 'node:fs'
 import path from 'node:path'
 
 import type { ExecOptions } from '@actions/exec'
@@ -56,20 +55,27 @@ async function setUpRscProject(
     CEDAR_FRAMEWORK_PATH,
     'packages/cli/dist/index.js',
   )
+  const createCedarAppBinPath = path.join(
+    CEDAR_FRAMEWORK_PATH,
+    'packages/create-cedar-app/dist/create-cedar-app.js',
+  )
+  const cfwBinPath = path.join(CEDAR_FRAMEWORK_PATH, 'packages/cli/dist/cfw.js')
 
   console.log(`Creating project at ${rscProjectPath}`)
   console.log()
-  await exec('npx', [
-    '-y',
-    'create-cedar-app@canary',
+
+  // `-y` implies `--install`, so this also creates the project's yarn.lock.
+  // Nothing else may run yarn in the project before this finishes — yarn 4's
+  // hardened mode (on for public PRs) rejects any invocation made without a
+  // lockfile present.
+  await exec('node', [
+    createCedarAppBinPath,
     '-y',
     '--no-git',
     '--pm',
     'yarn',
     rscProjectPath,
   ])
-  await execInProject('yarn install')
-  await execInProject('yarn cedar upgrade --yes --tag canary')
 
   console.log(`Setting up Streaming/SSR in ${rscProjectPath}`)
   const cmdSetupStreamingSSR = `node ${cedarBinPath} experimental setup-streaming-ssr -f`
@@ -80,8 +86,14 @@ async function setUpRscProject(
   await execInProject(`node ${cedarBinPath} experimental setup-rsc`)
   console.log()
 
+  // Run the cfw bin built from this commit rather than the project's own
+  // (`yarn cfw`). The project installs the last *released* `@cedarjs/*`
+  // packages, so `yarn cfw` would resolve to a released tarsync, which is both
+  // older than the framework it is syncing and blind to any tarsync change the
+  // PR makes. The RSA and RSC-kitchen-sink setups already invoke the local bin
+  // this way (see `actionsLib.mjs`).
   console.log('Syncing framework')
-  await execInProject(`yarn cfw project:tarsync --verbose`, {
+  await execInProject(`node ${cfwBinPath} project:tarsync --verbose`, {
     env: {
       CFW_PATH: CEDAR_FRAMEWORK_PATH,
     },


### PR DESCRIPTION
## Summary

The RSC smoke test was the only CI job whose result depended on npm registry state the PR under test couldn't control. It scaffolded its project with `create-cedar-app@canary` and then ran `yarn cedar upgrade --yes --tag canary`, so a canary publish that was mid-flight — or that had failed partway through — showed up as an unrelated install failure on whatever PR happened to be running at the time.

This switches the scaffolding to local sources, in line with every other smoke test.

## Background

Every other smoke test builds its project from local sources only:

- `set-up-test-project` / `set-up-test-project-esm` copy a committed `__fixtures__/*` project. Their `canary` input defaults to `'false'` and no caller sets it to `'true'`.
- `set-up-rsa-project` and `set-up-rsc-kitchen-sink-project` — the other two setup steps in *this same workflow* — copy `__fixtures__/test-project-rsa` and `__fixtures__/test-project-rsc-kitchen-sink` via `setUpRscTestProject` in `actionsLib.mjs`, then go straight to tarsync.

So `set-up-rsc-project` was the outlier.

This is the failure class documented in `docs/implementation-plans/flaky-smoke-tests-investigation.md` under
*"Update 2026-07-21 — Root cause identified and fixed: canary-registry `ETARGET` / no-candidates"*. #2147 made `publish-prerelease.mts` stage all packages under a throwaway tag and only flip `canary`/`next` once every package
landed, which narrows the window a lot — but it doesn't remove the dependency. A genuinely broken canary publish still red-lights unrelated PRs, and a PR that needs a coordinated framework change still can't be tested here, because the baseline is whatever `main`/`next` last published.

Nothing was gained in exchange. `project:tarsync` replaces every `@cedarjs/*` package with a tarball built from the PR's own commit, so the canary versions were only ever scaffolding that got overwritten a few steps later.

The `yarn cedar upgrade --tag canary` was also close to a no-op on its own: `publish-prerelease.mts` calls `updateCreateCedarAppTemplates()` before publishing, so a project scaffolded from `create-cedar-app@canary` is *already* on canary. The upgrade mostly just resolved the same dist-tag a second time, doubling the exposure window for no benefit.

## What changed

| Before | After |
| --- | --- |
| `npx -y create-cedar-app@canary` | `node <fw>/packages/create-cedar-app/dist/create-cedar-app.js` |
| `yarn install` | removed — `-y` implies `--install`, so CCA had already done it |
| `yarn cedar upgrade --yes --tag canary` | removed — no released baseline left to upgrade away from |
| `yarn cfw project:tarsync` | `node <fw>/packages/cli/dist/cfw.js project:tarsync` |

`create-cedar-app` is bundled by esbuild (`bundle: true` in its
`scripts/build.ts`), so `dist/create-cedar-app.js` runs standalone with no
dependency resolution of its own. `set-up-job`'s build step is
`nx run-many -t build`, which already builds it.

### Why the `cfw` change is in here

`yarn cfw` resolves from the *project's* `node_modules`. With the canary
upgrade gone, the project installs the last **released** `@cedarjs/*` packages,
so `yarn cfw` would have resolved to released-5.0.3 tarsync — both older than
the framework it's syncing, and blind to any tarsync change made by the PR.
Dropping the upgrade forces this, so it's part of the same change rather than
drive-by. The RSA and RSC-kitchen-sink setups already invoke the local bin this
way.

### On the version pins

The local templates pin `@cedarjs/*` to the last released version (currently an
exact `5.0.3`, not a dist-tag), which resolves deterministically and can't hit
the `ETARGET` race. `updateCreateCedarAppTemplates()` only rewrites
`@cedarjs/*` entries, so the local templates are otherwise identical to the
canary ones — same React, same Vite. tarsync then overrides the `@cedarjs/*`
pins with local tarballs. Net effect on what gets tested: equivalent to canary,
sourced locally.

A small bonus: template changes made by a PR are now exercised by this job,
instead of whatever `main` last published.

## Tradeoff

`create-cedar-app`'s lockfile overlays are generated by `build:pack` and
deleted right after packing, so they only exist inside the published tarball.
Running from `dist/` means the scaffolded project starts without a `yarn.lock`
and its first install does a full resolution rather than a lockfile-pinned one.
That's slower than before.

It isn't a correctness problem — tarsync re-installs anyway, and
`YARN_ENABLE_IMMUTABLE_INSTALLS: false` is already set for this step — and it
doesn't reintroduce any dist-tag dependency, since the pins are exact versions.
The alternative would be running `yarn workspace create-cedar-app build:pack`
first and scaffolding from the tarball, but that step generates six lockfiles
(3 package managers × 2 template bases) with six real installs, which is a
worse flake surface than the one it fixes.

If the added install time turns out to matter, that's the knob to revisit.

## Testing

- Verified `node packages/create-cedar-app/dist/create-cedar-app.js -y --no-git
  --pm yarn <path>` scaffolds correctly when run standalone from the monorepo,
  outside any project context.
- Confirmed the scaffolded project has no `yarn.lock` (the tradeoff above) and
  that its `@cedarjs/*` pins are exact versions.
- `eslint` and `prettier --check` on `.github/actions/set-up-rsc-project/` are
  clean. Also removed a pre-existing unused `fs` import that eslint was
  flagging in this file.
- `tsc --noEmit -p .github/actions/set-up-rsc-project/tsconfig.json` reports
  nothing for these files (its only output is pre-existing `node_modules`
  type errors, unchanged by this PR).
- The end-to-end chain (scaffold → setup-streaming-ssr → setup-rsc → tarsync →
  build → Playwright) is exercised by this PR's own RSC Smoke Tests job.

## Not addressed here

`setup-rsc` still does a live fetch of
`raw.githubusercontent.com/cedarjs/cedar/main/packages/create-cedar-app/templates/ts/web/package.json`
at runtime to pick React versions (`setupRscHandler.ts`). That's the same class
of problem — the result depends on `main`'s state rather than the PR's — but
it's in shipped CLI code that affects real users, so changing it is a separate
decision from a CI cleanup.
