### PR TITLE
feat(create-cedar-app): Add `build` and `start` scripts to app templates

### DIFF
--- a/__fixtures__/test-project-esm/package.json
+++ b/__fixtures__/test-project-esm/package.json
@@ -6,6 +6,11 @@
     "web",
     "packages/*"
   ],
+  "scripts": {
+    "build": "cedar build",
+    "dev": "cedar dev",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/__fixtures__/test-project-esm/package.json
+++ b/__fixtures__/test-project-esm/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -6,6 +6,11 @@
     "web",
     "packages/*"
   ],
+  "scripts": {
+    "build": "cedar build",
+    "dev": "cedar dev",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/esm-js/package.json
+++ b/packages/create-cedar-app/templates/esm-js/package.json
@@ -5,6 +5,10 @@
     "api",
     "web"
   ],
+  "scripts": {
+    "build": "cedar build",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/packages/create-cedar-app/templates/esm-js/package.json
+++ b/packages/create-cedar-app/templates/esm-js/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/esm-js/package.json
+++ b/packages/create-cedar-app/templates/esm-js/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "build": "cedar build",
+    "dev": "cedar dev",
     "start": "cedar serve"
   },
   "devDependencies": {

--- a/packages/create-cedar-app/templates/esm-ts/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/package.json
@@ -5,6 +5,10 @@
     "api",
     "web"
   ],
+  "scripts": {
+    "build": "cedar build",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/packages/create-cedar-app/templates/esm-ts/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/esm-ts/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "build": "cedar build",
+    "dev": "cedar dev",
     "start": "cedar serve"
   },
   "devDependencies": {

--- a/packages/create-cedar-app/templates/js/package.json
+++ b/packages/create-cedar-app/templates/js/package.json
@@ -5,6 +5,10 @@
     "api",
     "web"
   ],
+  "scripts": {
+    "build": "cedar build",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/packages/create-cedar-app/templates/js/package.json
+++ b/packages/create-cedar-app/templates/js/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/js/package.json
+++ b/packages/create-cedar-app/templates/js/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "build": "cedar build",
+    "dev": "cedar dev",
     "start": "cedar serve"
   },
   "devDependencies": {

--- a/packages/create-cedar-app/templates/overlays/cjs/npm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/npm/package.json
@@ -5,6 +5,10 @@
     "api",
     "web"
   ],
+  "scripts": {
+    "build": "cedar build",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/cjs/npm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/npm/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/cjs/npm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/npm/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "build": "cedar build",
+    "dev": "cedar dev",
     "start": "cedar serve"
   },
   "devDependencies": {

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -3,6 +3,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "cedar build",
+    "dev": "cedar dev",
     "start": "cedar serve"
   },
   "devDependencies": {

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -1,6 +1,10 @@
 {
   "private": true,
   "type": "commonjs",
+  "scripts": {
+    "build": "cedar build",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -4,7 +4,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/cjs/yarn/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/yarn/package.json
@@ -5,6 +5,10 @@
     "api",
     "web"
   ],
+  "scripts": {
+    "build": "cedar build",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/cjs/yarn/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/yarn/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/cjs/yarn/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/yarn/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "build": "cedar build",
+    "dev": "cedar dev",
     "start": "cedar serve"
   },
   "devDependencies": {

--- a/packages/create-cedar-app/templates/overlays/esm/npm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/npm/package.json
@@ -5,6 +5,10 @@
     "api",
     "web"
   ],
+  "scripts": {
+    "build": "cedar build",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/esm/npm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/npm/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/esm/npm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/npm/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "build": "cedar build",
+    "dev": "cedar dev",
     "start": "cedar serve"
   },
   "devDependencies": {

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -1,6 +1,10 @@
 {
   "private": true,
   "type": "module",
+  "scripts": {
+    "build": "cedar build",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -4,7 +4,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "scripts": {
     "build": "cedar build",
+    "dev": "cedar dev",
     "start": "cedar serve"
   },
   "devDependencies": {

--- a/packages/create-cedar-app/templates/overlays/esm/yarn/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/yarn/package.json
@@ -5,6 +5,10 @@
     "api",
     "web"
   ],
+  "scripts": {
+    "build": "cedar build",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/esm/yarn/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/yarn/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/esm/yarn/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/yarn/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "build": "cedar build",
+    "dev": "cedar dev",
     "start": "cedar serve"
   },
   "devDependencies": {

--- a/packages/create-cedar-app/templates/ts/package.json
+++ b/packages/create-cedar-app/templates/ts/package.json
@@ -5,6 +5,10 @@
     "api",
     "web"
   ],
+  "scripts": {
+    "build": "cedar build",
+    "start": "cedar serve"
+  },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",
     "@cedarjs/eslint-config": "5.0.6",

--- a/packages/create-cedar-app/templates/ts/package.json
+++ b/packages/create-cedar-app/templates/ts/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve"
+    "start": "cedar serve",
+    "start:api": "cedar serve api",
+    "start:web": "cedar serve web"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/ts/package.json
+++ b/packages/create-cedar-app/templates/ts/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "build": "cedar build",
+    "dev": "cedar dev",
     "start": "cedar serve"
   },
   "devDependencies": {


### PR DESCRIPTION
Implements #2 from `docs/implementation-plans/2026-08-03-deploy-simplification.md`.

## Problem

Generated Cedar apps have no `scripts` key in their root `package.json` at all.

Zero-config builders — Railpack (Railway), Nixpacks, Paketo (DigitalOcean), Google Cloud buildpacks, Heroku — detect a start command in the order `start` script → `main` → `index.js`, and run `build` if one is defined. A Cedar app offers none of those, so detection finds nothing and every container host forces you into config-as-code just to boot the app.

## Change

Adds to the root `package.json` of all four templates and all six package-manager overlays:

```json
"scripts": {
  "build": "cedar build",
  "dev": "cedar dev",
  "start": "cedar serve",
  "start:api": "cedar serve api",
  "start:web": "cedar serve web"
}
```

The `cedar` bin comes from `@cedarjs/core` (`packages/core/package.json:13`), already a root devDependency in every template, so it resolves from `node_modules/.bin` under yarn, npm and pnpm alike.

Overlays are included because they replace the base template's root `package.json` wholesale (see the comment in `scripts/generateLockfile.js`) — without them npm and pnpm projects would miss out. The two CI-verified fixtures (`test-project`, `test-project-esm`) are updated to match.

## Topology decision this encodes

`start` is the **single-container** path and `start:api` / `start:web` are the **two-service** path. Both ship deliberately:

- **Single-container is the convenient topology.** It needs no service-to-service wiring — the web server proxies to the api in-process — which is precisely why one `start` script plus `PORT` handling yields a working deploy with no per-platform integration to write or maintain.
- **api-process + static/CDN web remains the recommended topology.** It's what the generated Dockerfile, the baremetal nginx setup and the Render blueprint all use, and it avoids serving assets through the un-tuned `@fastify/static`.

**Considered and rejected:** `start` scripts in `api/package.json` and `web/package.json`. Railway's JS monorepo autodetection would pick them up and stage a service per package (it keeps the monorepo root and uses workspace-filtered commands, so installing works). But it's Railway-only, and it still leaves the proxy target unset — a half-staged two-service deploy that fails until you find the right setting is worse than one service that works immediately.

## Platform support is two-tier, not uniform

`start` resolves the `cedar` bin from a root **devDependency**. That's fine on platforms that keep devDependencies around for the start step. It is not fine on the ones that prune them by default before running `start`:

- **Genuinely zero-config** — Railway (Railpack), Render, Google Cloud Run, Coolify, Dokku, Dokploy, Koyeb, Northflank. Nothing extra needed.
- **Supported, but not zero-config** — **Heroku** and **DigitalOcean App Platform (Paketo)** both strip `devDependencies` after build by default, so `start` fails there (command not found) unless pruning is disabled — `NPM_CONFIG_PRODUCTION=false` / `YARN_PRODUCTION=false` on Heroku, `YARN2_SKIP_PRUNING=true` / `NPM_CONFIG_PRODUCTION=false` on DigitalOcean. With that one env var set, both work fine.

#2302 tracks moving `start` off the CLI and onto a runtime dependency (`@cedarjs/api-server`'s `cedarjs-server` bin), which would make Heroku and DigitalOcean genuinely zero-config too. Not blocking this PR on it — landing now with the caveat above documented, since the CLI-based `start` already unblocks the platforms in the first tier and is a strict improvement over today's no-scripts-at-all baseline everywhere else.

## Pairs with #2292

That PR makes `PORT` apply to the public side only, so under `cedar serve` the web side picks up `$PORT` while the api stays on 8911 internally.