### PR TITLE
fix(api): Thread the request body through to where it's used

### DIFF
--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -10,7 +10,7 @@ import type {
   HTTPMethods,
 } from 'fastify'
 
-import { buildCedarContext, noopAuthDecoder } from '@cedarjs/api/runtime'
+import { buildCedarContext } from '@cedarjs/api/runtime'
 import type { GlobalContext } from '@cedarjs/context'
 import { getAsyncStoreInstance } from '@cedarjs/context/dist/store'
 import { coerceRootPath } from '@cedarjs/fastify-web/dist/helpers.js'
@@ -87,9 +87,12 @@ export async function redwoodFastifyGraphQLServer(
         url: `${redwoodOptions.apiRootPath}${graphqlEndpoint}${routePath}`,
         method,
         handler: async (req, reply) => {
-          const request = createFetchRequest(req, reply)
+          const { request, body } = createFetchRequest(req, reply)
           const cedarContext = await buildCedarContext(request, {
-            authDecoder: graphqlOptions.authDecoder ?? noopAuthDecoder,
+            authDecoder: graphqlOptions.authDecoder,
+            // Fastify has already parsed the body, so hand it over rather than
+            // reading the request's stream
+            body,
           })
 
           // Phase 1 of transitional context bridge: pass both the Fetch-native
@@ -183,10 +186,14 @@ function createFetchRequest(req: FastifyRequest, reply: FastifyReply) {
           : undefined
 
   const href = `${req.protocol}://${req.hostname}${req.raw.url ?? '/'}`
-  return new Request(href, {
+  const request = new Request(href, {
     method: req.method,
     headers: req.headers as HeadersInit,
     body: requestBody,
     signal: controller.signal,
   })
+
+  // Return the body too. Yoga consumes it, so anything building a Lambda-style
+  // event from this request afterwards can't read it back off the request
+  return { request, body: requestBody ?? '' }
 }

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -235,6 +235,9 @@ export const lambdaRequestHandler = async (
       params: {
         routeName,
       },
+      // Fastify has already read the body, so hand it over rather than
+      // reading the request's stream
+      body: requestBody ?? '',
     })
 
     const response = await cedarHandler(request, ctx)

--- a/packages/api/src/__tests__/runtime.test.ts
+++ b/packages/api/src/__tests__/runtime.test.ts
@@ -1,11 +1,11 @@
 import type { APIGatewayProxyResult } from 'aws-lambda'
 import { describe, expect, it, vi } from 'vitest'
 
+import { getAuthenticationContext } from '../auth/index.js'
 import {
   buildCedarContext,
   composeCedarMiddleware,
   legacyResultToResponse,
-  noopAuthDecoder,
   requestToLegacyEvent,
   routeManifestToJSON,
   wrapLegacyHandler,
@@ -92,11 +92,45 @@ describe('buildCedarContext', () => {
     expect(ctx.serverAuthState).toBeUndefined()
   })
 
-  // GraphQL routes have to resolve auth state up front even when the project
-  // has no auth set up, because `useRedwoodAuthContext`'s fallback runs after
-  // Yoga has consumed the request body – cloning it there throws `unusable`.
-  // `noopAuthDecoder` is what keeps the resolve eager for those projects.
-  it('resolves auth state with `noopAuthDecoder`', async () => {
+  // A project with no auth set up has no decoder, so nothing resolves auth
+  // state here and `useRedwoodAuthContext` resolves it during context building
+  // instead — after the GraphQL server has read the body. That only works
+  // because the body read here is carried on the context.
+  it('resolves auth state after the body has been read, using ctx.body', async () => {
+    const body = JSON.stringify({ query: '{ __typename }' })
+    const request = new Request('http://localhost:8911/graphql', {
+      method: 'POST',
+      body,
+      headers: {
+        cookie: 'auth-provider=dbAuth; session=abc123',
+      },
+    })
+
+    // No decoder, so nothing is resolved up front — but the body is captured
+    const ctx = await buildCedarContext(request)
+    expect(ctx.serverAuthState).toBeUndefined()
+    expect(ctx.body).toEqual(body)
+
+    // Yoga reads the body
+    await request.text()
+
+    // Now the late resolve, which used to throw `TypeError: unusable`
+    const authState = await getAuthenticationContext({
+      event: request,
+      body: ctx.body,
+    })
+
+    expect(authState?.[1]).toEqual({
+      type: 'dbAuth',
+      schema: 'cookie',
+      token: 'auth-provider=dbAuth; session=abc123',
+    })
+    expect(authState?.[2].event.body).toEqual(body)
+  })
+
+  // Degrade instead of taking the request down, so a missed capture doesn't
+  // turn into a 500
+  it('builds an event with a null body when nothing captured it', async () => {
     const request = new Request('http://localhost:8911/graphql', {
       method: 'POST',
       body: JSON.stringify({ query: '{ __typename }' }),
@@ -105,21 +139,11 @@ describe('buildCedarContext', () => {
       },
     })
 
-    const ctx = await buildCedarContext(request, {
-      authDecoder: noopAuthDecoder,
-    })
-
-    // Reading the body afterwards is what Yoga does. The resolve above already
-    // happened, so no fallback is needed and nothing clones a used `Request`
     await request.text()
 
-    expect(ctx.serverAuthState).toBeDefined()
-    expect(ctx.serverAuthState?.[0]).toBeNull()
-    expect(ctx.serverAuthState?.[1]).toEqual({
-      type: 'dbAuth',
-      schema: 'cookie',
-      token: 'auth-provider=dbAuth; session=abc123',
-    })
+    const authState = await getAuthenticationContext({ event: request })
+
+    expect(authState?.[2].event.body).toBeNull()
   })
 
   it('hydrates auth state when an auth decoder is provided', async () => {

--- a/packages/api/src/__tests__/transforms.test.ts
+++ b/packages/api/src/__tests__/transforms.test.ts
@@ -1,6 +1,112 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 
-import { removeNulls } from '../transforms.js'
+import { requestToLegacyEvent } from '../runtime.js'
+import {
+  readRequestBody,
+  removeNulls,
+  requestToBaseEvent,
+} from '../transforms.js'
+
+const BODY = JSON.stringify({ query: '{ __typename }' })
+
+const postRequest = () =>
+  new Request('http://localhost:8911/graphql', {
+    method: 'POST',
+    body: BODY,
+  })
+
+describe('request body threading', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('reads the body while it is still readable', async () => {
+    await expect(readRequestBody(postRequest())).resolves.toEqual(BODY)
+  })
+
+  it('returns undefined rather than throwing once the body is consumed', async () => {
+    const request = postRequest()
+    await request.text()
+
+    await expect(readRequestBody(request)).resolves.toBeUndefined()
+  })
+
+  it('uses the passed body after the request has been consumed', async () => {
+    const request = postRequest()
+    await request.text()
+
+    const event = await requestToBaseEvent(request, BODY)
+
+    expect(event.body).toEqual(BODY)
+  })
+
+  it('reads from the request when no body is passed and it is untouched', async () => {
+    const event = await requestToBaseEvent(postRequest())
+
+    expect(event.body).toEqual(BODY)
+  })
+
+  // The degradation path: a consumed body that nobody threaded through. Better
+  // to build an event with no body than to take the whole request down
+  it('falls back to a null body when consumed and nothing was passed', async () => {
+    const request = postRequest()
+    await request.text()
+
+    const event = await requestToBaseEvent(request)
+
+    expect(event.body).toBeNull()
+  })
+
+  it('warns in development when it falls back to a null body', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const request = postRequest()
+    await request.text()
+    await requestToBaseEvent(request)
+
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toMatch(/already been read/)
+  })
+
+  it('does not warn outside development', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const request = postRequest()
+    await request.text()
+    await requestToBaseEvent(request)
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('treats an empty body as a null body', async () => {
+    const request = new Request('http://localhost:8911/health', {
+      method: 'GET',
+    })
+
+    const event = await requestToBaseEvent(request, '')
+
+    expect(event.body).toBeNull()
+  })
+
+  // Legacy handlers read `event.body`, so this is the path where losing it
+  // actually changes what a user's code sees
+  it('gives legacy handlers the body carried on the context', async () => {
+    const request = postRequest()
+    await request.text()
+
+    const event = await requestToLegacyEvent(request, {
+      params: {},
+      query: new URLSearchParams(),
+      cookies: new Map(),
+      body: BODY,
+    })
+
+    expect(event.body).toEqual(BODY)
+  })
+})
 
 describe('removeNulls utility', () => {
   it('Changes nulls to undefined', () => {

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -132,10 +132,18 @@ export const getAuthenticationContext = async ({
   authDecoder,
   event,
   context,
+  body,
 }: {
   authDecoder?: Decoder | Decoder[]
   event: APIGatewayProxyEvent | Request
   context?: LambdaContext
+  /**
+   * The request body text, read at the entry point. Only relevant when `event`
+   * is a fetch `Request`: building the Lambda-style event handed to decoders
+   * and `getCurrentUser` needs the body, and by the time this runs the GraphQL
+   * server has usually consumed it.
+   */
+  body?: string
 }): Promise<undefined | AuthContextPayload> => {
   const cookieHeader = parseAuthorizationCookie(event)
   const typeFromHeader = getAuthProviderHeader(event)
@@ -185,7 +193,7 @@ export const getAuthenticationContext = async ({
   let decoded = null
 
   const normalizedEvent = isFetchApiRequest(event)
-    ? await requestToBaseEvent(event)
+    ? await requestToBaseEvent(event, body)
     : event
   const underlyingRequest = isFetchApiRequest(event) ? event : undefined
 

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -8,40 +8,21 @@ import * as cookie from 'cookie'
 import { parse } from 'picoquery'
 
 import { getAuthenticationContext } from './auth/index.js'
-import type { Decoder } from './auth/index.js'
-import { requestToBaseEvent } from './transforms.js'
-
-/**
- * A decoder that decodes nothing.
- *
- * Resolving `serverAuthState` has to happen before the GraphQL server reads
- * the request body:
- *
- * 1. Resolving it materialises the request body — `getAuthenticationContext`
- *    builds a Lambda-style event via `requestToBaseEvent`, which does
- *    `request.clone().text()`
- * 2. `clone()` only works while the body is untouched
- * 3. So once the GraphQL server has read the body, resolving throws
- *    `TypeError: unusable`
- *
- * `buildCedarContext` only resolves auth state when it's given a decoder, so
- * GraphQL call sites pass this one for projects that have no auth set up, to
- * keep the resolve eager. Resolving with it produces the same payload as
- * resolving with no decoders at all.
- *
- * (When it isn't resolved eagerly, `useRedwoodAuthContext` resolves it during
- * context building instead — too late. That's how this surfaces.)
- *
- * TODO: Remove this once the request body is captured at the entry point rather
- * than read lazily from the auth path, which drops the ordering constraint.
- */
-export const noopAuthDecoder: Decoder = async () => null
+import { readRequestBody, requestToBaseEvent } from './transforms.js'
 
 export interface CedarRequestContext {
   params: Record<string, string>
   query: URLSearchParams
   cookies: ReadonlyMap<string, string>
   serverAuthState?: Awaited<ReturnType<typeof getAuthenticationContext>>
+  /**
+   * The request body text, read while the body was still readable.
+   *
+   * Anything that builds a Lambda-style event from the request later in the
+   * request lifecycle needs this — by then the body has usually been consumed,
+   * and reading it again throws.
+   */
+  body?: string
 }
 
 export type CedarHandler = (
@@ -71,6 +52,15 @@ export interface BuildCedarContextOptions {
   params?: Record<string, string>
   authDecoder?: Parameters<typeof getAuthenticationContext>[0]['authDecoder']
   lambdaContext?: LambdaContext
+  /**
+   * The request body text, when the caller already has it — as both Fastify
+   * entry points do, because Fastify has already parsed it. Passing it avoids
+   * reading the request's body stream at all.
+   *
+   * When it's not passed, the body is read here, which is safe because this
+   * runs before anything else has had a chance to consume it.
+   */
+  body?: string
 }
 
 export interface LegacyHandlerContext {
@@ -135,11 +125,16 @@ export async function buildCedarContext(
   )
   const params = options.params ?? {}
 
+  // Read the body while it's still readable and carry it on the context, so
+  // that anything building a Lambda-style event later in the request — auth
+  // state resolution, legacy handler invocation — doesn't have to read from a
+  // `Request` that the GraphQL server has since consumed.
+  const body = options.body ?? (await readRequestBody(request))
+
   // Only GraphQL consumes `serverAuthState`, and it's the only caller that
-  // supplies an auth decoder — passing `noopAuthDecoder` when the project has
-  // no auth set up. Computing it for plain function routes is wasted work —
-  // without a decoder nothing can be decoded, so the payload could only ever
-  // come back with `decoded` set to `null` — and it lets `Authorization`
+  // supplies an auth decoder. Computing it for plain function routes is wasted
+  // work — without a decoder nothing can be decoded, so the payload could only
+  // ever come back with `decoded` set to `null` — and it lets `Authorization`
   // header parse errors escape and turn requests to functions that don't use
   // auth at all into 500s.
   const serverAuthState = hasAuthDecoder(options.authDecoder)
@@ -147,6 +142,7 @@ export async function buildCedarContext(
         authDecoder: options.authDecoder,
         event: request,
         context: options.lambdaContext,
+        body,
       })
     : undefined
 
@@ -154,6 +150,7 @@ export async function buildCedarContext(
     params,
     query,
     cookies,
+    body,
     serverAuthState,
   }
 }
@@ -202,7 +199,7 @@ export async function requestToLegacyEvent(
   ctx: CedarRequestContext,
 ): Promise<APIGatewayProxyEvent> {
   const url = new URL(request.url)
-  const base = await requestToBaseEvent(request)
+  const base = await requestToBaseEvent(request, ctx.body)
   // @ts-expect-error - picoquery returns nested objects and arrays for
   // bracket-notation params (e.g. ids[]=1&ids[]=2, user[name]=alice).
   // APIGatewayProxyEventQueryStringParameters is too narrow for this richer

--- a/packages/api/src/transforms.ts
+++ b/packages/api/src/transforms.ts
@@ -43,11 +43,47 @@ export const parseFetchEventBody = async (event: Request) => {
   return body ? JSON.parse(body) : {}
 }
 
+/**
+ * Read a request's body text without throwing if it's already been consumed.
+ *
+ * A `Request` body is a single-use stream: `clone()` throws
+ * `TypeError: unusable` once anything has read it. Call this at the point a
+ * request enters Cedar, while the body is still readable, and thread the result
+ * through to whatever needs to build a Lambda-style event from the request
+ * later on.
+ *
+ * Returns undefined when the body has already been consumed, which is only
+ * reachable if nothing captured it at the entry point.
+ */
+export const readRequestBody = async (
+  request: Request,
+): Promise<string | undefined> => {
+  try {
+    return await request.clone().text()
+  } catch {
+    return undefined
+  }
+}
+
 export const requestToBaseEvent = async (
   request: Request,
+  /**
+   * The body text, read at the entry point. Pass it whenever it's available —
+   * without it this has to read from the request itself, which fails once the
+   * body has been consumed.
+   */
+  capturedBody?: string,
 ): Promise<APIGatewayProxyEvent> => {
   const url = new URL(request.url)
-  const bodyText = await request.clone().text()
+  const bodyText = capturedBody ?? (await readRequestBody(request))
+
+  if (bodyText === undefined && process.env.NODE_ENV === 'development') {
+    console.warn(
+      'Building a Lambda-style event for a request whose body has already ' +
+        'been read, and which was not captured when it entered Cedar. ' +
+        '`event.body` will be null.',
+    )
+  }
   const queryStringParameters: Record<string, string> = {}
 
   url.searchParams.forEach((value, key) => {

--- a/packages/graphql-server/src/plugins/useRedwoodAuthContext.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodAuthContext.ts
@@ -27,6 +27,9 @@ export const useRedwoodAuthContext = (
             authDecoder,
             event: authEvent,
             context: context.requestContext,
+            // Yoga has read the body by now, so building the Lambda-style
+            // event depends on the body captured when the request came in
+            body: context.cedarContext?.body,
           })
         }
       } catch (error: any) {

--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -363,7 +363,7 @@ async function generateGraphQLModule(distPath: string): Promise<string> {
   })
 
   return `
-    import { buildCedarContext, noopAuthDecoder, requestToLegacyEvent } from '@cedarjs/api/runtime';
+    import { buildCedarContext, requestToLegacyEvent } from '@cedarjs/api/runtime';
     import { createGraphQLYoga } from '@cedarjs/graphql-server';
 
     // Inlined bundle of ${path.basename(distPath)} (node_modules kept external)
@@ -384,7 +384,7 @@ async function generateGraphQLModule(distPath: string): Promise<string> {
       async fetch(request) {
         const { yoga, graphqlOptions } = await getYoga();
         const cedarContext = await buildCedarContext(request, {
-          authDecoder: graphqlOptions?.authDecoder ?? noopAuthDecoder,
+          authDecoder: graphqlOptions?.authDecoder,
         });
         const event = await requestToLegacyEvent(request, cedarContext);
         // Wrap yoga.handle in an AsyncLocalStorage run so directive


### PR DESCRIPTION
**Alternative to #2275.** Same fix, same behaviour, but the body is passed explicitly instead of stashed in a module-level `WeakMap`. Merge one or the other, not both.

## The constraint this removes

Converting a `Request` into a Lambda-style event reads the body, via `requestToBaseEvent`'s `request.clone().text()`. A `Request` body is a single-use stream, so `clone()` throws `TypeError: unusable` once anything has read it. That put an ordering constraint on everything downstream: auth state had to be resolved before the GraphQL server read the body, or the request died. #2270 and #2271 were both consequences of it.

2.x had no such constraint. The Fastify handler built the Lambda event eagerly (`event: lambdaEventForFastifyRequest(req)`) and `getAuthenticationContext` passed it straight through without ever touching a body, so `useRedwoodAuthContext` could resolve auth state lazily during context building — after the body had been read — and it worked. The regression wasn't switching to `Request`; it was moving an irreversible read out of the entry point and into the auth path.

## Fix

Read the body once, where the request enters Cedar, and pass it along the call chain:

| where | what |
|---|---|
| `BuildCedarContextOptions.body` | entry points that already hold the body text pass it in; both Fastify ones do, so they never touch the stream |
| `CedarRequestContext.body` | carries it to `requestToLegacyEvent` → `requestToBaseEvent` |
| `getAuthenticationContext({ body })` | carries it to `requestToBaseEvent`, including from `useRedwoodAuthContext`'s late fallback |

`buildCedarContext` reads the body itself when the caller doesn't supply one, which is safe because it runs before anything else can consume it. So the fetch-native entry points need no changes at all.

With the ordering constraint gone, `noopAuthDecoder` is deleted and both GraphQL call sites go back to plain `authDecoder: graphqlOptions.authDecoder`.

## Versus #2275

The behaviour is identical; the difference is entirely in how the body reaches `requestToBaseEvent`.

|  | #2275 (`WeakMap`) | this PR (threading) |
|---|---|---|
| plumbing | `captureRequestBody` / `captureRequestBodyByCloning` at 4 entry points, module-level `WeakMap` | one new option, one new context field, one new named argument |
| public API added | 2 exported functions | `BuildCedarContextOptions.body`, `CedarRequestContext.body`, `getAuthenticationContext({ body })` |
| entry points touched | 4 (each needs an explicit capture call) | 2 (the Fastify ones, as an optimisation; the other two work without changes) |
| depends on single module instance | **yes** — unsafe to backport to 5.0.x, where `@cedarjs/api` has condition-split exports and `graphql-server`'s CJS build would get a second `WeakMap` | no |
| a new entry point that forgets to opt in | silently gets a null body | gets the body automatically, because `buildCedarContext` reads it |

That last row is the real argument for this shape. In #2275 a fifth entry point that forgets to call `captureRequestBody` silently hands user code `event.body === null`. Here the default path reads the body itself, and passing it explicitly is only an optimisation for callers that already have it.

The cost is a wider signature surface — three call sites in the chain grow a parameter — which is the thing you didn't want on `buildCedarContext` for `withAuthState`. The difference is that this is data rather than a control flag, and it's the data the callee actually needs.

## Degradation

A late conversion with nothing threaded through yields an event with a **null body** and a development-only warning, instead of throwing. Nothing in the auth path needs the body, so the request survives. Same trade as #2275, and the same caveat: only the unit tests catch a missed thread-through, because they assert body content rather than status.

Mutation-tested to confirm the threading is what carries the e2e, rather than the degradation masking it: making `requestToBaseEvent` ignore the passed body and read from the request instead makes `udServe` fail.

## Testing

- 9 unit tests in `transforms.test.ts` covering `readRequestBody`, the passed-body path, the fallback, the warning firing only in development, empty bodies, and the legacy handler path via `requestToLegacyEvent`
- `runtime.test.ts` covers a late resolve using `ctx.body` after the body has been read, and the null-body degradation
- `tasks/ud-tests` — 9 passing, including the `udServe` and `udDev` assertions from #2271, which stay green through the removal of `noopAuthDecoder`
- `@cedarjs/api` 266, `@cedarjs/graphql-server` 141, `@cedarjs/api-server` 100 (+2 skipped), `@cedarjs/vite` 234
- builds, `eslint` and `prettier` clean