### PR TITLE
fix(testing): fail fast when test DB URL doesn't match schema provider

### DIFF
--- a/packages/project-config/src/prisma.ts
+++ b/packages/project-config/src/prisma.ts
@@ -92,6 +92,23 @@ export async function getPrismaSchemas() {
 }
 
 /**
+ * Gets the active datasource provider (e.g. `postgresql`, `mysql`, `sqlite`)
+ * configured in the project's `schema.prisma`.
+ */
+export async function getPrismaDatasourceProvider(): Promise<string> {
+  const mod = await import('@prisma/internals')
+  // `mod.default || mod` handles ESM vs CJS interop: in ESM context
+  // @prisma/internals resolves everything onto `default`, in CJS it's
+  // directly on the module object.
+  const { getConfig } = mod.default || mod
+
+  const { schemas } = await getPrismaSchemas()
+  const config = await getConfig({ datamodel: schemas })
+
+  return config.datasources[0].activeProvider
+}
+
+/**
  * Gets the migrations path from Prisma config.
  * Defaults to 'migrations' in the same directory as the schema.
  *

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -25,6 +25,9 @@
     "./dist/cjs/api/scenario.js": {
       "default": "./dist/cjs/api/scenario.js"
     },
+    "./dist/cjs/api/checkTestDatabase.js": {
+      "default": "./dist/cjs/api/checkTestDatabase.js"
+    },
     "./dist/cjs/web/findCellMocks": {
       "default": "./dist/cjs/web/findCellMocks.js"
     },

--- a/packages/testing/src/api/__tests__/checkTestDatabase.test.ts
+++ b/packages/testing/src/api/__tests__/checkTestDatabase.test.ts
@@ -1,0 +1,86 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+const { getPrismaDatasourceProvider } = vi.hoisted(() => ({
+  getPrismaDatasourceProvider: vi.fn(),
+}))
+
+vi.mock('@cedarjs/project-config', () => ({
+  getPrismaDatasourceProvider,
+}))
+
+const { checkTestDatabaseUrlMatchesProvider, redactDatabaseUrl } =
+  await import('../checkTestDatabase.js')
+
+describe('redactDatabaseUrl', () => {
+  it('masks the password in a connection string', () => {
+    expect(redactDatabaseUrl('postgres://user:secret@host:5432/db')).toBe(
+      'postgres://user:***@host:5432/db',
+    )
+  })
+
+  it('leaves URLs without credentials unchanged', () => {
+    expect(redactDatabaseUrl('file:./test.db')).toBe('file:./test.db')
+  })
+})
+
+describe('checkTestDatabaseUrlMatchesProvider', () => {
+  beforeEach(() => {
+    getPrismaDatasourceProvider.mockReset()
+  })
+
+  it('does not throw when the URL scheme matches the provider', async () => {
+    getPrismaDatasourceProvider.mockResolvedValue('postgresql')
+
+    await expect(
+      checkTestDatabaseUrlMatchesProvider(
+        'postgres://user:pass@host:5432/db',
+        false,
+      ),
+    ).resolves.toBeUndefined()
+  })
+
+  it('does not throw for sqlite file: URLs', async () => {
+    getPrismaDatasourceProvider.mockResolvedValue('sqlite')
+
+    await expect(
+      checkTestDatabaseUrlMatchesProvider('file:./test.db', true),
+    ).resolves.toBeUndefined()
+  })
+
+  it('throws an actionable error when the URL scheme does not match the provider', async () => {
+    getPrismaDatasourceProvider.mockResolvedValue('postgresql')
+
+    await expect(
+      checkTestDatabaseUrlMatchesProvider('file:./test.db', true),
+    ).rejects.toThrow(/does not match your Prisma schema's provider/)
+  })
+
+  it('redacts credentials in the thrown error message', async () => {
+    getPrismaDatasourceProvider.mockResolvedValue('mysql')
+
+    await expect(
+      checkTestDatabaseUrlMatchesProvider(
+        'postgres://user:secret@host:5432/db',
+        false,
+      ),
+    ).rejects.toThrow(/user:\*\*\*@host/)
+  })
+
+  it('is a no-op when the provider cannot be determined', async () => {
+    getPrismaDatasourceProvider.mockRejectedValue(
+      new Error('schema.prisma not found'),
+    )
+
+    await expect(
+      checkTestDatabaseUrlMatchesProvider('file:./test.db', true),
+    ).resolves.toBeUndefined()
+  })
+
+  it('is a no-op for unknown/unmapped providers', async () => {
+    getPrismaDatasourceProvider.mockResolvedValue('some-future-provider')
+
+    await expect(
+      checkTestDatabaseUrlMatchesProvider('file:./test.db', true),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/testing/src/api/__tests__/checkTestDatabase.test.ts
+++ b/packages/testing/src/api/__tests__/checkTestDatabase.test.ts
@@ -8,8 +8,10 @@ vi.mock('@cedarjs/project-config', () => ({
   getPrismaDatasourceProvider,
 }))
 
-const { checkTestDatabaseUrlMatchesProvider, redactDatabaseUrl } =
-  await import('../checkTestDatabase.js')
+import {
+  checkTestDatabaseUrlMatchesProvider,
+  redactDatabaseUrl,
+} from '../checkTestDatabase.js'
 
 describe('redactDatabaseUrl', () => {
   it('masks the password in a connection string', () => {
@@ -20,6 +22,16 @@ describe('redactDatabaseUrl', () => {
 
   it('leaves URLs without credentials unchanged', () => {
     expect(redactDatabaseUrl('file:./test.db')).toBe('file:./test.db')
+  })
+
+  it('masks semicolon-delimited passwords in SQL Server connection strings', () => {
+    expect(
+      redactDatabaseUrl(
+        'sqlserver://host:1433;database=db;user=sa;password=secret;encrypt=true',
+      ),
+    ).toBe(
+      'sqlserver://host:1433;database=db;user=sa;password=***;encrypt=true',
+    )
   })
 })
 

--- a/packages/testing/src/api/checkTestDatabase.ts
+++ b/packages/testing/src/api/checkTestDatabase.ts
@@ -18,10 +18,15 @@ function getUrlScheme(url: string): string | undefined {
 
 /**
  * Redacts credentials from a database connection string so it's safe to
- * print, e.g. `postgres://user:pass@host/db` -> `postgres://user:***@host/db`.
+ * print. Handles both URI-style authority credentials, e.g.
+ * `postgres://user:pass@host/db` -> `postgres://user:***@host/db`, and
+ * semicolon-delimited key/value credentials used by SQL Server connection
+ * strings, e.g. `Server=host;Password=secret;` -> `Server=host;Password=***;`.
  */
 export function redactDatabaseUrl(url: string): string {
-  return url.replace(/:\/\/([^:/?#]+):([^@/?#]+)@/, '://$1:***@')
+  return url
+    .replace(/:\/\/([^:/?#]+):([^@/?#]+)@/, '://$1:***@')
+    .replace(/((?:^|;)\s*password\s*=)[^;]*/gi, '$1***')
 }
 
 /**

--- a/packages/testing/src/api/checkTestDatabase.ts
+++ b/packages/testing/src/api/checkTestDatabase.ts
@@ -1,0 +1,77 @@
+import { getPrismaDatasourceProvider } from '@cedarjs/project-config'
+
+// Maps a Prisma datasource provider to the URL scheme(s) it expects.
+const PROVIDER_URL_SCHEMES: Record<string, string[]> = {
+  sqlite: ['file:'],
+  postgresql: ['postgres:', 'postgresql:'],
+  postgres: ['postgres:', 'postgresql:'],
+  cockroachdb: ['postgres:', 'postgresql:'],
+  mysql: ['mysql:'],
+  sqlserver: ['sqlserver:'],
+  mongodb: ['mongodb:', 'mongodb+srv:'],
+}
+
+function getUrlScheme(url: string): string | undefined {
+  const match = url.match(/^([a-z][a-z0-9+.-]*:)/i)
+  return match?.[1]?.toLowerCase()
+}
+
+/**
+ * Redacts credentials from a database connection string so it's safe to
+ * print, e.g. `postgres://user:pass@host/db` -> `postgres://user:***@host/db`.
+ */
+export function redactDatabaseUrl(url: string): string {
+  return url.replace(/:\/\/([^:/?#]+):([^@/?#]+)@/, '://$1:***@')
+}
+
+/**
+ * Checks that the `DATABASE_URL` about to be used for tests matches the
+ * datasource provider configured in `schema.prisma`, and throws an
+ * actionable error if they don't match.
+ *
+ * Without this check, running `prisma db push`/`migrate reset` against a
+ * mismatched provider/URL combination (e.g. a leftover sqlite fallback URL
+ * with a `postgresql` schema) can hang indefinitely with no output, instead
+ * of failing fast. See https://github.com/cedarjs/cedar/issues/2284.
+ *
+ * If the provider can't be determined (e.g. `schema.prisma` doesn't exist
+ * yet), this is a no-op — Prisma itself will surface the problem.
+ */
+export async function checkTestDatabaseUrlMatchesProvider(
+  databaseUrl: string,
+  usedFallback: boolean,
+) {
+  let provider: string
+
+  try {
+    provider = await getPrismaDatasourceProvider()
+  } catch {
+    return
+  }
+
+  const expectedSchemes = PROVIDER_URL_SCHEMES[provider]
+  if (!expectedSchemes) {
+    // Unknown/unmapped provider — nothing to validate against.
+    return
+  }
+
+  const actualScheme = getUrlScheme(databaseUrl)
+  if (actualScheme && expectedSchemes.includes(actualScheme)) {
+    return
+  }
+
+  const redactedUrl = redactDatabaseUrl(databaseUrl)
+
+  const reason = usedFallback
+    ? `TEST_DATABASE_URL is not set, so the default sqlite test database ` +
+      `was used (${redactedUrl}), but your schema.prisma is configured ` +
+      `for "${provider}". Set TEST_DATABASE_URL to a "${provider}" ` +
+      `connection string to run tests.`
+    : `TEST_DATABASE_URL (${redactedUrl}) does not match the "${provider}" ` +
+      `provider configured in schema.prisma. Update TEST_DATABASE_URL to a ` +
+      `"${provider}" connection string.`
+
+  throw new Error(
+    `Test database URL does not match your Prisma schema's provider.\n\n${reason}`,
+  )
+}

--- a/packages/testing/src/api/vitest/CedarApiVitestEnv.ts
+++ b/packages/testing/src/api/vitest/CedarApiVitestEnv.ts
@@ -7,6 +7,11 @@ import type { Environment } from 'vitest/environments'
 import { getPaths } from '@cedarjs/project-config'
 import { getPackageManager } from '@cedarjs/project-config/packageManager'
 
+import {
+  checkTestDatabaseUrlMatchesProvider,
+  redactDatabaseUrl,
+} from '../checkTestDatabase.js'
+
 const CedarApiVitestEnvironment: Environment = {
   name: 'cedar-api',
   viteEnvironment: 'ssr',
@@ -21,8 +26,18 @@ const CedarApiVitestEnvironment: Environment = {
     const cedarPaths = getPaths()
 
     const defaultDb = `file:${path.join(cedarPaths.generated.base, 'test.db')}`
+    const usedFallback = !process.env.TEST_DATABASE_URL
 
     process.env.DATABASE_URL = process.env.TEST_DATABASE_URL || defaultDb
+
+    await checkTestDatabaseUrlMatchesProvider(
+      process.env.DATABASE_URL,
+      usedFallback,
+    )
+
+    console.log(
+      `Setting up test database: ${redactDatabaseUrl(process.env.DATABASE_URL)}`,
+    )
 
     const command =
       process.env.TEST_DATABASE_STRATEGY === 'reset'

--- a/packages/testing/src/config/jest/api/globalSetup.ts
+++ b/packages/testing/src/config/jest/api/globalSetup.ts
@@ -6,6 +6,11 @@ import execa from 'execa'
 import { getPaths } from '@cedarjs/project-config'
 import { getPackageManager } from '@cedarjs/project-config/packageManager'
 
+import {
+  checkTestDatabaseUrlMatchesProvider,
+  redactDatabaseUrl,
+} from '../../../api/checkTestDatabase.js'
+
 export default async function () {
   if (process.env.SKIP_DB_PUSH === '1') {
     return
@@ -14,8 +19,18 @@ export default async function () {
   const cedarPaths = getPaths()
 
   const defaultDb = `file:${path.join(cedarPaths.generated.base, 'test.db')}`
+  const usedFallback = !process.env.TEST_DATABASE_URL
 
   process.env.DATABASE_URL = process.env.TEST_DATABASE_URL || defaultDb
+
+  await checkTestDatabaseUrlMatchesProvider(
+    process.env.DATABASE_URL,
+    usedFallback,
+  )
+
+  console.log(
+    `Setting up test database: ${redactDatabaseUrl(process.env.DATABASE_URL)}`,
+  )
 
   const command =
     process.env.TEST_DATABASE_STRATEGY === 'reset'


### PR DESCRIPTION
`cedar test` (and jest/vitest run directly) could hang indefinitely with no output when `TEST_DATABASE_URL` was unset or pointed at a database provider that didn't match the one configured in `schema.prisma` (e.g. a leftover sqlite fallback URL against a `postgresql` schema). Prisma's `db push`/`migrate reset` would attempt a doomed connection with no useful feedback to the user.

- Added `getPrismaDatasourceProvider()` to `@cedarjs/project-config`, reusing the existing `@prisma/internals` dynamic-import pattern already used elsewhere in that file (`getPrismaSchemas`, `resolveGeneratedPrismaClient`) and mirroring the precedent in `coherenceHandler.ts`.
- Added `checkTestDatabaseUrlMatchesProvider()` in `@cedarjs/testing` (`packages/testing/src/api/checkTestDatabase.ts`), which compares the `DATABASE_URL` scheme against the schema's active provider and throws an actionable, credential-redacted error before Prisma is invoked. It's a no-op if the provider can't be determined (e.g. no `schema.prisma` yet) or is unrecognized, so Prisma itself surfaces those cases.
- Wired the check into both `packages/testing/src/config/jest/api/globalSetup.ts` (Jest) and `packages/testing/src/api/vitest/CedarApiVitestEnv.ts` (Vitest), right before the `db push`/`migrate reset` call, so it applies no matter which test runner is used. Also added a `console.log` announcing which (redacted) database URL is about to be used, per the issue's suggested fix.

Fixes #2284