### PR TITLE
fix(ci): capture Playwright traces on failure for smoke tests

### DIFF
--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -60,3 +60,11 @@ jobs:
           CEDAR_TEST_PROJECT_PATH: ${{ github.workspace }}/../cedar-test-app
           CEDAR_SERVE_UD: '1'
           REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 🎭 Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-traces-e2e-node-${{ runner.os }}
+          path: tasks/smoke-tests/*/test-results/**
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -66,5 +66,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-traces-e2e-node-${{ runner.os }}
-          path: tasks/smoke-tests/*/test-results/**
+          path: tasks/smoke-tests/test-results/**
           if-no-files-found: ignore

--- a/.github/workflows/fragments-smoke-tests.yml
+++ b/.github/workflows/fragments-smoke-tests.yml
@@ -80,3 +80,11 @@ jobs:
         env:
           CEDAR_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
           REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 🎭 Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-traces-fragments-smoke-tests-${{ runner.os }}
+          path: tasks/smoke-tests/*/test-results/**
+          if-no-files-found: ignore

--- a/.github/workflows/fragments-smoke-tests.yml
+++ b/.github/workflows/fragments-smoke-tests.yml
@@ -86,5 +86,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-traces-fragments-smoke-tests-${{ runner.os }}
-          path: tasks/smoke-tests/*/test-results/**
+          path: tasks/smoke-tests/test-results/**
           if-no-files-found: ignore

--- a/.github/workflows/live-smoke-tests.yml
+++ b/.github/workflows/live-smoke-tests.yml
@@ -48,5 +48,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-traces-live-smoke-tests-${{ runner.os }}
-          path: tasks/smoke-tests/*/test-results/**
+          path: tasks/smoke-tests/test-results/**
           if-no-files-found: ignore

--- a/.github/workflows/live-smoke-tests.yml
+++ b/.github/workflows/live-smoke-tests.yml
@@ -42,3 +42,11 @@ jobs:
         env:
           CEDAR_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
           REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 🎭 Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-traces-live-smoke-tests-${{ runner.os }}
+          path: tasks/smoke-tests/*/test-results/**
+          if-no-files-found: ignore

--- a/.github/workflows/rsc-smoke-tests.yml
+++ b/.github/workflows/rsc-smoke-tests.yml
@@ -90,5 +90,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-traces-rsc-smoke-tests-${{ runner.os }}
-          path: tasks/smoke-tests/*/test-results/**
+          path: tasks/smoke-tests/test-results/**
           if-no-files-found: ignore

--- a/.github/workflows/rsc-smoke-tests.yml
+++ b/.github/workflows/rsc-smoke-tests.yml
@@ -84,3 +84,11 @@ jobs:
         env:
           CEDAR_TEST_PROJECT_PATH: ${{ steps.set-up-rsc-test-project.outputs.test-project-path }}
           REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 🎭 Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-traces-rsc-smoke-tests-${{ runner.os }}
+          path: tasks/smoke-tests/*/test-results/**
+          if-no-files-found: ignore

--- a/.github/workflows/smoke-tests-react-18-test.yml
+++ b/.github/workflows/smoke-tests-react-18-test.yml
@@ -107,5 +107,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-traces-smoke-tests-react-18-${{ runner.os }}
-          path: tasks/smoke-tests/*/test-results/**
+          path: tasks/smoke-tests/test-results/**
           if-no-files-found: ignore

--- a/.github/workflows/smoke-tests-react-18-test.yml
+++ b/.github/workflows/smoke-tests-react-18-test.yml
@@ -101,3 +101,11 @@ jobs:
         env:
           CEDAR_TEST_PROJECT_PATH: ${{ steps.set-up-test-project-react-18.outputs.test-project-path }}
           REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 🎭 Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-traces-smoke-tests-react-18-${{ runner.os }}
+          path: tasks/smoke-tests/*/test-results/**
+          if-no-files-found: ignore

--- a/.github/workflows/smoke-tests-test-esm.yml
+++ b/.github/workflows/smoke-tests-test-esm.yml
@@ -101,3 +101,11 @@ jobs:
         env:
           CEDAR_TEST_PROJECT_PATH: ${{ steps.set-up-test-project-esm.outputs.test-project-path }}
           REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 🎭 Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-traces-smoke-tests-esm-${{ runner.os }}
+          path: tasks/smoke-tests/*/test-results/**
+          if-no-files-found: ignore

--- a/.github/workflows/smoke-tests-test-esm.yml
+++ b/.github/workflows/smoke-tests-test-esm.yml
@@ -107,5 +107,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-traces-smoke-tests-esm-${{ runner.os }}
-          path: tasks/smoke-tests/*/test-results/**
+          path: tasks/smoke-tests/test-results/**
           if-no-files-found: ignore

--- a/.github/workflows/smoke-tests-test.yml
+++ b/.github/workflows/smoke-tests-test.yml
@@ -107,5 +107,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-traces-smoke-tests-${{ runner.os }}
-          path: tasks/smoke-tests/*/test-results/**
+          path: tasks/smoke-tests/test-results/**
           if-no-files-found: ignore

--- a/.github/workflows/smoke-tests-test.yml
+++ b/.github/workflows/smoke-tests-test.yml
@@ -101,3 +101,11 @@ jobs:
         env:
           CEDAR_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
           REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 🎭 Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-traces-smoke-tests-${{ runner.os }}
+          path: tasks/smoke-tests/*/test-results/**
+          if-no-files-found: ignore

--- a/.github/workflows/ssr-smoke-tests.yml
+++ b/.github/workflows/ssr-smoke-tests.yml
@@ -68,3 +68,11 @@ jobs:
         env:
           CEDAR_TEST_PROJECT_PATH: '${{ steps.set-up-test-project.outputs.test-project-path }}'
           REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 🎭 Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-traces-ssr-smoke-tests-${{ runner.os }}
+          path: tasks/smoke-tests/*/test-results/**
+          if-no-files-found: ignore

--- a/.github/workflows/ssr-smoke-tests.yml
+++ b/.github/workflows/ssr-smoke-tests.yml
@@ -74,5 +74,5 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-traces-ssr-smoke-tests-${{ runner.os }}
-          path: tasks/smoke-tests/*/test-results/**
+          path: tasks/smoke-tests/test-results/**
           if-no-files-found: ignore

--- a/tasks/smoke-tests/basePlaywright.config.mts
+++ b/tasks/smoke-tests/basePlaywright.config.mts
@@ -34,7 +34,14 @@ export const basePlaywrightConfig: PlaywrightTestConfig = {
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      // `retain-on-failure` keeps a trace.zip (inspectable via
+      // `npx playwright show-trace`) for any failing test and discards it on
+      // pass, which is invaluable for diagnosing flaky Windows CI failures
+      // after the fact. Lives here (rather than in each suite's own
+      // `playwright.config.ts`) because every downstream config does
+      // `{ ...basePlaywrightConfig, use: { baseURL: ... } }`, which would
+      // silently discard a top-level `use.trace` setting via shallow spread.
+      use: { ...devices['Desktop Chrome'], trace: 'retain-on-failure' },
       dependencies: fs.existsSync('./tests/setup.ts') ? ['setup'] : undefined,
     },
 


### PR DESCRIPTION
- Enable `trace: 'retain-on-failure'` in `tasks/smoke-tests/basePlaywright.config.mts` so every smoke-test suite records a Playwright trace (`trace.zip`) for any failing test, discarded automatically on pass.
- Upload the traces as a build artifact (`if: failure()`) in each of the 8 workflows that run `npx playwright test` against the smoke-test suites, so they're downloadable and inspectable (`npx playwright show-trace <file>`) after a CI failure instead of just a bare log.
- The trace setting lives inside `basePlaywrightConfig.projects[0].use` rather than the top-level `use`, since every suite's own `playwright.config.ts` does `{ ...basePlaywrightConfig, use: { baseURL: ... } }` — a shallow spread that would otherwise silently discard a top-level `use.trace` setting.
- Artifact names are suffixed with `${{ runner.os }}` (and the calling job's name) to stay unique when the same reusable workflow runs on both `ubuntu-latest` and `windows-latest` in one CI run.

Traces only, no screenshots, per request. This is the second of two follow-ups to the Windows nightly CI flakiness discussion — the other one, Windows Defender disable, is a separate PR (#2272).
