### PR TITLE
fix(deploy): Point Render's health check at /graphql/health

### DIFF
--- a/packages/cli/src/commands/setup/deploy/providers/renderHandler.ts
+++ b/packages/cli/src/commands/setup/deploy/providers/renderHandler.ts
@@ -8,13 +8,7 @@ import { getPaths, getPrismaSchemas } from '@cedarjs/project-config'
 import { errorTelemetry } from '@cedarjs/telemetry'
 
 import { writeFilesTask, printSetupNotes } from '../../../../lib/index.js'
-import { addFilesTask } from '../helpers/index.js'
-import {
-  POSTGRES_YAML,
-  RENDER_HEALTH_CHECK,
-  RENDER_YAML,
-  SQLITE_YAML,
-} from '../templates/render.js'
+import { POSTGRES_YAML, RENDER_YAML, SQLITE_YAML } from '../templates/render.js'
 
 const { getConfig } = prismaInternals
 
@@ -72,13 +66,7 @@ const notes = [
   'Go to https://dashboard.render.com/iacs to create your account and deploy to Render',
   'Check out the deployment docs at https://cedarjs.com/docs/deploy/render for detailed instructions',
   'Note: After first deployment to Render update the rewrite rule destination in `./render.yaml`',
-]
-
-const additionalFiles = [
-  {
-    path: path.join(getPaths().base, 'api/src/functions/healthz.js'),
-    content: RENDER_HEALTH_CHECK,
-  },
+  'Note: The api service now health checks `/graphql/health`. If a previous setup left an unused `api/src/functions/healthz.js` behind, you can delete it',
 ]
 
 export const handler = async ({
@@ -104,11 +92,6 @@ export const handler = async ({
           return writeFilesTask(files, { overwriteExisting: force })
         },
       },
-      // Add health check api function
-      addFilesTask({
-        files: additionalFiles,
-        force,
-      }),
       printSetupNotes(notes),
     ],
     { rendererOptions: { collapseSubtasks: false } },

--- a/packages/cli/src/commands/setup/deploy/templates/render.ts
+++ b/packages/cli/src/commands/setup/deploy/templates/render.ts
@@ -50,6 +50,10 @@ services:
   buildCommand: npm install --global corepack && yarn install && yarn cedar build api
   startCommand: yarn cedar deploy render api
 
+  # Proves the GraphQL server is actually serving, not just that the process
+  # is alive. Returns 200 with an \`x-yoga-id\` response header.
+  healthCheckPath: /graphql/health
+
   envVars:
 ${database}
 `
@@ -72,12 +76,3 @@ export const SQLITE_YAML = `\
     name: sqlite-data
     mountPath: /opt/render/project/src/api/db/data
     sizeGB: 1`
-
-export const RENDER_HEALTH_CHECK = `\
-// render-health-check
-export const handler = async () => {
-  return {
-    statusCode: 200,
-  }
-}
-`

--- a/packages/cli/src/commands/setup/deploy/templates/render.ts
+++ b/packages/cli/src/commands/setup/deploy/templates/render.ts
@@ -52,6 +52,13 @@ services:
 
   # Proves the GraphQL server is actually serving, not just that the process
   # is alive. Returns 200 with an \`x-yoga-id\` response header.
+  #
+  # The route is \`<apiRootPath><graphiQLEndpoint>/health\`, and the value below
+  # assumes both defaults (\`/\` and \`/graphql\`). Update it to match if you
+  # customize either — by setting \`CEDAR_API_ROOT_PATH\` in the envVars below,
+  # by passing \`apiRootPath\` to \`createServer\` in \`api/src/server.ts\`, or by
+  # setting \`graphiQLEndpoint\` in \`api/src/functions/graphql.ts\`. A mismatch
+  # here 404s, and Render will not promote the deploy.
   healthCheckPath: /graphql/health
 
   envVars:


### PR DESCRIPTION
Fixes #2298.

## Problem

`yarn cedar setup deploy render` generated `api/src/functions/healthz.js`, but the generated `render.yaml` never referenced it — there was no `healthCheckPath` field in the template at all. So Render fell back to its default check (does the port respond), and the generated file was inert unless a user wired it up in the dashboard themselves.

As the issue put it: a health check file that's generated and then ignored is the one option not worth keeping.

## Change

This takes **option 2** from the issue:

- Removes the generated `api/src/functions/healthz.js` (and the now-unused `RENDER_HEALTH_CHECK` template export)
- Adds `healthCheckPath: /graphql/health` to the api service in `render.yaml`

No codegen, consistent with `templates/flightcontrol.ts:34` which already uses `/graphql/health`, and a stronger check — it proves GraphQL is actually serving rather than just that the process is alive. That also means it catches the #2299 failure mode, where the GraphQL plugin fails to register and the server comes up 404ing `/graphql`.

A setup note tells users a leftover `healthz.js` from a previous setup can be deleted, since existing projects will still have one.

## Why not `/graphql/readiness`

It's deliberately not used, and worth recording so nobody reaches for it later. `useReadinessCheck` requires the *request* to carry a matching `x-yoga-id` header (`createGraphQLYoga.ts:192-194`), so a plain GET from a platform health checker gets a 503 — by design. Render's `healthCheckPath` is a bare path with no header support, so it can't satisfy that.

Having the generated `healthz.js` proxy to `/graphql/readiness` with the header was considered and rejected: readiness's only value over health is the identity guard ("the caller knew the id"), which is meaningless when we generate the caller inside the same process. It would also have had to hardcode `'yoga'`, silently breaking any project that sets a custom `healthCheckId` — a documented, supported option.

## Testing

- `npx vitest --run src/commands/deploy/__tests__/ src/commands/setup/deploy` in `packages/cli` — 116 passed
- eslint + prettier clean on both changed files; `tsc --noEmit` reports no new errors in them
- Rendered the template for all three database variants (`postgresql`, `sqlite`, `none`), parsed each with a YAML parser, and confirmed the api service carries `healthCheckPath: /graphql/health`

Verified the path is right for this service: `cedar deploy render api` serves via `apiCLIConfigHandler.ts:12`, where `apiRootPath` defaults to `/`, so GraphQL is at `/graphql` — the same assumption the flightcontrol template already makes.

Generated api service:

```yaml
- name: my-app-api
  type: web
  plan: free
  runtime: node
  region: oregon
  buildCommand: npm install --global corepack && yarn install && yarn cedar build api
  startCommand: yarn cedar deploy render api

  # Proves the GraphQL server is actually serving, not just that the process
  # is alive. Returns 200 with an `x-yoga-id` response header.
  healthCheckPath: /graphql/health

  envVars:
  - key: DATABASE_URL
    fromDatabase:
      name: my-app-db
      property: connectionString
```