### PR TITLE
fix(router): make PrivateSet discoverable by name and by common alias

### DIFF
--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -67,6 +67,14 @@ export function Private<WrapperProps>(props: PrivateSetProps<WrapperProps>) {
   return <>{props.children}</>
 }
 
+/**
+ * Wraps a set of routes that require the user to be authenticated before
+ * rendering. Unauthenticated users are redirected to the route named by
+ * `unauthenticated`.
+ *
+ * Coming from React Router or a similar library and looking for something
+ * like `RequireAuth` or `ProtectedRoute`? This is the Cedar equivalent.
+ */
 export function PrivateSet<WrapperProps>(props: PrivateSetProps<WrapperProps>) {
   // @MARK Virtual Component, this is actually never rendered
   // See analyzeRoutes in utils.tsx, inside the isSetNode block

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -16,7 +16,15 @@ export { Router } from './router.js'
 export { Route } from './Route.js'
 export { namedRoutes as routes } from './namedRoutes.js'
 
-export * from './Set.js'
+export {
+  Set,
+  Private,
+  PrivateSet,
+  isSetNode,
+  isPrivateSetNode,
+  isPrivateNode,
+} from './Set.js'
+export type { WrapperType } from './Set.js'
 
 export { default as RouteAnnouncement } from './route-announcement.js'
 export * from './route-announcement.js'


### PR DESCRIPTION
## Summary

`PrivateSet` (Cedar's route-protection component) was hard to find:

1. `packages/router/src/index.ts` re-exported `Set.js` with `export *`, so `PrivateSet` never appeared as a text token in the router's own source — grepping the package root for it would fail; you had to already know to look inside `Set.tsx`.
2. Nothing bridged the common `RequireAuth`/`ProtectedRoute` mental model (familiar from React Router and similar libraries) to Cedar's actual `PrivateSet` name. There's a `@deprecated` note pointing *backward* (`Private` → use `PrivateSet`), but nothing points *forward* from how people are likely to search for it.

## Changes

- Switched the wildcard re-export in `index.ts` to explicit named exports (`Set`, `Private`, `PrivateSet`, `isSetNode`, `isPrivateSetNode`, `isPrivateNode`, and the `WrapperType` type), so `PrivateSet` is a discoverable text token at the package root.
- Added a JSDoc comment on `PrivateSet` mentioning `RequireAuth`/`ProtectedRoute` explicitly, so it's a discoverable token in source, generated `.d.ts` files, and IDE hover tooltips.

Deliberately did **not** introduce an actual `RequireAuth` export/alias — that would mean two permanent public names for one concept, relocating the "which one do I use" confusion into future docs/tutorials (the same pattern that led to the existing `Private` → `PrivateSet` deprecation). The doc-comment approach gets full discoverability with no new API surface to maintain.

Fixes #2288