### PR TITLE
fix(graphql): Fail loudly when GraphQL options cannot be extracted

### DIFF
--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -146,7 +146,15 @@ export async function redwoodFastifyGraphQLServer(
       done()
     })
   } catch (e) {
-    console.log(e)
+    // Rethrow rather than swallow. Anything thrown in here means no GraphQL
+    // routes got registered, so the server would come up healthy while 404ing
+    // /graphql and everything under it. Failing to start with the actual cause
+    // is far easier to diagnose than a silently empty route table.
+    const message = e instanceof Error ? e.message : String(e)
+
+    fastify.log.error(e, `Failed to set up the GraphQL server: ${message}`)
+
+    throw e
   }
 }
 

--- a/packages/internal/src/build/__tests__/api-graphql-transforms.test.ts
+++ b/packages/internal/src/build/__tests__/api-graphql-transforms.test.ts
@@ -139,7 +139,7 @@ export const handler = createGraphQLHandler(__cedar_graphqlOptions)`
     expect(applyGraphqlOptionsExtract(code)).toBeNull()
   })
 
-  it('returns null when there are multiple createGraphQLHandler calls', () => {
+  it('throws when there are multiple createGraphQLHandler calls', () => {
     const code = dedent`
       import { createGraphQLHandler } from '@cedarjs/graphql-server'
 
@@ -147,7 +147,45 @@ export const handler = createGraphQLHandler(__cedar_graphqlOptions)`
       export const b = createGraphQLHandler({ y: 2 })
     `
 
-    expect(applyGraphqlOptionsExtract(code)).toBeNull()
+    expect(() => applyGraphqlOptionsExtract(code)).toThrow(
+      'Found more than one call to createGraphQLHandler',
+    )
+  })
+
+  it('throws when createGraphQLHandler is imported but never called', () => {
+    const code = dedent`
+      import { createGraphQLHandler } from '@cedarjs/graphql-server'
+
+      export const handler = somethingElse()
+    `
+
+    expect(() => applyGraphqlOptionsExtract(code)).toThrow(
+      'createGraphQLHandler is imported but never called',
+    )
+  })
+
+  it('throws when createGraphQLHandler is called without options', () => {
+    const code = dedent`
+      import { createGraphQLHandler } from '@cedarjs/graphql-server'
+
+      export const handler = createGraphQLHandler()
+    `
+
+    expect(() => applyGraphqlOptionsExtract(code)).toThrow(
+      'createGraphQLHandler was called without any options',
+    )
+  })
+
+  it('throws when the options argument cannot be read statically', () => {
+    const code = dedent`
+      import { createGraphQLHandler } from '@cedarjs/graphql-server'
+
+      export const handler = createGraphQLHandler(config.graphql)
+    `
+
+    expect(() => applyGraphqlOptionsExtract(code)).toThrow(
+      "which can't be read statically",
+    )
   })
 
   it('extracts a conditional (ternary) options argument with a member-expression condition', () => {

--- a/packages/internal/src/build/api-graphql-transforms.ts
+++ b/packages/internal/src/build/api-graphql-transforms.ts
@@ -10,6 +10,12 @@ import {
   importStatementPath,
 } from '@cedarjs/project-config'
 
+const GRAPHQL_OPTIONS_ERROR_PREFIX =
+  'Could not read the GraphQL options in api/src/functions/graphql. Cedar needs to statically extract them so the api server can serve /graphql and its health endpoint. '
+
+const GRAPHQL_OPTIONS_ERROR_SUFFIX =
+  ' Expected a single `createGraphQLHandler({ ... })` call with the options passed directly as an object, an identifier, a call, or a ternary.'
+
 /**
  * Extracts the options argument from createGraphQLHandler calls and stores
  * them in an exported variable. Returns the transformed code, or null if no
@@ -71,17 +77,29 @@ export function applyGraphqlOptionsExtract(code: string): string | null {
   }).visit(program)
 
   if (callExpressionPaths.length > 1) {
-    return null
+    throw new Error(
+      GRAPHQL_OPTIONS_ERROR_PREFIX +
+        'Found more than one call to createGraphQLHandler.' +
+        GRAPHQL_OPTIONS_ERROR_SUFFIX,
+    )
   }
 
   const callExpression = callExpressionPaths[0]
   if (!callExpression) {
-    return null
+    throw new Error(
+      GRAPHQL_OPTIONS_ERROR_PREFIX +
+        'createGraphQLHandler is imported but never called.' +
+        GRAPHQL_OPTIONS_ERROR_SUFFIX,
+    )
   }
 
   const options = callExpression.arguments[0]
   if (!options) {
-    return null
+    throw new Error(
+      GRAPHQL_OPTIONS_ERROR_PREFIX +
+        'createGraphQLHandler was called without any options.' +
+        GRAPHQL_OPTIONS_ERROR_SUFFIX,
+    )
   }
 
   if (
@@ -90,7 +108,12 @@ export function applyGraphqlOptionsExtract(code: string): string | null {
     options.type !== 'CallExpression' &&
     options.type !== 'ConditionalExpression'
   ) {
-    return null
+    throw new Error(
+      GRAPHQL_OPTIONS_ERROR_PREFIX +
+        `The options argument is a ${options.type}, which can't be read ` +
+        'statically.' +
+        GRAPHQL_OPTIONS_ERROR_SUFFIX,
+    )
   }
 
   // Extract the options into a new exported variable. We place it immediately

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -297,34 +297,39 @@ export async function createApiViteServer(): Promise<ViteDevServer> {
             return null
           }
 
-          try {
-            // Apply graphql-specific and OTel transforms BEFORE Babel CJS
-            // compilation. These transforms use AST patterns that match ESM
-            // syntax; running them first ensures they always work regardless
-            // of the project's module format.
-            let sourceCode = code
-            // Exact sourcemap for the string transforms applied so far. Only
-            // the graphql options extract produces one; if a later transform
-            // changes the code again the map no longer matches and is
-            // cleared.
-            let sourceMap: SourceMap | null = null
-            if (
-              normalizePath(id).endsWith('/graphql.ts') ||
-              normalizePath(id).endsWith('/graphql.js')
-            ) {
-              const extracted = applyGraphqlOptionsExtract(sourceCode)
-              if (extracted) {
-                sourceCode = extracted.code
-                sourceMap = extracted.map
-              }
-
-              const injected = applyGqlormInject(sourceCode, id)
-              if (injected) {
-                sourceCode = injected
-                sourceMap = null
-              }
+          // Apply graphql-specific transforms BEFORE Babel CJS compilation
+          // (and before the tolerant try/catch below). These transforms use
+          // AST patterns that match ESM syntax; running them first ensures
+          // they always work regardless of the project's module format.
+          let sourceCode = code
+          // Exact sourcemap for the string transforms applied so far. Only
+          // the graphql options extract produces one; if a later transform
+          // changes the code again the map no longer matches and is cleared.
+          let sourceMap: SourceMap | null = null
+          if (
+            normalizePath(id).endsWith('/graphql.ts') ||
+            normalizePath(id).endsWith('/graphql.js')
+          ) {
+            // Deliberately outside the try/catch below: a graphql.ts Cedar
+            // can't statically read means the app has no working GraphQL
+            // server. That's a hard failure that should abort startup, not
+            // something to warn-and-continue past like a Babel hiccup —
+            // continuing here previously left the dev server starting
+            // successfully with GraphQL silently uninitialized.
+            const extracted = applyGraphqlOptionsExtract(sourceCode)
+            if (extracted) {
+              sourceCode = extracted.code
+              sourceMap = extracted.map
             }
 
+            const injected = applyGqlormInject(sourceCode, id)
+            if (injected) {
+              sourceCode = injected
+              sourceMap = null
+            }
+          }
+
+          try {
             if (
               cedarConfig.experimental?.opentelemetry?.enabled &&
               cedarConfig.experimental?.opentelemetry?.wrapApi

--- a/packages/vite/src/plugins/__tests__/vite-plugin-cedar-graphql-options-extract.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-cedar-graphql-options-extract.test.ts
@@ -300,7 +300,7 @@ describe('cedarGraphqlOptionsExtractPlugin', () => {
     }
   })
 
-  it('returns null for multiple createGraphQLHandler calls', () => {
+  it('throws for multiple createGraphQLHandler calls', () => {
     const code = dedent`
       import { createGraphQLHandler } from '@cedarjs/graphql-server'
 
@@ -308,8 +308,9 @@ describe('cedarGraphqlOptionsExtractPlugin', () => {
       export const b = createGraphQLHandler({ y: 2 })
     `
 
-    const result = plugin.transform!(code, 'api/src/functions/graphql.ts')
-    expect(result).toBeNull()
+    expect(() =>
+      plugin.transform!(code, 'api/src/functions/graphql.ts'),
+    ).toThrow('Found more than one call to createGraphQLHandler')
   })
 
   it('extracts a conditional (ternary) options argument with a member-expression condition', () => {

--- a/packages/vite/src/plugins/vite-plugin-cedar-graphql-options-extract.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-graphql-options-extract.ts
@@ -52,6 +52,12 @@ export function cedarGraphqlOptionsExtractPlugin(): Plugin {
   }
 }
 
+const GRAPHQL_OPTIONS_ERROR_PREFIX =
+  'Could not read the GraphQL options in api/src/functions/graphql. Cedar needs to statically extract them so the api server can serve /graphql and its health endpoint. '
+
+const GRAPHQL_OPTIONS_ERROR_SUFFIX =
+  ' Expected a single `createGraphQLHandler({ ... })` call with the options passed directly as an object, an identifier, a call, or a ternary.'
+
 /**
  * Extracts the options argument from createGraphQLHandler calls and stores
  * them in an exported variable. Returns the transformed code with a sourcemap,
@@ -119,17 +125,29 @@ export function applyGraphqlOptionsExtract(
   }).visit(program)
 
   if (callExpressionPaths.length > 1) {
-    return null
+    throw new Error(
+      GRAPHQL_OPTIONS_ERROR_PREFIX +
+        'Found more than one call to createGraphQLHandler.' +
+        GRAPHQL_OPTIONS_ERROR_SUFFIX,
+    )
   }
 
   const callExpression = callExpressionPaths[0]
   if (!callExpression) {
-    return null
+    throw new Error(
+      GRAPHQL_OPTIONS_ERROR_PREFIX +
+        'createGraphQLHandler is imported but never called.' +
+        GRAPHQL_OPTIONS_ERROR_SUFFIX,
+    )
   }
 
   const options = callExpression.arguments[0]
   if (!options) {
-    return null
+    throw new Error(
+      GRAPHQL_OPTIONS_ERROR_PREFIX +
+        'createGraphQLHandler was called without any options.' +
+        GRAPHQL_OPTIONS_ERROR_SUFFIX,
+    )
   }
 
   if (
@@ -138,7 +156,12 @@ export function applyGraphqlOptionsExtract(
     options.type !== 'CallExpression' &&
     options.type !== 'ConditionalExpression'
   ) {
-    return null
+    throw new Error(
+      GRAPHQL_OPTIONS_ERROR_PREFIX +
+        `The options argument is a ${options.type}, which can't be read ` +
+        'statically.' +
+        GRAPHQL_OPTIONS_ERROR_SUFFIX,
+    )
   }
 
   // Extract the options into a new exported variable. We place it immediately


### PR DESCRIPTION
Closes #2299.

Two silent failure modes with the same symptom: a server that starts healthy and 404s every GraphQL route, with nothing saying why.

## Build time

`applyGraphqlOptionsExtract` returned `null` for every shape it couldn't read, so the build succeeded and the app simply had no `__cedar_graphqlOptions` export — which is what the api server reads to register `/graphql` and its health endpoint. Four bails now throw:

| Case | Message |
| --- | --- |
| more than one `createGraphQLHandler` call | "Found more than one call to createGraphQLHandler." |
| imported but never called | "createGraphQLHandler is imported but never called." |
| called with no options | "createGraphQLHandler was called without any options." |
| options not statically readable | "The options argument is a `MemberExpression`, which can't be read statically." |

Each is prefixed with what Cedar was trying to do and suffixed with the expected shape, so the error is actionable rather than just a rejection.

## Deliberately unchanged

**A file with no `createGraphQLHandler` import still returns `null`.** #2299 suggested erroring on every bail, but I don't think that one belongs with the others: "this file doesn't use Cedar's handler" is a different statement from "this file uses it in a way we can't read", and there's an existing test pinning that contract (`returns null when the file has no createGraphQLHandler import`). Erroring there is a product call about what Cedar refuses to build, which felt like more than this PR should decide unilaterally — happy to add it if you want it.

The already-transformed idempotency guard also still returns `null`, as #2299 noted it should.

## Runtime

`plugins/graphql.ts` caught every setup error into a bare `console.log(e)` and then returned, having registered no routes. It now logs through the Fastify logger at error level and **rethrows**, so a broken GraphQL setup fails to start instead of coming up subtly wrong.

## Both copies

Applied to `@cedarjs/internal`'s implementation and the documented duplicate in `@cedarjs/vite`'s plugin, which is also used by `apiDevMiddleware`.