### PR TITLE
fix(api): Capture the request body at the entry point

### DIFF
--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -10,7 +10,7 @@ import type {
   HTTPMethods,
 } from 'fastify'
 
-import { buildCedarContext, noopAuthDecoder } from '@cedarjs/api/runtime'
+import { buildCedarContext, captureRequestBody } from '@cedarjs/api/runtime'
 import type { GlobalContext } from '@cedarjs/context'
 import { getAsyncStoreInstance } from '@cedarjs/context/dist/store'
 import { coerceRootPath } from '@cedarjs/fastify-web/dist/helpers.js'
@@ -89,7 +89,7 @@ export async function redwoodFastifyGraphQLServer(
         handler: async (req, reply) => {
           const request = createFetchRequest(req, reply)
           const cedarContext = await buildCedarContext(request, {
-            authDecoder: graphqlOptions.authDecoder ?? noopAuthDecoder,
+            authDecoder: graphqlOptions.authDecoder,
           })
 
           // Phase 1 of transitional context bridge: pass both the Fetch-native
@@ -183,10 +183,16 @@ function createFetchRequest(req: FastifyRequest, reply: FastifyReply) {
           : undefined
 
   const href = `${req.protocol}://${req.hostname}${req.raw.url ?? '/'}`
-  return new Request(href, {
+  const request = new Request(href, {
     method: req.method,
     headers: req.headers as HeadersInit,
     body: requestBody,
     signal: controller.signal,
   })
+
+  // Yoga consumes the body, so anything building a Lambda-style event from
+  // this request afterwards (auth state resolution) needs it captured here
+  captureRequestBody(request, requestBody ?? '')
+
+  return request
 }

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -17,7 +17,11 @@ import type {
   CedarRouteRecord,
   LegacyHandler,
 } from '@cedarjs/api/runtime'
-import { buildCedarContext, wrapLegacyHandler } from '@cedarjs/api/runtime'
+import {
+  buildCedarContext,
+  captureRequestBody,
+  wrapLegacyHandler,
+} from '@cedarjs/api/runtime'
 import { getPaths } from '@cedarjs/project-config'
 
 import { requestHandler } from '../requestHandlers/awsLambdaFastify.js'
@@ -230,6 +234,10 @@ export const lambdaRequestHandler = async (
       headers: req.headers as HeadersInit,
       body: requestBody,
     })
+
+    // Handlers consume the body, so anything building a Lambda-style event
+    // from this request afterwards needs it captured here
+    captureRequestBody(request, requestBody ?? '')
 
     const ctx = await buildCedarContext(request, {
       params: {

--- a/packages/api/src/__tests__/runtime.test.ts
+++ b/packages/api/src/__tests__/runtime.test.ts
@@ -1,11 +1,12 @@
 import type { APIGatewayProxyResult } from 'aws-lambda'
 import { describe, expect, it, vi } from 'vitest'
 
+import { getAuthenticationContext } from '../auth/index.js'
 import {
   buildCedarContext,
+  captureRequestBody,
   composeCedarMiddleware,
   legacyResultToResponse,
-  noopAuthDecoder,
   requestToLegacyEvent,
   routeManifestToJSON,
   wrapLegacyHandler,
@@ -92,11 +93,11 @@ describe('buildCedarContext', () => {
     expect(ctx.serverAuthState).toBeUndefined()
   })
 
-  // GraphQL routes have to resolve auth state up front even when the project
-  // has no auth set up, because `useRedwoodAuthContext`'s fallback runs after
-  // Yoga has consumed the request body – cloning it there throws `unusable`.
-  // `noopAuthDecoder` is what keeps the resolve eager for those projects.
-  it('resolves auth state with `noopAuthDecoder`', async () => {
+  // A project with no auth set up has no decoder, so nothing resolves auth
+  // state here and `useRedwoodAuthContext` resolves it during context building
+  // instead — after the GraphQL server has read the body. That only works
+  // because the entry point captured the body.
+  it('resolves auth state after the body has been read, when captured', async () => {
     const request = new Request('http://localhost:8911/graphql', {
       method: 'POST',
       body: JSON.stringify({ query: '{ __typename }' }),
@@ -105,21 +106,44 @@ describe('buildCedarContext', () => {
       },
     })
 
-    const ctx = await buildCedarContext(request, {
-      authDecoder: noopAuthDecoder,
-    })
+    captureRequestBody(request, JSON.stringify({ query: '{ __typename }' }))
 
-    // Reading the body afterwards is what Yoga does. The resolve above already
-    // happened, so no fallback is needed and nothing clones a used `Request`
+    // No decoder, so nothing is resolved up front
+    const ctx = await buildCedarContext(request)
+    expect(ctx.serverAuthState).toBeUndefined()
+
+    // Yoga reads the body
     await request.text()
 
-    expect(ctx.serverAuthState).toBeDefined()
-    expect(ctx.serverAuthState?.[0]).toBeNull()
-    expect(ctx.serverAuthState?.[1]).toEqual({
+    // Now the late resolve, which used to throw `TypeError: unusable`
+    const authState = await getAuthenticationContext({ event: request })
+
+    expect(authState?.[1]).toEqual({
       type: 'dbAuth',
       schema: 'cookie',
       token: 'auth-provider=dbAuth; session=abc123',
     })
+    expect(authState?.[2].event.body).toEqual(
+      JSON.stringify({ query: '{ __typename }' }),
+    )
+  })
+
+  // Degrade instead of taking the request down, so a missed capture doesn't
+  // turn into a 500
+  it('builds an event with a null body when nothing captured it', async () => {
+    const request = new Request('http://localhost:8911/graphql', {
+      method: 'POST',
+      body: JSON.stringify({ query: '{ __typename }' }),
+      headers: {
+        cookie: 'auth-provider=dbAuth; session=abc123',
+      },
+    })
+
+    await request.text()
+
+    const authState = await getAuthenticationContext({ event: request })
+
+    expect(authState?.[2].event.body).toBeNull()
   })
 
   it('hydrates auth state when an auth decoder is provided', async () => {

--- a/packages/api/src/__tests__/transforms.test.ts
+++ b/packages/api/src/__tests__/transforms.test.ts
@@ -1,6 +1,130 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 
-import { removeNulls } from '../transforms.js'
+import { requestToLegacyEvent } from '../runtime.js'
+import {
+  captureRequestBody,
+  captureRequestBodyByCloning,
+  removeNulls,
+  requestToBaseEvent,
+} from '../transforms.js'
+
+const BODY = JSON.stringify({ query: '{ __typename }' })
+
+const postRequest = () =>
+  new Request('http://localhost:8911/graphql', {
+    method: 'POST',
+    body: BODY,
+  })
+
+describe('request body capture', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the body when captured from a known string', async () => {
+    const request = postRequest()
+    captureRequestBody(request, BODY)
+
+    // Whatever handles the request consumes the body
+    await request.text()
+
+    const event = await requestToBaseEvent(request)
+
+    expect(event.body).toEqual(BODY)
+  })
+
+  it('keeps the body when captured by cloning', async () => {
+    const request = postRequest()
+    await captureRequestBodyByCloning(request)
+
+    await request.text()
+
+    const event = await requestToBaseEvent(request)
+
+    expect(event.body).toEqual(BODY)
+  })
+
+  it('reads from the request itself when the body is still untouched', async () => {
+    const event = await requestToBaseEvent(postRequest())
+
+    expect(event.body).toEqual(BODY)
+  })
+
+  // The degradation path: a consumed body that nobody captured. Better to
+  // build an event with no body than to take the whole request down
+  it('falls back to a null body when consumed and never captured', async () => {
+    const request = postRequest()
+    await request.text()
+
+    const event = await requestToBaseEvent(request)
+
+    expect(event.body).toBeNull()
+  })
+
+  it('warns in development when it falls back to a null body', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const request = postRequest()
+    await request.text()
+    await requestToBaseEvent(request)
+
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toMatch(/captureRequestBody/)
+  })
+
+  it('does not warn outside development', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const request = postRequest()
+    await request.text()
+    await requestToBaseEvent(request)
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  // Entry points capture unconditionally, so capturing a request that
+  // something else already consumed has to be a no-op rather than a throw
+  it('does not throw when capturing an already consumed body', async () => {
+    const request = postRequest()
+    await request.text()
+
+    await expect(captureRequestBodyByCloning(request)).resolves.toBeUndefined()
+
+    const event = await requestToBaseEvent(request)
+    expect(event.body).toBeNull()
+  })
+
+  it('captures an empty body as a null body', async () => {
+    const request = new Request('http://localhost:8911/health', {
+      method: 'GET',
+    })
+    captureRequestBody(request, '')
+
+    const event = await requestToBaseEvent(request)
+
+    expect(event.body).toBeNull()
+  })
+
+  // Legacy handlers read `event.body`, so this is the path where losing it
+  // actually changes what a user's code sees
+  it('gives legacy handlers the captured body after it was consumed', async () => {
+    const request = postRequest()
+    captureRequestBody(request, BODY)
+
+    await request.text()
+
+    const event = await requestToLegacyEvent(request, {
+      params: {},
+      query: new URLSearchParams(),
+      cookies: new Map(),
+    })
+
+    expect(event.body).toEqual(BODY)
+  })
+})
 
 describe('removeNulls utility', () => {
   it('Changes nulls to undefined', () => {

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -8,34 +8,12 @@ import * as cookie from 'cookie'
 import { parse } from 'picoquery'
 
 import { getAuthenticationContext } from './auth/index.js'
-import type { Decoder } from './auth/index.js'
 import { requestToBaseEvent } from './transforms.js'
 
-/**
- * A decoder that decodes nothing.
- *
- * Resolving `serverAuthState` has to happen before the GraphQL server reads
- * the request body:
- *
- * 1. Resolving it materialises the request body — `getAuthenticationContext`
- *    builds a Lambda-style event via `requestToBaseEvent`, which does
- *    `request.clone().text()`
- * 2. `clone()` only works while the body is untouched
- * 3. So once the GraphQL server has read the body, resolving throws
- *    `TypeError: unusable`
- *
- * `buildCedarContext` only resolves auth state when it's given a decoder, so
- * GraphQL call sites pass this one for projects that have no auth set up, to
- * keep the resolve eager. Resolving with it produces the same payload as
- * resolving with no decoders at all.
- *
- * (When it isn't resolved eagerly, `useRedwoodAuthContext` resolves it during
- * context building instead — too late. That's how this surfaces.)
- *
- * TODO: Remove this once the request body is captured at the entry point rather
- * than read lazily from the auth path, which drops the ordering constraint.
- */
-export const noopAuthDecoder: Decoder = async () => null
+export {
+  captureRequestBody,
+  captureRequestBodyByCloning,
+} from './transforms.js'
 
 export interface CedarRequestContext {
   params: Record<string, string>
@@ -136,12 +114,15 @@ export async function buildCedarContext(
   const params = options.params ?? {}
 
   // Only GraphQL consumes `serverAuthState`, and it's the only caller that
-  // supplies an auth decoder — passing `noopAuthDecoder` when the project has
-  // no auth set up. Computing it for plain function routes is wasted work —
-  // without a decoder nothing can be decoded, so the payload could only ever
-  // come back with `decoded` set to `null` — and it lets `Authorization`
+  // supplies an auth decoder. Computing it for plain function routes is wasted
+  // work — without a decoder nothing can be decoded, so the payload could only
+  // ever come back with `decoded` set to `null` — and it lets `Authorization`
   // header parse errors escape and turn requests to functions that don't use
   // auth at all into 500s.
+  //
+  // Resolving it later is safe as long as the entry point captured the request
+  // body (see `captureRequestBody`), which is what `useRedwoodAuthContext`
+  // relies on when no auth state was resolved here.
   const serverAuthState = hasAuthDecoder(options.authDecoder)
     ? await getAuthenticationContext({
         authDecoder: options.authDecoder,

--- a/packages/api/src/transforms.ts
+++ b/packages/api/src/transforms.ts
@@ -43,11 +43,83 @@ export const parseFetchEventBody = async (event: Request) => {
   return body ? JSON.parse(body) : {}
 }
 
+const capturedBodies = new WeakMap<Request, string>()
+
+/**
+ * Remember a request's body text, so that Lambda-style events can still be
+ * built from it after the body stream has been consumed.
+ *
+ * A `Request` body is a single-use stream: `clone()` throws
+ * `TypeError: unusable` once anything has read it. Anything that converts a
+ * `Request` into a Lambda-style event later in the request lifecycle — auth
+ * state resolution, legacy handler invocation — therefore depends on the body
+ * having been captured up front.
+ *
+ * Call this at the point a request enters Cedar, before anything reads the
+ * body. Use this overload when the caller already holds the body text — as
+ * both Fastify entry points do — so that the stream is never read at all. Use
+ * {@link captureRequestBodyByCloning} when it doesn't.
+ */
+export const captureRequestBody = (request: Request, body: string): void => {
+  capturedBodies.set(request, body)
+}
+
+/**
+ * {@link captureRequestBody} for entry points that are handed a `Request` they
+ * didn't build, and so have to read the body from a clone to capture it.
+ *
+ * Must be called before anything else reads the body. A request whose body has
+ * already been consumed can't be captured, and is left for `readRequestBody`
+ * to report.
+ */
+export const captureRequestBodyByCloning = async (
+  request: Request,
+): Promise<void> => {
+  if (capturedBodies.has(request)) {
+    return
+  }
+
+  try {
+    capturedBodies.set(request, await request.clone().text())
+  } catch {
+    // Already consumed
+  }
+}
+
+/**
+ * The captured body if there is one, otherwise a best-effort read from a
+ * clone. Returns null rather than throwing when the body has been consumed and
+ * was never captured, so that a late conversion degrades to an event with no
+ * body instead of taking the whole request down.
+ */
+const readRequestBody = async (request: Request): Promise<string | null> => {
+  const captured = capturedBodies.get(request)
+
+  if (captured !== undefined) {
+    return captured
+  }
+
+  try {
+    return await request.clone().text()
+  } catch {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(
+        'Building a Lambda-style event for a request whose body has already ' +
+          'been read, and which was not captured when it entered Cedar. ' +
+          '`event.body` will be null. Call `captureRequestBody` at the entry ' +
+          'point to fix this.',
+      )
+    }
+
+    return null
+  }
+}
+
 export const requestToBaseEvent = async (
   request: Request,
 ): Promise<APIGatewayProxyEvent> => {
   const url = new URL(request.url)
-  const bodyText = await request.clone().text()
+  const bodyText = await readRequestBody(request)
   const queryStringParameters: Record<string, string> = {}
 
   url.searchParams.forEach((value, key) => {

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -20,7 +20,11 @@ const tsconfigPaths =
   // interop
   tsPathsMod.default?.default || tsPathsMod.default || tsPathsMod
 
-import { buildCedarContext, wrapLegacyHandler } from '@cedarjs/api/runtime'
+import {
+  buildCedarContext,
+  captureRequestBodyByCloning,
+  wrapLegacyHandler,
+} from '@cedarjs/api/runtime'
 import type { CedarHandler, LegacyHandler } from '@cedarjs/api/runtime'
 import {
   getApiSideBabelConfigPath,
@@ -506,6 +510,10 @@ export function createApiFetchHandler() {
   const apiUrlPrefix = cedarConfig.web.apiUrl.replace(/\/$/, '')
 
   return async (request: Request): Promise<Response> => {
+    // This request is handed to us already built, so capture the body by
+    // cloning before Yoga or a function handler consumes it
+    await captureRequestBodyByCloning(request)
+
     const url = new URL(request.url)
     let pathname = url.pathname
 

--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -363,7 +363,7 @@ async function generateGraphQLModule(distPath: string): Promise<string> {
   })
 
   return `
-    import { buildCedarContext, noopAuthDecoder, requestToLegacyEvent } from '@cedarjs/api/runtime';
+    import { buildCedarContext, captureRequestBodyByCloning, requestToLegacyEvent } from '@cedarjs/api/runtime';
     import { createGraphQLYoga } from '@cedarjs/graphql-server';
 
     // Inlined bundle of ${path.basename(distPath)} (node_modules kept external)
@@ -382,9 +382,13 @@ async function generateGraphQLModule(distPath: string): Promise<string> {
 
     export default {
       async fetch(request) {
+        // Capture the body before Yoga consumes it, so that building a
+        // Lambda-style event from this request later still works
+        await captureRequestBodyByCloning(request);
+
         const { yoga, graphqlOptions } = await getYoga();
         const cedarContext = await buildCedarContext(request, {
-          authDecoder: graphqlOptions?.authDecoder ?? noopAuthDecoder,
+          authDecoder: graphqlOptions?.authDecoder,
         });
         const event = await requestToLegacyEvent(request, cedarContext);
         // Wrap yoga.handle in an AsyncLocalStorage run so directive
@@ -440,7 +444,7 @@ async function generateFunctionModule(distPath: string): Promise<string> {
   )
 
   return `
-    import { wrapLegacyHandler, buildCedarContext } from '@cedarjs/api/runtime';
+    import { wrapLegacyHandler, buildCedarContext, captureRequestBodyByCloning } from '@cedarjs/api/runtime';
 
     // Inlined bundle of ${path.basename(distPath)} (node_modules kept external)
     ${bundledCode}
@@ -475,6 +479,10 @@ async function generateFunctionModule(distPath: string): Promise<string> {
 
     export default {
       async fetch(request) {
+        // Capture the body before the handler consumes it, so that building a
+        // Lambda-style event from this request later still works
+        await captureRequestBodyByCloning(request);
+
         const ctx = await buildCedarContext(request);
         // Wrap the handler in an AsyncLocalStorage run so the global
         // @cedarjs/context is available inside it (and isolated per request).


### PR DESCRIPTION
Follow-up to #2271, which is now merged. This deletes the `noopAuthDecoder` scaffolding that PR introduced.

## The constraint this removes

Converting a `Request` into a Lambda-style event reads the body, via `requestToBaseEvent`'s `request.clone().text()`. A `Request` body is a single-use stream, so `clone()` throws `TypeError: unusable` once anything has read it. That put an ordering constraint on everything downstream: auth state had to be resolved before the GraphQL server read the body, or the request died. #2270 and #2271 were both consequences of that constraint.

2.x had no such constraint. The Fastify handler built the Lambda event eagerly (`event: lambdaEventForFastifyRequest(req)`) and `getAuthenticationContext` passed it straight through without ever touching a body, so `useRedwoodAuthContext` could resolve auth state lazily during context building — after the body had been read — and it worked. The regression wasn't switching to `Request`; it was moving an irreversible read out of the entry point and into the auth path.

## Fix

Capture the body where the request enters Cedar:

- `captureRequestBody(request, body)` — sync, for entry points that already hold the body text
- `captureRequestBodyByCloning(request)` — async, for entry points handed a `Request` they didn't build

Applied at all four entry points. Both Fastify ones (`api-server`'s `createFetchRequest` and `lambdaLoader`) already hold the body as a string from `req.body` / `req.rawBody`, so they **never touch the stream**. The Vite dev middleware and the two generated UD modules clone once on entry.

`requestToBaseEvent` then reads from the capture. With the ordering constraint gone, `noopAuthDecoder` is deleted and both GraphQL call sites go back to plain `authDecoder: graphqlOptions.authDecoder`.

## Degradation, and the honest limits of it

A late conversion with no capture yields an event with a **null body** and a development-only warning, instead of throwing. Nothing in the auth path needs the body, so the request survives.

That safety net is load-bearing, and it has a cost worth understanding before approving. I mutation-tested `udServe` (`cedar serve api --ud`, the fixture with no `authDecoder`) to find out what actually carries it:

| mutation | `udServe` |
|---|---|
| none | passes |
| capture removed from the UD graphql module | **passes** — degrades silently to a null body |
| degradation made to rethrow | passes — capture still supplies the body |
| both | **fails** |

So a forgotten capture at some future fifth entry point would **not** be caught end-to-end. It would silently hand user code `event.body === null`. Only the unit tests in `transforms.test.ts` catch that, because they assert body content rather than status. If you'd rather trade the safety net for loudness, the alternative is to let `requestToLegacyEvent` throw — legacy handlers are the ones that genuinely need the body — while the auth path keeps degrading. Happy to change it.

## Module state

The capture map is a module-level `WeakMap`, which is only sound with a single module instance. `main` is ESM-only after #2254, and I confirmed `import` and `require` of `@cedarjs/api/runtime` return identical function references. **This must not be backported to the 5.0.x line**, where `@cedarjs/api` has condition-split exports (`require` → `dist/cjs`) and `graphql-server`'s CJS build would get a second `WeakMap`, silently producing null bodies.

## Testing

- 9 new unit tests in `transforms.test.ts` covering both capture helpers, the fallback, the warning firing only in development, capturing an already-consumed body, and the legacy handler path. Mutation-tested: making the fallback rethrow fails 4 of them.
- `tasks/ud-tests` — 9 passing, including the `udServe` and `udDev` assertions from #2271, which stay green through the removal of `noopAuthDecoder`.
- `@cedarjs/api` 266, `@cedarjs/graphql-server` 141, `@cedarjs/api-server` 100 (+2 skipped), `@cedarjs/vite` 234
- builds and `eslint` clean

The Cypress spec added in #2271 (`00-stray-auth-provider.cy.js`) also covers this branch, but it needs a full CI run to exercise.