### PR TITLE
fix(ci): disable Windows Defender real-time scanning on Windows runners

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -25,6 +25,17 @@ runs:
   using: composite
 
   steps:
+    - name: 🛡️ Disable Windows Defender real-time scanning
+      # Windows Defender's real-time scanning competes for file handles during
+      # yarn installs and builds, and is a recurring cause of transient
+      # EPERM/EBUSY errors on windows-latest runners (see
+      # docs/implementation-plans/flaky-smoke-tests-investigation.md). These
+      # runners are ephemeral and torn down after the job, so disabling
+      # scanning here is safe.
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: Set-MpPreference -DisableRealtimeMonitoring $true
+
     - name: ⬢ Enable Corepack
       shell: bash
       # Using --force to make this work on Windows


### PR DESCRIPTION
- Disable Windows Defender real-time scanning at the start of every job that runs on `windows-latest`, via `.github/actions/set-up-job/action.yml`.
- Windows Defender's real-time scanning competes for file handles during `yarn install` and builds, and is a recurring cause of transient `EPERM`/`EBUSY` errors on Windows runners — including the `EPERM: operation not permitted, rename` failure documented in `docs/implementation-plans/flaky-smoke-tests-investigation.md`, which was attributed to "an antivirus scan, a lingering node process, or a filesystem indexer".
- `set-up-job` is the single shared composite action used by essentially every CI job in this repo (confirmed no windows-latest-running workflow bypasses it), so this is a comprehensive, one-place fix.
- These runners are ephemeral and torn down at the end of the job, so disabling scanning here doesn't introduce any lasting risk.

## References

Disabling (or excluding paths from) Windows Defender real-time scanning is a common fix for exactly this class of flakiness in other projects' Windows CI:

- [pytorch/pytorch#96931](https://github.com/pytorch/pytorch/pull/96931) — `Re-enable test_ops_jit on Windows` (merged **2023-03-17**) added the shared `.github/actions/setup-win/action.yml` step that excludes the workspace + TEMP dirs *and* disables real-time monitoring, with the comment: _"Let's both exclude the path and disable Windows Defender completely just to be sure that it doesn't interfere."_ Still in use today, generated into every Windows workflow (e.g. [`generated-windows-binary-wheel-nightly.yml`](https://github.com/pytorch/pytorch/blob/main/.github/workflows/generated-windows-binary-wheel-nightly.yml#L341-L349)).
- [postgres/postgres — `pg-ci.yml`](https://github.com/postgres/postgres/blob/d374280e1837adc1f8218bb0d69ffbae5d808fc6/.github/workflows/pg-ci.yml#L880-L884) has a dedicated "Disable Windows Defender" step using `Set-MpPreference -DisableRealtimeMonitoring`, added **2026-06-04** as part of adding their GitHub Actions CI. No PR link available — postgres doesn't use GitHub PRs (development happens via mailing list, commits are pushed directly to `master`), so this is the commit itself: [`9c126063`](https://github.com/postgres/postgres/commit/9c126063b19adc53a0ce15ac1ae1a70979e3c12e).
- [aeron-io/aeron — `ci.yml`](https://github.com/aeron-io/aeron/blob/693c7929584ed90fb9952a637e8468ca4834e0de/.github/workflows/ci.yml#L47-L54) disables real-time monitoring and excludes the `C:\` and `D:\` drives outright, added **2026-01-13** in a commit titled *"Workaround Windows CI issues by manually disabling CPU hogs"*. Also no PR — this repo does use PRs generally, but this particular commit ([`a26cf921`](https://github.com/aeron-io/aeron/commit/a26cf921497032a7617e5233813719b98d888be9)) was pushed straight to `master`, not through one.

Worth noting: [`actions/runner-images`](https://github.com/actions/runner-images/blob/main/images/windows/scripts/build/Configure-WindowsDefender.ps1) (GitHub's own hosted-runner image repo) already sets `DisableRealtimeMonitoring = $true` and excludes `C:\`/`D:\` at image-provisioning time — and has done so since **2022-07-26** ([#5969](https://github.com/actions/runner-images/pull/5969)). So in theory `windows-latest` runners have shipped with this already off for years. The postgres and aeron examples above were both added in **2026**, well after that baseline existed — meaning these aren't stale fixes predating GitHub's change, they're recent, deliberate re-assertions by projects still hitting Windows CI flakiness despite the base image setting. That's a decent signal this is worth keeping as a cheap, zero-risk defensive step here too.

