### PR TITLE
chore(test): Cover function routes receiving a stray auth-provider

### DIFF
--- a/tasks/smoke-tests/serve/tests/authChecks.spec.ts
+++ b/tasks/smoke-tests/serve/tests/authChecks.spec.ts
@@ -49,6 +49,43 @@ test('useAuth hook, auth redirects checks', async ({ page }) => {
   await expect(page.getByText('Log In')).toBeVisible()
 })
 
+const unauthenticatedFunctions = [
+  { name: 'hello', route: '/.api/functions/hello', data: 'hello from cedar' },
+  {
+    name: 'legacyHello',
+    route: '/.api/functions/legacyHello',
+    data: 'hello from legacy handler',
+  },
+]
+
+for (const fn of unauthenticatedFunctions) {
+  test(`${fn.name} ignores an auth-provider header with no token`, async ({
+    request,
+  }) => {
+    const response = await request.get(fn.route, {
+      headers: { 'auth-provider': 'dbAuth' },
+    })
+
+    expect(response.status()).toBe(200)
+    expect((await response.json()).data).toBe(fn.data)
+  })
+
+  test(`${fn.name} ignores an API key sent with no auth scheme`, async ({
+    request,
+  }) => {
+    const response = await request.get(fn.route, {
+      headers: {
+        'auth-provider': 'dbAuth',
+        // Not `<scheme> <token>`, so it can't be parsed as an auth header
+        authorization: 'some-raw-api-key',
+      },
+    })
+
+    expect(response.status()).toBe(200)
+    expect((await response.json()).data).toBe(fn.data)
+  })
+}
+
 const post = {
   title: 'Hello world! Soft kittens are the best.',
   body: 'Bazinga, bazinga, bazinga',


### PR DESCRIPTION
Adds a regression test for the bug fixed in #2270

## What it covers

API consumers sometimes send `auth-provider` unconditionally, including to endpoints that don't use auth at all (as we saw in #2270). Auth state used to be resolved for every function route, so an `auth-provider` with no usable `Authorization` header made `parseAuthorizationHeader` throw and the request came back 500.

Two functions × two header shapes:

- `hello` (a `handleRequest` export) and `legacyHello` (a legacy `handler`). They reach `buildCedarContext` through different wrappers, so both are worth asserting
- `auth-provider` with no `Authorization` at all, and `auth-provider` with an API key sent as a bare value with no scheme, which is the shape the original reporter's clients used

Before #2270 all four returned 500. They pass on `main`, and they go red again if an eager resolve is ever reintroduced for function routes.

`test-project` works as the host despite having dbAuth configured: the function route in `lambdaLoader` never passes an `authDecoder`, so the project's auth setup doesn't affect this path. No new fixture needed.

## Why the header and not a cookie

`auth-provider` as a *cookie* does not reproduce this. It takes the `cookieHeader?.type` branch in `getAuthenticationContext`, which sets `schema: 'cookie'` and uses the raw cookie as the token. For that branch `parseAuthorizationHeader` is never reached:

```
auth-provider COOKIE, no token -> no throw; result: payload
auth-provider HEADER, no token -> THREW: The `Authorization` header is not valid.
```

