### PR TITLE
fix(cca): Switch app template start scripts to the cedarjs-server bin

### DIFF
--- a/__fixtures__/test-project-esm/package.json
+++ b/__fixtures__/test-project-esm/package.json
@@ -9,9 +9,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/__fixtures__/test-project-esm/web/package.json
+++ b/__fixtures__/test-project-esm/web/package.json
@@ -29,7 +29,7 @@
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10.5.4",
-    "postcss": "^8.5.22",
+    "postcss": "^8.5.25",
     "tailwindcss": "^3.4.17",
     "vite": "7.3.6"
   }

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -9,9 +9,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10.5.4",
-    "postcss": "^8.5.22",
+    "postcss": "^8.5.25",
     "tailwindcss": "^3.4.17"
   }
 }

--- a/docs/implementation-plans/2026-08-03-deploy-simplification.md
+++ b/docs/implementation-plans/2026-08-03-deploy-simplification.md
@@ -38,17 +38,17 @@ Railway-only.
 
 ## Status
 
-| #   | Item                                       | Status                                        |
-| --- | ------------------------------------------ | --------------------------------------------- |
-| 1   | Read `PORT` and `HOST`                     | **Done** — #2292                              |
-| 2   | `build` / `start` scripts in templates     | PR #2294 — blocked on #2302                   |
-| 3   | Runtime deps out of root `devDependencies` | Reframed — #2295 done, rest folded into #2294 |
-| 4   | Web server cache headers + compression     | #2301                                         |
-| 5   | Dual-stack host default                    | Open                                          |
-| 6   | Generic `setup deploy container`           | **Superseded** — #2303                        |
-| 7   | Built-in health endpoint                   | #2298                                         |
-| 8   | Rename `REDWOOD_*` → `CEDAR_*`             | **Done** — #2292                              |
-| 9   | Document the serve tiers                   | #2300                                         |
+| #   | Item                                       | Status                                         |
+| --- | ------------------------------------------ | ---------------------------------------------- |
+| 1   | Read `PORT` and `HOST`                     | **Done** — #2292                               |
+| 2   | `build` / `start` scripts in templates     | #2294 done; switch to `cedarjs-server` — #2323 |
+| 3   | Runtime deps out of root `devDependencies` | Reframed — #2295 superseded by #2312/#2313     |
+| 4   | Web server cache headers + compression     | #2301                                          |
+| 5   | Dual-stack host default                    | Open                                           |
+| 6   | Generic `setup deploy container`           | **Superseded** — #2303                         |
+| 7   | Built-in health endpoint                   | #2298                                          |
+| 8   | Rename `REDWOOD_*` → `CEDAR_*`             | **Done** — #2292                               |
+| 9   | Document the serve tiers                   | #2300                                          |
 
 Also opened along the way: #2296, #2297, #2299, #2302.
 
@@ -72,9 +72,9 @@ Shipping five scripts rather than the two originally planned:
 ```json
 "build": "cedar build",
 "dev": "cedar dev",
-"start": "cedar serve",
-"start:api": "cedar serve api",
-"start:web": "cedar serve web"
+"start": "cedarjs-server",
+"start:api": "cedarjs-server api",
+"start:web": "cedarjs-server web"
 ```
 
 `start` is the single-container path; `start:api` / `start:web` are the
@@ -87,7 +87,11 @@ it's Railway-only and still leaves the proxy target unset — a half-staged
 two-service deploy that fails until you find the right setting is worse than one
 service that works immediately.
 
-Blocked on #2302 before the scripts can switch to the `cedarjs-server` bin.
+`#2302` was the blocker (`cedarjs-server` skipped server files) — fixed by
+#2318. The scripts now run through `@cedarjs/api-server`'s `cedarjs-server` bin
+directly, with `@cedarjs/api-server` added as a root **dependency**, in #2323.
+See item 3 below for why that dependency has to be a runtime one, not a dev
+one.
 
 ## 3. Runtime deps out of `devDependencies` — reframed
 
@@ -101,14 +105,20 @@ runtime concern. The fix is to stop routing `start` through the CLI at all —
 add `@cedarjs/api-server` as a root **dependency** and use the `cedarjs-server`
 bin. Cedar already does exactly this in `setup docker`, which adds
 `@cedarjs/api-server` and `@cedarjs/web-server` to the api and web workspaces.
+The root-scripts case only needs `@cedarjs/api-server` — its `cedarjs-server`
+bin has a `web` subcommand that calls straight into `@cedarjs/web-server`'s own
+handler, so there's no need for a second explicit dependency there. (`setup
+docker` adds both separately because its `web_serve` image never installs the
+api workspace at all, so it can't reach `@cedarjs/api-server` transitively.)
 
 **This is not cosmetic.** Heroku's Node buildpack and DigitalOcean/Paketo both
 strip `devDependencies` after build **by default**, so `start: cedar serve`
 fails on those platforms: build succeeds, deploy succeeds, container starts,
 command not found. Railway only works because `RAILPACK_PRUNE_DEPS` is opt-in.
 
-Blocked on #2302, because `cedarjs-server` does not do the server-file dispatch
-that `cedar serve` does.
+`#2302` was the blocker (`cedarjs-server` didn't do the server-file dispatch
+that `cedar serve` does) — fixed by #2318. Root dependency + script switch
+landed in #2323.
 
 ## 4. Web server cache headers and compression — #2301
 
@@ -265,11 +275,13 @@ lands, not as another bespoke provider.
 ## Sequencing
 
 1. **#2302** — `cedarjs-server api` runs the server file; modes that can't, fail
-   loudly. Blocks the rest, and fixes a live bug.
+   loudly. Blocks the rest, and fixes a live bug. **Done**, via #2318.
 2. **#2295** — `@cedarjs/internal` to an optional peer, so the new root
-   dependency is lean. Independent of 1, same release.
+   dependency is lean. Independent of 1, same release. **Superseded**, by
+   #2312/#2313 (split `@cedarjs/api-server-watch` out instead).
 3. **#2294** — add the root `@cedarjs/api-server` dependency, switch the scripts
-   to `cedarjs-server`, merge.
+   to `cedarjs-server`. #2294 shipped the scripts as `cedar serve`; the switch to
+   `cedarjs-server` landed in #2323, once unblocked by 1 and 2.
 4. **#2301** and **#5** — the two things that make the blessed single-container
    path actually good.
 5. **#2303**, then docs (#2300).

--- a/packages/create-cedar-app/templates/esm-js/package.json
+++ b/packages/create-cedar-app/templates/esm-js/package.json
@@ -8,9 +8,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/esm-ts/package.json
+++ b/packages/create-cedar-app/templates/esm-ts/package.json
@@ -8,9 +8,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/js/package.json
+++ b/packages/create-cedar-app/templates/js/package.json
@@ -8,9 +8,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/cjs/npm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/npm/package.json
@@ -8,9 +8,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/pnpm/package.json
@@ -4,9 +4,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/cjs/yarn/package.json
+++ b/packages/create-cedar-app/templates/overlays/cjs/yarn/package.json
@@ -8,9 +8,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/esm/npm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/npm/package.json
@@ -8,9 +8,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/pnpm/package.json
@@ -4,9 +4,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/overlays/esm/yarn/package.json
+++ b/packages/create-cedar-app/templates/overlays/esm/yarn/package.json
@@ -8,9 +8,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",

--- a/packages/create-cedar-app/templates/ts/package.json
+++ b/packages/create-cedar-app/templates/ts/package.json
@@ -8,9 +8,12 @@
   "scripts": {
     "build": "cedar build",
     "dev": "cedar dev",
-    "start": "cedar serve",
-    "start:api": "cedar serve api",
-    "start:web": "cedar serve web"
+    "start": "cedarjs-server",
+    "start:api": "cedarjs-server api",
+    "start:web": "cedarjs-server web"
+  },
+  "dependencies": {
+    "@cedarjs/api-server": "5.0.6"
   },
   "devDependencies": {
     "@cedarjs/core": "5.0.6",


### PR DESCRIPTION
## Summary

- `start` / `start:api` / `start:web` in the generated app's root `package.json` ran `cedar serve`, `cedar serve api`, `cedar serve web` — but the `cedar` binary lives in `@cedarjs/core`, a devDependency. Platforms that prune devDependencies by default before running `start` (Heroku's Node buildpack, DigitalOcean/Paketo) build and deploy successfully and then fail at boot with `command not found`.
- Switches all three scripts to `@cedarjs/api-server`'s `cedarjs-server` bin (`cedarjs-server`, `cedarjs-server api`, `cedarjs-server web`), and adds `@cedarjs/api-server` as a root `dependencies` entry (not `devDependencies`) so it survives pruning.
- Only `@cedarjs/api-server` is needed — its `cedarjs-server web` subcommand calls straight into `@cedarjs/web-server`'s own handler, so there's no need for a second explicit dependency on `@cedarjs/web-server` (unlike `setup docker`'s per-workspace split, which needs both because its `web_serve` image never installs the api workspace).
- This was blocked on #2302 (`cedarjs-server` silently skipped a project's custom server file instead of running it, unlike `cedar serve`) — fixed by #2318, which shipped in the meantime.
- Updates `docs/implementation-plans/2026-08-03-deploy-simplification.md` to reflect current state (marks #2302 done via #2318, #2295 superseded by #2312/#2313, and this item as a follow-up to #2294).

Applies to all four base templates (ts/js × cjs/esm) and all six package-manager overlays (yarn/pnpm/npm × cjs/esm) — the overlay's `package.json` fully replaces the base template's at generation time, so both had to change.

## Test plan

- [x] `node -e "JSON.parse(...)"` on all 10 changed `package.json` files
- [x] `yarn prettier --check` on all 10 files
- [x] Simulated the overlay merge (`fs.cpSync` template → overlay, same as `createProjectFiles`) and inspected the resulting `package.json`
- [x] `yarn workspace create-cedar-app test --run` — template directory-structure snapshot tests still pass (no files added/removed)
- [x] `yarn prettier --check` on the plan doc
- [ ] CI