### PR TITLE
fix(api): Only build server auth state when an auth decoder is given

### DIFF
--- a/packages/api/src/__tests__/runtime.test.ts
+++ b/packages/api/src/__tests__/runtime.test.ts
@@ -62,6 +62,35 @@ describe('buildCedarContext', () => {
     expect(ctx.query.getAll('tag')).toEqual(['cedar', 'framework'])
   })
 
+  // Function routes never pass an auth decoder, so there's nothing to decode
+  // and no reason to parse the `Authorization` header. Consumers that always
+  // send `auth-provider` used to get a 500 out of routes that don't use auth.
+  it('skips auth state for routes without an auth decoder', async () => {
+    const request = new Request('http://localhost:8911/tokenFromApiKey', {
+      headers: {
+        'auth-provider': 'custom',
+      },
+    })
+
+    const ctx = await buildCedarContext(request, {
+      params: { routeName: 'tokenFromApiKey' },
+    })
+
+    expect(ctx.serverAuthState).toBeUndefined()
+  })
+
+  it('skips auth state when the auth decoder array is empty', async () => {
+    const request = new Request('http://localhost:8911/tokenFromApiKey', {
+      headers: {
+        'auth-provider': 'custom',
+      },
+    })
+
+    const ctx = await buildCedarContext(request, { authDecoder: [] })
+
+    expect(ctx.serverAuthState).toBeUndefined()
+  })
+
   it('hydrates auth state when an auth decoder is provided', async () => {
     const authDecoder = vi.fn(async (token: string, type: string) => {
       expect(token).toBe('auth-provider=test; session=token-123')

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -83,6 +83,16 @@ const DEFAULT_LAMBDA_CONTEXT: LambdaContext = {
   },
 }
 
+function hasAuthDecoder(
+  authDecoder: BuildCedarContextOptions['authDecoder'],
+): authDecoder is NonNullable<BuildCedarContextOptions['authDecoder']> {
+  if (Array.isArray(authDecoder)) {
+    return authDecoder.length > 0
+  }
+
+  return !!authDecoder
+}
+
 export async function buildCedarContext(
   request: Request,
   options: BuildCedarContextOptions = {},
@@ -98,11 +108,19 @@ export async function buildCedarContext(
   )
   const params = options.params ?? {}
 
-  const serverAuthState = await getAuthenticationContext({
-    authDecoder: options.authDecoder,
-    event: request,
-    context: options.lambdaContext,
-  })
+  // Only GraphQL consumes `serverAuthState`, and it's the only caller that
+  // supplies an auth decoder. Computing it for plain function routes is wasted
+  // work — without a decoder nothing can be decoded, so the payload could only
+  // ever come back with `decoded` set to `null` — and it lets `Authorization`
+  // header parse errors escape and turn requests to functions that don't use
+  // auth at all into 500s.
+  const serverAuthState = hasAuthDecoder(options.authDecoder)
+    ? await getAuthenticationContext({
+        authDecoder: options.authDecoder,
+        event: request,
+        context: options.lambdaContext,
+      })
+    : undefined
 
   return {
     params,

--- a/packages/graphql-server/src/functions/__tests__/useRequireAuthFetchPath.test.ts
+++ b/packages/graphql-server/src/functions/__tests__/useRequireAuthFetchPath.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildCedarContext, wrapLegacyHandler } from '@cedarjs/api/runtime'
+
+import { useRequireAuth } from '../useRequireAuth.js'
+
+import { getCurrentUser } from './fixtures/auth.js'
+
+const authDecoder = async (token: string, type: string) => {
+  if (type !== 'custom') {
+    return null
+  }
+
+  return { sub: 'user-1', token }
+}
+
+const myHandler = async () => {
+  const globalContext = (await import('@cedarjs/context')).context
+
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      currentUser: globalContext.currentUser ?? 'NO_CURRENT_USER',
+    }),
+  }
+}
+
+// This is exactly what a user's `export const handler = useRequireAuth({...})`
+// becomes once `lambdaLoader` wraps it via `wrapLegacyHandler`.
+const cedarHandler = wrapLegacyHandler(
+  useRequireAuth({ handlerFn: myHandler, getCurrentUser, authDecoder }),
+)
+
+async function invoke(headers: Record<string, string>) {
+  const request = new Request('http://localhost:8911/myHandler', {
+    method: 'POST',
+    body: '',
+    headers,
+  })
+
+  const ctx = await buildCedarContext(request, {
+    params: { routeName: 'myHandler' },
+  })
+
+  const response = await cedarHandler(request, ctx)
+
+  return { status: response.status, body: await response.json() }
+}
+
+describe('useRequireAuth through the fetch-native path', () => {
+  it('still populates currentUser from a Bearer token', async () => {
+    const result = await invoke({
+      'auth-provider': 'custom',
+      authorization: 'Bearer auth-test-token',
+    })
+
+    expect(result.status).toBe(200)
+    expect(result.body.currentUser).toMatchObject({ sub: 'user-1' })
+  })
+
+  it('does not 500 when auth-provider is sent without an Authorization header', async () => {
+    const result = await invoke({ 'auth-provider': 'custom' })
+
+    expect(result.status).toBe(200)
+    expect(result.body.currentUser).toBe('NO_CURRENT_USER')
+  })
+
+  it('does not 500 when the API key is sent with no auth scheme', async () => {
+    const result = await invoke({
+      'auth-provider': 'custom',
+      authorization: 'rawapikey',
+    })
+
+    expect(result.status).toBe(200)
+    expect(result.body.currentUser).toBe('NO_CURRENT_USER')
+  })
+})


### PR DESCRIPTION
## Problem

A request that carries an `auth-provider` header but no well-formed `Authorization` header returns a 500 with ``The `Authorization` header is not valid.``. It does this even for API functions that don't use auth at all.

This is a regression on the 2.x -> 5.x path, reported by a user whose API consumers always send `AUTH_PROVIDER_HEADER` against an endpoint that exchanges an API key for a token. Some of those consumers are OTT device apps that take a long time to update.
https://discord.com/channels/1375421480858423408/1375421481839755377/1532438431848857840

Two changes compound:

1. #1616 added `buildCedarContext()`, which calls `getAuthenticationContext()` for **every** API request, including plain functions, and including legacy `handler` exports, which `wrapLegacyHandler` routes through the same fetch-native path. In 2.x a plain function never touched `getAuthenticationContext`; only GraphQL and `useRequireAuth` did, and `useRequireAuth` deliberately swallows this exact exception.
2. #1750 then made `getAuthProviderHeader` able to read `auth-provider` off a fetch `Request`. Before that, `Object.keys(headersInstance)` returned `[]`, so it always returned `undefined` on that path and `getAuthenticationContext` short-circuited to "unauthenticated".

Post-#1750: the header is seen -> no auth cookie -> `parseAuthorizationHeader()` throws -> the error escapes `buildCedarContext` uncaught -> 500 before the handler runs.

Note the failure is narrow: `Authorization: Bearer abc` passes through fine (it's two non-empty parts). A bare API key with no scheme, or no `Authorization` header at all alongside `auth-provider`, is what blows up.

## Fix

Only GraphQL consumes `serverAuthState` and the sole consumer is `useRedwoodAuthContext.ts:20`. The GraphQL call sites are the only ones that pass an `authDecoder` (`api-server/src/plugins/graphql.ts:92`, and the UD graphql module). Function routes pass none, so `getAuthenticationContext` runs there with an empty decoder list and the result can only ever be `[null, { type, schema, token }, …]`, which nobody reads. It's wasted work that can only throw.

So: gate the call on an auth decoder actually being present, rather than sniffing the route type. `buildCedarContext` can't reliably tell what route it's on anyway because the UD (universal-deploy) function wrapper calls it with no options at all, and only two of the four call sites pass `params.routeName`.

An empty `authDecoder` array is treated as "no decoder", since `[]` is truthy but has nothing to decode with.

## GraphQL behaviour is unchanged

- Where a decoder is passed, the state is still computed and still throws, and `useRedwoodAuthContext` still rethrows as `Exception in getAuthenticationContext`. This matches 2.x behavior.
- Where one isn't (the Vite dev middleware serves GraphQL on its own branch and never passes a decoder), `useRedwoodAuthContext`'s `if (!authContext)` fallback recomputes using the decoder it was constructed with.

A GraphQL request with a stray `auth-provider` and no `Authorization` still 500s, exactly as it did in 2.x. Whether `parseAuthorizationHeader` should throw at all rather than treating a malformed header as unauthenticated is a separate, broader question this PR deliberately leaves alone.