### PR TITLE
fix(api-server,web-server): Default host to :: for dual-stack binding

### DIFF
--- a/docs/docs/app-configuration-cedar-toml.md
+++ b/docs/docs/app-configuration-cedar-toml.md
@@ -29,17 +29,17 @@ For certain options, instead of having to configure build tools directly, there'
 
 ## [web]
 
-| Key                           | Description                                                                                                     | Default                                                         |
-| :---------------------------- | :-------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------- |
-| `title`                       | Title of your Cedar app                                                                                         | `'Cedar App'`                                                   |
-| `port`                        | Port for the web server to listen at                                                                            | `8910`                                                          |
-| `apiUrl`                      | URL to your api server. This can be a relative URL in which case it acts like a proxy, or a fully-qualified URL | `'/.api/functions'`                                             |
-| `includeEnvironmentVariables` | Environment variables made available to the web side during dev and build                                       | `[]`                                                            |
-| `host`                        | Hostname for the web server to listen at                                                                        | Defaults to `'0.0.0.0'` in production and `'::'` in development |
-| `apiGraphQLUrl`               | URL to your GraphQL function                                                                                    | `'${apiUrl}/graphql'`                                           |
-| `apiDbAuthUrl`                | URL to your dbAuth function                                                                                     | `'${apiUrl}/auth'`                                              |
-| `sourceMap`                   | Enable source maps for production builds                                                                        | `false`                                                         |
-| `a11y`                        | Enable storybook `addon-a11y` and `eslint-plugin-jsx-a11y`                                                      | `true`                                                          |
+| Key                           | Description                                                                                                     | Default               |
+| :---------------------------- | :-------------------------------------------------------------------------------------------------------------- | :-------------------- |
+| `title`                       | Title of your Cedar app                                                                                         | `'Cedar App'`         |
+| `port`                        | Port for the web server to listen at                                                                            | `8910`                |
+| `apiUrl`                      | URL to your api server. This can be a relative URL in which case it acts like a proxy, or a fully-qualified URL | `'/.api/functions'`   |
+| `includeEnvironmentVariables` | Environment variables made available to the web side during dev and build                                       | `[]`                  |
+| `host`                        | Hostname for the web server to listen at                                                                        | `'::'`                |
+| `apiGraphQLUrl`               | URL to your GraphQL function                                                                                    | `'${apiUrl}/graphql'` |
+| `apiDbAuthUrl`                | URL to your dbAuth function                                                                                     | `'${apiUrl}/auth'`    |
+| `sourceMap`                   | Enable source maps for production builds                                                                        | `false`               |
+| `a11y`                        | Enable storybook `addon-a11y` and `eslint-plugin-jsx-a11y`                                                      | `true`                |
 
 ### Customizing the GraphQL Endpoint
 
@@ -108,12 +108,12 @@ Don't make secrets available to your web side. Everything in `includeEnvironment
 
 ## [api]
 
-| Key            | Description                              | Default                                                         |
-| :------------- | :--------------------------------------- | :-------------------------------------------------------------- |
-| `port`         | Port for the api server to listen at     | `8911`                                                          |
-| `host`         | Hostname for the api server to listen at | Defaults to `'0.0.0.0'` in production and `'::'` in development |
-| `prismaConfig` | Path to the Prisma configuration file    | Defaults to `./api/prisma.config.cjs`                           |
-| `debugPort`    | Port for the debugger to listen at       | `18911`                                                         |
+| Key            | Description                              | Default                               |
+| :------------- | :--------------------------------------- | :------------------------------------ |
+| `port`         | Port for the api server to listen at     | `8911`                                |
+| `host`         | Hostname for the api server to listen at | `'::'`                                |
+| `prismaConfig` | Path to the Prisma configuration file    | Defaults to `./api/prisma.config.cjs` |
+| `debugPort`    | Port for the debugger to listen at       | `18911`                               |
 
 Additional server configuration can be done using [Server File](docker.md#using-the-server-file)
 
@@ -186,7 +186,11 @@ Just remember two things:
 
 ## Running in a Container or VM
 
-To run a Cedar app in a container or VM, you'll want to set both the web and api's `host` to `0.0.0.0` to allow network connections to and from the host:
+The web and api servers both default to `host = '::'`, which binds dual-stack
+(IPv4 and IPv6) on hosts that support it — no configuration needed to accept
+connections from outside the container.
+
+If you need to pin to IPv4 only, set `host` explicitly:
 
 ```toml title="cedar.toml"
 [web]
@@ -196,7 +200,6 @@ To run a Cedar app in a container or VM, you'll want to set both the web and api
 ```
 
 You can also configure these values via `CEDAR_WEB_HOST` and `CEDAR_API_HOST`.
-And if you set `NODE_ENV` to production, these will be the defaults anyway.
 
 ### Container hosts
 

--- a/docs/docs/server-file.md
+++ b/docs/docs/server-file.md
@@ -263,5 +263,6 @@ await server.listen({
 })
 ```
 
-If you don't specify a host, `createServer` uses `NODE_ENV` to set it. If `NODE_ENV` is production, it defaults to `'0.0.0.0'` and `'::'` otherwise.
-Our default Dockerfile sets `NODE_ENV` to production so that things work out of the box.
+If you don't specify a host, `createServer` defaults to `'::'`, which binds
+dual-stack (IPv4 and IPv6) on hosts that support it — no `NODE_ENV`-specific
+behavior, so it works the same in development and production.

--- a/docs/implementation-plans/2026-08-03-deploy-simplification.md
+++ b/docs/implementation-plans/2026-08-03-deploy-simplification.md
@@ -43,14 +43,14 @@ Railway-only.
 | 1   | Read `PORT` and `HOST`                     | **Done** — #2292                               |
 | 2   | `build` / `start` scripts in templates     | #2294 done; switch to `cedarjs-server` — #2323 |
 | 3   | Runtime deps out of root `devDependencies` | Reframed — #2295 superseded by #2312/#2313     |
-| 4   | Web server cache headers + compression     | #2301                                          |
-| 5   | Dual-stack host default                    | Open                                           |
-| 6   | Generic `setup deploy container`           | **Superseded** — #2303                         |
+| 4   | Web server cache headers + compression     | **Done** — #2301                               |
+| 5   | Dual-stack host default                    | **Done**                                       |
+| 6   | Generic `setup deploy container`           | **Done** — #2303 (#2331), follow-up in #2336   |
 | 7   | Built-in health endpoint                   | #2298                                          |
 | 8   | Rename `REDWOOD_*` → `CEDAR_*`             | **Done** — #2292                               |
 | 9   | Document the serve tiers                   | #2300                                          |
 
-Also opened along the way: #2296, #2297, #2299, #2302.
+Also opened along the way: #2296, #2297, #2299, #2302, #2336.
 
 ## 1. Read `PORT` and `HOST` — done (#2292)
 
@@ -120,7 +120,7 @@ command not found. Railway only works because `RAILPACK_PRUNE_DEPS` is opt-in.
 that `cedar serve` does) — fixed by #2318. Root dependency + script switch
 landed in #2323.
 
-## 4. Web server cache headers and compression — #2301
+## 4. Web server cache headers and compression — done (#2301)
 
 `adapters/fastify/web/src/web.ts:26` is
 `fastify.register(fastifyStatic, { root: getPaths().web.dist })` — no `maxAge`,
@@ -135,17 +135,23 @@ people serve assets through Fastify rather than a CDN, and telling someone their
 zero-config deploy needs a CDN bolted on undercuts the point. Note `srvx/static`
 on the UD path is equally bare, so any fix should consider both.
 
-## 5. Dual-stack host default — open
+## 5. Dual-stack host default — done
 
-`cliHelpers.ts` still defaults to `0.0.0.0` in production, which is IPv4-only.
-Railway's private network is IPv6-native, so the two-service topology needs an
-explicit `--host ::` on the api service. `::` accepts both on dual-stack.
+`cliHelpers.ts` defaulted to `0.0.0.0` in production, which is IPv4-only.
+Railway's private network is IPv6-native, so the two-service topology needed
+an explicit `--host ::` on the api service. `::` accepts both on dual-stack.
 
-Either default to `::` and drop the `0.0.0.0` warning, or document the gotcha
-prominently. This is the single most likely thing to break a first Railway
-two-service deploy.
+Took the stronger of the two options laid out originally: default to `::`
+unconditionally (dropping the `NODE_ENV`-based split) and drop the `0.0.0.0`
+warning entirely, rather than just documenting the gotcha. Changed in
+`getAPIHost`/`getWebHost` (`@cedarjs/api-server`'s `cliHelpers.ts`) and the
+duplicated logic in `@cedarjs/web-server`'s `webServer.ts`. Also dropped the
+now-inaccurate "you most likely want `0.0.0.0` in production" hints from the
+`--host` flag descriptions in `apiCLIConfig.ts`, `bothCLIConfig.ts`, and
+`web-server`'s `cliConfig.ts`, and corrected the same claim in
+`app-configuration-cedar-toml.md` and `server-file.md`.
 
-## 6. Generic `setup deploy container` — superseded by #2303
+## 6. Generic `setup deploy container` — superseded by #2303, done via #2331
 
 The original argument was that one generic target plus thin presets beats a
 hardcoded provider enum. Tracing it through, that doesn't survive contact with
@@ -159,7 +165,12 @@ What _is_ worth extracting: `yarn cedar setup neon` already performs the whole
 SQLite → Postgres migration, and only one of its eleven steps (provisioning) is
 Neon-specific. Pulling the provider-agnostic part out serves every container
 deploy — it's the biggest manual step in any non-SQLite deployment. Tracked in
-#2303.
+#2303, landed via #2331 as `setup database postgres`. A precondition gate
+(`checkProjectShape`) decides up front whether the project is safe to convert
+automatically; anything else is a manual conversion, not a guessed one. One
+follow-up spun out of review, tracked separately rather than blocking: #2336
+(`setup neon`'s "already configured" guard doesn't validate that an existing
+`DATABASE_URL` is actually a usable Postgres connection string).
 
 ## 7. Built-in health endpoint — #2298
 
@@ -267,8 +278,8 @@ comments. `preDeployCommand` suits migrations. Railway's CDN is per-service,
 free on all plans, and caches static assets by `Content-Type` — the thing that
 most compensates for #4. Private networking is IPv6-native, hence #5.
 
-**`yarn cedar setup deploy railway`** — worth it only as a thin preset once #2303
-lands, not as another bespoke provider.
+**`yarn cedar setup deploy railway`** — now that #2303 has landed, worth doing
+only as a thin preset on top of it, not as another bespoke provider.
 
 **Don't** build a Railway-specific build path. The gaps are all on Cedar's side.
 
@@ -283,7 +294,7 @@ lands, not as another bespoke provider.
    to `cedarjs-server`. #2294 shipped the scripts as `cedar serve`; the switch to
    `cedarjs-server` landed in #2323, once unblocked by 1 and 2.
 4. **#2301** and **#5** — the two things that make the blessed single-container
-   path actually good.
-5. **#2303**, then docs (#2300).
+   path actually good. **Done.**
+5. **#2303** — **Done**, via #2331. **Next: docs (#2300).**
 
 #2296, #2297, #2298 and #2299 are independent and can land whenever.

--- a/packages/api-server/src/__tests__/cliHelpers.test.ts
+++ b/packages/api-server/src/__tests__/cliHelpers.test.ts
@@ -161,6 +161,23 @@ describe('host helpers', () => {
 
     expect(getAPIHost({ isPublicSide: true })).toBe('10.0.0.2')
   })
+
+  it.each([
+    ['development', getAPIHost],
+    ['production', getAPIHost],
+    ['development', getWebHost],
+    ['production', getWebHost],
+  ])(
+    // `::` binds dual-stack (IPv4 and IPv6), unlike `0.0.0.0` — needed for
+    // platforms with IPv6-native private networking (e.g. Railway). Same
+    // default in both environments, unlike the old NODE_ENV-based split.
+    'falls back to `::` in %s when nothing else is configured',
+    (nodeEnv, getHost) => {
+      vi.stubEnv('NODE_ENV', nodeEnv)
+
+      expect(getHost()).toBe('::')
+    },
+  )
 })
 
 describe('deprecated REDWOOD_ aliases', () => {

--- a/packages/api-server/src/apiCLIConfig.ts
+++ b/packages/api-server/src/apiCLIConfig.ts
@@ -12,9 +12,7 @@ export function builder(yargs: Argv<APIParsedOptions>) {
       alias: 'p',
     },
     host: {
-      description:
-        'The host to listen at. Note that you most likely want this to be ' +
-        "'0.0.0.0' in production",
+      description: 'The host to listen at',
       type: 'string',
     },
     apiRootPath: {

--- a/packages/api-server/src/bothCLIConfig.ts
+++ b/packages/api-server/src/bothCLIConfig.ts
@@ -12,8 +12,7 @@ export function builder(yargs: Argv<BothParsedOptions>) {
       alias: ['web-port'],
     },
     webHost: {
-      description:
-        "The host for the web server to listen on. Note that you most likely want this to be '0.0.0.0' in production",
+      description: 'The host for the web server to listen on',
       type: 'string',
       alias: ['web-host'],
     },
@@ -23,8 +22,7 @@ export function builder(yargs: Argv<BothParsedOptions>) {
       alias: ['api-port'],
     },
     apiHost: {
-      description:
-        "The host for the api server to listen on. Note that you most likely want this to be '0.0.0.0' in production",
+      description: 'The host for the api server to listen on',
       type: 'string',
       alias: ['api-host'],
     },

--- a/packages/api-server/src/cliHelpers.ts
+++ b/packages/api-server/src/cliHelpers.ts
@@ -27,7 +27,10 @@ export function getAPIHost({ isPublicSide = false }: SideOptions = {}) {
   }
 
   host ??= getConfig().api.host
-  host ??= process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::'
+  // `::` binds dual-stack (IPv4 and IPv6) on hosts that support it, unlike
+  // `0.0.0.0` — needed for platforms with IPv6-native private networking
+  // (e.g. Railway).
+  host ??= '::'
   return host
 }
 
@@ -61,7 +64,10 @@ export function getWebHost({ isPublicSide = false }: SideOptions = {}) {
   }
 
   host ??= getConfig().web.host
-  host ??= process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::'
+  // `::` binds dual-stack (IPv4 and IPv6) on hosts that support it, unlike
+  // `0.0.0.0` — needed for platforms with IPv6-native private networking
+  // (e.g. Railway).
+  host ??= '::'
   return host
 }
 

--- a/packages/web-server/src/cliConfig.ts
+++ b/packages/web-server/src/cliConfig.ts
@@ -12,9 +12,7 @@ export function builder(yargs: Argv<ParsedOptions>) {
       alias: 'p',
     },
     host: {
-      description:
-        'The host to listen on. Note that you most likely want this to be ' +
-        "'0.0.0.0' in production",
+      description: 'The host to listen on',
       type: 'string',
     },
     apiProxyTarget: {

--- a/packages/web-server/src/webServer.ts
+++ b/packages/web-server/src/webServer.ts
@@ -52,13 +52,10 @@ export async function serveWeb(options: ParsedOptions = {}) {
   })
   options.host ??= process.env.HOST
   options.host ??= getConfig().web.host
-  options.host ??= process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::'
-
-  if (process.env.NODE_ENV === 'production' && options.host !== '0.0.0.0') {
-    console.warn(
-      `Warning: host '${options.host}' may need to be '0.0.0.0' in production for containerized deployments`,
-    )
-  }
+  // `::` binds dual-stack (IPv4 and IPv6) on hosts that support it, unlike
+  // `0.0.0.0` — needed for platforms with IPv6-native private networking
+  // (e.g. Railway).
+  options.host ??= '::'
 
   const fastify = Fastify({
     requestTimeout: 15_000,

--- a/tasks/server-tests/bothServer.test.mts
+++ b/tasks/server-tests/bothServer.test.mts
@@ -29,15 +29,11 @@ describe('cedar serve', () => {
             --webPort, --web-port                 The port for the web server to
                                                   listen on                   [number]
             --webHost, --web-host                 The host for the web server to
-                                                  listen on. Note that you most likely
-                                                  want this to be '0.0.0.0' in
-                                                  production                  [string]
+                                                  listen on                   [string]
             --apiPort, --api-port                 The port for the api server to
                                                   listen on                   [number]
             --apiHost, --api-host                 The host for the api server to
-                                                  listen on. Note that you most likely
-                                                  want this to be '0.0.0.0' in
-                                                  production                  [string]
+                                                  listen on                   [string]
             --apiRootPath, --api-root-path,       Root path where your api functions
             --rootPath, --root-path               are served   [string] [default: "/"]
             --ud                                  Use the Universal Deploy server for
@@ -83,15 +79,11 @@ describe('cedar serve', () => {
               --webPort, --web-port                 The port for the web server to
                                                     listen on                   [number]
               --webHost, --web-host                 The host for the web server to
-                                                    listen on. Note that you most likely
-                                                    want this to be '0.0.0.0' in
-                                                    production                  [string]
+                                                    listen on                   [string]
               --apiPort, --api-port                 The port for the api server to
                                                     listen on                   [number]
               --apiHost, --api-host                 The host for the api server to
-                                                    listen on. Note that you most likely
-                                                    want this to be '0.0.0.0' in
-                                                    production                  [string]
+                                                    listen on                   [string]
               --apiRootPath, --api-root-path,       Root path where your api functions
               --rootPath, --root-path               are served   [string] [default: "/"]
               --ud                                  Use the Universal Deploy server for
@@ -128,15 +120,11 @@ describe('cedarServer', () => {
             --webPort, --web-port                 The port for the web server to
                                                   listen on                   [number]
             --webHost, --web-host                 The host for the web server to
-                                                  listen on. Note that you most likely
-                                                  want this to be '0.0.0.0' in
-                                                  production                  [string]
+                                                  listen on                   [string]
             --apiPort, --api-port                 The port for the api server to
                                                   listen on                   [number]
             --apiHost, --api-host                 The host for the api server to
-                                                  listen on. Note that you most likely
-                                                  want this to be '0.0.0.0' in
-                                                  production                  [string]
+                                                  listen on                   [string]
             --apiRootPath, --api-root-path,       Root path where your api functions
             --rootPath, --root-path               are served   [string] [default: "/"]
         -h, --help                                Show help                  [boolean]
@@ -166,15 +154,11 @@ describe('cedarServer', () => {
               --webPort, --web-port                 The port for the web server to
                                                     listen on                   [number]
               --webHost, --web-host                 The host for the web server to
-                                                    listen on. Note that you most likely
-                                                    want this to be '0.0.0.0' in
-                                                    production                  [string]
+                                                    listen on                   [string]
               --apiPort, --api-port                 The port for the api server to
                                                     listen on                   [number]
               --apiHost, --api-host                 The host for the api server to
-                                                    listen on. Note that you most likely
-                                                    want this to be '0.0.0.0' in
-                                                    production                  [string]
+                                                    listen on                   [string]
               --apiRootPath, --api-root-path,       Root path where your api functions
               --rootPath, --root-path               are served   [string] [default: "/"]
           -h, --help                                Show help                  [boolean]


### PR DESCRIPTION
## Summary

Item 5 from `docs/implementation-plans/2026-08-03-deploy-simplification.md`.

`cliHelpers.ts` (and the duplicated logic in `web-server`'s `webServer.ts`) defaulted the server host to `0.0.0.0` in production, which is IPv4-only. Platforms with IPv6-native private networking, like Railway's two-service topology, need an explicit `--host ::` to be reachable there, and getting this wrong is called out in the plan doc as "the single most likely thing to break a first Railway two-service deploy."

- `getAPIHost`/`getWebHost` and `web-server`'s duplicated host resolution now default to `::` unconditionally (dropping the `NODE_ENV`-based `0.0.0.0`/`::` split). `::` binds dual-stack (both IPv4 and IPv6) on hosts that support it, so this needs no configuration for the common container/VM case.
- Removed `webServer.ts`'s now-obsolete `"...may need to be '0.0.0.0' in production..."` warning.
- Removed the stale `"you most likely want this to be '0.0.0.0' in production"` hints from the `--host` flag descriptions in `apiCLIConfig.ts`, `bothCLIConfig.ts`, and `web-server`'s `cliConfig.ts`.
- Corrected the same now-inaccurate default claims in `app-configuration-cedar-toml.md` and `server-file.md`.
- Updated the plan doc's status table, sections 5 and 6, sequencing, and the Railway-specific note to reflect current state (this PR, plus #2331/#2336 for item 6).

## Where the `NODE_ENV` split came from

Worth recording, since the split looks deliberate but isn't. `git log -S` traces the exact ternary to redwoodjs/redwood#3681 (Nov 2021, "Move api-server to fastify"):

```js
-  const server = app.listen(socket || port)      // Express
+  const host = process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::'
+  app.listen(socket || port, host)               // Fastify
```

The forcing function was mechanical: **Express with no host binds all interfaces, Fastify with no host binds `localhost`.** So the migration had to pass an explicit host or every container deploy would silently break. The two halves have separate provenances — `::` in dev preserved the old Express behaviour, and `0.0.0.0` in prod was the "you must bind 0.0.0.0 in Docker" folk wisdom.

That last part is the actual error. The real content of that advice is *"don't bind `localhost`"*, and `::` already satisfies it. `NODE_ENV` was never the relevant axis — both branches were already on the correct side of the only distinction that mattered, so the split encoded a difference that didn't need to exist.

It then spread by copy-paste (`serveBothHandler.js`, `web-server`, redwoodjs/redwood#9115) until redwoodjs/redwood#9948 formalised it in `cliHelpers.ts` as "our default which is based on `NODE_ENV`" — justified by internal precedent rather than a fresh diagnosis.

Fastify's own docs confirm `::` is a strict superset of `0.0.0.0`, which is what makes dropping the split safe rather than merely convenient:

| Host | IPv4 | IPv6 |
|---|---|---|
| `::` | ✅ | ✅ |
| `0.0.0.0` | ✅ | 🚫 |

### The Fly.io warning behind redwoodjs/redwood#9115

That PR is the one place in the chain where a concrete failure was cited, so it's worth pinning down. Its screenshot shows:

```
WARNING The app is not listening on the expected address and will not be
reachable by fly-proxy. You can fix this by configuring your app to listen
on the following addresses:
  - 0.0.0.0:8910
Found these processes inside the machine with open listening sockets:
  PROCESS       | ADDRESSES
  --------------*------------------------------
  .fly/hallpass | [fdaa:2:e9c1:a7b:1d8:5275:6d0f:2]:22
```

`0.0.0.0:8910` there is Fly's canned suggestion, generated from the configured `internal_port` — not a readback of what the app was bound to. And the socket enumeration lists only `.fly/hallpass`, Fly's own SSH daemon; the app process is absent entirely. Had the app been listening on `::` while Fly wanted IPv4, it would have appeared as `[::]:8910`.

So there was no listener on 8910 in any address family at check time, which points at a startup race during the rolling deploy (or a crash) rather than a bind-address mismatch. The `0.0.0.0` default was written to satisfy the warning's suggested remedy rather than the condition it actually reported — and that is the line that propagated onward into `cliHelpers.ts`.

## Test plan

- [x] `yarn workspace @cedarjs/api-server test --run` — 127 passed (13 test files), including 4 new tests covering the `::` default in both `development` and `production` for `getAPIHost`/`getWebHost`
- [x] `tsc --noEmit` clean for both `api-server` and `web-server`
- [x] `eslint` clean on all touched files
- [x] `yarn workspace @cedarjs/api-server build` and `yarn workspace @cedarjs/web-server build` both succeed

### Cross-container verification

Two containers ("api" and "web") on a user-defined bridge network with `EnableIPv6=false` — i.e. IPv4-only private networking, the case most likely to break if `::` were wrong. Both bound to `::`; requests succeeded in both directions, by Docker DNS name and by raw IP:

```
web → api by name:  {"role":"api","remoteAddress":"::ffff:172.18.0.3", ...}
web → api by IP:    {"role":"api","remoteAddress":"::ffff:172.18.0.3", ...}
api → web by name:  {"role":"web","remoteAddress":"::ffff:172.18.0.2", ...}
```

The `::ffff:` prefixes are IPv4-mapped addresses, confirming the dual-stack socket accepted genuine IPv4 connections. Also verified against the two scenarios where `0.0.0.0` could plausibly have beaten `::`:

| Scenario | `::` binds? | IPv4 traffic? |
|---|---|---|
| IPv4-only bridge network | ✅ | ✅ |
| `net.ipv6.conf.all.disable_ipv6=1` (no IPv6 addrs on iface) | ✅ | ✅ |
| `net.ipv6.bindv6only=1` (verified `/proc` reads `1`) | ✅ | ✅ |

`bindv6only=1` doesn't break it because Node clears `IPV6_V6ONLY` on the socket unless Fastify's `ipv6Only` option is set, which Cedar never sets.

Tested with a minimal `http.createServer().listen(port, host)` rather than a full Cedar app — that's the exact primitive both servers reach via `fastify.listen({ host, port })`, so it exercises the changed code path faithfully.

All escape hatches are unchanged (`--host`, `CEDAR_API_HOST`/`HOST`, TOML), so a platform that genuinely needs `0.0.0.0` can still ask for it.
