### PR TITLE
feat(serve)!: Deploy related env vars `PORT`, `CEDAR_*`, etc

### DIFF
--- a/docs/docs/app-configuration-cedar-toml.md
+++ b/docs/docs/app-configuration-cedar-toml.md
@@ -195,5 +195,32 @@ To run a Cedar app in a container or VM, you'll want to set both the web and api
   host = '0.0.0.0'
 ```
 
-You can also configure these values via `REDWOOD_WEB_HOST` and `REDWOOD_API_HOST`.
+You can also configure these values via `CEDAR_WEB_HOST` and `CEDAR_API_HOST`.
 And if you set `NODE_ENV` to production, these will be the defaults anyway.
+
+:::note Deprecated env vars
+
+`REDWOOD_WEB_HOST`, `REDWOOD_API_HOST`, `REDWOOD_WEB_PORT` and
+`REDWOOD_API_PORT` still work, but they're deprecated in favour of their
+`CEDAR_`-prefixed equivalents, which take precedence when both are set.
+
+:::
+
+### Container hosts
+
+Most container hosts (Railway, Render, Fly.io, Cloud Run, Heroku) tell your app
+what to bind to with the `HOST` and `PORT` env vars. Cedar reads both, so you
+usually don't have to configure anything.
+
+`PORT` is only used by the side serving public traffic. When you run both sides
+together with `yarn cedar serve`, that's the web server — the api server keeps
+its own port, because the two would otherwise try to bind the same one. Serving
+a single side with `yarn cedar serve api` or `yarn cedar serve web` makes that
+side the public one.
+
+The full order of precedence is:
+
+1. CLI flags (`--port`, `--host`, `--api-port`, …)
+2. `CEDAR_API_PORT` / `CEDAR_WEB_PORT` (and the `_HOST` equivalents)
+3. `PORT` / `HOST`, for the public side only
+4. `[api].port` / `[web].port` in `cedar.toml`

--- a/docs/docs/app-configuration-cedar-toml.md
+++ b/docs/docs/app-configuration-cedar-toml.md
@@ -198,14 +198,6 @@ To run a Cedar app in a container or VM, you'll want to set both the web and api
 You can also configure these values via `CEDAR_WEB_HOST` and `CEDAR_API_HOST`.
 And if you set `NODE_ENV` to production, these will be the defaults anyway.
 
-:::note Deprecated env vars
-
-`REDWOOD_WEB_HOST`, `REDWOOD_API_HOST`, `REDWOOD_WEB_PORT` and
-`REDWOOD_API_PORT` still work, but they're deprecated in favour of their
-`CEDAR_`-prefixed equivalents, which take precedence when both are set.
-
-:::
-
 ### Container hosts
 
 Most container hosts (Railway, Render, Fly.io, Cloud Run, Heroku) tell your app

--- a/docs/docs/server-file.md
+++ b/docs/docs/server-file.md
@@ -230,11 +230,11 @@ It takes the same arguments as `listen`, except for host and port. It computes t
 yarn node api/dist/server.js --apiHost 0.0.0.0 --apiPort 8913
 ```
 
-2. `REDWOOD_API_HOST` or `REDWOOD_API_PORT` env vars:
+2. `CEDAR_API_HOST` or `CEDAR_API_PORT` env vars:
 
 ```
-export REDWOOD_API_HOST='0.0.0.0'
-export REDWOOD_API_PORT='8913'
+export CEDAR_API_HOST='0.0.0.0'
+export CEDAR_API_PORT='8913'
 yarn node api/dist/server.js
 ```
 

--- a/docs/implementation-plans/2026-08-03-deploy-simplification.md
+++ b/docs/implementation-plans/2026-08-03-deploy-simplification.md
@@ -1,106 +1,264 @@
 # Deploy Simplification (General + Railway)
 
-Most of what makes Railway annoying isn't Railway — it's general gaps that any
-container PaaS would hit. So the general list is where the leverage is; the
-Railway-specific list nearly empties out if the general fixes land.
+Started as "why is deploying to Railway annoying?" and became a general audit.
+Most of what makes Railway annoying isn't Railway — it's gaps any container PaaS
+hits. The general list is where the leverage is; the Railway-specific list nearly
+empties out once the general fixes land.
 
-## The framing problem underneath all of it
+This document has been updated as the work progressed. Items now link to the PRs
+and issues that carry them, and several original conclusions have been revised —
+those are called out rather than quietly edited, since the reasoning matters.
 
-Cedar is currently incoherent about `cedar serve`. The command binds `0.0.0.0`
-in production, warns about "containerized deployments" (`webServer.ts:34`), and
-looks production-ready — but no deploy path uses it, and Cedar's own docs say
-the web server "isn't really configured for a high traffic, production website"
-(`baremetal.md:654`).
+## The framing question — resolved
 
-Pick a side. Recommendation: **bless `cedar serve` as the supported
-single-container topology** and fix the things that make it indefensible. That's
-the shape every buildpack PaaS expects, and the two-service split becomes an
-optimization you graduate into rather than the only blessed path. The
-alternative — keep it local-only — means zero-config PaaS deploy is permanently
-impossible for Cedar, which seems like the wrong trade.
+The original version of this doc said Cedar was incoherent about `cedar serve`:
+the command binds `0.0.0.0` in production and warns about "containerized
+deployments" (`webServer.ts:34`), yet no deploy path used it and Cedar's own docs
+say the web server "isn't really configured for a high traffic, production
+website" (`baremetal.md:654`). It asked for a decision.
 
-Everything below assumes that choice.
+**Decision:** bless single-container as the **convenient** topology, keep
+api-process + static/CDN web as the **recommended** one. Recorded on #2294.
 
-## General deploy changes, ranked by leverage
+The reasoning that settled it: single-container needs no service-to-service
+wiring, because the web server proxies to the api in-process. That is precisely
+why one `start` script plus `PORT` handling yields working deploys on Railway,
+Render, Cloud Run, DigitalOcean App Platform, Heroku, Coolify, Dokku, Dokploy,
+Koyeb and Northflank with no per-platform integration to write or maintain.
 
-**1. Read `PORT` and `HOST`.** `cliHelpers.ts:10-31` reads only
-`REDWOOD_API_PORT`/`REDWOOD_WEB_PORT`. Railway, Render, Fly, Cloud Run, Heroku,
-and App Runner all inject `PORT`. Today only the `--ud` api path honors it
-(`serve.ts:306`) — an inconsistency that's arguably just a bug. Fallback chain:
-`CEDAR_* → REDWOOD_* → PORT/HOST → cedar.toml → default`. This one change
-removes a mandatory config step from every container host.
+Genuine zero-config with a _separate_ api service is not achievable. The two
+services must be wired to each other — a proxy target, or `apiUrl` pointing at a
+domain that doesn't exist until after the first deploy — and that wiring is
+irreducibly deployment-specific. Railway's JS monorepo autodetection comes
+closest (it stages a service per package, keeps the monorepo root, and uses
+workspace-filtered commands) but still leaves the proxy target unset, and it's
+Railway-only.
 
-**2. Add `build` and `start` scripts to the app template.**
-`create-cedar-app/templates/*/package.json` has no `scripts` key at all.
-Railpack's detection is `start` script → `main` → `index.js`, and it runs
-`build` if defined — so it finds nothing and you're forced into config-as-code.
-Adding `"build": "cedar build"` and `"start": "cedar serve"` makes Cedar deploy
-to Railway, Render, Fly, and Heroku with _zero_ config files. Combined with #1,
-that's the whole game.
+## Status
 
-**3. Get runtime deps out of root `devDependencies`.** `@cedarjs/core` pulls in
-`@cedarjs/cli` and `@cedarjs/api-server` (`core/package.json:51-52`) and lives
-in devDependencies. So `RAILPACK_PRUNE_DEPS`, `npm prune --production`, or
-`yarn workspaces focus --production` all break the start command with a
-confusing "command not found." The thing you need to _run_ the server shouldn't
-be a dev dependency.
+| #   | Item                                       | Status                                        |
+| --- | ------------------------------------------ | --------------------------------------------- |
+| 1   | Read `PORT` and `HOST`                     | **Done** — #2292                              |
+| 2   | `build` / `start` scripts in templates     | PR #2294 — blocked on #2302                   |
+| 3   | Runtime deps out of root `devDependencies` | Reframed — #2295 done, rest folded into #2294 |
+| 4   | Web server cache headers + compression     | #2301                                         |
+| 5   | Dual-stack host default                    | Open                                          |
+| 6   | Generic `setup deploy container`           | **Superseded** — #2303                        |
+| 7   | Built-in health endpoint                   | #2298                                         |
+| 8   | Rename `REDWOOD_*` → `CEDAR_*`             | **Done** — #2292                              |
+| 9   | Document the serve tiers                   | #2300                                         |
 
-**4. Make the web server production-defensible.**
+Also opened along the way: #2296, #2297, #2299, #2302.
+
+## 1. Read `PORT` and `HOST` — done (#2292)
+
+`cliHelpers.ts` read only `REDWOOD_API_PORT` / `REDWOOD_WEB_PORT`. Every
+container host injects `PORT`; only the `--ud` api path honoured it.
+
+Resolved with a `CEDAR_* → REDWOOD_* → PORT/HOST → cedar.toml → default` chain.
+The important refinement over the original plan: `PORT` applies to the **public
+side only**, via an `isPublicSide` option. Without that, `cedar serve` would
+have had both listeners bind `PORT` and collide.
+
+## 2. `build` / `start` scripts — PR #2294
+
+Generated apps had no `scripts` key at all, so zero-config builders (Railpack,
+Nixpacks, Paketo, Google Cloud buildpacks, Heroku) found nothing to run.
+
+Shipping five scripts rather than the two originally planned:
+
+```json
+"build": "cedar build",
+"dev": "cedar dev",
+"start": "cedar serve",
+"start:api": "cedar serve api",
+"start:web": "cedar serve web"
+```
+
+`start` is the single-container path; `start:api` / `start:web` are the
+two-service path, so platform config can call standard scripts instead of
+`cedar deploy <provider>` glue.
+
+**Considered and rejected:** `start` scripts in `api/package.json` and
+`web/package.json`. Railway's monorepo autodetection would pick them up, but
+it's Railway-only and still leaves the proxy target unset — a half-staged
+two-service deploy that fails until you find the right setting is worse than one
+service that works immediately.
+
+Blocked on #2302 before the scripts can switch to the `cedarjs-server` bin.
+
+## 3. Runtime deps out of `devDependencies` — reframed
+
+**The original prescription was wrong.** It implied promoting `@cedarjs/core`,
+which reviewers correctly rejected — core is the whole CLI and build toolchain
+and belongs in `devDependencies`.
+
+The correct framing is that the scripts split by phase: `build` and `dev` are
+build-time and should use the CLI from `devDependencies`; only `start` is a
+runtime concern. The fix is to stop routing `start` through the CLI at all —
+add `@cedarjs/api-server` as a root **dependency** and use the `cedarjs-server`
+bin. Cedar already does exactly this in `setup docker`, which adds
+`@cedarjs/api-server` and `@cedarjs/web-server` to the api and web workspaces.
+
+**This is not cosmetic.** Heroku's Node buildpack and DigitalOcean/Paketo both
+strip `devDependencies` after build **by default**, so `start: cedar serve`
+fails on those platforms: build succeeds, deploy succeeds, container starts,
+command not found. Railway only works because `RAILPACK_PRUNE_DEPS` is opt-in.
+
+Blocked on #2302, because `cedarjs-server` does not do the server-file dispatch
+that `cedar serve` does.
+
+## 4. Web server cache headers and compression — #2301
+
 `adapters/fastify/web/src/web.ts:26` is
 `fastify.register(fastifyStatic, { root: getPaths().web.dist })` — no `maxAge`,
-and `@fastify/compress` isn't a dependency of any package. Assets in
-`web/dist/assets` are content-hashed and immutable, so
-`Cache-Control: public, max-age=31536000, immutable` on that prefix (with
-`no-cache` on `index.html`) is safe and near-free. Add compression too. This is
-what turns "don't use this in production" into "this is fine behind any CDN."
+no compression, and `@fastify/compress` is not a dependency of any package.
 
-**5. Dual-stack host default.** `cliHelpers.ts:6,23` defaults to `0.0.0.0` in
-production — IPv4-only, which breaks IPv6-native private networking (Railway,
-Fly). `::` accepts both on dual-stack. At minimum, document it; ideally default
-to `::` and drop the `0.0.0.0` warning.
+Assets in `web/dist/assets` are content-hashed, so
+`Cache-Control: public, max-age=31536000, immutable` is safe there, with
+`no-cache` on `index.html`.
 
-**6. A generic `setup deploy container` target.** The provider list is a
-hardcoded enum, so every new PaaS needs a framework PR. But Railway, Fly, Koyeb,
-Northflank, and Cloud Run all want the same three things: build command, start
-command bound to `$PORT`, migration hook. One generic target plus thin provider
-presets would cover the entire category.
+Raised in priority by the framing decision: blessing single-container means more
+people serve assets through Fastify rather than a CDN, and telling someone their
+zero-config deploy needs a CDN bolted on undercuts the point. Note `srvx/static`
+on the UD path is equally bare, so any fix should consider both.
 
-**7. Built-in health endpoint.** Render's setup generates
-`api/src/functions/healthz.js` (`renderHandler.ts:80`) — provider-specific, when
-every container host wants one. Ship it always.
+## 5. Dual-stack host default — open
 
-**8. Rename `REDWOOD_*` → `CEDAR_*` with aliases.** There are ~30 `CEDAR_*` vars
-including `CEDAR_API_ROOT_PATH`, but the port/host vars were missed. Low value
-functionally, real value for the fork's coherence.
+`cliHelpers.ts` still defaults to `0.0.0.0` in production, which is IPv4-only.
+Railway's private network is IPv6-native, so the two-service topology needs an
+explicit `--host ::` on the api service. `::` accepts both on dual-stack.
 
-**9. Document the three tiers.** `serve api` = production. `serve web` =
-production behind a CDN/proxy. `serve` = single-container or local. This has to
-be reverse-engineered from deploy templates today; it should be in
-`deploy/introduction.md` and in `--help`.
+Either default to `::` and drop the `0.0.0.0` warning, or document the gotcha
+prominently. This is the single most likely thing to break a first Railway
+two-service deploy.
+
+## 6. Generic `setup deploy container` — superseded by #2303
+
+The original argument was that one generic target plus thin presets beats a
+hardcoded provider enum. Tracing it through, that doesn't survive contact with
+the platforms: once the conventions land there is almost nothing left to emit.
+Coolify is dashboard-only, Cloud Run is `gcloud` flags, Heroku is at most a
+`Procfile` containing `web: yarn start`, and Dokku/Dokploy/Koyeb/Northflank need
+nothing. Only Railway, DigitalOcean and Fly have a config file, and all three are
+different.
+
+What _is_ worth extracting: `yarn cedar setup neon` already performs the whole
+SQLite → Postgres migration, and only one of its eleven steps (provisioning) is
+Neon-specific. Pulling the provider-agnostic part out serves every container
+deploy — it's the biggest manual step in any non-SQLite deployment. Tracked in
+#2303.
+
+## 7. Built-in health endpoint — #2298
+
+`setup deploy render` generates `api/src/functions/healthz.js`, but the
+generated `render.yaml` never references it — there is no `healthCheckPath`
+field at all, so the file is inert.
+
+Verified by booting the Fastify server and injecting requests:
+
+| Request                  | Result                 |
+| ------------------------ | ---------------------- |
+| `GET /graphql/health`    | 200, `x-yoga-id: yoga` |
+| `GET /graphql/readiness` | 503                    |
+
+So `/graphql/health` is usable as a health check path. `/graphql/readiness` is
+not — `createGraphQLYoga.ts:183-194` requires the _request_ to carry a matching
+`x-yoga-id` header, so a plain platform health check gets 503.
+
+## 8. `REDWOOD_*` → `CEDAR_*` — done (#2292)
+
+Port and host vars now read `CEDAR_*` first with `REDWOOD_*` as deprecated
+aliases.
+
+## 9. Document the serve tiers — #2300
+
+Folded into one consolidated docs issue along with the topology framing, a
+Railway page, a Coolify page, an "any container host" page, and fixes for stale
+`yarn rw` usages across the deploy docs.
+
+## Discoveries not in the original plan
+
+**`@cedarjs/web-server` is already the model.** It depends only on
+`fastify-web`, `project-config`, fastify and small utilities — no build
+toolchain. `@cedarjs/api-server` was one import away from matching it; that
+import was `@cedarjs/internal` in the dev watcher, now an optional peer
+dependency (#2295). "Make api-server look like web-server" turned out to be a
+much smaller ask than "split up api-server".
+
+**`@cedarjs/project-config` pulls `@prisma/internals`** (#2296) — Prisma's
+CLI-side internals, not `@prisma/client`. It sits on every runtime path,
+including the otherwise-clean `@cedarjs/web-server`. Already dynamically
+imported, and no server touches the code that needs it.
+
+**`cedarjs-server` silently ignores server files** (#2302). This is a live bug,
+not a future one: the generated Dockerfile already uses `cedarjs-server api` as
+its `CMD`, so a project with Realtime configured deploys today with no
+subscriptions and no indication anything is wrong.
+
+**The Render deploy command must stay.** An earlier revision of #2297 proposed
+deleting it in favour of Render's `preDeployCommand`. It carries a guard that
+nothing else in the CLI does: `@cedarjs/cli-data-migrate` is a CLI _plugin_
+(`plugin.ts:60`), so without it the `dataMigrate` command doesn't exist, and the
+guard also warns about the memory cost of installing it mid-deploy. #2297 is now
+blueprint modernization only.
+
+**The GraphQL plugin fails silently** (#2299). If options extraction bails, or
+plugin setup throws, the plugin registers zero routes and the whole GraphQL
+endpoint 404s — the outer catch is a bare `console.log(e)`. For an opinionated
+framework the right behaviour is to fail loudly at build time.
+
+**Universal Deploy is a parallel mode, not a successor.** Per
+`cedar-serve-ud-both-sides-plan.md`, `cedar serve api --ud` is the production
+entry (srvx hosting `api/dist/ud/index.js`, behind nginx), `cedar serve --ud` is
+local testing only, and Fastify was explicitly decided against for the UD api
+side. The `@cedarjs/cli` dependency on the local-testing path is therefore fine.
+
+**If `--ud` ever becomes the default**, the api half of zero-config is solved
+structurally: the UD entry inlines framework glue via `.toString()`, so it
+imports nothing from `api-server`, `internal`, `cli` or `project-config`, and
+#2296 becomes moot for the serve path. The gap moves to the web half —
+single-container means one runtime serving both sides, which is exactly the case
+`virtual:cedar-web` was built for before being removed as unreachable dead code
+(see the Phase 6 Addendum in `universal-deploy-integration-plan-refined.md`,
+which includes a recipe for restoring it). Custom server files remain the open
+product question, since UD ignores them by design.
+
+**Platform landscape.** Ten hosts work purely on conventions: Railway, Render,
+Cloud Run, DigitalOcean App Platform, Heroku, Coolify, Dokku, Dokploy, Koyeb,
+Northflank. Fly.io is Dockerfile-first — its own docs call buildpacks "brittle,
+bloated, and prone to change" — and is already served by `setup docker`. Coolify
+is the standout for self-hosters: its Static build pack alongside Nixpacks means
+it can natively express Cedar's _recommended_ topology rather than forcing
+single-container.
 
 ## Railway-specific
 
-If #1 and #2 ship, Railway deployment becomes: create service, add Postgres, set
-`DATABASE_URL`, push. No config files at all. So the Railway-specific work is
-mostly docs:
+Once #2 and #3 land, Railway becomes: create service, add Postgres, set
+`DATABASE_URL`, push. So the Railway work is mostly docs (#2300).
 
-**`docs/docs/deploy/railway.md`** — the page that never existed. Cover the
-single-service default; the two-service split as the scale-up path; enabling
-Railway's CDN (the thing that actually compensates for #4); `preDeployCommand`
-for migrations; and the `--host ::` private-networking gotcha, which is the one
-genuinely Railway-shaped trap here.
+Verified about Railway: Railpack is the default builder (Nixpacks deprecated),
+and it handles Cedar's Yarn 4 + workspaces + `engines.node` correctly. Config as
+code is `railway.json` / `railway.toml` — **no JSONC**, so use TOML when you want
+comments. `preDeployCommand` suits migrations. Railway's CDN is per-service,
+free on all plans, and caches static assets by `Content-Type` — the thing that
+most compensates for #4. Private networking is IPv6-native, hence #5.
 
-**`yarn cedar setup deploy railway`** — worth it only as a preset on the generic
-container target from #6, not as another bespoke provider. It'd emit the two
-TOMLs, add `@prisma/adapter-pg`, and print the env vars to set.
+**`yarn cedar setup deploy railway`** — worth it only as a thin preset once #2303
+lands, not as another bespoke provider.
 
-**Don't** build a Railway-specific build path. Railpack handles Cedar's Yarn 4 +
-workspaces + `engines.node` correctly already — each of those was verified
-against Railpack's detection order. The gaps are all on Cedar's side.
+**Don't** build a Railway-specific build path. The gaps are all on Cedar's side.
 
 ## Sequencing
 
-Start with #1 and #2 as a single PR — they're both small, they're the ones that
-unlock every other container host, and the tests can point at the existing
-`cliHelpers` suite. Hold #3 and #4 as separate PRs since they have real blast
-radius.
+1. **#2302** — `cedarjs-server api` runs the server file; modes that can't, fail
+   loudly. Blocks the rest, and fixes a live bug.
+2. **#2295** — `@cedarjs/internal` to an optional peer, so the new root
+   dependency is lean. Independent of 1, same release.
+3. **#2294** — add the root `@cedarjs/api-server` dependency, switch the scripts
+   to `cedarjs-server`, merge.
+4. **#2301** and **#5** — the two things that make the blessed single-container
+   path actually good.
+5. **#2303**, then docs (#2300).
+
+#2296, #2297, #2298 and #2299 are independent and can land whenever.

--- a/docs/implementation-plans/2026-08-03-deploy-simplification.md
+++ b/docs/implementation-plans/2026-08-03-deploy-simplification.md
@@ -1,0 +1,106 @@
+# Deploy Simplification (General + Railway)
+
+Most of what makes Railway annoying isn't Railway — it's general gaps that any
+container PaaS would hit. So the general list is where the leverage is; the
+Railway-specific list nearly empties out if the general fixes land.
+
+## The framing problem underneath all of it
+
+Cedar is currently incoherent about `cedar serve`. The command binds `0.0.0.0`
+in production, warns about "containerized deployments" (`webServer.ts:34`), and
+looks production-ready — but no deploy path uses it, and Cedar's own docs say
+the web server "isn't really configured for a high traffic, production website"
+(`baremetal.md:654`).
+
+Pick a side. Recommendation: **bless `cedar serve` as the supported
+single-container topology** and fix the things that make it indefensible. That's
+the shape every buildpack PaaS expects, and the two-service split becomes an
+optimization you graduate into rather than the only blessed path. The
+alternative — keep it local-only — means zero-config PaaS deploy is permanently
+impossible for Cedar, which seems like the wrong trade.
+
+Everything below assumes that choice.
+
+## General deploy changes, ranked by leverage
+
+**1. Read `PORT` and `HOST`.** `cliHelpers.ts:10-31` reads only
+`REDWOOD_API_PORT`/`REDWOOD_WEB_PORT`. Railway, Render, Fly, Cloud Run, Heroku,
+and App Runner all inject `PORT`. Today only the `--ud` api path honors it
+(`serve.ts:306`) — an inconsistency that's arguably just a bug. Fallback chain:
+`CEDAR_* → REDWOOD_* → PORT/HOST → cedar.toml → default`. This one change
+removes a mandatory config step from every container host.
+
+**2. Add `build` and `start` scripts to the app template.**
+`create-cedar-app/templates/*/package.json` has no `scripts` key at all.
+Railpack's detection is `start` script → `main` → `index.js`, and it runs
+`build` if defined — so it finds nothing and you're forced into config-as-code.
+Adding `"build": "cedar build"` and `"start": "cedar serve"` makes Cedar deploy
+to Railway, Render, Fly, and Heroku with _zero_ config files. Combined with #1,
+that's the whole game.
+
+**3. Get runtime deps out of root `devDependencies`.** `@cedarjs/core` pulls in
+`@cedarjs/cli` and `@cedarjs/api-server` (`core/package.json:51-52`) and lives
+in devDependencies. So `RAILPACK_PRUNE_DEPS`, `npm prune --production`, or
+`yarn workspaces focus --production` all break the start command with a
+confusing "command not found." The thing you need to _run_ the server shouldn't
+be a dev dependency.
+
+**4. Make the web server production-defensible.**
+`adapters/fastify/web/src/web.ts:26` is
+`fastify.register(fastifyStatic, { root: getPaths().web.dist })` — no `maxAge`,
+and `@fastify/compress` isn't a dependency of any package. Assets in
+`web/dist/assets` are content-hashed and immutable, so
+`Cache-Control: public, max-age=31536000, immutable` on that prefix (with
+`no-cache` on `index.html`) is safe and near-free. Add compression too. This is
+what turns "don't use this in production" into "this is fine behind any CDN."
+
+**5. Dual-stack host default.** `cliHelpers.ts:6,23` defaults to `0.0.0.0` in
+production — IPv4-only, which breaks IPv6-native private networking (Railway,
+Fly). `::` accepts both on dual-stack. At minimum, document it; ideally default
+to `::` and drop the `0.0.0.0` warning.
+
+**6. A generic `setup deploy container` target.** The provider list is a
+hardcoded enum, so every new PaaS needs a framework PR. But Railway, Fly, Koyeb,
+Northflank, and Cloud Run all want the same three things: build command, start
+command bound to `$PORT`, migration hook. One generic target plus thin provider
+presets would cover the entire category.
+
+**7. Built-in health endpoint.** Render's setup generates
+`api/src/functions/healthz.js` (`renderHandler.ts:80`) — provider-specific, when
+every container host wants one. Ship it always.
+
+**8. Rename `REDWOOD_*` → `CEDAR_*` with aliases.** There are ~30 `CEDAR_*` vars
+including `CEDAR_API_ROOT_PATH`, but the port/host vars were missed. Low value
+functionally, real value for the fork's coherence.
+
+**9. Document the three tiers.** `serve api` = production. `serve web` =
+production behind a CDN/proxy. `serve` = single-container or local. This has to
+be reverse-engineered from deploy templates today; it should be in
+`deploy/introduction.md` and in `--help`.
+
+## Railway-specific
+
+If #1 and #2 ship, Railway deployment becomes: create service, add Postgres, set
+`DATABASE_URL`, push. No config files at all. So the Railway-specific work is
+mostly docs:
+
+**`docs/docs/deploy/railway.md`** — the page that never existed. Cover the
+single-service default; the two-service split as the scale-up path; enabling
+Railway's CDN (the thing that actually compensates for #4); `preDeployCommand`
+for migrations; and the `--host ::` private-networking gotcha, which is the one
+genuinely Railway-shaped trap here.
+
+**`yarn cedar setup deploy railway`** — worth it only as a preset on the generic
+container target from #6, not as another bespoke provider. It'd emit the two
+TOMLs, add `@prisma/adapter-pg`, and print the env vars to set.
+
+**Don't** build a Railway-specific build path. Railpack handles Cedar's Yarn 4 +
+workspaces + `engines.node` correctly already — each of those was verified
+against Railpack's detection order. The gaps are all on Cedar's side.
+
+## Sequencing
+
+Start with #1 and #2 as a single PR — they're both small, they're the ones that
+unlock every other container host, and the tests can point at the existing
+`cliHelpers` suite. Hold #3 and #4 as separate PRs since they have real blast
+radius.

--- a/packages/api-server/src/__tests__/cliHelpers.test.ts
+++ b/packages/api-server/src/__tests__/cliHelpers.test.ts
@@ -70,7 +70,7 @@ describe('getAPIPort', () => {
     expect(() =>
       getAPIPort({ isPublicSide: true }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Invalid PORT env var. "eight-oh-eight-oh" must be an integer.]`,
+      `[Error: Invalid PORT env var value: "eight-oh-eight-oh". Must be an integer.]`,
     )
   })
 
@@ -82,7 +82,7 @@ describe('getAPIPort', () => {
     expect(() =>
       getAPIPort({ isPublicSide: true }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Invalid PORT env var. "8080abc" must be an integer.]`,
+      `[Error: Invalid PORT env var value: "8080abc". Must be an integer.]`,
     )
   })
 
@@ -92,7 +92,7 @@ describe('getAPIPort', () => {
     expect(() =>
       getAPIPort({ isPublicSide: true }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Invalid PORT env var. "1.5" must be an integer.]`,
+      `[Error: Invalid PORT env var value: "1.5". Must be an integer.]`,
     )
   })
 
@@ -100,7 +100,7 @@ describe('getAPIPort', () => {
     vi.stubEnv('CEDAR_API_PORT', '8920nope')
 
     expect(() => getAPIPort()).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Invalid CEDAR_API_PORT env var. "8920nope" must be an integer.]`,
+      `[Error: Invalid CEDAR_API_PORT env var value: "8920nope". Must be an integer.]`,
     )
   })
 })

--- a/packages/api-server/src/__tests__/cliHelpers.test.ts
+++ b/packages/api-server/src/__tests__/cliHelpers.test.ts
@@ -70,7 +70,37 @@ describe('getAPIPort', () => {
     expect(() =>
       getAPIPort({ isPublicSide: true }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Invalid PORT env var: "eight-oh-eight-oh". Must be an integer.]`,
+      `[Error: Invalid PORT env var. "eight-oh-eight-oh" must be an integer.]`,
+    )
+  })
+
+  // These parse as 8080 and 1 with a bare `parseInt`, which would bind a port
+  // nobody asked for and leave the deployment unreachable
+  it('throws on a PORT with a numeric prefix', () => {
+    vi.stubEnv('PORT', '8080abc')
+
+    expect(() =>
+      getAPIPort({ isPublicSide: true }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invalid PORT env var. "8080abc" must be an integer.]`,
+    )
+  })
+
+  it('throws on a decimal PORT', () => {
+    vi.stubEnv('PORT', '1.5')
+
+    expect(() =>
+      getAPIPort({ isPublicSide: true }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invalid PORT env var. "1.5" must be an integer.]`,
+    )
+  })
+
+  it('throws on a CEDAR_API_PORT with a numeric prefix', () => {
+    vi.stubEnv('CEDAR_API_PORT', '8920nope')
+
+    expect(() => getAPIPort()).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invalid CEDAR_API_PORT env var. "8920nope" must be an integer.]`,
     )
   })
 })

--- a/packages/api-server/src/__tests__/cliHelpers.test.ts
+++ b/packages/api-server/src/__tests__/cliHelpers.test.ts
@@ -1,0 +1,161 @@
+import path from 'path'
+
+import {
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  describe,
+  it,
+  expect,
+} from 'vitest'
+
+import { getConfig } from '@cedarjs/project-config'
+
+import {
+  getAPIHost,
+  getAPIPort,
+  getWebHost,
+  getWebPort,
+} from '../cliHelpers.js'
+
+let original_CEDAR_CWD: string | undefined
+
+beforeAll(() => {
+  original_CEDAR_CWD = process.env.CEDAR_CWD
+  process.env.CEDAR_CWD = path.join(__dirname, './fixtures/graphql/cedar-app')
+})
+
+afterAll(() => {
+  process.env.CEDAR_CWD = original_CEDAR_CWD
+})
+
+beforeEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('getAPIPort', () => {
+  it('falls back to [api].port in cedar.toml', () => {
+    expect(getAPIPort()).toBe(getConfig().api.port)
+  })
+
+  it('prefers CEDAR_API_PORT over cedar.toml', () => {
+    vi.stubEnv('CEDAR_API_PORT', '8920')
+
+    expect(getAPIPort()).toBe(8920)
+  })
+
+  it('ignores PORT when the api side is not public', () => {
+    vi.stubEnv('PORT', '8080')
+
+    expect(getAPIPort()).toBe(getConfig().api.port)
+  })
+
+  it('uses PORT when the api side is public', () => {
+    vi.stubEnv('PORT', '8080')
+
+    expect(getAPIPort({ isPublicSide: true })).toBe(8080)
+  })
+
+  it('prefers CEDAR_API_PORT over PORT', () => {
+    vi.stubEnv('CEDAR_API_PORT', '8920')
+    vi.stubEnv('PORT', '8080')
+
+    expect(getAPIPort({ isPublicSide: true })).toBe(8920)
+  })
+
+  it('throws on a non-integer PORT', () => {
+    vi.stubEnv('PORT', 'eight-oh-eight-oh')
+
+    expect(() =>
+      getAPIPort({ isPublicSide: true }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invalid PORT env var: "eight-oh-eight-oh". Must be an integer.]`,
+    )
+  })
+})
+
+describe('getWebPort', () => {
+  it('falls back to [web].port in cedar.toml', () => {
+    expect(getWebPort()).toBe(getConfig().web.port)
+  })
+
+  it('prefers CEDAR_WEB_PORT over cedar.toml', () => {
+    vi.stubEnv('CEDAR_WEB_PORT', '8930')
+
+    expect(getWebPort()).toBe(8930)
+  })
+
+  it('ignores PORT when the web side is not public', () => {
+    vi.stubEnv('PORT', '8080')
+
+    expect(getWebPort()).toBe(getConfig().web.port)
+  })
+
+  it('uses PORT when the web side is public', () => {
+    vi.stubEnv('PORT', '8080')
+
+    expect(getWebPort({ isPublicSide: true })).toBe(8080)
+  })
+})
+
+describe('both sides in one process', () => {
+  // Regression test: `cedar serve` runs both servers in one process, so only
+  // the public side (web) may take PORT. If both did they'd collide.
+  it('does not give the same port to both sides', () => {
+    vi.stubEnv('PORT', '8080')
+
+    expect(getWebPort({ isPublicSide: true })).toBe(8080)
+    expect(getAPIPort()).not.toBe(8080)
+  })
+})
+
+describe('host helpers', () => {
+  it('ignores HOST when the side is not public', () => {
+    vi.stubEnv('HOST', '10.0.0.1')
+
+    expect(getAPIHost()).not.toBe('10.0.0.1')
+    expect(getWebHost()).not.toBe('10.0.0.1')
+  })
+
+  it('uses HOST when the side is public', () => {
+    vi.stubEnv('HOST', '10.0.0.1')
+
+    expect(getAPIHost({ isPublicSide: true })).toBe('10.0.0.1')
+    expect(getWebHost({ isPublicSide: true })).toBe('10.0.0.1')
+  })
+
+  it('prefers CEDAR_API_HOST over HOST', () => {
+    vi.stubEnv('CEDAR_API_HOST', '10.0.0.2')
+    vi.stubEnv('HOST', '10.0.0.1')
+
+    expect(getAPIHost({ isPublicSide: true })).toBe('10.0.0.2')
+  })
+})
+
+describe('deprecated REDWOOD_ aliases', () => {
+  it.each([
+    ['REDWOOD_API_PORT', 'CEDAR_API_PORT', () => getAPIPort(), 8920],
+    ['REDWOOD_WEB_PORT', 'CEDAR_WEB_PORT', () => getWebPort(), 8930],
+  ])('still reads %s', (deprecatedName, _name, read, expected) => {
+    vi.stubEnv(deprecatedName, String(expected))
+
+    expect(read()).toBe(expected)
+  })
+
+  it.each([
+    ['REDWOOD_API_HOST', () => getAPIHost()],
+    ['REDWOOD_WEB_HOST', () => getWebHost()],
+  ])('still reads %s', (deprecatedName, read) => {
+    vi.stubEnv(deprecatedName, '10.0.0.3')
+
+    expect(read()).toBe('10.0.0.3')
+  })
+
+  it('prefers the CEDAR_ name over the deprecated alias', () => {
+    vi.stubEnv('CEDAR_API_PORT', '8920')
+    vi.stubEnv('REDWOOD_API_PORT', '8921')
+
+    expect(getAPIPort()).toBe(8920)
+  })
+})

--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -206,8 +206,27 @@ describe('createServer', () => {
       await server.close()
     })
 
-    it('the `REDWOOD_API_PORT` env var takes precedence over [api].port', async () => {
-      process.env.REDWOOD_API_PORT = '8920'
+    it('the `CEDAR_API_PORT` env var takes precedence over [api].port', async () => {
+      process.env.CEDAR_API_PORT = '8920'
+
+      const server = await createServer()
+      await server.start()
+
+      const address = server.server.address()
+
+      if (!address || typeof address === 'string') {
+        throw new Error('No address or address is a string')
+      }
+
+      expect(address.port).toBe(+process.env.CEDAR_API_PORT)
+
+      await server.close()
+
+      delete process.env.CEDAR_API_PORT
+    })
+
+    it('the deprecated `REDWOOD_API_PORT` env var still works', async () => {
+      process.env.REDWOOD_API_PORT = '8921'
 
       const server = await createServer()
       await server.start()

--- a/packages/api-server/src/bothCLIConfigHandler.ts
+++ b/packages/api-server/src/bothCLIConfigHandler.ts
@@ -11,8 +11,11 @@ export async function handler(options: BothParsedOptions) {
   const timeStart = Date.now()
   console.log(ansis.dim.italic('Starting API and Web Servers...'))
 
-  options.webHost ??= getWebHost()
-  options.webPort ??= getWebPort()
+  // The web server is the one taking public traffic here — it proxies api
+  // requests through to the api server — so it's the side that gets to use the
+  // host's `HOST`/`PORT` env vars.
+  options.webHost ??= getWebHost({ isPublicSide: true })
+  options.webPort ??= getWebPort({ isPublicSide: true })
   options.apiHost ??= getAPIHost()
   options.apiPort ??= getAPIPort()
 

--- a/packages/api-server/src/cliHelpers.ts
+++ b/packages/api-server/src/cliHelpers.ts
@@ -1,31 +1,94 @@
-import { getConfig } from '@cedarjs/project-config'
+import { getConfig, readEnvVar } from '@cedarjs/project-config'
 
-export function getAPIHost() {
-  let host = process.env.REDWOOD_API_HOST
+interface SideOptions {
+  /**
+   * Whether this side receives the deployment's public traffic.
+   *
+   * Container hosts (Railway, Render, Fly.io, Cloud Run, Heroku) tell an app
+   * which host and port to bind with the `HOST` and `PORT` env vars. Only the
+   * side serving public traffic falls back to them — when the api and web
+   * servers run in the same deployment they would otherwise both bind to
+   * `PORT` and collide.
+   *
+   * The web side is the public one whenever both sides are served together,
+   * because it proxies api requests. The api side is only public when it is
+   * served on its own.
+   */
+  isPublicSide?: boolean
+}
+
+function parsePort(value: string, envVarName: string) {
+  const port = parseInt(value, 10)
+
+  if (Number.isNaN(port)) {
+    throw new Error(
+      `Invalid ${envVarName} env var: "${value}". Must be an integer.`,
+    )
+  }
+
+  return port
+}
+
+export function getAPIHost({ isPublicSide = false }: SideOptions = {}) {
+  let host = readEnvVar('CEDAR_API_HOST', {
+    deprecatedAlias: 'REDWOOD_API_HOST',
+  })
+
+  if (isPublicSide) {
+    host ??= process.env.HOST
+  }
+
   host ??= getConfig().api.host
   host ??= process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::'
   return host
 }
 
-export function getAPIPort() {
-  return process.env.REDWOOD_API_PORT
-    ? parseInt(process.env.REDWOOD_API_PORT)
-    : getConfig().api.port
+export function getAPIPort({ isPublicSide = false }: SideOptions = {}) {
+  const apiPort = readEnvVar('CEDAR_API_PORT', {
+    deprecatedAlias: 'REDWOOD_API_PORT',
+  })
+
+  if (apiPort) {
+    return parsePort(apiPort, 'CEDAR_API_PORT')
+  }
+
+  if (isPublicSide && process.env.PORT) {
+    return parsePort(process.env.PORT, 'PORT')
+  }
+
+  return getConfig().api.port
 }
 
 export function getAPIRootPath() {
   return process.env.CEDAR_API_ROOT_PATH ?? '/'
 }
 
-export function getWebHost() {
-  let host = process.env.REDWOOD_WEB_HOST
+export function getWebHost({ isPublicSide = false }: SideOptions = {}) {
+  let host = readEnvVar('CEDAR_WEB_HOST', {
+    deprecatedAlias: 'REDWOOD_WEB_HOST',
+  })
+
+  if (isPublicSide) {
+    host ??= process.env.HOST
+  }
+
   host ??= getConfig().web.host
   host ??= process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::'
   return host
 }
 
-export function getWebPort() {
-  return process.env.REDWOOD_WEB_PORT
-    ? parseInt(process.env.REDWOOD_WEB_PORT)
-    : getConfig().web.port
+export function getWebPort({ isPublicSide = false }: SideOptions = {}) {
+  const webPort = readEnvVar('CEDAR_WEB_PORT', {
+    deprecatedAlias: 'REDWOOD_WEB_PORT',
+  })
+
+  if (webPort) {
+    return parsePort(webPort, 'CEDAR_WEB_PORT')
+  }
+
+  if (isPublicSide && process.env.PORT) {
+    return parsePort(process.env.PORT, 'PORT')
+  }
+
+  return getConfig().web.port
 }

--- a/packages/api-server/src/cliHelpers.ts
+++ b/packages/api-server/src/cliHelpers.ts
@@ -1,4 +1,4 @@
-import { getConfig, readEnvVar } from '@cedarjs/project-config'
+import { getConfig, parsePort, readEnvVar } from '@cedarjs/project-config'
 
 interface SideOptions {
   /**
@@ -15,18 +15,6 @@ interface SideOptions {
    * served on its own.
    */
   isPublicSide?: boolean
-}
-
-function parsePort(value: string, envVarName: string) {
-  const port = parseInt(value, 10)
-
-  if (Number.isNaN(port)) {
-    throw new Error(
-      `Invalid ${envVarName} env var: "${value}". Must be an integer.`,
-    )
-  }
-
-  return port
 }
 
 export function getAPIHost({ isPublicSide = false }: SideOptions = {}) {

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -165,11 +165,11 @@ export async function createServer(options: CreateServerOptions = {}) {
   })
 
   /**
-   * A wrapper around `fastify.listen` that handles `--apiPort`, `REDWOOD_API_PORT` and [api].port in cedar.toml (and redwood.toml) (same for host)
+   * A wrapper around `fastify.listen` that handles `--apiPort`, `CEDAR_API_PORT` and [api].port in cedar.toml (and redwood.toml) (same for host)
    *
    * The order of precedence is:
    * - `--apiPort`
-   * - `REDWOOD_API_PORT`
+   * - `CEDAR_API_PORT`
    * - [api].port in cedar.toml (and redwood.toml)
    */
   server.start = (options: StartOptions = {}) => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -165,8 +165,10 @@ export const builder = async (yargs: Argv) => {
 
           const apiPort = argv.apiPort ?? getAPIPort()
           const apiHost = argv.apiHost ?? getAPIHost()
-          const webPort = argv.webPort ?? getWebPort()
-          const webHost = argv.webHost ?? getWebHost()
+          // The web server is the one taking public traffic here, so it's the
+          // side that gets to use the host's `HOST`/`PORT` env vars.
+          const webPort = argv.webPort ?? getWebPort({ isPublicSide: true })
+          const webHost = argv.webHost ?? getWebHost({ isPublicSide: true })
 
           const apiRootPath = argv.apiRootPath ?? '/'
           const apiTarget = `http://${apiHost.includes(':') ? `[${apiHost}]` : apiHost}:${apiPort}`
@@ -287,6 +289,17 @@ export const builder = async (yargs: Argv) => {
           apiRootPath: argv.apiRootPath,
         })
 
+        // Serving the api on its own makes it the side taking public traffic,
+        // so it's the side that gets to use the host's `HOST`/`PORT` env vars.
+        const { getAPIHost, getAPIPort } =
+          await import('@cedarjs/api-server/cliHelpers')
+
+        const apiPort = argv.port ?? getAPIPort({ isPublicSide: true })
+        const apiHost = argv.host ?? getAPIHost({ isPublicSide: true })
+
+        argv.port = apiPort
+        argv.host = apiHost
+
         if (argv.ud) {
           // Import the built Fetchable and host it in-process with srvx.
           // The artifact at api/dist/ud/index.js is a pure Fetchable (`export
@@ -302,9 +315,6 @@ export const builder = async (yargs: Argv) => {
             )
             process.exit(1)
           }
-
-          const apiPort = argv.port ?? parseInt(process.env.PORT ?? '8911', 10)
-          const apiHost = argv.host ?? process.env.HOST ?? 'localhost'
 
           process.stdout.write(
             `API server starting at http://${apiHost}:${apiPort}...`,

--- a/packages/cli/src/commands/serveBothHandler.ts
+++ b/packages/cli/src/commands/serveBothHandler.ts
@@ -53,8 +53,10 @@ export const bothServerFileHandler = async (argv: ServeBothArgv) => {
   } else {
     argv.apiPort ??= getAPIPort()
     argv.apiHost ??= getAPIHost()
-    argv.webPort ??= getWebPort()
-    argv.webHost ??= getWebHost()
+    // The web server is the one taking public traffic here, so it's the side
+    // that gets to use the host's `HOST`/`PORT` env vars.
+    argv.webPort ??= getWebPort({ isPublicSide: true })
+    argv.webHost ??= getWebHost({ isPublicSide: true })
 
     const apiRootPath = argv.apiRootPath ?? getAPIRootPath()
 

--- a/packages/cli/src/commands/setup/docker/templates/docker-compose.dev.yml
+++ b/packages/cli/src/commands/setup/docker/templates/docker-compose.dev.yml
@@ -18,7 +18,7 @@ services:
       - SESSION_SECRET=super_secret_session_key_change_me_in_production_please
       - CI=
       - NODE_ENV=development
-      - REDWOOD_API_HOST=0.0.0.0
+      - CEDAR_API_HOST=0.0.0.0
 
   db:
     image: postgres:18-bookworm

--- a/packages/project-config/src/__tests__/envVars.test.ts
+++ b/packages/project-config/src/__tests__/envVars.test.ts
@@ -76,4 +76,16 @@ describe('parsePort', () => {
       'Invalid CEDAR_API_PORT env var value: "nope". Must be an integer.',
     )
   })
+
+  it('accepts the highest valid port', () => {
+    expect(parsePort('65535', 'PORT')).toBe(65535)
+  })
+
+  // Without this these reach `listen()` and fail with ERR_SOCKET_BAD_PORT,
+  // which doesn't tell you which env var was wrong
+  it.each(['65536', '99999999'])('rejects out-of-range %j', (value) => {
+    expect(() => parsePort(value, 'CEDAR_WEB_PORT')).toThrow(
+      `Invalid CEDAR_WEB_PORT env var value: "${value}". Must be between 0 and 65535.`,
+    )
+  })
 })

--- a/packages/project-config/src/__tests__/envVars.test.ts
+++ b/packages/project-config/src/__tests__/envVars.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+
+import { parsePort, readEnvVar } from '../envVars.js'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('readEnvVar', () => {
+  it('returns undefined when neither name is set', () => {
+    expect(
+      readEnvVar('CEDAR_THING', { deprecatedAlias: 'REDWOOD_THING' }),
+    ).toBe(undefined)
+  })
+
+  it('prefers the Cedar name over the deprecated alias', () => {
+    vi.stubEnv('CEDAR_THING', 'cedar')
+    vi.stubEnv('REDWOOD_THING', 'redwood')
+
+    expect(
+      readEnvVar('CEDAR_THING', { deprecatedAlias: 'REDWOOD_THING' }),
+    ).toBe('cedar')
+  })
+
+  it('falls back to the deprecated alias', () => {
+    vi.stubEnv('REDWOOD_THING', 'redwood')
+
+    expect(
+      readEnvVar('CEDAR_THING', { deprecatedAlias: 'REDWOOD_THING' }),
+    ).toBe('redwood')
+  })
+
+  it('treats an empty string as unset', () => {
+    vi.stubEnv('CEDAR_THING', '')
+    vi.stubEnv('REDWOOD_THING', 'redwood')
+
+    expect(
+      readEnvVar('CEDAR_THING', { deprecatedAlias: 'REDWOOD_THING' }),
+    ).toBe('redwood')
+  })
+})
+
+describe('parsePort', () => {
+  it('parses a whole number', () => {
+    expect(parsePort('8080', 'PORT')).toBe(8080)
+  })
+
+  it('ignores surrounding whitespace', () => {
+    expect(parsePort(' 8080 ', 'PORT')).toBe(8080)
+  })
+
+  it('parses zero', () => {
+    expect(parsePort('0', 'PORT')).toBe(0)
+  })
+
+  // `parseInt` stops at the first non-digit, so these used to be silently
+  // truncated to 8080 and 1 respectively, binding a port nobody asked for.
+  it.each([
+    ['8080abc', 'a numeric prefix'],
+    ['1.5', 'a decimal'],
+    ['-1', 'a negative number'],
+    ['8080 8081', 'two numbers'],
+    ['eight-oh-eight-oh', 'a non-number'],
+    ['', 'an empty string'],
+    ['   ', 'only whitespace'],
+    ['0x1f90', 'a hex literal'],
+    ['1e3', 'exponent notation'],
+  ])('rejects %j (%s)', (value) => {
+    expect(() => parsePort(value, 'PORT')).toThrowError(
+      `Invalid PORT env var. "${value}" must be an integer.`,
+    )
+  })
+
+  it('names the env var it was given', () => {
+    expect(() => parsePort('nope', 'CEDAR_API_PORT')).toThrowError(
+      'Invalid CEDAR_API_PORT env var. "nope" must be an integer.',
+    )
+  })
+})

--- a/packages/project-config/src/__tests__/envVars.test.ts
+++ b/packages/project-config/src/__tests__/envVars.test.ts
@@ -55,7 +55,7 @@ describe('parsePort', () => {
 
   // `parseInt` stops at the first non-digit, so these used to be silently
   // truncated to 8080 and 1 respectively, binding a port nobody asked for.
-  it.each([
+  it.each<[string, string]>([
     ['8080abc', 'a numeric prefix'],
     ['1.5', 'a decimal'],
     ['-1', 'a negative number'],
@@ -67,13 +67,13 @@ describe('parsePort', () => {
     ['1e3', 'exponent notation'],
   ])('rejects %j (%s)', (value) => {
     expect(() => parsePort(value, 'PORT')).toThrowError(
-      `Invalid PORT env var. "${value}" must be an integer.`,
+      `Invalid PORT env var value: "${value}". Must be an integer.`,
     )
   })
 
   it('names the env var it was given', () => {
     expect(() => parsePort('nope', 'CEDAR_API_PORT')).toThrowError(
-      'Invalid CEDAR_API_PORT env var. "nope" must be an integer.',
+      'Invalid CEDAR_API_PORT env var value: "nope". Must be an integer.',
     )
   })
 })

--- a/packages/project-config/src/__tests__/envVars.test.ts
+++ b/packages/project-config/src/__tests__/envVars.test.ts
@@ -55,7 +55,7 @@ describe('parsePort', () => {
 
   // `parseInt` stops at the first non-digit, so these used to be silently
   // truncated to 8080 and 1 respectively, binding a port nobody asked for.
-  it.each<[string, string]>([
+  it.each([
     ['8080abc', 'a numeric prefix'],
     ['1.5', 'a decimal'],
     ['-1', 'a negative number'],
@@ -66,13 +66,13 @@ describe('parsePort', () => {
     ['0x1f90', 'a hex literal'],
     ['1e3', 'exponent notation'],
   ])('rejects %j (%s)', (value) => {
-    expect(() => parsePort(value, 'PORT')).toThrowError(
+    expect(() => parsePort(value, 'PORT')).toThrow(
       `Invalid PORT env var value: "${value}". Must be an integer.`,
     )
   })
 
   it('names the env var it was given', () => {
-    expect(() => parsePort('nope', 'CEDAR_API_PORT')).toThrowError(
+    expect(() => parsePort('nope', 'CEDAR_API_PORT')).toThrow(
       'Invalid CEDAR_API_PORT env var value: "nope". Must be an integer.',
     )
   })

--- a/packages/project-config/src/envVars.ts
+++ b/packages/project-config/src/envVars.ts
@@ -21,3 +21,23 @@ export function readEnvVar(
 ): string | undefined {
   return process.env[name] || process.env[deprecatedAlias] || undefined
 }
+
+/**
+ * Parse a port from an env var, rejecting anything that isn't a whole number.
+ *
+ * `parseInt` alone is not enough here: it stops at the first non-digit, so
+ * `"8080abc"` would become `8080` and `"1.5"` would become `1`. Silently
+ * binding a port the user didn't ask for is how a deployment ends up
+ * unreachable, so the whole value has to look like an integer.
+ */
+export function parsePort(value: string, envVarName: string): number {
+  const trimmed = value.trim()
+
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(
+      `Invalid ${envVarName} env var. "${value}" must be an integer.`,
+    )
+  }
+
+  return Number(trimmed)
+}

--- a/packages/project-config/src/envVars.ts
+++ b/packages/project-config/src/envVars.ts
@@ -35,7 +35,7 @@ export function parsePort(value: string, envVarName: string): number {
 
   if (!/^\d+$/.test(trimmed)) {
     throw new Error(
-      `Invalid ${envVarName} env var. "${value}" must be an integer.`,
+      `Invalid ${envVarName} env var value: "${value}". Must be an integer.`,
     )
   }
 

--- a/packages/project-config/src/envVars.ts
+++ b/packages/project-config/src/envVars.ts
@@ -23,12 +23,16 @@ export function readEnvVar(
 }
 
 /**
- * Parse a port from an env var, rejecting anything that isn't a whole number.
+ * Parse a port from an env var, rejecting anything that isn't a usable port.
  *
  * `parseInt` alone is not enough here: it stops at the first non-digit, so
  * `"8080abc"` would become `8080` and `"1.5"` would become `1`. Silently
  * binding a port the user didn't ask for is how a deployment ends up
  * unreachable, so the whole value has to look like an integer.
+ *
+ * Out-of-range values are rejected here too, so a bad env var is reported as
+ * a bad env var rather than surfacing later as a `ERR_SOCKET_BAD_PORT` from
+ * `listen()`. Port 0 is allowed — it means "pick a free port".
  */
 export function parsePort(value: string, envVarName: string): number {
   const trimmed = value.trim()
@@ -39,5 +43,13 @@ export function parsePort(value: string, envVarName: string): number {
     )
   }
 
-  return Number(trimmed)
+  const port = Number(trimmed)
+
+  if (port > 65535) {
+    throw new Error(
+      `Invalid ${envVarName} env var value: "${value}". Must be between 0 and 65535.`,
+    )
+  }
+
+  return port
 }

--- a/packages/project-config/src/envVars.ts
+++ b/packages/project-config/src/envVars.ts
@@ -1,0 +1,23 @@
+interface ReadEnvVarOptions {
+  /**
+   * The pre-fork `REDWOOD_`-prefixed name for this env var. Still read, so
+   * projects don't break on upgrade, but the `CEDAR_`-prefixed name wins.
+   */
+  deprecatedAlias: string
+}
+
+/**
+ * Read an env var that was renamed when Cedar forked from Redwood.
+ *
+ * The `CEDAR_`-prefixed name wins. The `REDWOOD_`-prefixed one keeps working
+ * so existing projects don't break on upgrade.
+ *
+ * Empty strings are treated as unset, matching how a `.env` file with a blank
+ * value behaves.
+ */
+export function readEnvVar(
+  name: string,
+  { deprecatedAlias }: ReadEnvVarOptions,
+): string | undefined {
+  return process.env[name] || process.env[deprecatedAlias] || undefined
+}

--- a/packages/project-config/src/index.ts
+++ b/packages/project-config/src/index.ts
@@ -1,5 +1,6 @@
 export * from './config.js'
 export * from './configPath.js'
+export * from './envVars.js'
 export * from './generatedDataDir.js'
 export * from './paths.js'
 export * from './findUp.js'

--- a/packages/vite/src/lib/__tests__/portEnvVars.test.ts
+++ b/packages/vite/src/lib/__tests__/portEnvVars.test.ts
@@ -1,0 +1,56 @@
+import path from 'node:path'
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  afterEach,
+} from 'vitest'
+
+let original_CEDAR_CWD: string | undefined
+
+beforeAll(() => {
+  original_CEDAR_CWD = process.env.CEDAR_CWD
+  process.env.CEDAR_CWD = path.join(
+    import.meta.dirname,
+    '..',
+    '..',
+    '..',
+    '..',
+    '..',
+    '__fixtures__',
+    'cedar-ud-app',
+  )
+})
+
+afterAll(() => {
+  process.env.CEDAR_CWD = original_CEDAR_CWD
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+// `parseInt` accepts a numeric prefix, so these used to configure the Vite
+// proxy as port 8080 and 1 respectively, silently sending API traffic to a
+// listener nobody asked for.
+describe('getMergedConfig with a malformed CEDAR_API_PORT', () => {
+  it.each(['8080abc', '1.5'])('rejects %j', async (value) => {
+    vi.stubEnv('CEDAR_API_PORT', value)
+
+    const { getConfig, getPaths } = await import('@cedarjs/project-config')
+    const { getMergedConfig } = await import('../getMergedConfig.js')
+
+    expect(() =>
+      getMergedConfig(getConfig(), getPaths())(
+        {},
+        { command: 'serve', mode: 'development' },
+      ),
+    ).toThrowError(
+      `Invalid CEDAR_API_PORT env var value: "${value}". Must be an integer.`,
+    )
+  })
+})

--- a/packages/vite/src/lib/getMergedConfig.ts
+++ b/packages/vite/src/lib/getMergedConfig.ts
@@ -8,6 +8,7 @@ import {
   getConfig,
   getEnvVarDefinitions,
   getPaths,
+  readEnvVar,
 } from '@cedarjs/project-config'
 
 import { getWorkspacePackageAliases } from './workspacePackageAliases.js'
@@ -29,7 +30,9 @@ export function getMergedConfig(cedarConfig: Config, cedarPaths: Paths) {
         ? getWorkspacePackageAliases(cedarPaths, cedarConfig)
         : {}
 
-    let apiHost = process.env.REDWOOD_API_HOST
+    let apiHost = readEnvVar('CEDAR_API_HOST', {
+      deprecatedAlias: 'REDWOOD_API_HOST',
+    })
     apiHost ??= cedarConfig.api.host
     // In dev, use the IPv4 loopback so Node's http-proxy can connect to the
     // API server. Vite's proxy library does a DNS lookup on the literal string
@@ -39,9 +42,13 @@ export function getMergedConfig(cedarConfig: Config, cedarPaths: Paths) {
     // @MARK: note that most RSC settings sit in their individual build functions
     const rscEnabled = cedarConfig.experimental.rsc?.enabled
 
+    const apiPortEnvVar = readEnvVar('CEDAR_API_PORT', {
+      deprecatedAlias: 'REDWOOD_API_PORT',
+    })
+
     let apiPort
-    if (process.env.REDWOOD_API_PORT) {
-      apiPort = parseInt(process.env.REDWOOD_API_PORT)
+    if (apiPortEnvVar) {
+      apiPort = parseInt(apiPortEnvVar)
     } else {
       apiPort = cedarConfig.api.port
     }

--- a/packages/vite/src/lib/getMergedConfig.ts
+++ b/packages/vite/src/lib/getMergedConfig.ts
@@ -8,6 +8,7 @@ import {
   getConfig,
   getEnvVarDefinitions,
   getPaths,
+  parsePort,
   readEnvVar,
 } from '@cedarjs/project-config'
 
@@ -48,7 +49,7 @@ export function getMergedConfig(cedarConfig: Config, cedarPaths: Paths) {
 
     let apiPort
     if (apiPortEnvVar) {
-      apiPort = parseInt(apiPortEnvVar)
+      apiPort = parsePort(apiPortEnvVar, 'CEDAR_API_PORT')
     } else {
       apiPort = cedarConfig.api.port
     }

--- a/packages/vite/src/lib/registerFwGlobalsAndShims.ts
+++ b/packages/vite/src/lib/registerFwGlobalsAndShims.ts
@@ -1,6 +1,10 @@
 import { createRequire } from 'node:module'
 
-import { getConfig, getEnvVarDefinitions } from '@cedarjs/project-config'
+import {
+  getConfig,
+  getEnvVarDefinitions,
+  readEnvVar,
+} from '@cedarjs/project-config'
 
 /**
  * Use this function on the web server
@@ -31,13 +35,19 @@ function registerFwGlobals() {
       if (/^[a-zA-Z][a-zA-Z\d+\-.]*?:/.test(apiPath)) {
         return apiPath
       } else {
-        let webHost = process.env.REDWOOD_WEB_HOST
+        let webHost = readEnvVar('CEDAR_WEB_HOST', {
+          deprecatedAlias: 'REDWOOD_WEB_HOST',
+        })
         webHost ??= rwConfig.web.host
         webHost ??= process.env.NODE_ENV === 'production' ? '0.0.0.0' : '[::]'
 
+        const webPortEnvVar = readEnvVar('CEDAR_WEB_PORT', {
+          deprecatedAlias: 'REDWOOD_WEB_PORT',
+        })
+
         let webPort
-        if (process.env.REDWOOD_WEB_PORT) {
-          webPort = parseInt(process.env.REDWOOD_WEB_PORT)
+        if (webPortEnvVar) {
+          webPort = parseInt(webPortEnvVar)
         } else {
           webPort = rwConfig.web.port
         }

--- a/packages/vite/src/lib/registerFwGlobalsAndShims.ts
+++ b/packages/vite/src/lib/registerFwGlobalsAndShims.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module'
 import {
   getConfig,
   getEnvVarDefinitions,
+  parsePort,
   readEnvVar,
 } from '@cedarjs/project-config'
 
@@ -47,7 +48,7 @@ function registerFwGlobals() {
 
         let webPort
         if (webPortEnvVar) {
-          webPort = parseInt(webPortEnvVar)
+          webPort = parsePort(webPortEnvVar, 'CEDAR_WEB_PORT')
         } else {
           webPort = rwConfig.web.port
         }

--- a/packages/web-server/src/webServer.ts
+++ b/packages/web-server/src/webServer.ts
@@ -5,9 +5,21 @@ import ansis from 'ansis'
 import Fastify from 'fastify'
 
 import { redwoodFastifyWeb } from '@cedarjs/fastify-web'
-import { getConfig, getPaths } from '@cedarjs/project-config'
+import { getConfig, getPaths, readEnvVar } from '@cedarjs/project-config'
 
 import type { ParsedOptions } from './types.js'
+
+function parsePort(value: string, envVarName: string) {
+  const port = parseInt(value, 10)
+
+  if (Number.isNaN(port)) {
+    throw new Error(
+      `Invalid ${envVarName} env var: "${value}". Must be an integer.`,
+    )
+  }
+
+  return port
+}
 
 export async function serveWeb(options: ParsedOptions = {}) {
   const start = Date.now()
@@ -22,12 +34,30 @@ export async function serveWeb(options: ParsedOptions = {}) {
     )
   }
 
-  if (process.env.REDWOOD_WEB_PORT) {
-    options.port ??= parseInt(process.env.REDWOOD_WEB_PORT)
+  // NOTE: This mirrors `getWebHost`/`getWebPort` in @cedarjs/api-server's
+  // cliHelpers. It's duplicated because this package doesn't depend on
+  // @cedarjs/api-server.
+  //
+  // `HOST`/`PORT` are how container hosts (Railway, Render, Fly.io, Cloud Run,
+  // Heroku) tell an app what to bind to. They're only consulted when nothing
+  // more specific was given, which means they don't apply when both sides are
+  // served together — `cedar serve` passes an explicit `--port` to this server.
+  const webPort = readEnvVar('CEDAR_WEB_PORT', {
+    deprecatedAlias: 'REDWOOD_WEB_PORT',
+  })
+
+  if (webPort) {
+    options.port ??= parsePort(webPort, 'CEDAR_WEB_PORT')
+  }
+  if (process.env.PORT) {
+    options.port ??= parsePort(process.env.PORT, 'PORT')
   }
   options.port ??= getConfig().web.port
 
-  options.host ??= process.env.REDWOOD_WEB_HOST
+  options.host ??= readEnvVar('CEDAR_WEB_HOST', {
+    deprecatedAlias: 'REDWOOD_WEB_HOST',
+  })
+  options.host ??= process.env.HOST
   options.host ??= getConfig().web.host
   options.host ??= process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::'
 

--- a/packages/web-server/src/webServer.ts
+++ b/packages/web-server/src/webServer.ts
@@ -5,21 +5,14 @@ import ansis from 'ansis'
 import Fastify from 'fastify'
 
 import { redwoodFastifyWeb } from '@cedarjs/fastify-web'
-import { getConfig, getPaths, readEnvVar } from '@cedarjs/project-config'
+import {
+  getConfig,
+  getPaths,
+  parsePort,
+  readEnvVar,
+} from '@cedarjs/project-config'
 
 import type { ParsedOptions } from './types.js'
-
-function parsePort(value: string, envVarName: string) {
-  const port = parseInt(value, 10)
-
-  if (Number.isNaN(port)) {
-    throw new Error(
-      `Invalid ${envVarName} env var: "${value}". Must be an integer.`,
-    )
-  }
-
-  return port
-}
 
 export async function serveWeb(options: ParsedOptions = {}) {
   const start = Date.now()

--- a/tasks/server-tests/bothServerAPI.test.mts
+++ b/tasks/server-tests/bothServerAPI.test.mts
@@ -17,20 +17,20 @@ describe.each([[[cedar, 'serve']], [cedarServer]])('serve both (%s)', (cmd) => {
       await test({ apiPort })
     })
 
-    it("`REDWOOD_API_PORT` changes the api server's port", async () => {
-      process.env.REDWOOD_API_PORT = '8921'
-      const apiPort = +process.env.REDWOOD_API_PORT
+    it("`CEDAR_API_PORT` changes the api server's port", async () => {
+      process.env.CEDAR_API_PORT = '8921'
+      const apiPort = +process.env.CEDAR_API_PORT
       testContext.p = $`yarn node ${cmd}`
       await test({ apiPort })
-      delete process.env.REDWOOD_API_PORT
+      delete process.env.CEDAR_API_PORT
     })
 
-    it('`--apiPort` takes precedence over `REDWOOD_API_PORT`', async () => {
+    it('`--apiPort` takes precedence over `CEDAR_API_PORT`', async () => {
       const apiPort = 8922
-      process.env.REDWOOD_API_PORT = '8923'
+      process.env.CEDAR_API_PORT = '8923'
       testContext.p = $`yarn node ${cmd} --apiPort ${apiPort}`
       await test({ apiPort })
-      delete process.env.REDWOOD_API_PORT
+      delete process.env.CEDAR_API_PORT
     })
 
     it('`[api].port` changes the port', async () => {
@@ -46,20 +46,20 @@ describe.each([[[cedar, 'serve']], [cedarServer]])('serve both (%s)', (cmd) => {
       await test({ apiHost })
     })
 
-    it("`REDWOOD_API_HOST` changes the api server's host", async () => {
-      process.env.REDWOOD_API_HOST = '::1'
-      const apiHost = process.env.REDWOOD_API_HOST
+    it("`CEDAR_API_HOST` changes the api server's host", async () => {
+      process.env.CEDAR_API_HOST = '::1'
+      const apiHost = process.env.CEDAR_API_HOST
       testContext.p = $`yarn node ${cmd}`
       await test({ apiHost })
-      delete process.env.REDWOOD_API_HOST
+      delete process.env.CEDAR_API_HOST
     })
 
-    it('`--apiHost` takes precedence over `REDWOOD_API_HOST`', async () => {
+    it('`--apiHost` takes precedence over `CEDAR_API_HOST`', async () => {
       const apiHost = '::'
-      process.env.REDWOOD_API_HOST = '0.0.0.0'
+      process.env.CEDAR_API_HOST = '0.0.0.0'
       testContext.p = $`yarn node ${cmd} --apiHost ${apiHost}`
       await test({ apiHost })
-      delete process.env.REDWOOD_API_HOST
+      delete process.env.CEDAR_API_HOST
     })
 
     it("`[api].host` changes the api server's host", async () => {

--- a/tasks/server-tests/bothServerWeb.test.mts
+++ b/tasks/server-tests/bothServerWeb.test.mts
@@ -11,20 +11,20 @@ describe.each([[[cedar, 'serve']], [cedarServer]])('serve both (%s)', (cmd) => {
       await test({ webPort })
     })
 
-    it("`REDWOOD_WEB_PORT` changes the web server's port", async () => {
-      process.env.REDWOOD_WEB_PORT = '8921'
-      const webPort = +process.env.REDWOOD_WEB_PORT
+    it("`CEDAR_WEB_PORT` changes the web server's port", async () => {
+      process.env.CEDAR_WEB_PORT = '8921'
+      const webPort = +process.env.CEDAR_WEB_PORT
       testContext.p = $`yarn node ${cmd}`
       await test({ webPort })
-      delete process.env.REDWOOD_WEB_PORT
+      delete process.env.CEDAR_WEB_PORT
     })
 
-    it('`--webPort` takes precedence over `REDWOOD_WEB_PORT`', async () => {
+    it('`--webPort` takes precedence over `CEDAR_WEB_PORT`', async () => {
       const webPort = 8922
-      process.env.REDWOOD_WEB_PORT = '8923'
+      process.env.CEDAR_WEB_PORT = '8923'
       testContext.p = $`yarn node ${cmd} --webPort ${webPort}`
       await test({ webPort })
-      delete process.env.REDWOOD_WEB_PORT
+      delete process.env.CEDAR_WEB_PORT
     })
 
     it('`[web].port` changes the port', async () => {
@@ -40,20 +40,20 @@ describe.each([[[cedar, 'serve']], [cedarServer]])('serve both (%s)', (cmd) => {
       await test({ webHost })
     })
 
-    it("`REDWOOD_WEB_HOST` changes the web server's host", async () => {
-      process.env.REDWOOD_WEB_HOST = '::1'
-      const webHost = process.env.REDWOOD_WEB_HOST
+    it("`CEDAR_WEB_HOST` changes the web server's host", async () => {
+      process.env.CEDAR_WEB_HOST = '::1'
+      const webHost = process.env.CEDAR_WEB_HOST
       testContext.p = $`yarn node ${cmd}`
       await test({ webHost })
-      delete process.env.REDWOOD_WEB_HOST
+      delete process.env.CEDAR_WEB_HOST
     })
 
-    it('`--webHost` takes precedence over `REDWOOD_WEB_HOST`', async () => {
+    it('`--webHost` takes precedence over `CEDAR_WEB_HOST`', async () => {
       const webHost = '::'
-      process.env.REDWOOD_WEB_HOST = '0.0.0.0'
+      process.env.CEDAR_WEB_HOST = '0.0.0.0'
       testContext.p = $`yarn node ${cmd} --webHost ${webHost}`
       await test({ webHost })
-      delete process.env.REDWOOD_WEB_HOST
+      delete process.env.CEDAR_WEB_HOST
     })
 
     it("`[web].host` changes the web server's host", async () => {


### PR DESCRIPTION
Two related deploy fixes that together let a Cedar app deploy to a container host with no configuration files at all.

**Breaking change:** `serve api --ud` now goes through the shared helpers instead of its own inline `process.env.PORT ?? '8911'`. That means its default host goes from `localhost` to `::` in dev / `0.0.0.0` in production, matching every other serve path. 

## 1. Read `PORT` and `HOST`

Every container PaaS (Railway, Render, Fly.io, Cloud Run, Heroku, App Runner) tells an app what to bind to via `PORT`/`HOST`. Cedar only read its own env vars, so all of them needed an explicit `--port` in the start command. Only the `--ud` api path honored `PORT`, which made it inconsistent as well as inconvenient.

`PORT` can't just be read by both sides. `cedar serve` runs the api and web servers in a single process, so both would bind it and collide with `EADDRINUSE` on exactly the platforms this is meant to help. It's therefore opt-in per side via `isPublicSide`:

- **web is public** whenever both sides are served together (it proxies api requests)
- **api is public** only when served on its own

Applied at the four call sites that know the topology, with a regression test pinning it.

Also adds a `NaN` guard. A non-integer port now throws a clear error instead of silently binding a random port.

## 2. Rename port/host env vars to `CEDAR_*`

`CEDAR_API_PORT`, `CEDAR_WEB_PORT`, `CEDAR_API_HOST` and `CEDAR_WEB_HOST` are now the primary names. The `REDWOOD_*` ones still work as **silent** fallbacks, matching how other `CEDAR_*`/`REDWOOD_*` vars already handle their aliases.

The lookup lives in a new `readEnvVar` in `@cedarjs/project-config`, which every affected package already depends on. That also removes the host/port duplication that existed between `@cedarjs/api-server` and `@cedarjs/web-server`.

## Resolution order

1. CLI flags (`--port`, `--host`, `--api-port`, …)
2. `CEDAR_API_PORT` / `CEDAR_WEB_PORT` (and `_HOST` equivalents)
3. `PORT` / `HOST` — public side only
4. `[api].port` / `[web].port` in `cedar.toml`
5. Built-in default