### PR TITLE
fix(api): Always pass authDecoder for graphql requests

### DIFF
--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -89,9 +89,6 @@ export async function redwoodFastifyGraphQLServer(
         handler: async (req, reply) => {
           const request = createFetchRequest(req, reply)
           const cedarContext = await buildCedarContext(request, {
-            // Projects without auth set up have no decoder. We still have to
-            // resolve auth state here, before Yoga reads the request body, so
-            // fall back to a decoder that decodes nothing
             authDecoder: graphqlOptions.authDecoder ?? noopAuthDecoder,
           })
 

--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -10,7 +10,7 @@ import type {
   HTTPMethods,
 } from 'fastify'
 
-import { buildCedarContext } from '@cedarjs/api/runtime'
+import { buildCedarContext, noopAuthDecoder } from '@cedarjs/api/runtime'
 import type { GlobalContext } from '@cedarjs/context'
 import { getAsyncStoreInstance } from '@cedarjs/context/dist/store'
 import { coerceRootPath } from '@cedarjs/fastify-web/dist/helpers.js'
@@ -89,7 +89,10 @@ export async function redwoodFastifyGraphQLServer(
         handler: async (req, reply) => {
           const request = createFetchRequest(req, reply)
           const cedarContext = await buildCedarContext(request, {
-            authDecoder: graphqlOptions.authDecoder,
+            // Projects without auth set up have no decoder. We still have to
+            // resolve auth state here, before Yoga reads the request body, so
+            // fall back to a decoder that decodes nothing
+            authDecoder: graphqlOptions.authDecoder ?? noopAuthDecoder,
           })
 
           // Phase 1 of transitional context bridge: pass both the Fetch-native

--- a/packages/api/src/__tests__/runtime.test.ts
+++ b/packages/api/src/__tests__/runtime.test.ts
@@ -94,7 +94,7 @@ describe('buildCedarContext', () => {
 
   // GraphQL routes have to resolve auth state up front even when the project
   // has no auth set up, because `useRedwoodAuthContext`'s fallback runs after
-  // Yoga has consumed the request body — cloning it there throws `unusable`.
+  // Yoga has consumed the request body – cloning it there throws `unusable`.
   // `noopAuthDecoder` is what keeps the resolve eager for those projects.
   it('resolves auth state with `noopAuthDecoder`', async () => {
     const request = new Request('http://localhost:8911/graphql', {

--- a/packages/api/src/__tests__/runtime.test.ts
+++ b/packages/api/src/__tests__/runtime.test.ts
@@ -5,6 +5,7 @@ import {
   buildCedarContext,
   composeCedarMiddleware,
   legacyResultToResponse,
+  noopAuthDecoder,
   requestToLegacyEvent,
   routeManifestToJSON,
   wrapLegacyHandler,
@@ -89,6 +90,36 @@ describe('buildCedarContext', () => {
     const ctx = await buildCedarContext(request, { authDecoder: [] })
 
     expect(ctx.serverAuthState).toBeUndefined()
+  })
+
+  // GraphQL routes have to resolve auth state up front even when the project
+  // has no auth set up, because `useRedwoodAuthContext`'s fallback runs after
+  // Yoga has consumed the request body — cloning it there throws `unusable`.
+  // `noopAuthDecoder` is what keeps the resolve eager for those projects.
+  it('resolves auth state with `noopAuthDecoder`', async () => {
+    const request = new Request('http://localhost:8911/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query: '{ __typename }' }),
+      headers: {
+        cookie: 'auth-provider=dbAuth; session=abc123',
+      },
+    })
+
+    const ctx = await buildCedarContext(request, {
+      authDecoder: noopAuthDecoder,
+    })
+
+    // Reading the body afterwards is what Yoga does. The resolve above already
+    // happened, so no fallback is needed and nothing clones a used `Request`
+    await request.text()
+
+    expect(ctx.serverAuthState).toBeDefined()
+    expect(ctx.serverAuthState?.[0]).toBeNull()
+    expect(ctx.serverAuthState?.[1]).toEqual({
+      type: 'dbAuth',
+      schema: 'cookie',
+      token: 'auth-provider=dbAuth; session=abc123',
+    })
   })
 
   it('hydrates auth state when an auth decoder is provided', async () => {

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -8,7 +8,34 @@ import * as cookie from 'cookie'
 import { parse } from 'picoquery'
 
 import { getAuthenticationContext } from './auth/index.js'
+import type { Decoder } from './auth/index.js'
 import { requestToBaseEvent } from './transforms.js'
+
+/**
+ * A decoder that decodes nothing.
+ *
+ * Resolving `serverAuthState` has to happen before the GraphQL server reads
+ * the request body:
+ *
+ * 1. Resolving it materialises the request body — `getAuthenticationContext`
+ *    builds a Lambda-style event via `requestToBaseEvent`, which does
+ *    `request.clone().text()`
+ * 2. `clone()` only works while the body is untouched
+ * 3. So once the GraphQL server has read the body, resolving throws
+ *    `TypeError: unusable`
+ *
+ * `buildCedarContext` only resolves auth state when it's given a decoder, so
+ * GraphQL call sites pass this one for projects that have no auth set up, to
+ * keep the resolve eager. Resolving with it produces the same payload as
+ * resolving with no decoders at all.
+ *
+ * (When it isn't resolved eagerly, `useRedwoodAuthContext` resolves it during
+ * context building instead — too late. That's how this surfaces.)
+ *
+ * TODO: Remove this once the request body is captured at the entry point rather
+ * than read lazily from the auth path, which drops the ordering constraint.
+ */
+export const noopAuthDecoder: Decoder = async () => null
 
 export interface CedarRequestContext {
   params: Record<string, string>
@@ -109,9 +136,10 @@ export async function buildCedarContext(
   const params = options.params ?? {}
 
   // Only GraphQL consumes `serverAuthState`, and it's the only caller that
-  // supplies an auth decoder. Computing it for plain function routes is wasted
-  // work — without a decoder nothing can be decoded, so the payload could only
-  // ever come back with `decoded` set to `null` — and it lets `Authorization`
+  // supplies an auth decoder — passing `noopAuthDecoder` when the project has
+  // no auth set up. Computing it for plain function routes is wasted work —
+  // without a decoder nothing can be decoded, so the payload could only ever
+  // come back with `decoded` set to `null` — and it lets `Authorization`
   // header parse errors escape and turn requests to functions that don't use
   // auth at all into 500s.
   const serverAuthState = hasAuthDecoder(options.authDecoder)

--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -384,12 +384,7 @@ async function generateGraphQLModule(distPath: string): Promise<string> {
       async fetch(request) {
         const { yoga, graphqlOptions } = await getYoga();
         const cedarContext = await buildCedarContext(request, {
-          // Projects without auth set up have no decoder. We still have to
-          // resolve auth state here, before Yoga reads the request body, so
-          // fall back to a decoder that decodes nothing
-          authDecoder:
-            (graphqlOptions ? graphqlOptions.authDecoder : undefined) ??
-            noopAuthDecoder,
+          authDecoder: graphqlOptions?.authDecoder ?? noopAuthDecoder,
         });
         const event = await requestToLegacyEvent(request, cedarContext);
         // Wrap yoga.handle in an AsyncLocalStorage run so directive

--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -363,7 +363,7 @@ async function generateGraphQLModule(distPath: string): Promise<string> {
   })
 
   return `
-    import { buildCedarContext, requestToLegacyEvent } from '@cedarjs/api/runtime';
+    import { buildCedarContext, noopAuthDecoder, requestToLegacyEvent } from '@cedarjs/api/runtime';
     import { createGraphQLYoga } from '@cedarjs/graphql-server';
 
     // Inlined bundle of ${path.basename(distPath)} (node_modules kept external)
@@ -384,7 +384,12 @@ async function generateGraphQLModule(distPath: string): Promise<string> {
       async fetch(request) {
         const { yoga, graphqlOptions } = await getYoga();
         const cedarContext = await buildCedarContext(request, {
-          authDecoder: graphqlOptions ? graphqlOptions.authDecoder : undefined,
+          // Projects without auth set up have no decoder. We still have to
+          // resolve auth state here, before Yoga reads the request body, so
+          // fall back to a decoder that decodes nothing
+          authDecoder:
+            (graphqlOptions ? graphqlOptions.authDecoder : undefined) ??
+            noopAuthDecoder,
         });
         const event = await requestToLegacyEvent(request, cedarContext);
         // Wrap yoga.handle in an AsyncLocalStorage run so directive

--- a/tasks/e2e/cypress/e2e/01-tutorial/00-stray-auth-provider.cy.js
+++ b/tasks/e2e/cypress/e2e/01-tutorial/00-stray-auth-provider.cy.js
@@ -1,0 +1,40 @@
+/* eslint-disable no-undef */
+/// <reference types="cypress" />
+
+// Runs before tutorial.cy.js, while the app is still exactly what
+// `create-cedar-app` generated — in particular, before anything sets up auth.
+
+const BASE_URL = 'http://localhost:8910'
+const GRAPHQL_URL = `${BASE_URL}/.api/functions/graphql`
+
+describe('GraphQL on a freshly created app', () => {
+  // A fresh app has no auth set up, so it has no auth decoder and nothing
+  // resolves auth state before the GraphQL server reads the request body.
+  // Resolving it afterwards means cloning an already consumed `Request`, which
+  // used to fail the whole request with
+  // `Exception in getAuthenticationContext: unusable`.
+  //
+  // API consumers send `auth-provider` for all sorts of reasons, and a stale
+  // cookie left on localhost by another project is enough on its own.
+  //
+  // It has to be the cookie rather than the header: a cookie sets
+  // type/schema/token and so reaches the point where the Lambda-style event is
+  // built, while a bare header throws earlier, in `parseAuthorizationHeader`.
+  it('handles a stray auth-provider cookie', () => {
+    cy.request({
+      method: 'POST',
+      url: GRAPHQL_URL,
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'auth-provider=dbAuth',
+      },
+      body: { query: '{ __typename }' },
+      // Assert on the status ourselves so a 500 reports the body
+      failOnStatusCode: false,
+    }).then((res) => {
+      expect(JSON.stringify(res.body)).to.not.contain('unusable')
+      expect(res.status).to.eq(200)
+      expect(res.body.data.__typename).to.eq('Query')
+    })
+  })
+})

--- a/tasks/ud-tests/udDev.test.mts
+++ b/tasks/ud-tests/udDev.test.mts
@@ -85,6 +85,30 @@ describe('cedar dev --ud', () => {
       data: { hello: 'Hello from Cedar GraphQL' },
     })
 
+    // 6b. GraphQL with an auth-provider cookie, on a fixture that has no auth
+    // set up. A stale cookie left on localhost by another project is enough to
+    // send this.
+    //
+    // The dev server resolves auth state in `useRedwoodAuthContext` rather than
+    // up front, and unlike `cedar serve api --ud` that happens while the
+    // request body is still readable — so this passes today. It's here to keep
+    // it that way, not because it ever failed.
+    const gqlAuthProviderRes = await fetchJson(
+      `${BASE_URL}/.api/functions/graphql`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: 'auth-provider=dbAuth',
+        },
+        body: JSON.stringify({ query: '{ hello }' }),
+      },
+    )
+    expect(gqlAuthProviderRes.status).toEqual(200)
+    expect(gqlAuthProviderRes.body).toMatchObject({
+      data: { hello: 'Hello from Cedar GraphQL' },
+    })
+
     // 7. HMR: modify the API function source and expect the change to be reflected
     const helloSrcPath = `${FIXTURE_PATH}/api/src/functions/hello.ts`
     const originalSrc = fs.readFileSync(helloSrcPath, 'utf-8')

--- a/tasks/ud-tests/udServe.test.mts
+++ b/tasks/ud-tests/udServe.test.mts
@@ -69,6 +69,27 @@ describe('cedar serve api --ud', () => {
       data: { hello: 'Hello from Cedar GraphQL' },
     })
 
+    // 6b. GraphQL with an auth-provider cookie, on a fixture that has no auth
+    // set up. A stale cookie left on localhost by another project is enough to
+    // send this. Auth state then has to be resolved after the body has been
+    // read, which used to fail with `Exception in getAuthenticationContext:
+    // unusable`
+    const gqlAuthProviderRes = await fetchJson(
+      `http://localhost:${API_PORT}/graphql`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: 'auth-provider=dbAuth',
+        },
+        body: JSON.stringify({ query: '{ hello }' }),
+      },
+    )
+    expect(gqlAuthProviderRes.status).toEqual(200)
+    expect(gqlAuthProviderRes.body).toMatchObject({
+      data: { hello: 'Hello from Cedar GraphQL' },
+    })
+
     // 7. Web route should return the SPA shell
     const webRes = await fetch(`http://localhost:${WEB_PORT}/`)
     expect(webRes.status).toEqual(200)


### PR DESCRIPTION
Follow-up to #2270, which introduced a regression.

## Problem

On a project with **no auth set up**, every GraphQL request dies with:

```
🚨 graphql-server Error building context. Error: Exception in getAuthenticationContext: unusable
    at onContextBuilding (@cedarjs/graphql-server/dist/cjs/plugins/useRedwoodAuthContext.js:39:15)
```

Reproduced from a fresh `create-cedar-app` project running `yarn cedar dev`.

## Root cause

#2270 stopped `buildCedarContext` from resolving `serverAuthState` for routes that don't need it, and used "was an `authDecoder` supplied?" as the proxy for "is this a GraphQL route?".

That proxy is wrong. A project without auth configured has no `authDecoder` at all, so `graphqlOptions.authDecoder` is `undefined` and GraphQL stopped resolving auth state up front. From there:

1. `buildCedarContext` skips the eager resolve, leaving `serverAuthState` undefined
2. Yoga parses the GraphQL params, **consuming the request body**
3. `useRedwoodAuthContext`'s `if (!authContext)` fallback resolves auth state itself
4. `getAuthenticationContext` → `requestToBaseEvent` → `request.clone()` on an already-consumed body → `TypeError: unusable`

Any request carrying an `auth-provider` cookie or header hits it — a stale `auth-provider` cookie left on `localhost` by an earlier test project is enough to trigger it on a project that has never had auth.

The timing is the crux: resolving auth state is only safe *before* the GraphQL server reads the body, so it can't be left to a fallback that runs during context building.

## Fix

GraphQL call sites pass a `noopAuthDecoder` when the project has no decoder of its own, which keeps `buildCedarContext`'s eager resolve running. Resolving with it produces the same payload as resolving with no decoders at all — `decoded` is `null` either way — so nothing else changes.

#2270's actual fix is preserved: plain function routes still skip the resolve, so a consumer that always sends `AUTH_PROVIDER_HEADER` no longer 500s an endpoint that doesn't use auth. `buildCedarContext` and `BuildCedarContextOptions` are unchanged from `main` apart from a comment.

## This is scaffolding

The underlying constraint is that `requestToBaseEvent` materialises the request body lazily, from inside the auth path. In 2.x there was no such constraint: the Fastify handler converted to a Lambda event eagerly (`event: lambdaEventForFastifyRequest(req)`), and `getAuthenticationContext` passed that event straight through without ever touching a body. `useRedwoodAuthContext` resolved auth state lazily during `onContextBuilding` — after Yoga had read the body — and that was fine.

The real fix is to capture the body at the entry point instead. Both Fastify entry points already construct the `Request` from a body string they hold (`req.body` / `req.rawBody`), so it costs nothing there; the fetch-native entry points need one `clone()` before anything reads. That drops the ordering constraint entirely and lets `noopAuthDecoder` be deleted. `noopAuthDecoder`'s JSDoc says as much.

It's also worth knowing that whether the late fallback survives is currently a matter of timing rather than design. Under `cedar dev --ud` the fallback runs while the body is still readable, so it works; under `cedar serve api --ud` the body has already been consumed, so it doesn't. Both are covered below. Capturing at the entry point would make that difference stop mattering.

## Testing

New assertions in `tasks/ud-tests`, against `__fixtures__/cedar-ud-app` — the fixture matters, because it has no `authDecoder`. `test-project` configures dbAuth, so the eager resolve always happens there and the failure cannot be reproduced.

The trigger has to be the `auth-provider` **cookie**, not the header. A cookie takes the `schema: 'cookie'` branch, which sets token/type/schema and so reaches the point where the event is built from a consumed `Request`. A bare `auth-provider` header throws earlier, in `parseAuthorizationHeader` — that's #2270's failure, covered separately by #2274.

Verified by reverting the three fixed files to `main`, rebuilding, and re-running:

| | without fix | with fix |
|---|---|---|
| `udServe` — `cedar serve api --ud` | **fails** | passes |
| `udDev` — `cedar dev --ud` | passes | passes |

`udDev` never failed, so its assertion is there to keep that path working rather than as a repro, and its comment says so.

- `tasks/ud-tests` — 9 passing
- `@cedarjs/api` — 256 passing
- `@cedarjs/graphql-server` — 141 passing
- `@cedarjs/api-server` — 100 passing, 2 skipped
- `@cedarjs/vite` — 234 passing
- `yarn build` — clean
- `eslint` and `prettier` on all changed files — clean