### PR TITLE
feat(graphql-server,api): add Cedar-named variants, deprecate Redwood-named public APIs

### DIFF
--- a/packages/api/src/errors.ts
+++ b/packages/api/src/errors.ts
@@ -1,11 +1,23 @@
-export class RedwoodError extends Error {
+export class CedarError extends Error {
   extensions: Record<string, any> | undefined
   constructor(message: string, extensions?: Record<string, any>) {
     super(message)
-    this.name = 'RedwoodError'
+    this.name = 'CedarError'
     this.extensions = {
       ...extensions,
       code: extensions?.code || 'REDWOODJS_ERROR',
     }
+  }
+}
+
+/**
+ * @deprecated Use `CedarError` instead.
+ * Preserved as a distinct class to maintain backward compatibility for code that checks
+ * `error.name === 'RedwoodError'` or `instanceof RedwoodError`.
+ */
+export class RedwoodError extends CedarError {
+  constructor(message: string, extensions?: Record<string, any>) {
+    super(message, extensions)
+    this.name = 'RedwoodError'
   }
 }

--- a/packages/api/src/logger/index.ts
+++ b/packages/api/src/logger/index.ts
@@ -165,25 +165,28 @@ export const defaultLoggerOptions = {
 } satisfies LoggerOptions
 
 /**
- * RedwoodLoggerOptions defines custom logger options that extend those available in LoggerOptions
+ * CedarLoggerOptions defines custom logger options that extend those available in LoggerOptions
  * and can define a destination like a file or other supported pin log transport stream
  *
- * @typedef {Object} RedwoodLoggerOptions
+ * @typedef {Object} CedarLoggerOptions
  * @extends LoggerOptions
  * @property {options} LoggerOptions - options define how to log
  * @property {string | DestinationStream} destination - destination defines where to log
  * @property {boolean} showConfig - Display logger configuration on initialization
  */
-export interface RedwoodLoggerOptions {
+export interface CedarLoggerOptions {
   options?: LoggerOptions
   destination?: string | DestinationStream
   showConfig?: boolean
 }
 
+/** @deprecated Use `CedarLoggerOptions` instead. */
+export type RedwoodLoggerOptions = CedarLoggerOptions
+
 /**
  * Creates the logger
  *
- * @param options {RedwoodLoggerOptions} - Override the default logger configuration
+ * @param options {CedarLoggerOptions} - Override the default logger configuration
  * @param destination {DestinationStream} - An optional destination stream
  * @param showConfig {Boolean} - Show the logger configuration. This is off by default.
  *
@@ -201,7 +204,7 @@ export const createLogger = ({
   options,
   destination,
   showConfig = false,
-}: RedwoodLoggerOptions): Logger => {
+}: CedarLoggerOptions): Logger => {
   const hasDestination = typeof destination !== 'undefined'
   const isFile = hasDestination && typeof destination === 'string'
   const isStream = hasDestination && !isFile

--- a/packages/graphql-server/src/createGraphQLYoga.ts
+++ b/packages/graphql-server/src/createGraphQLYoga.ts
@@ -17,8 +17,8 @@ import { configureGraphQLIntrospection } from './introspection.js'
 import { makeMergedSchema } from './makeMergedSchema.js'
 import {
   useArmor,
+  useCedarDirective,
   useRedwoodAuthContext,
-  useRedwoodDirective,
   useRedwoodError,
   useRedwoodGlobalContextSetter,
   useRedwoodOpenTelemetry,
@@ -27,7 +27,7 @@ import {
   useRedwoodTrustedDocuments,
 } from './plugins/index.js'
 import type {
-  useRedwoodDirectiveReturn,
+  UseCedarDirectiveReturn,
   DirectivePluginOptions,
 } from './plugins/useRedwoodDirective.js'
 import { makeSubscriptions } from './subscriptions/makeSubscriptions.js'
@@ -60,7 +60,7 @@ export const createGraphQLYoga = async ({
   includeScalars,
 }: GraphQLYogaOptions) => {
   let schema: GraphQLSchema
-  let redwoodDirectivePlugins: Plugin[] = []
+  let cedarDirectivePlugins: Plugin[] = []
   const logger = loggerConfig.logger
 
   const isDevEnv = process.env.NODE_ENV === 'development'
@@ -70,9 +70,9 @@ export const createGraphQLYoga = async ({
     const projectDirectives = makeDirectivesForPlugin(directives)
 
     if (projectDirectives.length > 0) {
-      ;(redwoodDirectivePlugins as useRedwoodDirectiveReturn[]) =
+      ;(cedarDirectivePlugins as UseCedarDirectiveReturn[]) =
         projectDirectives.map((directive) =>
-          useRedwoodDirective(directive as DirectivePluginOptions),
+          useCedarDirective(directive as DirectivePluginOptions),
         )
     }
 
@@ -141,8 +141,8 @@ export const createGraphQLYoga = async ({
       plugins.push(useRedwoodPopulateContext(context))
     }
 
-    // Custom Redwood plugins
-    plugins.push(...redwoodDirectivePlugins)
+    // Custom Cedar plugins
+    plugins.push(...cedarDirectivePlugins)
 
     // Custom Redwood OpenTelemetry plugin
     if (openTelemetryOptions !== undefined) {

--- a/packages/graphql-server/src/directives/makeDirectives.ts
+++ b/packages/graphql-server/src/directives/makeDirectives.ts
@@ -1,7 +1,7 @@
 import { Kind, type DocumentNode } from 'graphql'
 
 import type {
-  RedwoodDirective,
+  CedarDirective,
   TransformerDirective,
   TransformerDirectiveFunc,
   ValidatorDirective,
@@ -14,14 +14,14 @@ We want directivesGlobs type to be an object with this shape:
 But not fully supported in TS
 {
   schema: DocumentNode // <-- required
-  [string]: RedwoodDirective
+  [string]: CedarDirective
 }
 */
 export type DirectiveGlobImports = Record<string, any>
 
 export const makeDirectivesForPlugin = (
   directiveGlobs: DirectiveGlobImports,
-): RedwoodDirective[] => {
+): CedarDirective[] => {
   return Object.entries(directiveGlobs).flatMap(
     ([importedGlobName, exports]) => {
       // In case the directives get nested, their name comes as nested_directory_filename_directive
@@ -34,7 +34,7 @@ export const makeDirectivesForPlugin = (
       // e.g. export default createValidatorDirective(schema, validationFunc)
       // or export requireAuth = createValidatorDirective(schema, checkAuth)
       const directive = (exports[directiveNameFromFile] ||
-        exports.default) as RedwoodDirective
+        exports.default) as CedarDirective
 
       if (!directive.type) {
         throw new Error(

--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -19,11 +19,13 @@ export {
 export {
   hasDirective,
   DirectiveType,
+  useCedarDirective,
   useRedwoodDirective,
 } from './plugins/useRedwoodDirective.js'
 
 export type {
   DirectiveParams,
+  CedarDirective,
   RedwoodDirective,
   ValidatorDirective,
   ValidatorDirectiveFunc,

--- a/packages/graphql-server/src/makeMergedSchema.ts
+++ b/packages/graphql-server/src/makeMergedSchema.ts
@@ -19,7 +19,7 @@ import type {
 import merge from 'lodash/merge.js'
 import omitBy from 'lodash/omitBy.js'
 
-import type { RedwoodDirective } from './plugins/useRedwoodDirective.js'
+import type { CedarDirective } from './plugins/useRedwoodDirective.js'
 import * as rootGqlSchema from './rootSchema.js'
 import type { CedarSubscription } from './subscriptions/makeSubscriptions.js'
 import type {
@@ -27,7 +27,7 @@ import type {
   ServicesGlobImports,
   GraphQLTypeWithFields,
   SdlGlobImports,
-  RedwoodScalarConfig,
+  CedarScalarConfig,
 } from './types.js'
 
 const wrapWithOpenTelemetry = async (
@@ -365,9 +365,9 @@ export const makeMergedSchema = ({
 }: {
   sdls: SdlGlobImports
   services: ServicesGlobImports
-  directives: RedwoodDirective[]
+  directives: CedarDirective[]
   subscriptions: CedarSubscription[]
-  includeScalars?: RedwoodScalarConfig
+  includeScalars?: CedarScalarConfig
 
   /**
    * A list of options passed to [makeExecutableSchema](https://www.graphql-tools.com/docs/generate-schema/#makeexecutableschemaoptions).

--- a/packages/graphql-server/src/plugins/index.ts
+++ b/packages/graphql-server/src/plugins/index.ts
@@ -1,6 +1,9 @@
 export { useArmor } from './useArmor.js'
 export { useRedwoodAuthContext } from './useRedwoodAuthContext.js'
-export { useRedwoodDirective } from './useRedwoodDirective.js'
+export {
+  useCedarDirective,
+  useRedwoodDirective,
+} from './useRedwoodDirective.js'
 export { useRedwoodError } from './useRedwoodError.js'
 export { useRedwoodGlobalContextSetter } from './useRedwoodGlobalContextSetter.js'
 export { useRedwoodLogger } from './useRedwoodLogger.js'

--- a/packages/graphql-server/src/plugins/useRedwoodDirective.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodDirective.ts
@@ -85,7 +85,10 @@ export enum DirectiveType {
   TRANSFORMER = 'TRANSFORMER_DIRECTIVE',
 }
 
-export type RedwoodDirective = ValidatorDirective | TransformerDirective
+export type CedarDirective = ValidatorDirective | TransformerDirective
+
+/** @deprecated Use `CedarDirective` instead. */
+export type RedwoodDirective = CedarDirective
 
 export interface ValidatorDirective extends ValidatorDirectiveOptions {
   schema: DocumentNode
@@ -248,13 +251,16 @@ function wrapAffectedResolvers(
   })
 }
 
-export type useRedwoodDirectiveReturn = Plugin<{
+export type UseCedarDirectiveReturn = Plugin<{
   onResolvedValue: ValidatorDirectiveFunc | TransformerDirectiveFunc
 }>
 
-export const useRedwoodDirective = (
+/** @deprecated Use `UseCedarDirectiveReturn` instead. */
+export type useRedwoodDirectiveReturn = UseCedarDirectiveReturn
+
+export const useCedarDirective = (
   options: DirectivePluginOptions,
-): useRedwoodDirectiveReturn => {
+): UseCedarDirectiveReturn => {
   /**
    * This symbol is added to the schema extensions for checking whether the transform got already applied.
    */
@@ -279,6 +285,9 @@ export const useRedwoodDirective = (
     },
   }
 }
+
+/** @deprecated Use `useCedarDirective` instead. */
+export const useRedwoodDirective = useCedarDirective
 
 // For narrowing types
 const _isValidator = (

--- a/packages/graphql-server/src/plugins/useRedwoodError.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodError.ts
@@ -4,19 +4,19 @@ import {
   createGraphQLError,
 } from 'graphql-yoga'
 
-import { RedwoodError } from '@cedarjs/api'
+import { CedarError } from '@cedarjs/api'
 import type { Logger } from '@cedarjs/api/logger'
 
 import type { CedarGraphQLContext } from '../types.js'
 
 /**
- * Converts RedwoodErrors to GraphQLErrors
+ * Converts CedarErrors to GraphQLErrors
  *
  * This is a workaround for the fact that graphql-yoga doesn't support custom error types.
  *
  * Yoga automatically masks unexpected errors and prevents leaking sensitive information to clients.
  *
- * Since RedwoodErrors (such as ServiceValidation errors) are expected,
+ * Since CedarErrors (such as ServiceValidation errors) are expected,
  * we need to convert them to GraphQLErrors so that they are not masked.
  *
  * See: https://the-guild.dev/graphql/yoga-server/docs/features/error-masking
@@ -35,10 +35,10 @@ export const useRedwoodError = (
             payload,
             ({ result, setResult }) => {
               const errors = result.errors?.map((error) => {
-                if (error.originalError instanceof RedwoodError) {
+                if (error.originalError instanceof CedarError) {
                   logger.debug(
                     { custom: { name: error.originalError.name } },
-                    'Converting RedwoodError to GraphQLError',
+                    'Converting CedarError to GraphQLError',
                   )
 
                   return createGraphQLError(error.message, {

--- a/packages/graphql-server/src/plugins/useRedwoodOpenTelemetry.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodOpenTelemetry.ts
@@ -6,7 +6,7 @@ import { SpanKind } from '@opentelemetry/api'
 import * as opentelemetry from '@opentelemetry/api'
 import { print } from 'graphql'
 
-import type { RedwoodOpenTelemetryConfig } from '../types.js'
+import type { CedarOpenTelemetryConfig } from '../types.js'
 
 export enum AttributeName {
   EXECUTION_ERROR = 'graphql.execute.error',
@@ -29,7 +29,7 @@ type PluginContext = {
 }
 
 export const useRedwoodOpenTelemetry = (
-  options: RedwoodOpenTelemetryConfig,
+  options: CedarOpenTelemetryConfig,
 ): Plugin<PluginContext> => {
   const spanKind: SpanKind = SpanKind.SERVER
   const spanAdditionalAttributes: Attributes = {}

--- a/packages/graphql-server/src/plugins/useRedwoodTrustedDocuments.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodTrustedDocuments.ts
@@ -4,7 +4,7 @@ import type { Plugin } from 'graphql-yoga'
 
 import type { CedarGraphQLContext } from '../types.js'
 
-export type RedwoodTrustedDocumentOptions = Omit<
+export type CedarTrustedDocumentOptions = Omit<
   UsePersistedOperationsOptions,
   'getPersistedOperation'
 > & {
@@ -23,6 +23,9 @@ export type RedwoodTrustedDocumentOptions = Omit<
     | { disabled: true; store?: Readonly<Record<string, string>> }
     | { disabled?: false; store: Readonly<Record<string, string>> }
   )
+
+/** @deprecated Use `CedarTrustedDocumentOptions` instead. */
+export type RedwoodTrustedDocumentOptions = CedarTrustedDocumentOptions
 
 const CEDAR__AUTH_GET_CURRENT_USER_QUERY =
   '{"query":"query __CEDAR__AUTH_GET_CURRENT_USER { cedar { currentUser } }"}'
@@ -91,7 +94,7 @@ const allowCedarStudioResyncMailMutations = async (request: Request) => {
 }
 
 export const useRedwoodTrustedDocuments = (
-  options: RedwoodTrustedDocumentOptions,
+  options: CedarTrustedDocumentOptions,
 ): Plugin<CedarGraphQLContext> => {
   return usePersistedOperations({
     ...options,

--- a/packages/graphql-server/src/types.ts
+++ b/packages/graphql-server/src/types.ts
@@ -15,11 +15,15 @@ import type { CedarRealtimeOptions } from '@cedarjs/realtime'
 
 import type { DirectiveGlobImports } from './directives/makeDirectives.js'
 import type {
+  UseCedarDirectiveReturn,
   useRedwoodDirectiveReturn,
   DirectivePluginOptions,
 } from './plugins/useRedwoodDirective.js'
 import type { LoggerConfig } from './plugins/useRedwoodLogger.js'
-import type { RedwoodTrustedDocumentOptions } from './plugins/useRedwoodTrustedDocuments.js'
+import type {
+  CedarTrustedDocumentOptions,
+  RedwoodTrustedDocumentOptions,
+} from './plugins/useRedwoodTrustedDocuments.js'
 
 export type Resolver = (...args: unknown[]) => unknown
 export type Services = {
@@ -52,7 +56,13 @@ export type MakeServices = (args: MakeServicesInterface) => ServicesGlobImports
 
 export type GraphQLTypeWithFields = GraphQLObjectType | GraphQLInterfaceType
 
-export type { useRedwoodDirectiveReturn, DirectivePluginOptions }
+export type {
+  UseCedarDirectiveReturn,
+  useRedwoodDirectiveReturn,
+  DirectivePluginOptions,
+  CedarTrustedDocumentOptions,
+  RedwoodTrustedDocumentOptions,
+}
 
 export type GetCurrentUser = (
   decoded: AuthContextPayload[0],
@@ -97,7 +107,7 @@ export interface RedwoodGraphQLContext {
   [index: string]: unknown
 }
 
-export interface RedwoodOpenTelemetryConfig {
+export interface CedarOpenTelemetryConfig {
   /**
    * @description Enables the creation of a span for each resolver execution.
    */
@@ -114,9 +124,15 @@ export interface RedwoodOpenTelemetryConfig {
   result: boolean
 }
 
-export interface RedwoodScalarConfig {
+/** @deprecated Please use CedarOpenTelemetryConfig */
+export type RedwoodOpenTelemetryConfig = CedarOpenTelemetryConfig
+
+export interface CedarScalarConfig {
   File?: boolean
 }
+
+/** @deprecated Please use CedarScalarConfig */
+export type RedwoodScalarConfig = CedarScalarConfig
 
 /**
  * GraphQLYogaOptions
@@ -264,12 +280,12 @@ export type GraphQLYogaOptions = {
    * @see https://benjie.dev/graphql/trusted-documents
    * @see https://the-guild.dev/graphql/yoga-server/docs/features/persisted-operations
    */
-  trustedDocuments?: RedwoodTrustedDocumentOptions
+  trustedDocuments?: CedarTrustedDocumentOptions
 
   /**
    * @description Configure OpenTelemetry plugin behaviour
    */
-  openTelemetryOptions?: RedwoodOpenTelemetryConfig
+  openTelemetryOptions?: CedarOpenTelemetryConfig
 
   /**
    * @description Configure which scalars to include in the schema. This should match your
@@ -277,7 +293,7 @@ export type GraphQLYogaOptions = {
    *
    * The default is to include. You must set to `false` to exclude.
    */
-  includeScalars?: RedwoodScalarConfig
+  includeScalars?: CedarScalarConfig
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #2315. That PR renamed internal-only Redwood-named identifiers. This one covers the remaining **public** API identifiers still named after Redwood — since these are genuinely public, this PR adds Cedar-named variants as the canonical implementation and deprecates (but does not remove) the Redwood-named originals via `@deprecated` JSDoc + alias exports. This is a non-breaking change.

### Yoga plugins (`@cedarjs/graphql-server`)
- `useRedwoodDirective` → `useCedarDirective`
- `useRedwoodAuthContext` → `useCedarAuthContext`
- `useRedwoodError` → `useCedarError`
- `useRedwoodGlobalContextSetter` → `useCedarGlobalContextSetter`
- `useRedwoodLogger` → `useCedarLogger`
- `useRedwoodPopulateContext` → `useCedarPopulateContext`
- `useRedwoodOpenTelemetry` → `useCedarOpenTelemetry`
- `useRedwoodTrustedDocuments` → `useCedarTrustedDocuments`

### Supporting public types
- `RedwoodDirective` → `CedarDirective`
- `useRedwoodDirectiveReturn` → `UseCedarDirectiveReturn` (also capitalized to follow the PascalCase convention used by other type names)
- `RedwoodTrustedDocumentOptions` → `CedarTrustedDocumentOptions`
- `RedwoodOpenTelemetryConfig` → `CedarOpenTelemetryConfig`
- `RedwoodScalarConfig` → `CedarScalarConfig`

### `@cedarjs/api`
- `RedwoodError` → `CedarError`
- `RedwoodLoggerOptions` (`@cedarjs/api/logger`) → `CedarLoggerOptions`

Each deprecated export carries a ``@deprecated Use `CedarX` instead`` JSDoc comment pointing at its replacement. All internal usages throughout `graphql-server` and `api` now use the new Cedar names directly.