### PR TITLE
chore(ci): More robust tag checking for RC publish

### DIFF
--- a/.github/scripts/publish-release-candidate.mts
+++ b/.github/scripts/publish-release-candidate.mts
@@ -245,7 +245,7 @@ function getLatestVersionTag(): string | null {
   const tags = execCommand("git tag -l 'v*'")
     .split('\n')
     .map((tag) => tag.trim())
-    .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag))
+    .filter((tag) => /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(tag))
 
   tags.sort((a, b) => {
     const partsA = a.slice(1).split('.').map(Number)

--- a/.github/scripts/publish-release-candidate.mts
+++ b/.github/scripts/publish-release-candidate.mts
@@ -240,18 +240,7 @@ function verifyWorkspaceDependencies(
   log('✅ All in-monorepo dependencies point at ' + version)
 }
 
-/**
- * The newest release tag in the repo.
- *
- * Deliberately not `git describe`. `git describe` resolves the newest tag
- * *reachable from HEAD*, and it matches any tag, not just release tags. This
- * repo carries tags inherited from the Redwood history (`rw-v8.0.0`) and
- * per-package tags (`create-redmix-rsc-app/v0.0.3`), and on a branch cut from
- * `main` those are what `git describe` returns. Those would parse to `NaN.0.0`
- * below.
- *
- * Mirrors `getLatestVersionTag` in `publish-prerelease.mts`.
- */
+/** The newest release tag in the repo (no matter what branch it's on) */
 function getLatestVersionTag(): string | null {
   const tags = execCommand("git tag -l 'v*'")
     .split('\n')

--- a/.github/scripts/publish-release-candidate.mts
+++ b/.github/scripts/publish-release-candidate.mts
@@ -240,6 +240,39 @@ function verifyWorkspaceDependencies(
   log('✅ All in-monorepo dependencies point at ' + version)
 }
 
+/**
+ * The newest release tag in the repo.
+ *
+ * Deliberately not `git describe`: that resolves the newest tag *reachable from
+ * HEAD*, and it matches any tag, not just release tags. This repo carries tags
+ * inherited from the Redwood history (`rw-v8.0.0`) and per-package tags
+ * (`create-redmix-rsc-app/v0.0.3`), and on a branch cut from `main` those are
+ * what `git describe` returns — which parses to `NaN.0.0` below.
+ *
+ * Mirrors `getLatestVersionTag` in `publish-prerelease.mts`.
+ */
+function getLatestVersionTag(): string | null {
+  const tags = execCommand("git tag -l 'v*'")
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag))
+
+  tags.sort((a, b) => {
+    const partsA = a.slice(1).split('.').map(Number)
+    const partsB = b.slice(1).split('.').map(Number)
+
+    for (let i = 0; i < 3; i++) {
+      if (partsA[i] !== partsB[i]) {
+        return partsA[i] - partsB[i]
+      }
+    }
+
+    return 0
+  })
+
+  return tags.at(-1) ?? null
+}
+
 async function removeCreateCedarAppFromWorkspaces(): Promise<() => void> {
   log('Temporarily removing create-cedar-app from workspaces')
 
@@ -351,7 +384,14 @@ async function main() {
 
     log('Step 2: Calculating RC version')
 
-    const latestTag = execCommand('git describe --abbrev=0 --tags').trim()
+    const latestTag = getLatestVersionTag()
+
+    if (!latestTag) {
+      throw new Error('No version tags (vX.Y.Z) found in the repository')
+    }
+
+    log(`Latest tag: ${latestTag}`)
+
     const currentVersion = latestTag.replace(/^v/, '')
     const [major, minor, patch] = currentVersion.split('.').map(Number)
 

--- a/.github/scripts/publish-release-candidate.mts
+++ b/.github/scripts/publish-release-candidate.mts
@@ -243,11 +243,12 @@ function verifyWorkspaceDependencies(
 /**
  * The newest release tag in the repo.
  *
- * Deliberately not `git describe`: that resolves the newest tag *reachable from
- * HEAD*, and it matches any tag, not just release tags. This repo carries tags
- * inherited from the Redwood history (`rw-v8.0.0`) and per-package tags
- * (`create-redmix-rsc-app/v0.0.3`), and on a branch cut from `main` those are
- * what `git describe` returns — which parses to `NaN.0.0` below.
+ * Deliberately not `git describe`. `git describe` resolves the newest tag
+ * *reachable from HEAD*, and it matches any tag, not just release tags. This
+ * repo carries tags inherited from the Redwood history (`rw-v8.0.0`) and
+ * per-package tags (`create-redmix-rsc-app/v0.0.3`), and on a branch cut from
+ * `main` those are what `git describe` returns. Those would parse to `NaN.0.0`
+ * below.
  *
  * Mirrors `getLatestVersionTag` in `publish-prerelease.mts`.
  */

--- a/.github/workflows/publish-release-candidate.yml
+++ b/.github/workflows/publish-release-candidate.yml
@@ -37,7 +37,13 @@ jobs:
 
       - name: 🏷 Check git tags
         run: |
-          CURRENT_TAG=$(git describe --abbrev=0)
+          # Deliberately not `git describe`. `git describe` resolves the newest
+          # tag *reachable from HEAD*, and matches any tag, not just release
+          # tags. This repo carries tags inherited from the Redwood history
+          # (`rw-v8.0.0`) and per-package tags (`create-redmix-rsc-app/v0.0.3`),
+          # and on a branch cut from `main` those are what `git describe`
+          # returns. That would fail the comparison below and skip the publish.
+          CURRENT_TAG=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
 
           # `github.ref_name` is something like `release/minor/v1.1.0`.
           # `basename` gets us `v1.1.0`

--- a/.github/workflows/publish-release-candidate.yml
+++ b/.github/workflows/publish-release-candidate.yml
@@ -37,12 +37,6 @@ jobs:
 
       - name: 🏷 Check git tags
         run: |
-          # Deliberately not `git describe`. `git describe` resolves the newest
-          # tag *reachable from HEAD*, and matches any tag, not just release
-          # tags. This repo carries tags inherited from the Redwood history
-          # (`rw-v8.0.0`) and per-package tags (`create-redmix-rsc-app/v0.0.3`),
-          # and on a branch cut from `main` those are what `git describe`
-          # returns. That would fail the comparison below and skip the publish.
           CURRENT_TAG=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
 
           # `github.ref_name` is something like `release/minor/v1.1.0`.

--- a/.github/workflows/publish-release-candidate.yml
+++ b/.github/workflows/publish-release-candidate.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: 🏷 Check git tags
         run: |
-          CURRENT_TAG=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
+          CURRENT_TAG=$(git tag -l 'v*' | grep -E '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' | sort -V | tail -n 1)
 
           # `github.ref_name` is something like `release/minor/v1.1.0`.
           # `basename` gets us `v1.1.0`


### PR DESCRIPTION
## Summary

The RC publish pipeline works out "what's the latest release?" with `git describe`, in two separate places. Both are wrong in the same two ways:

- `git describe` returns the newest tag **reachable from HEAD**, not the newest tag in the repo
- it matches **any** tag, not just `vX.Y.Z` release tags

This repo carries tags inherited from the Redwood history (`rw-v8.0.0`) and per-package tags (`create-redmix-rsc-app/v0.0.3`), so both of those bite. Concretely, today:

| | `git describe --abbrev=0` | `git describe --abbrev=0 --tags` |
|---|---|---|
| `origin/next` | `v5.0.1` | `v5.0.1` |
| `origin/main` | `v8.0.0-2817-gc51010a2…` | `create-redmix-rsc-app/v0.0.3` |

The actual latest release is `v5.0.6`.

## What breaks

A release branch cut from `main` — which is what release-tooling offers for a **major** — publishes no RC at all:

- `check-git-tags` compares `$CURRENT_TAG lt $BRANCH_TAG`. From `main` that's `v8.0.0-2817-g… lt v6.0.0` → false → the job fails → `publish-release-candidate` is skipped, since it's `needs: check-git-tags`.
- Had it got past that, the script would have parsed `create-redmix-rsc-app/v0.0.3` into `NaN.0.0`.

From `next` it happens to work, because the major bump only reads the major component and `5 + 1 === 6` whether the tag is `v5.0.1` or `v5.0.6`. So this has been latent rather than visible.

## The fix

Both places now take the newest tag matching `^v\d+\.\d+\.\d+$` from the full tag list, sorted numerically.

- `.github/scripts/publish-release-candidate.mts` — adds `getLatestVersionTag()`, copied from `publish-prerelease.mts`, which already did this correctly. Also brings across the null guard and the `Latest tag:` log line, so the two scripts now agree line for line.
- `.github/workflows/publish-release-candidate.yml` — the same thing in shell, for `check-git-tags`.

## Behaviour change

`latestTag` goes from *newest tag reachable from HEAD* to *newest release tag in the repo*. That shifts the RC number, but not the base version, for every branch type:

| Branch base | Old tag | New tag | Base version |
|---|---|---|---|
| `next`, major | v5.0.1 | v5.0.6 | 6.0.0 either way |
| `next`, minor | v5.0.1 | v5.0.6 | 5.1.0 either way |
| patch branch | v5.0.6 | v5.0.6 | unchanged — cut from the tag, so already reachable |

Minor lands in the same place because `minor + 1` zeroes the patch. The RC number moves because it's `git rev-list --count $latestTag..HEAD`: a v6 RC off `next` becomes `6.0.0-rc.186` rather than `6.0.0-rc.187`.

The new semantics also match how release-tooling already picks its base release (`git tag --sort="-version:refname" --list "v*.*.*" | head -n 1`), so the two sides agree now.

## Why now

Prep for v6. This makes `main` a viable base for the release branch — `v5.0.6 lt v6.0.0` passes, and the script computes `6.0.0-rc.2817` — which it wasn't before.

Worth noting for the v6 timeline: CI runs the script from the pushed branch's own checkout, so this needs to reach `next` (or the release branch itself) before it affects any v6 RC. Landing it on `main` alone won't.
