### PR TITLE
chore(api): Drop a redundant multi-value query param override

### DIFF
--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -217,7 +217,6 @@ export async function requestToLegacyEvent(
   return {
     ...base,
     queryStringParameters,
-    multiValueQueryStringParameters: toMultiValueQueryStringParameters(url),
     pathParameters:
       Object.keys(ctx.params).length > 0 ? ctx.params : base.pathParameters,
   }
@@ -277,22 +276,4 @@ export function legacyResultToResponse(result: LegacyHandlerResult): Response {
     status,
     headers,
   })
-}
-
-function toMultiValueQueryStringParameters(
-  url: URL,
-): Record<string, string[]> | null {
-  const values = new Map<string, string[]>()
-
-  for (const [name, value] of url.searchParams.entries()) {
-    const existing = values.get(name) ?? []
-    existing.push(value)
-    values.set(name, existing)
-  }
-
-  if (values.size === 0) {
-    return null
-  }
-
-  return Object.fromEntries(values.entries())
 }


### PR DESCRIPTION
`requestToLegacyEvent` builds its result by spreading the event from `requestToBaseEvent` and then overriding a few fields:

```ts
return {
  ...base,
  queryStringParameters,
  multiValueQueryStringParameters: toMultiValueQueryStringParameters(url),
  pathParameters:
    Object.keys(ctx.params).length > 0 ? ctx.params : base.pathParameters,
}
```

Two of those overrides earn their place. `queryStringParameters` is re-parsed with picoquery so bracket and index syntax (`ids[]=1&ids[]=2`, `user[name]=alice`) survives, and `pathParameters` needs the route params from `CedarRequestContext`, which the base event has no way to know about.

The third didn't. `requestToBaseEvent` already sets `multiValueQueryStringParameters` by calling `toMultiValueQueryStringParameters(url)` on the same URL — and there were two copies of that helper, one in `transforms.ts` and one in `runtime.ts`, byte-for-byte identical. So the override always recomputed the exact value the spread had just supplied.