### PR TITLE
fix(api-server): Make `@cedarjs/internal` an optional peer dependency

### DIFF
--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -103,7 +103,6 @@
     "@cedarjs/api": "workspace:*",
     "@cedarjs/context": "workspace:*",
     "@cedarjs/fastify-web": "workspace:*",
-    "@cedarjs/internal": "workspace:*",
     "@cedarjs/project-config": "workspace:*",
     "@cedarjs/web-server": "workspace:*",
     "@fastify/multipart": "9.4.0",
@@ -124,6 +123,7 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
+    "@cedarjs/internal": "workspace:*",
     "@types/aws-lambda": "8.10.162",
     "@types/dotenv-defaults": "^5.0.0",
     "@types/split2": "4.2.3",
@@ -138,10 +138,14 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@cedarjs/graphql-server": "workspace:*"
+    "@cedarjs/graphql-server": "workspace:*",
+    "@cedarjs/internal": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@cedarjs/graphql-server": {
+      "optional": true
+    },
+    "@cedarjs/internal": {
       "optional": true
     }
   },

--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -4,6 +4,12 @@ import ansis from 'ansis'
 import chokidar from 'chokidar'
 import { config } from 'dotenv-defaults'
 
+// `@cedarjs/internal` is an optional peer dependency, not a regular one, so
+// that it stays out of production installs — it pulls in Babel and the whole
+// graphql-codegen suite. This watcher is the only thing in this package that
+// needs it, and it only ever runs under `cedar dev`, where `@cedarjs/cli`
+// provides it. Keep it that way: nothing reachable from `bin.ts` may import
+// `@cedarjs/internal`.
 import {
   buildApi,
   cleanApiBuild,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,8 +2092,11 @@ __metadata:
     yargs: "npm:17.7.3"
   peerDependencies:
     "@cedarjs/graphql-server": "workspace:*"
+    "@cedarjs/internal": "workspace:*"
   peerDependenciesMeta:
     "@cedarjs/graphql-server":
+      optional: true
+    "@cedarjs/internal":
       optional: true
   bin:
     cedar-api-server-watch: ./dist/watch.js


### PR DESCRIPTION
## Problem

`@cedarjs/api-server` declared `@cedarjs/internal` as a regular `dependency`. That drags the full Babel toolchain and ~13 `@graphql-codegen/*` packages plus `@graphql-tools/*` into every production install — roughly 25 MB in this repo's *deduped* `node_modules`, more standalone. It also pulls `@cedarjs/structure`, `@cedarjs/babel-config`, `@cedarjs/cli-helpers` and `@cedarjs/router` (a web router, in an API server's production tree).

That's what made `@cedarjs/api-server` unusable as a production dependency, and it's the same bloat objection that was raised against promoting `@cedarjs/core`.

## Nothing on the serve path actually uses it

`@cedarjs/internal` has exactly one importer: `watch.ts:11-12`, the dev watcher. It isn't reachable from `bin.ts` → `bothCLIConfigHandler` → `createServer`.

`build.mts` builds `watch.ts` as its own bin entry with `packages: 'external'`, so this is verifiable in the built output:

```
$ rg -l "@cedarjs/internal" packages/api-server/dist/
packages/api-server/dist/watch.js
```

`dist/bin.js` — the `cedarjs-server` production bin — has zero references.

This also finishes a decoupling that was already underway: `lambdaLoader.ts:169-171` carries a comment explaining that a helper was copied inline "to avoid depending on @cedarjs/internal."

## Change

Declares it as an **optional peer dependency**, matching the pattern this package already uses for `@cedarjs/graphql-server`:

- removed from `dependencies`
- added to `peerDependencies` + `peerDependenciesMeta.optional`
- added to `devDependencies` so the package's own build and tests resolve it

Satisfied under `cedar dev` (`@cedarjs/cli:39` depends on `@cedarjs/internal` directly), absent in production.

### Why an optional peer rather than just `devDependencies`

A published package's `devDependencies` aren't installed for consumers. Under yarn/npm's hoisted layout `dist/watch.js` would still resolve `@cedarjs/internal` from the root by accident, but under **pnpm's isolated layout it would not** — `cedar dev` would break for pnpm projects. An optional peer states the requirement explicitly and resolves correctly under all three package managers.

A comment in `watch.ts` records the constraint so the dependency doesn't creep back in.

## Result

This brings `@cedarjs/api-server` in line with `@cedarjs/web-server`, which is already a clean runtime-only package (`fastify-web` + `project-config` + fastify + small utilities). Same layering, same bin pattern — the two sides are now symmetric, and `cedarjs-server` becomes viable as a `start` command.

## Testing

- `yarn workspace @cedarjs/api-server test --run` — 100 passed, 2 skipped
- `yarn workspace @cedarjs/api-server build` — clean; verified `dist/bin.js` has no `@cedarjs/internal` references
- `yarn workspace @cedarjs/{cli,core,vite} build` — all clean (direct dependents)
- `yarn constraints` — clean
- `yarn install` — no new peer warnings; lockfile diff is 3 lines

## Note

`chokidar` is also watcher-only but stays a regular dependency — it's small and genuinely a runtime package, unlike a build toolchain. Worth revisiting only if `@cedarjs/api-server`'s dependency list gets a broader audit.