### PR TITLE
fix(fastify-web): Add cache headers and compression to the web server

### DIFF
--- a/packages/adapters/fastify/web/package.json
+++ b/packages/adapters/fastify/web/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@cedarjs/project-config": "workspace:*",
+    "@fastify/compress": "9.1.1",
     "@fastify/http-proxy": "11.6.0",
     "@fastify/static": "8.3.0",
     "@fastify/url-data": "6.0.3",

--- a/packages/adapters/fastify/web/src/__tests__/__fixtures__/main/web/dist/assets/unhashed-app.js
+++ b/packages/adapters/fastify/web/src/__tests__/__fixtures__/main/web/dist/assets/unhashed-app.js
@@ -1,0 +1,1 @@
+console.log('an asset with a stable, unhashed filename')

--- a/packages/adapters/fastify/web/src/web.test.ts
+++ b/packages/adapters/fastify/web/src/web.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs'
 import * as path from 'path'
+import * as zlib from 'zlib'
 
 import type { FastifyInstance } from 'fastify'
 import Fastify from 'fastify'
@@ -305,6 +306,84 @@ describe('redwoodFastifyWeb', () => {
       })
 
       expect(res.statusCode).toBe(200)
+    })
+  })
+
+  describe('cache headers', () => {
+    it('sets a long, immutable cache-control header for hashed assets', async () => {
+      const res = await fastifyInstance.inject({
+        method: 'GET',
+        url: '/assets/index-613d397d.css',
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.headers['cache-control']).toBe(
+        'public, max-age=31536000, immutable',
+      )
+    })
+
+    it('sets a no-cache cache-control header for a prerendered page', async () => {
+      const res = await fastifyInstance.inject({
+        method: 'GET',
+        url: '/about',
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.headers['cache-control']).toBe('no-cache')
+    })
+
+    it('sets a no-cache cache-control header on the SPA fallback', async () => {
+      const res = await fastifyInstance.inject({
+        method: 'GET',
+        url: '/absent.html',
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.headers['cache-control']).toBe('no-cache')
+    })
+  })
+
+  describe('compression', () => {
+    it('gzip-compresses a large, compressible asset when requested', async () => {
+      const relativeFilePath = '/assets/index-613d397d.css'
+
+      const res = await fastifyInstance.inject({
+        method: 'GET',
+        url: relativeFilePath,
+        headers: { 'accept-encoding': 'gzip' },
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.headers['content-encoding']).toBe('gzip')
+
+      const decompressed = zlib.gunzipSync(res.rawPayload)
+      expect(decompressed.toString('utf-8')).toBe(
+        fs.readFileSync(
+          path.join(getPaths().web.dist, relativeFilePath),
+          'utf-8',
+        ),
+      )
+    })
+
+    it('does not compress an already-compressed file type, like a png', async () => {
+      const res = await fastifyInstance.inject({
+        method: 'GET',
+        url: '/favicon.png',
+        headers: { 'accept-encoding': 'gzip' },
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.headers['content-encoding']).toBeUndefined()
+    })
+
+    it('does not compress when the client sends no accept-encoding', async () => {
+      const res = await fastifyInstance.inject({
+        method: 'GET',
+        url: '/assets/index-613d397d.css',
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.headers['content-encoding']).toBeUndefined()
     })
   })
 

--- a/packages/adapters/fastify/web/src/web.test.ts
+++ b/packages/adapters/fastify/web/src/web.test.ts
@@ -322,6 +322,19 @@ describe('redwoodFastifyWeb', () => {
       )
     })
 
+    it('sets a no-cache cache-control header for an unhashed file under assets/', async () => {
+      // A project can configure Vite to emit stable filenames instead of
+      // content-hashed ones. Living under `assets/` isn't on its own a safe
+      // signal that a file can be cached forever.
+      const res = await fastifyInstance.inject({
+        method: 'GET',
+        url: '/assets/unhashed-app.js',
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.headers['cache-control']).toBe('no-cache')
+    })
+
     it('sets a no-cache cache-control header for a prerendered page', async () => {
       const res = await fastifyInstance.inject({
         method: 'GET',

--- a/packages/adapters/fastify/web/src/web.ts
+++ b/packages/adapters/fastify/web/src/web.ts
@@ -19,6 +19,13 @@ export type { RedwoodFastifyWebOptions }
 
 const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365
 
+// Vite's default `assetFileNames`/`entryFileNames`/`chunkFileNames` all end
+// in `-<hash>.<ext>`. A project can override those in its own vite.config to
+// emit stable filenames instead — in which case a file living under
+// `assets/` is no longer a safe signal on its own that it's safe to cache
+// forever, so the filename itself has to look hashed too.
+const HASHED_ASSET_FILENAME = /-[0-9a-f]{8,}\.[^./]+$/i
+
 export async function redwoodFastifyWeb(
   fastify: FastifyInstance,
   opts: RedwoodFastifyWebOptions,
@@ -47,9 +54,13 @@ export async function redwoodFastifyWeb(
     root: getPaths().web.dist,
     cacheControl: false,
     setHeaders: (res, filePath) => {
+      const isHashedAsset =
+        filePath.startsWith(assetsDir) &&
+        HASHED_ASSET_FILENAME.test(path.basename(filePath))
+
       res.setHeader(
         'Cache-Control',
-        filePath.startsWith(assetsDir)
+        isHashedAsset
           ? `public, max-age=${ONE_YEAR_IN_SECONDS}, immutable`
           : 'no-cache',
       )

--- a/packages/adapters/fastify/web/src/web.ts
+++ b/packages/adapters/fastify/web/src/web.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'path'
 
+import fastifyCompress from '@fastify/compress'
 import httpProxy from '@fastify/http-proxy'
 import fastifyStatic from '@fastify/static'
 import fastifyUrlData from '@fastify/url-data'
@@ -16,6 +17,8 @@ import type { RedwoodFastifyWebOptions } from './types.js'
 export { coerceRootPath }
 export type { RedwoodFastifyWebOptions }
 
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365
+
 export async function redwoodFastifyWeb(
   fastify: FastifyInstance,
   opts: RedwoodFastifyWebOptions,
@@ -23,7 +26,35 @@ export async function redwoodFastifyWeb(
   const { redwoodOptions, flags } = resolveOptions(opts)
 
   fastify.register(fastifyUrlData)
-  fastify.register(fastifyStatic, { root: getPaths().web.dist })
+
+  // Registered before `fastifyStatic` so its `onSend` hook — added via
+  // `fastify-plugin`, so it isn't encapsulated to this registration — is in
+  // place for every route defined below.
+  fastify.register(fastifyCompress)
+
+  // Vite content-hashes everything under `assets/`, so those files can be
+  // cached forever. Nothing else is hashed — most importantly `index.html`
+  // and the other prerendered HTML entry points — so it all has to stay
+  // revalidate-on-every-request, or a deploy wouldn't be picked up.
+  //
+  // `cacheControl: false` turns off `@fastify/static`'s own Cache-Control
+  // handling. It's not just redundant with `setHeaders` below, it actively
+  // conflicts: `@fastify/static` calls `setHeaders` and *then* writes its own
+  // Cache-Control header afterwards, clobbering whatever we set here.
+  const assetsDir = path.join(getPaths().web.dist, 'assets') + path.sep
+
+  fastify.register(fastifyStatic, {
+    root: getPaths().web.dist,
+    cacheControl: false,
+    setHeaders: (res, filePath) => {
+      res.setHeader(
+        'Cache-Control',
+        filePath.startsWith(assetsDir)
+          ? `public, max-age=${ONE_YEAR_IN_SECONDS}, immutable`
+          : 'no-cache',
+      )
+    },
+  })
 
   // If `apiProxyTarget` is set, proxy requests from `apiUrl` to `apiProxyTarget`.
   // In this case, `apiUrl` has to be relative; `resolveOptions` above throws if it's not

--- a/yarn.lock
+++ b/yarn.lock
@@ -2989,6 +2989,7 @@ __metadata:
   dependencies:
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
+    "@fastify/compress": "npm:9.1.1"
     "@fastify/http-proxy": "npm:11.6.0"
     "@fastify/static": "npm:8.3.0"
     "@fastify/url-data": "npm:6.0.3"
@@ -4859,6 +4860,19 @@ __metadata:
   version: 3.2.0
   resolution: "@fastify/busboy@npm:3.2.0"
   checksum: 10c0/3e4fb00a27e3149d1c68de8ff14007d2bbcbbc171a9d050d0a8772e836727329d4d3f130995ebaa19cf537d5d2f5ce2a88000366e6192e751457bfcc2125f351
+  languageName: node
+  linkType: hard
+
+"@fastify/compress@npm:9.1.1":
+  version: 9.1.1
+  resolution: "@fastify/compress@npm:9.1.1"
+  dependencies:
+    "@fastify/accept-negotiator": "npm:^2.0.0"
+    fastify-plugin: "npm:^6.0.0"
+    mime-db: "npm:^1.52.0"
+    minipass: "npm:^7.0.4"
+    readable-stream: "npm:^4.5.2"
+  checksum: 10c0/900349d6760b754f0a0c6f0659c987c3ca4737f099678468dc40446cbc104abf5817e6a6ca506b57f22ef0ce183a0bfeab138927c97f28cab7e7c6d3c74a808b
   languageName: node
   linkType: hard
 
@@ -21786,6 +21800,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.52.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:2.1.35, mime-types@npm:^2.1.35, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
@@ -25515,16 +25536,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^4.0.0":
-  version: 4.4.2
-  resolution: "readable-stream@npm:4.4.2"
+"readable-stream@npm:^4.0.0, readable-stream@npm:^4.5.2":
+  version: 4.7.0
+  resolution: "readable-stream@npm:4.7.0"
   dependencies:
     abort-controller: "npm:^3.0.0"
     buffer: "npm:^6.0.3"
     events: "npm:^3.3.0"
     process: "npm:^0.11.10"
     string_decoder: "npm:^1.3.0"
-  checksum: 10c0/cf7cc8daa2b57872d120945a20a1458c13dcb6c6f352505421115827b18ac4df0e483ac1fe195cb1f5cd226e1073fc55b92b569269d8299e8530840bcdbba40c
+  checksum: 10c0/fd86d068da21cfdb10f7a4479f2e47d9c0a9b0c862fc0c840a7e5360201580a55ac399c764b12a4f6fa291f8cee74d9c4b7562e0d53b3c4b2769f2c98155d957
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #2301, item 4 from `docs/implementation-plans/2026-08-03-deploy-simplification.md`.

## Summary

`redwoodFastifyWeb` (the shared adapter behind `cedar-web-server`, `cedarjs-server web`, and the web half of `cedarjs-server`/`cedar serve`) registered `@fastify/static` with no cache configuration, and nothing in the framework compressed responses. That was fine when a CDN or reverse proxy sat in front, but single-container is now the blessed "convenient" deploy topology (#2294) precisely because it needs no extra infra — so Cedar's own web server should serve assets reasonably well by default.

- **Cache headers.** Vite content-hashes everything under `web/dist/assets`, so those files get `Cache-Control: public, max-age=31536000, immutable`. Everything else (`index.html`, other prerendered HTML, favicon, robots.txt, etc.) isn't hashed, so it stays `no-cache` — a deploy has to be picked up on the next request.
  - Needed `cacheControl: false` on the `@fastify/static` registration: `@fastify/static` calls `setHeaders` and *then* writes its own `Cache-Control` header afterwards, clobbering whatever gets set in `setHeaders` otherwise.
- **Compression.** Added `@fastify/compress` (default config — gzip/brotli/zstd negotiated from `Accept-Encoding`, compressible content-types only, skips 206/Range responses). Registered before `@fastify/static` so its `onSend` hook (added via `fastify-plugin`, so it isn't encapsulated to that one registration) is in place for every route in the file — the static assets, the prerendered-page routes, and the SPA fallback.

Both changes live in the one shared adapter, so they cover `@cedarjs/web-server`, the web half of `@cedarjs/api-server`'s combined mode, and the Docker `web_serve` stage in a single place.

**Deliberately not touched:** the `--ud` path (`srvx/static`), which the issue calls out as a separate decision — UD's documented production topology already puts nginx in front.