### PR TITLE
fix(test): avoid race in prerender rehydration waitForResponse checks

### DIFF
--- a/tasks/smoke-tests/prerender/tests/prerender.spec.ts
+++ b/tasks/smoke-tests/prerender/tests/prerender.spec.ts
@@ -43,13 +43,17 @@ test('Check that rehydration works for page not wrapped in Set', async ({
     }
   })
 
-  await page.goto('/double')
-
   // Wait for page to have been rehydrated before getting page content.
-  // We know the page has been rehydrated when it sends an auth request
-  await page.waitForResponse((response) =>
+  // We know the page has been rehydrated when it sends an auth request.
+  // We need to start waiting for the response *before* navigating, since the
+  // auth request fires as part of hydration and can complete before our
+  // `waitForResponse` listener would otherwise be attached, causing this to
+  // hang until timeout (https://playwright.dev/docs/api/class-page#page-wait-for-response).
+  const authResponse = page.waitForResponse((response) =>
     response.url().includes('/.api/functions/auth'),
   )
+  await page.goto('/double')
+  await authResponse
 
   await page.locator('h1').first().waitFor()
   const headerCount = await page
@@ -83,14 +87,16 @@ test('Check that rehydration works for page with Cell in Set', async ({
     }
   })
 
-  await page.goto('/')
-
   // Wait for page to have been rehydrated and cells have fetched their data
   // before getting page content.
-  // We know cells have started fetching data when we see graphql requests
-  await page.waitForResponse((response) =>
+  // We know cells have started fetching data when we see graphql requests.
+  // Start waiting for the response *before* navigating, so we can't miss a
+  // request that fires as part of hydration and races the `goto` promise.
+  const graphqlResponse = page.waitForResponse((response) =>
     response.url().includes('/.api/functions/graphql'),
   )
+  await page.goto('/')
+  await graphqlResponse
 
   await page.locator('h2').first().waitFor()
   const mainText = await page.locator('main').innerText()
@@ -129,16 +135,19 @@ test('Check that rehydration works for page with code split chunks', async ({
     }
   })
 
+  // Wait for page to have been rehydrated before getting page content.
+  // We know the page has been rehydrated when it sends an auth request.
+  // Start waiting for the response *before* navigating (see comment in the
+  // "not wrapped in Set" test above for why).
+  const authResponse = page.waitForResponse((response) =>
+    response.url().includes('/.api/functions/auth'),
+  )
+
   // This page uses Cedar Forms, and so does /posts/new. Vite splits Cedar
   // Forms out into a separate chunk. We need to make sure our prerender
   // code can handle that
   await page.goto('/contacts/new')
-
-  // Wait for page to have been rehydrated before getting page content.
-  // We know the page has been rehydrated when it sends an auth request
-  await page.waitForResponse((response) =>
-    response.url().includes('/.api/functions/auth'),
-  )
+  await authResponse
 
   await expect(page.getByLabel('Name')).toBeVisible()
   await expect(page.getByLabel('Email')).toBeVisible()


### PR DESCRIPTION
## Summary

`prerender.spec.ts`'s rehydration checks call `page.waitForResponse(...)` **after** `await page.goto(...)` resolves. But the auth/graphql request being waited for fires as part of client hydration, and can complete before Playwright's listener is registered — leaving the test waiting for a response that already happened, until it times out at 30s.

This is the underlying cause of the intermittent CI failures on:
- `Check that rehydration works for page not wrapped in Set`
- `Check that rehydration works for page with code split chunks`

(and the same anti-pattern existed in `Check that rehydration works for page with Cell in Set`, fixed here too even though it hasn't been observed failing yet)

## Evidence

Captured Playwright traces from a failing CI run (`playwright-traces-smoke-tests-Linux` artifact) and compared network timing against Playwright's internal wait-registration events. Across all 6 recorded attempts (2 tests × 3 retries), the response consistently arrived **2-5ms before** the `waitForResponse` listener was attached:

| Attempt | Response arrives | Listener registered | Gap |
|---|---|---|---|
| not-wrapped-in-Set (orig) | 3920.77ms | 3924.34ms | +3.6ms late |
| not-wrapped-in-Set (retry1) | 34687.6ms | 34692.1ms | +4.5ms late |
| not-wrapped-in-Set (retry2) | 65384.2ms | 65388.6ms | +4.5ms late |
| code-split-chunks (orig) | 96571.0ms | 96573.3ms | +2.4ms late |
| code-split-chunks (retry1) | 127330.0ms | 127334.3ms | +4.3ms late |
| code-split-chunks (retry2) | 158025.4ms | 158030.0ms | +4.6ms late |

This explains why the failure is intermittent (~20% of the time) rather than deterministic — it's a pure scheduling race between the CDP round-trip that attaches the listener and the response actually landing, not app breakage.

## Fix

Start waiting for the response *before* triggering the navigation — the standard Playwright pattern for avoiding exactly this race:

```ts
const authResponse = page.waitForResponse((response) =>
  response.url().includes('/.api/functions/auth'),
)
await page.goto('/double')
await authResponse
```

## Test plan
- [x] `yarn prettier --check` passes
- [x] `yarn eslint` passes
- [ ] CI run to confirm the previously-flaky prerender tests are stable