### PR TITLE
chore(knip): `@cedarjs/api-server-watch`

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -31,12 +31,17 @@
   },
   "workspaces": {
     "packages/api-server": {
-      "entry": ["src/bin.ts", "src/watch.ts", "src/logFormatter/bin.ts"],
+      "entry": ["src/bin.ts", "src/logFormatter/bin.ts"],
       // publint: only invoked via `concurrently`'s `yarn:publint` job syntax
       // in the "check:package" script, which knip doesn't parse.
       // @cedarjs/graphql-server: optional peer dep, dynamically imported in
       // src/plugins/graphql.ts only when a project has a GraphQL function.
       "ignoreDependencies": ["publint", "@cedarjs/graphql-server"]
+    },
+    "packages/api-server-watch": {
+      // package.json main/bin point into dist/, which is globally ignored, so
+      // knip needs to be pointed at the sources explicitly.
+      "entry": ["src/watch.ts", "src/bin.ts"]
     },
     "packages/eslint-config": {
       // eslint-plugin-react-compiler: optional peer dep, dynamically imported


### PR DESCRIPTION
Configure knip for the new api-server-watch package

`knip` reported all seven of `@cedarjs/api-server-watch`'s declared dependencies as unused:

```
Unused dependencies (5)
@cedarjs/api-server  packages/api-server-watch/package.json:32:6
@cedarjs/internal    packages/api-server-watch/package.json:33:6
ansis                packages/api-server-watch/package.json:35:6
dotenv-defaults      packages/api-server-watch/package.json:37:6
yargs                packages/api-server-watch/package.json:38:6
Unused devDependencies (2)
@types/dotenv-defaults  packages/api-server-watch/package.json:42:6
@types/yargs            packages/api-server-watch/package.json:43:6
```

All seven were false positives. The package's `main`/`bin` fields point at `./dist/watch.js` and `./dist/bin.js`, and `packages/**/dist/**` is in the global `ignore` list — so knip had no entry point into the package and never walked `src/` at all.

This adds a workspace entry pointing knip at the sources, matching what `packages/api-server` already does.

No `ignoreDependencies` are needed here — every declared dependency is genuinely reachable from the two entry points.

Dropped the now-stale `src/watch.ts` entry from `packages/api-server`. A full-repo run flagged it:

```
Configuration hints (1)
src/watch.ts  packages/api-server  knip.jsonc  Refine entry pattern (no matches)
```

That file moved into this new package, so the pattern no longer matched anything.
