### PR TITLE
feat(cell): Allow skip on beforeQuery

### DIFF
--- a/docs/docs/cells.md
+++ b/docs/docs/cells.md
@@ -189,6 +189,89 @@ export const beforeQuery = ({ word }: { word: string }) => {
 </TabItem>
 </Tabs>
 
+#### Skipping the query
+
+Sometimes you don't want a Cell's query to run at all—maybe a value it depends on isn't available yet. Say you have a search page where `SearchResultsCell` takes the search term as a prop: until the user has typed something, there's nothing to search for. Most of the time the idiomatic solution is to not render the Cell until you have what you need:
+
+```jsx
+const SearchPage = () => {
+  const [searchTerm, setSearchTerm] = useState('')
+
+  return (
+    <>
+      <SearchInput value={searchTerm} onChange={setSearchTerm} />
+      {searchTerm ? (
+        <SearchResultsCell searchTerm={searchTerm} />
+      ) : (
+        <p>Start typing to search</p>
+      )}
+    </>
+  )
+}
+```
+
+This keeps the Cell's contract simple (a rendered Cell always shows one of
+`Loading`, `Empty`, `Failure` or `Success`), and TypeScript checks the Cell's
+props at the call site with no extra work.
+
+But sometimes the condition is the Cell's own business rather than the parent's.
+Maybe the query depends on a value from a global store, or should only run when
+there's a signed-in user. The parent could check that too, but then every place
+that renders the Cell has to duplicate the check. To keep the condition in the
+Cell itself, return Apollo's
+[`skipToken`](https://www.apollographql.com/docs/react/api/react/skipToken)
+from `beforeQuery` instead of an options object:
+
+```jsx
+import { skipToken } from '@apollo/client/react'
+
+export const beforeQuery = ({ id }) => {
+  const otherId = useStore((state) => state.getOther(id))
+
+  return otherId ? { variables: { id, otherId } } : skipToken
+}
+```
+
+A skipped Cell renders nothing at all (neither `Loading`, `Empty`, `Failure` nor
+`Success`) just as if the parent hadn't rendered it.
+
+You can also skip by returning Apollo's `skip` option
+(`{ variables, skip: true }`), but prefer `skipToken`: with `skip` you still
+have to supply fully typed variables even though the query won't run, which
+tends to force non-null assertions like `id!`. With `skipToken` each branch of
+the ternary type-checks on its own.
+([Apollo recommends `skipToken` for the same reason](https://www.apollographql.com/docs/react/api/react/skipToken#why-do-we-recommend-skiptoken-over--skip-true-).)
+In TypeScript, you can annotate `beforeQuery`'s return type with
+`CellBeforeQueryResult<YourQueryVariables>` from `@cedarjs/web` to get full type
+checking of your variables.
+
+Finally, if you want to keep showing the previous result instead of rendering
+nothing, like keeping the last search results on screen while the user clears
+the search box, don't skip. Render the Cell unconditionally, freeze the
+variables at their last valid value, and let the cache serve the stale data:
+
+```jsx
+export const beforeQuery = ({ searchTerm }) => {
+  const lastSearchTerm = useRef(searchTerm)
+
+  if (searchTerm) {
+    lastSearchTerm.current = searchTerm
+  }
+
+  if (searchTerm) {
+    return { variables: { searchTerm } }
+  } else if (lastSearchTerm.current) {
+    // Serve the last result from the cache without hitting the network
+    return {
+      variables: { searchTerm: lastSearchTerm.current },
+      fetchPolicy: 'cache-first',
+    }
+  }
+
+  return skipToken
+}
+```
+
 ### isEmpty
 
 `isEmpty` is an optional lifecycle hook. It returns a boolean to indicate if the Cell should render empty. Use it to override the default check, which checks if the Cell's root fields are null or empty arrays.

--- a/packages/web/src/__typetests__/cellProps.test.tsx
+++ b/packages/web/src/__typetests__/cellProps.test.tsx
@@ -1,10 +1,11 @@
 // These are normally auto-imported by babel
 import React from 'react'
 
+import { skipToken } from '@apollo/client/react'
 import { gql } from 'graphql-tag'
 import { describe, expect, test } from 'tstyche'
 
-import { createCell, skipToken } from '@cedarjs/web'
+import { createCell } from '@cedarjs/web'
 import type { CellProps, CellSuccessProps } from '@cedarjs/web'
 
 type ExampleQueryVariables = {

--- a/packages/web/src/__typetests__/cellProps.test.tsx
+++ b/packages/web/src/__typetests__/cellProps.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { gql } from 'graphql-tag'
 import { describe, expect, test } from 'tstyche'
 
+import { createCell, skipToken } from '@cedarjs/web'
 import type { CellProps, CellSuccessProps } from '@cedarjs/web'
 
 type ExampleQueryVariables = {
@@ -192,6 +193,42 @@ describe('CellProps mapper type', () => {
       expect<CellWithBeforeQueryInputs>().type.toBeAssignableFrom({
         customProp: 55,
       })
+    })
+  })
+
+  describe('what beforeQuery is allowed to return', () => {
+    test('Just variables', () => {
+      expect(
+        createCell({
+          ...recipeCell,
+          beforeQuery: ({ word }: { word: string }) => ({
+            variables: { category: word, saved: true },
+          }),
+        }),
+      ).type.not.toRaiseError()
+    })
+
+    test('Other query hook options alongside the variables', () => {
+      expect(
+        createCell({
+          ...recipeCell,
+          beforeQuery: ({ word }: { word: string }) => ({
+            variables: { category: word, saved: true },
+            fetchPolicy: 'cache-only' as const,
+            skip: !word,
+          }),
+        }),
+      ).type.not.toRaiseError()
+    })
+
+    test('skipToken, to not run the query at all', () => {
+      expect(
+        createCell({
+          ...recipeCell,
+          beforeQuery: ({ word }: { word: string }) =>
+            word ? { variables: { category: word, saved: true } } : skipToken,
+        }),
+      ).type.not.toRaiseError()
     })
   })
 })

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -7,6 +7,7 @@ import type {
 } from '@apollo/client'
 import type {
   QueryRef,
+  SkipToken,
   useBackgroundQuery,
   useQuery,
 } from '@apollo/client/react'
@@ -137,6 +138,38 @@ export type CellSuccessProps<
 export type DataObject = { [key: string]: unknown }
 
 /**
+ * What `beforeQuery` returns is handed straight to the GraphQL client's query
+ * hook, so any of that hook's options can be set here – not just `variables`.
+ *
+ * These are `useQuery`'s options. With streaming SSR enabled a Cell runs
+ * through `useBackgroundQuery` instead, which accepts a slightly narrower set
+ * (no `fetchPolicy: 'cache-only'`, for example).
+ */
+export type CellBeforeQueryOptions<CellVariables> = {
+  variables: CellVariables
+} & Omit<useQuery.Options<DataObject, OperationVariables>, 'variables'>
+
+/**
+ * `beforeQuery` can return `skipToken` instead of an options object to keep the
+ * query from being executed at all. A skipped Cell renders nothing – none of
+ * `Loading`, `Empty`, `Failure` or `Success` are rendered.
+ *
+ * @see {@link https://www.apollographql.com/docs/react/api/react/hooks#skiptoken}
+ *
+ * @example
+ * ```ts
+ * export const beforeQuery = ({ id }) => {
+ *   const otherId = useStore((state) => state.getOther(id))
+ *
+ *   return otherId ? { variables: { id, otherId } } : skipToken
+ * }
+ * ```
+ */
+export type CellBeforeQueryResult<CellVariables> =
+  | CellBeforeQueryOptions<CellVariables>
+  | SkipToken
+
+/**
  * The main interface.
  */
 export interface CreateCellProps<CellProps, CellVariables> {
@@ -160,10 +193,13 @@ export interface CreateCellProps<CellProps, CellVariables> {
   FRAGMENT?: DocumentNode
   /**
    * Parse `props` into query variables. Most of the time `props` are appropriate variables as is.
+   *
+   * Any other option the GraphQL client's query hook accepts can be returned
+   * here as well. Return `skipToken` to not execute the query at all.
    */
   beforeQuery?:
-    | ((props: CellProps) => { variables: CellVariables })
-    | (() => { variables: CellVariables })
+    | ((props: CellProps) => CellBeforeQueryResult<CellVariables>)
+    | (() => CellBeforeQueryResult<CellVariables>)
   /**
    * Sanitize the data returned from the query.
    */
@@ -235,8 +271,7 @@ export type NonSuspenseCellQueryResult<
 export interface SuspenseCellQueryResult<
   _TData = any,
   _TVariables extends OperationVariables = any,
->
-  extends useBackgroundQuery.Result {
+> extends useBackgroundQuery.Result<DataObject> {
   client: ApolloClient
   // fetchMore & refetch come from useBackgroundQuery.Result
   networkStatus?: NetworkStatus

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -158,6 +158,8 @@ export type CellBeforeQueryOptions<CellVariables> = {
  *
  * @example
  * ```ts
+ * import { skipToken } from '@apollo/client/react'
+ *
  * export const beforeQuery = ({ id }) => {
  *   const otherId = useStore((state) => state.getOther(id))
  *

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -139,11 +139,7 @@ export type DataObject = { [key: string]: unknown }
 
 /**
  * What `beforeQuery` returns is handed straight to the GraphQL client's query
- * hook, so any of that hook's options can be set here – not just `variables`.
- *
- * These are `useQuery`'s options. With streaming SSR enabled a Cell runs
- * through `useBackgroundQuery` instead, which accepts a slightly narrower set
- * (no `fetchPolicy: 'cache-only'`, for example).
+ * hook, so any of that hook's options can be set here.
  */
 export type CellBeforeQueryOptions<CellVariables> = {
   variables: CellVariables
@@ -151,7 +147,7 @@ export type CellBeforeQueryOptions<CellVariables> = {
 
 /**
  * `beforeQuery` can return `skipToken` instead of an options object to keep the
- * query from being executed at all. A skipped Cell renders nothing – none of
+ * query from being executed at all. A skipped Cell renders nothing -- none of
  * `Loading`, `Empty`, `Failure` or `Success` are rendered.
  *
  * @see {@link https://www.apollographql.com/docs/react/api/react/hooks#skiptoken}

--- a/packages/web/src/components/cell/createCell.test.tsx
+++ b/packages/web/src/components/cell/createCell.test.tsx
@@ -9,7 +9,7 @@ import { vi, describe, beforeAll, beforeEach, test, expect } from 'vitest'
 import { createCell } from './createCell.js'
 
 vi.mock('@apollo/client/react', async (importOriginal) => ({
-  // Keep the real `skipToken` – it's a symbol the Cell compares against
+  // Keep the real `skipToken`. It's a symbol the Cell compares against
   ...(await importOriginal<typeof ApolloClientReact>()),
   useQuery: vi.fn(),
 }))

--- a/packages/web/src/components/cell/createCell.test.tsx
+++ b/packages/web/src/components/cell/createCell.test.tsx
@@ -439,4 +439,28 @@ describe('createCell', () => {
 
     screen.getByText(/^Hello Bob!$/)
   })
+  
+  test('Allows skip option in beforeQuery', () => {
+    const TestCell = createCell({
+      // @ts-expect-error - Purposefully using a plain string here.
+      QUERY: 'query TestQuery { answer }',
+      Success: () => <>Should not be</>,
+      Loading: () => <>Should not be</>,
+      Empty: () => <>Should not be</>,
+      beforeQuery: () => ({
+        skip: true
+      }),
+    })
+
+    const myUseQueryHook = () => ({ data: undefined, loading: false, error: undefined })
+
+    render(
+      <GraphQLHooksProvider useQuery={myUseQueryHook} useMutation={null}>
+        <TestCell />
+      </GraphQLHooksProvider>,
+    )
+
+    const child = screen.queryByText('/^Should not be$/');
+    expect(child).toBeNull();
+  })
 })

--- a/packages/web/src/components/cell/createCell.test.tsx
+++ b/packages/web/src/components/cell/createCell.test.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
 
-import { useQuery } from '@apollo/client/react'
+import type * as ApolloClientReact from '@apollo/client/react'
+import { skipToken, useQuery } from '@apollo/client/react'
 import { render, screen } from '@testing-library/react'
 import type { Mock } from 'vitest'
 import { vi, describe, beforeAll, beforeEach, test, expect } from 'vitest'
 
 import { createCell } from './createCell.js'
 
-vi.mock('@apollo/client/react', () => ({
+vi.mock('@apollo/client/react', async (importOriginal) => ({
+  // Keep the real `skipToken` – it's a symbol the Cell compares against
+  ...(await importOriginal<typeof ApolloClientReact>()),
   useQuery: vi.fn(),
 }))
 
@@ -439,28 +442,78 @@ describe('createCell', () => {
 
     screen.getByText(/^Hello Bob!$/)
   })
-  
-  test('Allows skip option in beforeQuery', () => {
+
+  test('Renders nothing when beforeQuery returns skipToken', () => {
     const TestCell = createCell({
       // @ts-expect-error - Purposefully using a plain string here.
       QUERY: 'query TestQuery { answer }',
-      Success: () => <>Should not be</>,
-      Loading: () => <>Should not be</>,
-      Empty: () => <>Should not be</>,
-      beforeQuery: () => ({
-        skip: true
-      }),
+      Success: () => <>Should not render</>,
+      Loading: () => <>Should not render</>,
+      Empty: () => <>Should not render</>,
+      Failure: () => <>Should not render</>,
+      beforeQuery: () => skipToken,
     })
 
-    const myUseQueryHook = () => ({ data: undefined, loading: false, error: undefined })
+    // What Apollo Client returns for a skipped query
+    mockUseQuery.mockImplementation(() => ({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    }))
 
-    render(
-      <GraphQLHooksProvider useQuery={myUseQueryHook} useMutation={null}>
-        <TestCell />
-      </GraphQLHooksProvider>,
-    )
+    const { container } = render(<TestCell />)
 
-    const child = screen.queryByText('/^Should not be$/');
-    expect(child).toBeNull();
+    expect(screen.queryByText(/^Should not render$/)).not.toBeInTheDocument()
+    expect(container).toBeEmptyDOMElement()
+    expect(mockUseQuery).toHaveBeenCalledWith(expect.anything(), skipToken)
+  })
+
+  test('Renders nothing when beforeQuery sets the skip option', () => {
+    const TestCell = createCell({
+      // @ts-expect-error - Purposefully using a plain string here.
+      QUERY: 'query TestQuery { answer }',
+      Success: () => <>Should not render</>,
+      Loading: () => <>Should not render</>,
+      Empty: () => <>Should not render</>,
+      Failure: () => <>Should not render</>,
+      beforeQuery: () => ({ variables: {}, skip: true }),
+    })
+
+    mockUseQuery.mockImplementation(() => ({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    }))
+
+    const { container } = render(<TestCell />)
+
+    expect(screen.queryByText(/^Should not render$/)).not.toBeInTheDocument()
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  test('Runs the query once beforeQuery stops skipping', () => {
+    const TestCell = createCell({
+      // @ts-expect-error - Purposefully using a plain string here.
+      QUERY: 'query TestQuery($name: String) { greeting(name: $name) }',
+      Success: ({ greeting }) => <>{greeting}</>,
+      beforeQuery: ({ name }: { name?: string }) =>
+        name ? { variables: { name } } : skipToken,
+    })
+
+    mockUseQuery.mockImplementation((_query: any, options: any) => {
+      if (options === skipToken) {
+        return { data: undefined, loading: false, error: undefined }
+      }
+
+      return { data: { greeting: `Hello ${options.variables.name}!` } }
+    })
+
+    const { container, rerender } = render(<TestCell />)
+
+    expect(container).toBeEmptyDOMElement()
+
+    rerender(<TestCell name="Bob" />)
+
+    screen.getByText(/^Hello Bob!$/)
   })
 })

--- a/packages/web/src/components/cell/createCell.tsx
+++ b/packages/web/src/components/cell/createCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { CombinedGraphQLErrors } from '@apollo/client'
-import { skipToken, useQuery } from '@apollo/client/react'
+import { useQuery } from '@apollo/client/react'
 
 import { fragmentRegistry } from '../../apollo/fragmentRegistry.js'
 import { getOperationName } from '../../graphql.js'
@@ -101,8 +101,11 @@ function createNonSuspendingCell<
     // `beforeQuery` can keep the query from running, either by returning
     // Apollo's `skipToken` (recommended) or by setting the `skip` option.
     // `skipToken` is a symbol rather than an options object, so everything that
-    // reads individual options has to go through `queryOptions`
-    const queryOptions = options === skipToken ? undefined : options
+    // reads individual options has to go through `queryOptions`.
+    // We check for a symbol instead of comparing against `skipToken` itself
+    // because Apollo Client deliberately leaves `skipToken` out of its
+    // react-server build, where importing it is a bundling error
+    const queryOptions = typeof options === 'symbol' ? undefined : options
     const skipped = !queryOptions || queryOptions.skip === true
 
     // While skipped the document is never executed, it just has to exist to

--- a/packages/web/src/components/cell/createCell.tsx
+++ b/packages/web/src/components/cell/createCell.tsx
@@ -134,7 +134,7 @@ function createNonSuspendingCell<
 
       // A skipped Cell doesn't render any data, so there's no point in having
       // the prerenderer execute its query. Note that the hook above still has
-      // to run unconditionally – `skipped` can change between renders
+      // to run unconditionally because `skipped` can change between renders
       if (!skipped) {
         const operationName = getOperationName(query)
         const transformedQuery = fragmentRegistry.transform(query)

--- a/packages/web/src/components/cell/createCell.tsx
+++ b/packages/web/src/components/cell/createCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { CombinedGraphQLErrors } from '@apollo/client'
-import { useQuery } from '@apollo/client/react'
+import { skipToken, useQuery } from '@apollo/client/react'
 
 import { fragmentRegistry } from '../../apollo/fragmentRegistry.js'
 import { getOperationName } from '../../graphql.js'
@@ -97,8 +97,20 @@ function createNonSuspendingCell<
      */
     const { children: _, ...variables } = props
     const options = beforeQuery(variables as CellProps)
+
+    // `beforeQuery` can keep the query from running, either by returning
+    // Apollo's `skipToken` (recommended) or by setting the `skip` option.
+    // `skipToken` is a symbol rather than an options object, so everything that
+    // reads individual options has to go through `queryOptions`
+    const queryOptions = options === skipToken ? undefined : options
+    const skipped = !queryOptions || queryOptions.skip === true
+
+    // While skipped the document is never executed, it just has to exist to
+    // satisfy the query hook
     const query =
-      typeof cellQuery === 'function' ? cellQuery(options) : cellQuery
+      typeof cellQuery === 'function'
+        ? cellQuery(queryOptions ?? {})
+        : cellQuery
 
     // queryRest includes `variables: { ... }`, with any variables returned
     // from beforeQuery
@@ -116,47 +128,60 @@ function createNonSuspendingCell<
       // statement
       /* eslint-disable-next-line react-hooks/rules-of-hooks */
       const { queryCache } = useCellCacheContext()
-      const operationName = getOperationName(query)
-      const transformedQuery = fragmentRegistry.transform(query)
 
-      let cacheKey
+      // A skipped Cell doesn't render any data, so there's no point in having
+      // the prerenderer execute its query. Note that the hook above still has
+      // to run unconditionally – `skipped` can change between renders
+      if (!skipped) {
+        const operationName = getOperationName(query)
+        const transformedQuery = fragmentRegistry.transform(query)
 
-      if (operationName) {
-        cacheKey = operationName + '_' + JSON.stringify(variables)
-      } else {
-        const cellName = displayName === 'Cell' ? 'the cell' : displayName
+        let cacheKey
 
-        throw new Error(
-          `The gql query in ${cellName} is missing an operation name. ` +
-            'Something like FindBlogPostQuery in ' +
-            '`query FindBlogPostQuery($id: Int!)`',
-        )
-      }
-
-      const queryInfo = queryCache[cacheKey]
-
-      // This is true when the graphql handler couldn't be loaded
-      // So we fallback to the loading state
-      if (queryInfo?.renderLoading) {
-        loading = true
-      } else {
-        if (queryInfo?.hasProcessed) {
-          loading = false
-          // The prerender query cache stores the untyped result of executing
-          // this Cell's query, so it has the `DataObject` shape
-          data = queryInfo.data as DataObject
-
-          // All of the gql client's props aren't available when pre-rendering,
-          // so using `any` here
-          queryResult = { variables } as any
+        if (operationName) {
+          cacheKey = operationName + '_' + JSON.stringify(variables)
         } else {
-          queryCache[cacheKey] ||= {
-            query: transformedQuery,
-            variables: options.variables,
-            hasProcessed: false,
+          const cellName = displayName === 'Cell' ? 'the cell' : displayName
+
+          throw new Error(
+            `The gql query in ${cellName} is missing an operation name. ` +
+              'Something like FindBlogPostQuery in ' +
+              '`query FindBlogPostQuery($id: Int!)`',
+          )
+        }
+
+        const queryInfo = queryCache[cacheKey]
+
+        // This is true when the graphql handler couldn't be loaded
+        // So we fallback to the loading state
+        if (queryInfo?.renderLoading) {
+          loading = true
+        } else {
+          if (queryInfo?.hasProcessed) {
+            loading = false
+            // The prerender query cache stores the untyped result of executing
+            // this Cell's query, so it has the `DataObject` shape
+            data = queryInfo.data as DataObject
+
+            // All of the gql client's props aren't available when pre-rendering,
+            // so using `any` here
+            queryResult = { variables } as any
+          } else {
+            queryCache[cacheKey] ||= {
+              query: transformedQuery,
+              variables: queryOptions.variables,
+              hasProcessed: false,
+            }
           }
         }
       }
+    }
+
+    // A skipped Cell never asked for any data, which is a different thing from
+    // asking and getting nothing back, so it renders nothing at all rather than
+    // `Empty` or `Loading`
+    if (skipped) {
+      return null
     }
 
     if (error) {
@@ -211,8 +236,6 @@ function createNonSuspendingCell<
       }
     } else if (loading) {
       return <Loading {...props} queryResult={queryResult} />
-    } else if(options?.skip)
-      return null
     } else {
       /**
        * There really shouldn't be an `else` here, but like any piece of software, GraphQL clients have bugs.

--- a/packages/web/src/components/cell/createCell.tsx
+++ b/packages/web/src/components/cell/createCell.tsx
@@ -211,6 +211,8 @@ function createNonSuspendingCell<
       }
     } else if (loading) {
       return <Loading {...props} queryResult={queryResult} />
+    } else if(options?.skip)
+      return null
     } else {
       /**
        * There really shouldn't be an `else` here, but like any piece of software, GraphQL clients have bugs.

--- a/packages/web/src/components/cell/createSuspendingCell.test.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.test.tsx
@@ -1,15 +1,22 @@
 import React from 'react'
 
 import { loadErrorMessages, loadDevMessages } from '@apollo/client/dev'
-import { useBackgroundQuery, useReadQuery } from '@apollo/client/react'
+import type * as ApolloClientReact from '@apollo/client/react'
+import {
+  skipToken,
+  useBackgroundQuery,
+  useReadQuery,
+} from '@apollo/client/react'
 import { render, screen } from '@testing-library/react'
 import type { Mock } from 'vitest'
-import { vi, describe, beforeAll, beforeEach, test } from 'vitest'
+import { vi, describe, beforeAll, beforeEach, test, expect } from 'vitest'
 
 import { createSuspendingCell } from './createSuspendingCell.js'
 
-vi.mock('@apollo/client/react', () => {
+vi.mock('@apollo/client/react', async (importOriginal) => {
   return {
+    // Keep the real `skipToken` – it's a symbol the Cell compares against
+    ...(await importOriginal<typeof ApolloClientReact>()),
     useApolloClient: vi.fn(),
     useBackgroundQuery: vi.fn(),
     useReadQuery: vi.fn(),
@@ -126,5 +133,34 @@ describe('createSuspendingCell', () => {
 
     screen.getByText(/bazinga/)
     screen.getByText(/kittens/)
+  })
+
+  test('Renders nothing when beforeQuery returns skipToken', () => {
+    const TestCell = createSuspendingCell({
+      // @ts-expect-error - Purposefully using a plain string here.
+      QUERY: 'query TestQuery { answer }',
+      Success: () => <>Should not render</>,
+      Loading: () => <>Should not render</>,
+      Empty: () => <>Should not render</>,
+      Failure: () => <>Should not render</>,
+      beforeQuery: () => skipToken,
+    })
+
+    // Apollo Client hands back an undefined query reference for a skipped query
+    mockUseBackgroundQuery.mockImplementation(() => {
+      return [undefined, { refetch: vi.fn(), fetchMore: vi.fn() }]
+    })
+
+    const { container } = render(<TestCell />)
+
+    expect(screen.queryByText(/^Should not render$/)).not.toBeInTheDocument()
+    expect(container).toBeEmptyDOMElement()
+    // `useReadQuery` throws when given an undefined query reference, so the
+    // Cell has to bail out before it gets there
+    expect(mockUseReadQuery).not.toHaveBeenCalled()
+    expect(mockUseBackgroundQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      skipToken,
+    )
   })
 })

--- a/packages/web/src/components/cell/createSuspendingCell.test.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.test.tsx
@@ -15,7 +15,8 @@ import { createSuspendingCell } from './createSuspendingCell.js'
 
 vi.mock('@apollo/client/react', async (importOriginal) => {
   return {
-    // Keep the real `skipToken` – it's a symbol the Cell compares against
+    // We want to keep the real `skipToken` because it's a symbol the Cell
+    // compares against
     ...(await importOriginal<typeof ApolloClientReact>()),
     useApolloClient: vi.fn(),
     useBackgroundQuery: vi.fn(),

--- a/packages/web/src/components/cell/createSuspendingCell.test.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.test.tsx
@@ -163,4 +163,32 @@ describe('createSuspendingCell', () => {
       skipToken,
     )
   })
+
+  test('Renders nothing when an active Cell becomes skipped', () => {
+    const TestCell = createSuspendingCell({
+      // @ts-expect-error - Purposefully using a plain string here.
+      QUERY: 'query TestQuery($name: String) { greeting(name: $name) }',
+      Success: ({ greeting }) => <>{greeting}</>,
+      beforeQuery: ({ name }: { name?: string }) =>
+        name ? { variables: { name } } : skipToken,
+    })
+
+    // Once the query has run, Apollo Client keeps handing back the same query
+    // reference even when the Cell is skipped again later
+    mockUseBackgroundQuery.mockImplementation(() => {
+      return ['mocked-query-ref', { refetch: vi.fn(), fetchMore: vi.fn() }]
+    })
+    mockUseReadQuery.mockImplementation(() => ({
+      data: { greeting: 'Hello Bob!' },
+    }))
+
+    const { container, rerender } = render(<TestCell name="Bob" />)
+
+    screen.getByText(/^Hello Bob!$/)
+
+    rerender(<TestCell />)
+
+    expect(screen.queryByText(/^Hello Bob!$/)).not.toBeInTheDocument()
+    expect(container).toBeEmptyDOMElement()
+  })
 })

--- a/packages/web/src/components/cell/createSuspendingCell.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.tsx
@@ -2,8 +2,9 @@ import React, { Suspense } from 'react'
 
 import type { OperationVariables } from '@apollo/client'
 import { CombinedGraphQLErrors } from '@apollo/client'
-import type { QueryRef } from '@apollo/client/react'
+import type { SkipToken } from '@apollo/client/react'
 import {
+  skipToken,
   useApolloClient,
   useBackgroundQuery,
   useReadQuery,
@@ -108,11 +109,38 @@ export function createSuspendingCell<
      */
     const { children: _, ...variables } = props
     const options = beforeQuery(variables)
+
+    // `skipToken` is a symbol rather than an options object, so there's nothing
+    // to hand to a `QUERY` function. While skipped the document is never
+    // executed, it just has to exist to satisfy the query hook
     const query =
-      typeof cellQuery === 'function' ? cellQuery(options) : cellQuery
-    const [queryRef, other] = useBackgroundQuery(query, options)
+      typeof cellQuery === 'function'
+        ? cellQuery(options === skipToken ? {} : options)
+        : cellQuery
+    // `beforeQuery`'s options are typed against `useQuery`, which accepts a
+    // slightly wider `fetchPolicy` than `useBackgroundQuery` does. Streaming
+    // Cells that set one of the extra policies aren't supported
+    const backgroundQueryOptions = options as
+      | SkipToken
+      | useBackgroundQuery.Options<OperationVariables>
+
+    // The query document is untyped, so Apollo Client would infer `unknown` for
+    // the data. Cells treat query results as `DataObject`s, same as `useQuery`
+    // is called in createCell
+    const [queryRef, other] = useBackgroundQuery<DataObject>(
+      query,
+      backgroundQueryOptions,
+    )
 
     const client = useApolloClient()
+
+    // `beforeQuery` can keep the query from running, either by returning
+    // `skipToken` or by setting the `skip` option. Either way there's no query
+    // reference to read from, and `useReadQuery` throws when given `undefined`.
+    // Like the non-suspending Cell, a skipped Cell renders nothing
+    if (!queryRef) {
+      return null
+    }
 
     const suspenseQueryResult: SuspenseCellQueryResult = {
       client,
@@ -179,7 +207,7 @@ export function createSuspendingCell<
         {wrapInSuspenseIfLoadingPresent(
           <SuspendingSuccess
             userProps={props}
-            queryRef={queryRef as QueryRef<DataObject>}
+            queryRef={queryRef}
             suspenseQueryResult={suspenseQueryResult}
           />,
           Loading,

--- a/packages/web/src/components/cell/createSuspendingCell.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.tsx
@@ -4,7 +4,6 @@ import type { OperationVariables } from '@apollo/client'
 import { CombinedGraphQLErrors } from '@apollo/client'
 import type { SkipToken } from '@apollo/client/react'
 import {
-  skipToken,
   useApolloClient,
   useBackgroundQuery,
   useReadQuery,
@@ -13,6 +12,7 @@ import {
 import type { FallbackProps } from './CellErrorBoundary.js'
 import { CellErrorBoundary } from './CellErrorBoundary.js'
 import type {
+  CellBeforeQueryResult,
   CreateCellProps,
   DataObject,
   SuspendingSuccessProps,
@@ -34,7 +34,11 @@ export function createSuspendingCell<
 ): React.FC<CellProps> {
   const {
     QUERY,
-    beforeQuery = (props) => ({
+    // Unlike in createCell this is destructured from a variable rather than
+    // from an annotated parameter, so the default's return type has to be
+    // spelled out. Without it the inferred object literal type widens the
+    // union and options like `skip` are no longer visible on it
+    beforeQuery = (props): CellBeforeQueryResult<CellVariables> => ({
       // By default, we assume that the props are the gql-variables.
       variables: props as unknown as CellVariables,
       /**
@@ -110,12 +114,21 @@ export function createSuspendingCell<
     const { children: _, ...variables } = props
     const options = beforeQuery(variables)
 
-    // `skipToken` is a symbol rather than an options object, so there's nothing
-    // to hand to a `QUERY` function. While skipped the document is never
-    // executed, it just has to exist to satisfy the query hook
+    // `beforeQuery` can keep the query from running, either by returning
+    // Apollo's `skipToken` (recommended) or by setting the `skip` option.
+    // `skipToken` is a symbol rather than an options object, so everything that
+    // reads individual options has to go through `queryOptions`.
+    // We check for a symbol instead of comparing against `skipToken` itself
+    // because Apollo Client deliberately leaves `skipToken` out of its
+    // react-server build, where importing it is a bundling error
+    const queryOptions = typeof options === 'symbol' ? undefined : options
+    const skipped = !queryOptions || queryOptions.skip === true
+
+    // While skipped the document is never executed, it just has to exist to
+    // satisfy the query hook
     const query =
       typeof cellQuery === 'function'
-        ? cellQuery(options === skipToken ? {} : options)
+        ? cellQuery(queryOptions ?? {})
         : cellQuery
     // `beforeQuery`'s options are typed against `useQuery`, which accepts a
     // slightly wider `fetchPolicy` than `useBackgroundQuery` does. Streaming
@@ -134,11 +147,15 @@ export function createSuspendingCell<
 
     const client = useApolloClient()
 
-    // `beforeQuery` can keep the query from running, either by returning
-    // `skipToken` or by setting the `skip` option. Either way there's no query
-    // reference to read from, and `useReadQuery` throws when given `undefined`.
-    // Like the non-suspending Cell, a skipped Cell renders nothing
-    if (!queryRef) {
+    // Like the non-suspending Cell, a skipped Cell renders nothing.
+    //
+    // `queryRef` is undefined while the query has never run, and passing that
+    // to `useReadQuery` throws. But once the query has run even once, Apollo
+    // Client keeps handing back the previous `queryRef` even if the Cell is
+    // skipped again later, so a Cell going from active to skipped would keep
+    // rendering stale data. That's why this checks `skipped` – derived from
+    // what `beforeQuery` returned – and not just the query reference
+    if (skipped || !queryRef) {
       return null
     }
 

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -7,7 +7,12 @@ export {
   FetchConfigProvider,
   useFetchConfig,
 } from './components/FetchConfigProvider.js'
-export { useQuery, useMutation, useSubscription } from '@apollo/client/react'
+export {
+  skipToken,
+  useQuery,
+  useMutation,
+  useSubscription,
+} from '@apollo/client/react'
 export { useFragment } from './apollo/fragmentRegistry.js'
 export type {
   FragmentHookOptions,
@@ -25,6 +30,8 @@ export type {
   CellLoadingProps,
   CellSuccessProps,
   CellSuccessData,
+  CellBeforeQueryOptions,
+  CellBeforeQueryResult,
 } from './components/cell/cellTypes.js'
 
 export * from './graphql.js'

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -7,12 +7,7 @@ export {
   FetchConfigProvider,
   useFetchConfig,
 } from './components/FetchConfigProvider.js'
-export {
-  skipToken,
-  useQuery,
-  useMutation,
-  useSubscription,
-} from '@apollo/client/react'
+export { useQuery, useMutation, useSubscription } from '@apollo/client/react'
 export { useFragment } from './apollo/fragmentRegistry.js'
 export type {
   FragmentHookOptions,


### PR DESCRIPTION
When `skip` is true, cell's data is `undefined`, and throw an error _"Cannot render Cell: reached an unexpected state where the query succeeded but `data` is `null` [...]"._

As we can return any valid option from `GraphQLQueryHookOptions<any, GraphQLOperationVariables>` from `beforeQuery`, IMO it should be handled. 

I personnaly use it to skip loading when some of the mandatory params are not retrieved yet from an internal store:
```
export const beforeQuery = (id): GraphQLQueryHookOptions<any, GraphQLOperationVariables> => {
    const other_id = useStore(state => state.getOther(id))
    return {
      skip: !other_id,
      variables: {
        id,
        other_id
      }
    }
}
```

I suggest returning null in that case, and wrote an (untested) test accordingly (maybe not optimal).