### PR TITLE
chore(rename): internal-only Redwood identifiers -> Cedar

### DIFF
--- a/packages/api-server/src/__tests__/api.test.ts
+++ b/packages/api-server/src/__tests__/api.test.ts
@@ -22,7 +22,7 @@ beforeAll(async () => {
   fastifyInstance = await createFastifyInstance()
 
   fastifyInstance.register(cedarFastifyAPI, {
-    redwood: {
+    cedar: {
       loadUserConfig: true,
     },
   })

--- a/packages/api-server/src/__tests__/graphqlPlugin.test.ts
+++ b/packages/api-server/src/__tests__/graphqlPlugin.test.ts
@@ -12,7 +12,7 @@ import {
 } from 'vitest'
 
 import { createFastifyInstance } from '../fastify.js'
-import { redwoodFastifyGraphQLServer } from '../plugins/graphql.js'
+import { cedarFastifyGraphQLServer } from '../plugins/graphql.js'
 
 // Set up CEDAR_CWD.
 let original_CEDAR_CWD: string | undefined
@@ -26,7 +26,7 @@ afterAll(() => {
   process.env.CEDAR_CWD = original_CEDAR_CWD
 })
 
-describe('RedwoodFastifyGraphqlServer Fastify Plugin', () => {
+describe('CedarFastifyGraphqlServer Fastify Plugin', () => {
   beforeAll(async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -48,8 +48,8 @@ describe('RedwoodFastifyGraphqlServer Fastify Plugin', () => {
 
     // Although this is not how you normally register a plugin, we're going to
     // doing it this way gives us the ability to spy on the register method
-    await redwoodFastifyGraphQLServer(fastifyInstance, {
-      redwood: {},
+    await cedarFastifyGraphQLServer(fastifyInstance, {
+      cedar: {},
     })
 
     expect(registerSpy).toHaveBeenCalledWith(fastifyMultipart)

--- a/packages/api-server/src/__tests__/requestHandlers/queryParams.test.ts
+++ b/packages/api-server/src/__tests__/requestHandlers/queryParams.test.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
   fastifyInstance = await createFastifyInstance()
 
   fastifyInstance.register(cedarFastifyAPI, {
-    redwood: {
+    cedar: {
       loadUserConfig: true,
     },
   })

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -117,7 +117,7 @@ export async function createServer(options: CreateServerOptions = {}) {
   })
 
   await server.register(cedarFastifyAPI, {
-    redwood: {
+    cedar: {
       apiRootPath,
       fastGlobOptions: {
         ignore: ['**/dist/functions/graphql.js'],
@@ -134,15 +134,15 @@ export async function createServer(options: CreateServerOptions = {}) {
   })
 
   if (graphqlFunctionPath) {
-    const { redwoodFastifyGraphQLServer } = await import('./plugins/graphql.js')
+    const { cedarFastifyGraphQLServer } = await import('./plugins/graphql.js')
     // This comes from a babel plugin that's applied to
     // api/dist/functions/graphql.{ts,js} in user projects
     const { __cedar_graphqlOptions } = await import(
       pathToFileURL(graphqlFunctionPath).href
     )
 
-    await server.register(redwoodFastifyGraphQLServer, {
-      redwood: {
+    await server.register(cedarFastifyGraphQLServer, {
+      cedar: {
         apiRootPath,
         graphql: __cedar_graphqlOptions,
       },

--- a/packages/api-server/src/plugins/api.ts
+++ b/packages/api-server/src/plugins/api.ts
@@ -13,8 +13,7 @@ import { loadFastifyConfig } from '../fastify.js'
 import { lambdaRequestHandler, loadFunctionsFromDist } from './lambdaLoader.js'
 
 export interface CedarFastifyAPIOptions {
-  // Have to keep this named `redwood` to avoid breaking changes
-  redwood: {
+  cedar: {
     apiRootPath?: string
     fastGlobOptions?: FastGlobOptions
     discoverFunctionsGlob?: string | string[]
@@ -30,7 +29,7 @@ export async function cedarFastifyAPI(
   fastify: FastifyInstance,
   opts: CedarFastifyAPIOptions,
 ) {
-  const cedarOptions = opts.redwood ?? {}
+  const cedarOptions = opts.cedar ?? {}
   cedarOptions.apiRootPath ??= '/'
   cedarOptions.apiRootPath = coerceRootPath(cedarOptions.apiRootPath)
   cedarOptions.fastGlobOptions ??= {}

--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -20,20 +20,20 @@ import { getPaths } from '@cedarjs/project-config'
 
 import { lambdaEventForFastifyRequest } from '../requestHandlers/awsLambdaFastify.js'
 
-export interface RedwoodFastifyGraphQLOptions {
-  redwood: {
+export interface CedarFastifyGraphQLOptions {
+  cedar: {
     apiRootPath?: string
     graphql?: GraphQLYogaOptions
   }
 }
 
-export async function redwoodFastifyGraphQLServer(
+export async function cedarFastifyGraphQLServer(
   fastify: FastifyInstance,
-  options: RedwoodFastifyGraphQLOptions,
+  options: CedarFastifyGraphQLOptions,
 ) {
-  const redwoodOptions = options.redwood ?? {}
-  redwoodOptions.apiRootPath ??= '/'
-  redwoodOptions.apiRootPath = coerceRootPath(redwoodOptions.apiRootPath)
+  const cedarOptions = options.cedar ?? {}
+  cedarOptions.apiRootPath ??= '/'
+  cedarOptions.apiRootPath = coerceRootPath(cedarOptions.apiRootPath)
 
   fastify.register(fastifyUrlData)
   // We register the multiPart plugin, but not the raw body plugin.
@@ -49,7 +49,7 @@ export async function redwoodFastifyGraphQLServer(
   try {
     // Load the graphql options from the user's graphql function if none are
     // explicitly provided
-    if (!redwoodOptions.graphql) {
+    if (!cedarOptions.graphql) {
       const [graphqlFunctionPath] = await fg('dist/functions/graphql.{ts,js}', {
         cwd: getPaths().api.base,
         absolute: true,
@@ -67,10 +67,10 @@ export async function redwoodFastifyGraphQLServer(
         return
       }
 
-      redwoodOptions.graphql = __cedar_graphqlOptions as GraphQLYogaOptions
+      cedarOptions.graphql = __cedar_graphqlOptions as GraphQLYogaOptions
     }
 
-    const graphqlOptions = redwoodOptions.graphql
+    const graphqlOptions = cedarOptions.graphql
 
     // Used for SSE single connection mode with the `/graphql/stream` endpoint
     if (graphqlOptions?.realtime?.subscriptions) {
@@ -84,7 +84,7 @@ export async function redwoodFastifyGraphQLServer(
     const routePaths = ['', '/health', '/readiness', '/stream']
     for (const routePath of routePaths) {
       fastify.route({
-        url: `${redwoodOptions.apiRootPath}${graphqlEndpoint}${routePath}`,
+        url: `${cedarOptions.apiRootPath}${graphqlEndpoint}${routePath}`,
         method,
         handler: async (req, reply) => {
           const request = createFetchRequest(req, reply)

--- a/packages/api-server/src/types.ts
+++ b/packages/api-server/src/types.ts
@@ -10,14 +10,14 @@ export type FastifySideConfigFnOptions = {
 export type FastifySideConfigFn = (
   fastify: FastifyInstance,
   options?: FastifySideConfigFnOptions &
-    Pick<CedarFastifyAPIOptions['redwood'], 'apiRootPath'>,
+    Pick<CedarFastifyAPIOptions['cedar'], 'apiRootPath'>,
 ) => Promise<FastifyInstance> | void
 
 export type APIParsedOptions = {
   port?: number
   host?: string
   loadEnvFiles?: boolean
-} & Omit<CedarFastifyAPIOptions['redwood'], 'fastGlobOptions'>
+} & Omit<CedarFastifyAPIOptions['cedar'], 'fastGlobOptions'>
 
 export type BothParsedOptions = {
   webPort?: number
@@ -25,4 +25,4 @@ export type BothParsedOptions = {
   apiPort?: number
   apiHost?: string
   apiRootPath?: string
-} & Omit<CedarFastifyAPIOptions['redwood'], 'fastGlobOptions'>
+} & Omit<CedarFastifyAPIOptions['cedar'], 'fastGlobOptions'>

--- a/packages/cli/src/commands/experimental/setupOpentelemetryHandler.ts
+++ b/packages/cli/src/commands/experimental/setupOpentelemetryHandler.ts
@@ -130,7 +130,7 @@ export const handler = async ({
       },
       task: (_ctx: unknown, task: { output: string }) => {
         task.output = [
-          "Please add the following to your 'redwoodFastifyGraphQLServer' plugin options to enable OTel for your graphql",
+          "Please add the following to your 'cedarFastifyGraphQLServer' plugin options to enable OTel for your graphql",
           'openTelemetryOptions: {',
           '  resolvers: true,',
           '  result: true,',

--- a/packages/graphql-server/src/createGraphQLYoga.ts
+++ b/packages/graphql-server/src/createGraphQLYoga.ts
@@ -31,7 +31,7 @@ import type {
   DirectivePluginOptions,
 } from './plugins/useRedwoodDirective.js'
 import { makeSubscriptions } from './subscriptions/makeSubscriptions.js'
-import type { RedwoodSubscription } from './subscriptions/makeSubscriptions.js'
+import type { CedarSubscription } from './subscriptions/makeSubscriptions.js'
 import type { GraphQLYogaOptions, CedarGraphQLContext } from './types.js'
 
 export const createGraphQLYoga = async ({
@@ -77,7 +77,7 @@ export const createGraphQLYoga = async ({
     }
 
     // @NOTE: Subscriptions are optional and only work in the context of a server
-    let projectSubscriptions: RedwoodSubscription[] = []
+    let projectSubscriptions: CedarSubscription[] = []
 
     if (realtime?.subscriptions?.subscriptions) {
       projectSubscriptions = makeSubscriptions(

--- a/packages/graphql-server/src/makeMergedSchema.ts
+++ b/packages/graphql-server/src/makeMergedSchema.ts
@@ -21,7 +21,7 @@ import omitBy from 'lodash/omitBy.js'
 
 import type { RedwoodDirective } from './plugins/useRedwoodDirective.js'
 import * as rootGqlSchema from './rootSchema.js'
-import type { RedwoodSubscription } from './subscriptions/makeSubscriptions.js'
+import type { CedarSubscription } from './subscriptions/makeSubscriptions.js'
 import type {
   Services,
   ServicesGlobImports,
@@ -331,7 +331,7 @@ const mergeResolversWithSubscriptions = ({
   inheritResolversFromInterfaces,
 }: {
   schema: GraphQLSchema
-  subscriptions: RedwoodSubscription[]
+  subscriptions: CedarSubscription[]
   resolverValidationOptions?: IResolverValidationOptions | undefined
   inheritResolversFromInterfaces?: boolean | undefined
 }) => {
@@ -366,7 +366,7 @@ export const makeMergedSchema = ({
   sdls: SdlGlobImports
   services: ServicesGlobImports
   directives: RedwoodDirective[]
-  subscriptions: RedwoodSubscription[]
+  subscriptions: CedarSubscription[]
   includeScalars?: RedwoodScalarConfig
 
   /**

--- a/packages/graphql-server/src/subscriptions/makeSubscriptions.ts
+++ b/packages/graphql-server/src/subscriptions/makeSubscriptions.ts
@@ -5,12 +5,12 @@ import type { DocumentNode } from 'graphql'
  * But not fully supported in TS
  * {
  *   schema: DocumentNode // <-- required
- *   [string]: RedwoodSubscription
+ *   [string]: CedarSubscription
  * }
  */
 export type SubscriptionGlobImports = Record<string, any>
 
-export type RedwoodSubscription = {
+export type CedarSubscription = {
   schema: DocumentNode
   resolvers: any
   name: string
@@ -18,7 +18,7 @@ export type RedwoodSubscription = {
 
 export const makeSubscriptions = (
   SubscriptionGlobs: SubscriptionGlobImports,
-): RedwoodSubscription[] => {
+): CedarSubscription[] => {
   return Object.entries(SubscriptionGlobs).flatMap(
     ([importedGlobName, exports]) => {
       // In case the Subscriptions get nested, their name comes as nested_directory_filename_Subscription


### PR DESCRIPTION
## Summary

Renames three internal-only "Redwood"-named identifiers on the API side to "Cedar". These are not part of any package's public `exports` map, so this isn't a breaking change:

- `RedwoodSubscription` → `CedarSubscription` (`@cedarjs/graphql-server`)
- `redwoodFastifyGraphQLServer` / `RedwoodFastifyGraphQLOptions` → `cedarFastifyGraphQLServer` / `CedarFastifyGraphQLOptions` (`@cedarjs/api-server`)
- `cedarFastifyAPI`'s `redwood` plugin option key → `cedar` (`@cedarjs/api-server`)

Verified each rename by checking the owning package's `package.json` `exports` field — `packages/api-server/src/plugins/graphql.ts` and `plugins/api.ts` are not exported subpaths, and `RedwoodSubscription` is a graphql-server-internal type not re-exported anywhere.

### Explicitly left untouched

- `@cedarjs/fastify-web`'s `redwoodFastifyWeb` / `RedwoodFastifyWebOptions` — this package has no `exports` restriction (falls back to `main`/`types`), so its entire entry point is genuinely public and consumed cross-package by `api-server`'s `bothCLIConfigHandler.ts` and `web-server`. Renaming this would be a breaking change.
- The deprecated `redwood` field on the `Redwood` GraphQL schema type (`packages/graphql-server/src/rootSchema.ts`) — this is a public runtime GraphQL schema contract shipped to every Cedar app, not just a TS identifier.