### PR TITLE
docs(deploy): Serve tiers, topologies, and container-host conventions

### DIFF
--- a/docs/docs/deploy/any-container-host.md
+++ b/docs/docs/deploy/any-container-host.md
@@ -1,10 +1,16 @@
 ---
-description: Deploy to Railway, Render, Cloud Run, and other container hosts with zero configuration
+description:
+  Deploy to Railway, Render, Cloud Run, and other container hosts with zero
+  configuration
 ---
 
 # Any Container Host
 
-Cedar's [single-container topology](./introduction.md#two-topologies-and-which-to-pick) works out of the box, with no per-platform integration to write or maintain, on any host that builds from a `package.json` and runs `yarn start`. That covers a wide range of platforms:
+Cedar's
+[single-container topology](./introduction.md#two-topologies-and-which-to-pick)
+works out of the box, with no per-platform integration to write or maintain, on
+any host that builds from a `package.json` and runs `yarn start`. That covers a
+wide range of platforms:
 
 - [Railway](./railway.md) (Railpack)
 - Render
@@ -17,7 +23,8 @@ Cedar's [single-container topology](./introduction.md#two-topologies-and-which-t
 - Koyeb
 - Northflank
 
-None of these need a Cedar-specific `setup deploy` command — they all build and run the same way.
+None of these need a Cedar-specific `setup deploy` command — they all build and
+run the same way.
 
 ## The conventions
 
@@ -31,26 +38,52 @@ Every generated Cedar app ships these `package.json` scripts:
 "start:web": "cedarjs-server web"
 ```
 
-A zero-config builder (Railpack, Nixpacks, Paketo, Google Cloud buildpacks, Heroku's buildpack) finds `build` and `start` and runs them without further input. `start` runs both sides in one process — the [single-container topology](./introduction.md#two-topologies-and-which-to-pick) — so there's no service-to-service wiring for the platform to get right.
+A zero-config builder (Railpack, Nixpacks, Paketo, Google Cloud buildpacks,
+Heroku's buildpack) finds `build` and `start` and runs them without further
+input. `start` runs both sides in one process — the
+[single-container topology](./introduction.md#two-topologies-and-which-to-pick)
+— so there's no service-to-service wiring for the platform to get right.
 
-The server also reads the two environment variables every container host sets automatically:
+The server also reads the two environment variables every container host sets
+automatically:
 
-- **`PORT`** — the port to listen on. Set by the platform; Cedar's public-facing side binds to it automatically.
-- **`HOST`** — the host to bind. Cedar defaults to `::`, which binds dual-stack (IPv4 and IPv6) on hosts that support it, so this rarely needs to be set explicitly.
+- **`PORT`** — the port to listen on. Set by the platform; Cedar's public-facing
+  side binds to it automatically.
+- **`HOST`** — the host to bind. Cedar defaults to `::`, which binds dual-stack
+  (IPv4 and IPv6) on hosts that support it, so this rarely needs to be set
+  explicitly.
 
-So the setup on any of these platforms is: connect the repo, point the build command at `yarn build`, point the start command at `yarn start`, add a `DATABASE_URL`. Nothing Cedar-specific beyond that.
+So the setup on any of these platforms is: connect the repo, point the build
+command at `yarn build`, point the start command at `yarn start`, add a
+`DATABASE_URL`. Nothing Cedar-specific beyond that.
 
 ## devDependency pruning caveat
 
-Two platforms in the list above strip `devDependencies` after the build step **by default**: **Heroku** and **DigitalOcean App Platform (Paketo)**. `start` resolves the `cedarjs-server` bin from `@cedarjs/api-server`, which is a root **dependency** (not a devDependency) specifically so this works — but if pruning removes more than expected, or you've moved something into `devDependencies` that `start` needs, you'll see the deploy succeed and the container fail immediately with a "command not found" error.
+Two platforms in the list above strip `devDependencies` after the build step
+**by default**: **Heroku** and **DigitalOcean App Platform (Paketo)**. `start`
+resolves the `cedarjs-server` bin from `@cedarjs/api-server`, which is a root
+**dependency** (not a devDependency) specifically so this works — but if pruning
+removes more than expected, or you've moved something into `devDependencies`
+that `start` needs, you'll see the deploy succeed and the container fail
+immediately with a "command not found" error.
 
 If you hit that, disable pruning:
 
 - **Heroku:** set `NPM_CONFIG_PRODUCTION=false` or `YARN_PRODUCTION=false`
-- **DigitalOcean App Platform:** set `YARN2_SKIP_PRUNING=true` or `NPM_CONFIG_PRODUCTION=false`
+- **DigitalOcean App Platform:** set `YARN2_SKIP_PRUNING=true` or
+  `NPM_CONFIG_PRODUCTION=false`
 
-The other platforms in the list (Railway, Render, Cloud Run, Coolify, Dokku, Dokploy, Koyeb, Northflank) don't prune by default, so this doesn't apply to them.
+The other platforms in the list (Railway, Render, Cloud Run, Coolify, Dokku,
+Dokploy, Koyeb, Northflank) don't prune by default, so this doesn't apply to
+them.
 
 ## Scaling up: the two-service topology
 
-Every platform above can also run the [recommended two-service topology](./introduction.md#two-topologies-and-which-to-pick) — `start:api` and `start:web` as two separate services — once you outgrow single-container. That split is inherently more platform-specific: the web service needs to know where the api service lives, and how you wire that (a proxy target, an internal DNS name, a private-network URL) differs per platform. See [Railway](./railway.md) and [Coolify](./coolify.md) for two platforms where that wiring is documented end to end.
+Every platform above can also run the
+[recommended two-service topology](./introduction.md#two-topologies-and-which-to-pick)
+— `start:api` and `start:web` as two separate services — once you outgrow
+single-container. That split is inherently more platform-specific: the web
+service needs to know where the api service lives, and how you wire that (a
+proxy target, an internal DNS name, a private-network URL) differs per platform.
+See [Railway](./railway.md) and [Coolify](./coolify.md) for two platforms where
+that wiring is documented end to end.

--- a/docs/docs/deploy/any-container-host.md
+++ b/docs/docs/deploy/any-container-host.md
@@ -1,0 +1,56 @@
+---
+description: Deploy to Railway, Render, Cloud Run, and other container hosts with zero configuration
+---
+
+# Any Container Host
+
+Cedar's [single-container topology](./introduction.md#two-topologies-and-which-to-pick) works out of the box, with no per-platform integration to write or maintain, on any host that builds from a `package.json` and runs `yarn start`. That covers a wide range of platforms:
+
+- [Railway](./railway.md) (Railpack)
+- Render
+- Google Cloud Run
+- DigitalOcean App Platform (Paketo)
+- Heroku
+- [Coolify](./coolify.md) (Nixpacks/Railpack)
+- Dokku
+- Dokploy
+- Koyeb
+- Northflank
+
+None of these need a Cedar-specific `setup deploy` command — they all build and run the same way.
+
+## The conventions
+
+Every generated Cedar app ships these `package.json` scripts:
+
+```json
+"build": "cedar build",
+"dev": "cedar dev",
+"start": "cedarjs-server",
+"start:api": "cedarjs-server api",
+"start:web": "cedarjs-server web"
+```
+
+A zero-config builder (Railpack, Nixpacks, Paketo, Google Cloud buildpacks, Heroku's buildpack) finds `build` and `start` and runs them without further input. `start` runs both sides in one process — the [single-container topology](./introduction.md#two-topologies-and-which-to-pick) — so there's no service-to-service wiring for the platform to get right.
+
+The server also reads the two environment variables every container host sets automatically:
+
+- **`PORT`** — the port to listen on. Set by the platform; Cedar's public-facing side binds to it automatically.
+- **`HOST`** — the host to bind. Cedar defaults to `::`, which binds dual-stack (IPv4 and IPv6) on hosts that support it, so this rarely needs to be set explicitly.
+
+So the setup on any of these platforms is: connect the repo, point the build command at `yarn build`, point the start command at `yarn start`, add a `DATABASE_URL`. Nothing Cedar-specific beyond that.
+
+## devDependency pruning caveat
+
+Two platforms in the list above strip `devDependencies` after the build step **by default**: **Heroku** and **DigitalOcean App Platform (Paketo)**. `start` resolves the `cedarjs-server` bin from `@cedarjs/api-server`, which is a root **dependency** (not a devDependency) specifically so this works — but if pruning removes more than expected, or you've moved something into `devDependencies` that `start` needs, you'll see the deploy succeed and the container fail immediately with a "command not found" error.
+
+If you hit that, disable pruning:
+
+- **Heroku:** set `NPM_CONFIG_PRODUCTION=false` or `YARN_PRODUCTION=false`
+- **DigitalOcean App Platform:** set `YARN2_SKIP_PRUNING=true` or `NPM_CONFIG_PRODUCTION=false`
+
+The other platforms in the list (Railway, Render, Cloud Run, Coolify, Dokku, Dokploy, Koyeb, Northflank) don't prune by default, so this doesn't apply to them.
+
+## Scaling up: the two-service topology
+
+Every platform above can also run the [recommended two-service topology](./introduction.md#two-topologies-and-which-to-pick) — `start:api` and `start:web` as two separate services — once you outgrow single-container. That split is inherently more platform-specific: the web service needs to know where the api service lives, and how you wire that (a proxy target, an internal DNS name, a private-network URL) differs per platform. See [Railway](./railway.md) and [Coolify](./coolify.md) for two platforms where that wiring is documented end to end.

--- a/docs/docs/deploy/coolify.md
+++ b/docs/docs/deploy/coolify.md
@@ -51,9 +51,17 @@ Dockerfile:
    `yarn build`. Coolify serves it directly rather than running a Node process
    for it.
 
-Wire the web service's api proxy target (`apiUrl` in `cedar.toml`, or
-`--apiProxyTarget`) at the api service's Coolify-provided domain.
+Because the web service is static, there's no Node process for it to proxy
+requests through — `--apiProxyTarget` is a Fastify feature, and Fastify only
+runs under `start:web`. Instead, before running `yarn build`, set `apiUrl` in
+`cedar.toml` to the api service's fully-qualified Coolify-provided domain (e.g.
+`https://api.yourapp.example`, not a relative path like the single-service
+setup uses). Cedar bakes `apiUrl` into the web bundle at build time, so the
+browser calls the api service directly — no proxy needed. This makes the two
+services cross-origin, so you'll also need to [configure CORS](../cors.md) on
+the api side.
 
 This is the one platform in this doc set where the recommended topology doesn't
-cost you anything extra to set up — no reverse proxy or nginx config to write,
-since Coolify's Static build pack already does that job.
+cost you anything extra to set up — no reverse proxy, nginx config, or Node
+process to run for the web side, since Coolify's Static build pack and a
+fully-qualified `apiUrl` cover it between them.

--- a/docs/docs/deploy/coolify.md
+++ b/docs/docs/deploy/coolify.md
@@ -4,20 +4,33 @@ description: Self-host Cedar on Coolify, with the recommended two-service topolo
 
 # Deploy to Coolify
 
-[Coolify](https://coolify.io) is a self-hosted alternative to Heroku/Railway-style PaaS platforms — you run it on your own server(s) and it manages builds and deploys for you. It's the best fit on the [any container host](./any-container-host.md) list for anyone self-hosting: it's free, open source, and — uniquely among the platforms Cedar documents — its build packs can natively express the [recommended two-service topology](./introduction.md#two-topologies-and-which-to-pick) instead of forcing single-container.
+[Coolify](https://coolify.io) is a self-hosted alternative to
+Heroku/Railway-style PaaS platforms — you run it on your own server(s) and it
+manages builds and deploys for you. It's the best fit on the
+[any container host](./any-container-host.md) list for anyone self-hosting: it's
+free, open source, and — uniquely among the platforms Cedar documents — its
+build packs can natively express the
+[recommended two-service topology](./introduction.md#two-topologies-and-which-to-pick)
+instead of forcing single-container.
 
 ## Single-service (start here)
 
 1. Create a new Coolify application from your Cedar repo.
-2. Leave the build pack on its default (Nixpacks or Railpack). Coolify finds `build` and `start` in `package.json` and runs them with no configuration.
-3. Add a Postgres database from Coolify's resource catalog, and set `DATABASE_URL` on the application to point at it.
+2. Leave the build pack on its default (Nixpacks or Railpack). Coolify finds
+   `build` and `start` in `package.json` and runs them with no configuration.
+3. Add a Postgres database from Coolify's resource catalog, and set
+   `DATABASE_URL` on the application to point at it.
 4. Deploy.
 
-This runs the [single-container topology](./introduction.md#two-topologies-and-which-to-pick) — the fastest way to get a working deploy.
+This runs the
+[single-container topology](./introduction.md#two-topologies-and-which-to-pick)
+— the fastest way to get a working deploy.
 
 ## Migrations
 
-Coolify doesn't have a dedicated pre-deploy hook the way Railway does. Run migrations as part of your build command, or as a one-off command against the running container:
+Coolify doesn't have a dedicated pre-deploy hook the way Railway does. Run
+migrations as part of your build command, or as a one-off command against the
+running container:
 
 ```shell
 yarn cedar prisma migrate deploy
@@ -25,11 +38,22 @@ yarn cedar prisma migrate deploy
 
 ## Scaling up: two services, the Coolify way
 
-This is what sets Coolify apart from the other platforms on the [any container host](./any-container-host.md) list: alongside Nixpacks/Railpack, Coolify also has a **Static** build pack. That means you can express Cedar's recommended topology — static `web/dist` served separately from a Node api process — as two Coolify resources instead of one, without reaching for a Dockerfile:
+This is what sets Coolify apart from the other platforms on the
+[any container host](./any-container-host.md) list: alongside Nixpacks/Railpack,
+Coolify also has a **Static** build pack. That means you can express Cedar's
+recommended topology — static `web/dist` served separately from a Node api
+process — as two Coolify resources instead of one, without reaching for a
+Dockerfile:
 
-1. **api service** — Nixpacks/Railpack build pack, start command `yarn start:api`.
-2. **web service** — Static build pack, pointed at `web/dist` after running `yarn build`. Coolify serves it directly rather than running a Node process for it.
+1. **api service** — Nixpacks/Railpack build pack, start command
+   `yarn start:api`.
+2. **web service** — Static build pack, pointed at `web/dist` after running
+   `yarn build`. Coolify serves it directly rather than running a Node process
+   for it.
 
-Wire the web service's api proxy target (`apiUrl` in `cedar.toml`, or `--apiProxyTarget`) at the api service's Coolify-provided domain.
+Wire the web service's api proxy target (`apiUrl` in `cedar.toml`, or
+`--apiProxyTarget`) at the api service's Coolify-provided domain.
 
-This is the one platform in this doc set where the recommended topology doesn't cost you anything extra to set up — no reverse proxy or nginx config to write, since Coolify's Static build pack already does that job.
+This is the one platform in this doc set where the recommended topology doesn't
+cost you anything extra to set up — no reverse proxy or nginx config to write,
+since Coolify's Static build pack already does that job.

--- a/docs/docs/deploy/coolify.md
+++ b/docs/docs/deploy/coolify.md
@@ -1,0 +1,35 @@
+---
+description: Self-host Cedar on Coolify, with the recommended two-service topology
+---
+
+# Deploy to Coolify
+
+[Coolify](https://coolify.io) is a self-hosted alternative to Heroku/Railway-style PaaS platforms — you run it on your own server(s) and it manages builds and deploys for you. It's the best fit on the [any container host](./any-container-host.md) list for anyone self-hosting: it's free, open source, and — uniquely among the platforms Cedar documents — its build packs can natively express the [recommended two-service topology](./introduction.md#two-topologies-and-which-to-pick) instead of forcing single-container.
+
+## Single-service (start here)
+
+1. Create a new Coolify application from your Cedar repo.
+2. Leave the build pack on its default (Nixpacks or Railpack). Coolify finds `build` and `start` in `package.json` and runs them with no configuration.
+3. Add a Postgres database from Coolify's resource catalog, and set `DATABASE_URL` on the application to point at it.
+4. Deploy.
+
+This runs the [single-container topology](./introduction.md#two-topologies-and-which-to-pick) — the fastest way to get a working deploy.
+
+## Migrations
+
+Coolify doesn't have a dedicated pre-deploy hook the way Railway does. Run migrations as part of your build command, or as a one-off command against the running container:
+
+```shell
+yarn cedar prisma migrate deploy
+```
+
+## Scaling up: two services, the Coolify way
+
+This is what sets Coolify apart from the other platforms on the [any container host](./any-container-host.md) list: alongside Nixpacks/Railpack, Coolify also has a **Static** build pack. That means you can express Cedar's recommended topology — static `web/dist` served separately from a Node api process — as two Coolify resources instead of one, without reaching for a Dockerfile:
+
+1. **api service** — Nixpacks/Railpack build pack, start command `yarn start:api`.
+2. **web service** — Static build pack, pointed at `web/dist` after running `yarn build`. Coolify serves it directly rather than running a Node process for it.
+
+Wire the web service's api proxy target (`apiUrl` in `cedar.toml`, or `--apiProxyTarget`) at the api service's Coolify-provided domain.
+
+This is the one platform in this doc set where the recommended topology doesn't cost you anything extra to set up — no reverse proxy or nginx config to write, since Coolify's Static build pack already does that job.

--- a/docs/docs/deploy/introduction.md
+++ b/docs/docs/deploy/introduction.md
@@ -16,19 +16,43 @@ Currently, these are the officially supported deploy targets:
 - Baremetal (physical server that you have SSH access to)
 - [Coherence](https://www.withcoherence.com/)
 - [Flightcontrol.dev](https://www.flightcontrol.dev?ref=redwood)
-- [Edg.io](https://edg.io)
 - [Netlify.com](https://www.netlify.com/)
 - [Render.com](https://render.com)
 - [Serverless.com](https://serverless.com)
 - [Vercel.com](https://vercel.com)
 
+Beyond these, [any container host](./any-container-host.md) — Railway, Google Cloud Run, DigitalOcean App Platform, Heroku, Coolify, Dokku, Dokploy, Koyeb, Northflank — works from the same set of conventions Cedar ships with by default, with no provider-specific integration required. See the dedicated pages for [Railway](./railway.md) and [Coolify](./coolify.md).
+
 Cedar has a CLI generator that adds the code and configuration required by the specified provider (see the [CLI Doc](cli-commands.md#deploy-config) for more information):
 
 ```shell
-yarn rw setup deploy <provider>
+yarn cedar setup deploy <provider>
 ```
 
 There are examples of deploying CedarJS on other providers such as Google Cloud and direct to AWS. You can find more information by searching the [CedarJS GitHub Issues](https://github.com/cedarjs/cedar/issues) and [RedwoodJS Forums](https://community.redwoodjs.com).
+
+## The `serve` command tiers
+
+`yarn cedar serve` has several forms, depending on which side(s) you're serving and whether you're using [Universal Deploy](./universal-deploy.md). It's worth knowing all of them, since the role each one plays isn't obvious from the command name alone:
+
+| Command                | Role                                                                                                                                                                 |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cedar serve api`      | Production. Web side served separately — by nginx, a CDN, or a static host.                                                                                          |
+| `cedar serve web`      | Production, behind a CDN or reverse proxy. Proxies API requests to `cedar serve api`.                                                                                |
+| `cedar serve`          | Single-container: both sides in one process. Also useful for local production-like testing.                                                                          |
+| `cedar serve api --ud` | Production, using [Universal Deploy](./universal-deploy.md). Runs `api/dist/ud/index.js` via [srvx](https://github.com/h3js/srvx), behind a reverse proxy.           |
+| `cedar serve --ud`     | Local production-like testing only, for a Universal Deploy build. Not a production topology — see [Universal Deploy](./universal-deploy.md#deploying-to-a-provider). |
+
+The generated `package.json` scripts map onto these: `start` is `cedar serve` (single-container), `start:api` is `cedar serve api`, `start:web` is `cedar serve web`.
+
+## Two topologies, and which to pick
+
+Once you're past `cedar dev`, there are two ways to run Cedar in production:
+
+- **Single-container** (`yarn start`) — one process serves both sides; the web server proxies API requests to the API in-process. This is the **convenient** path: no service-to-service wiring, so it works with zero configuration on any container host — see [any container host](./any-container-host.md).
+- **api process + static/CDN web** (`yarn start:api`, with the web side served separately) — this is the **recommended** path, and what the generated Dockerfile, the baremetal nginx setup, and the Render blueprint all use.
+
+Start with single-container — it's the fastest way to get a working deploy, and for small apps or early-stage projects it's often all you need. Move to the two-part topology when you want your web assets served from a CDN edge (rather than round-tripping through your api process), or when you want to scale the api and web sides independently. The reason this needs to be stated explicitly: without it, it's easy to land on single-container, get a working app, and never learn why the split is worth doing later.
 
 ## General Deployment Setup
 
@@ -45,34 +69,29 @@ The most important Cedar configuration is to set the `apiUrl` in your `cedar.tom
 The build command is used to prepare the Web and API for deployment. Additionally, other actions can be run during build such as database migrations. The Cedar build command must specify one of the supported hosting providers (aka `target`):
 
 ```shell
-yarn rw deploy <target>
+yarn cedar deploy <target>
 ```
 
 For example:
 
 ```shell
 # Build command for Netlify deploy target
-yarn rw deploy netlify
+yarn cedar deploy netlify
 ```
 
 ```shell
 # Build command for Vercel deploy target
-yarn rw deploy vercel
+yarn cedar deploy vercel
 ```
 
 ```shell
 # Build command for AWS Lambdas using the https://serverless.com framework
-yarn rw deploy serverless --side api
-```
-
-```shell
-# Build command for Edgio deploy target
-yarn rw deploy edgio
+yarn cedar deploy serverless --side api
 ```
 
 ```shell
 # Build command for baremetal deploy target
-yarn rw deploy baremetal [--first-run]
+yarn cedar deploy baremetal [--first-run]
 ```
 
 ### 3. Prisma and Database
@@ -94,7 +113,7 @@ The database URL is configured both in the Prisma config file (`api/prisma.confi
 Whenever you make changes to your `schema.prisma`, you must run the following command:
 
 ```shell
-yarn rw prisma migrate dev # creates and applies a new Prisma DB migration
+yarn cedar prisma migrate dev # creates and applies a new Prisma DB migration
 ```
 
 > Note: when setting your production DATABASE_URL env var, be sure to also set any connection-pooling or sslmode parameters. For example, if using Supabase Postgres with pooling, then you would use a connection string similar to `postgresql://postgres:mydb.supabase.co:6432/postgres?sslmode=require&pgbouncer=true` that uses a specific 6432 port, informs Prisma to consider pgBouncer, and also to use SSL. See: [Connection Pooling](connection-pooling.md) for more info.

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -58,12 +58,16 @@ To split into the
    yarn start:web --api-proxy-target=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
    ```
 
-   Swap in `${{api.RAILWAY_PRIVATE_DOMAIN}}` (with `http://`, since Railway's
-   private network doesn't terminate TLS) to keep this traffic off the public
-   internet. Either way, replace `api` with your api service's actual name —
-   Railway resolves `${{<service>.<VAR>}}` at deploy time. A missing or
-   schemeless `apiProxyTarget` leaves `apiUrl` requests unhandled and Cedar
-   returns a Bad Gateway error.
+   Swap in `http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}` to keep this
+   traffic off the public internet instead (Railway's private network doesn't
+   terminate TLS, so use `http://`). The port is required here —
+   `RAILWAY_PRIVATE_DOMAIN` is a bare hostname, and unlike the public domain
+   (where Railway's edge proxy forwards to your app's actual port for you),
+   private-network traffic connects to that port directly. Either way, replace
+   `api` with your api service's actual name — Railway resolves
+   `${{<service>.<VAR>}}` at deploy time. A missing or schemeless
+   `apiProxyTarget` leaves `apiUrl` requests unhandled and Cedar returns a Bad
+   Gateway error.
 
 ## Config as code
 

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -58,18 +58,14 @@ To split into the
    yarn start:web --api-proxy-target=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
    ```
 
-   Swap in `http://${{api.RAILWAY_PRIVATE_DOMAIN}}:8911` to keep this traffic
-   off the public internet instead (Railway's private network doesn't
+   Swap in `http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}` to keep this
+   traffic off the public internet instead (Railway's private network doesn't
    terminate TLS, so use `http://`). The port is required here —
    `RAILWAY_PRIVATE_DOMAIN` is a bare hostname, and unlike the public domain
    (where Railway's edge proxy forwards to your app's actual port for you),
-   private-network traffic connects to that port directly. `8911` is Cedar's
-   default api port, not Railway's `PORT` — `start:api` runs `cedarjs-server
-api`, which (unlike `cedar serve api`) doesn't read `PORT`, so it always
-   binds to `CEDAR_API_PORT`/`[api].port` in `cedar.toml`, or `8911` if you
-   haven't set either. Use that value here instead if you've customized it.
-   Either way, replace `api` with your api service's actual name — Railway
-   resolves `${{<service>.<VAR>}}` at deploy time. A missing or schemeless
+   private-network traffic connects to that port directly. Either way, replace
+   `api` with your api service's actual name — Railway resolves
+   `${{<service>.<VAR>}}` at deploy time. A missing or schemeless
    `apiProxyTarget` leaves `apiUrl` requests unhandled and Cedar returns a Bad
    Gateway error.
 

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -4,43 +4,66 @@ description: Deploy to Railway, single-service or split into api/web services
 
 # Deploy to Railway
 
-Railway builds with [Railpack](https://railpack.com) by default (Nixpacks is deprecated), and it handles Cedar's Yarn 4 workspaces and `engines.node` correctly with no configuration. Cedar needs nothing beyond the conventions described in [any container host](./any-container-host.md) to deploy there.
+Railway builds with [Railpack](https://railpack.com) by default (Nixpacks is
+deprecated), and it handles Cedar's Yarn 4 workspaces and `engines.node`
+correctly with no configuration. Cedar needs nothing beyond the conventions
+described in [any container host](./any-container-host.md) to deploy there.
 
 ## Single-service (start here)
 
 1. Create a new Railway project, and add a service from your Cedar repo.
-2. Add a Postgres database from Railway's plugin catalog. Railway sets `DATABASE_URL` on services in the same project automatically — check your service's Variables tab to reference it (usually `${{Postgres.DATABASE_URL}}`).
-3. Push. Railpack finds `build` and `start` in `package.json` and runs them — no build or start command configuration needed.
+2. Add a Postgres database from Railway's plugin catalog. Railway sets
+   `DATABASE_URL` on services in the same project automatically — check your
+   service's Variables tab to reference it (usually
+   `${{Postgres.DATABASE_URL}}`).
+3. Push. Railpack finds `build` and `start` in `package.json` and runs them — no
+   build or start command configuration needed.
 
-That's the whole setup: create service, add Postgres, reference `DATABASE_URL`, push. This runs the [single-container topology](./introduction.md#two-topologies-and-which-to-pick) — one service serving both sides.
+That's the whole setup: create service, add Postgres, reference `DATABASE_URL`,
+push. This runs the
+[single-container topology](./introduction.md#two-topologies-and-which-to-pick)
+— one service serving both sides.
 
 ## Migrations
 
-Set your service's **Pre-Deploy Command** (in the service's Settings tab) to run migrations before the new deploy goes live:
+Set your service's **Pre-Deploy Command** (in the service's Settings tab) to run
+migrations before the new deploy goes live:
 
 ```shell
 yarn cedar prisma migrate deploy
 ```
 
-Railway runs this once per deploy, before traffic is switched over, which is a better fit than trying to run migrations from inside `start`.
+Railway runs this once per deploy, before traffic is switched over, which is a
+better fit than trying to run migrations from inside `start`.
 
 ## Enabling Railway's CDN
 
-Railway's CDN is per-service, free on all plans, and caches static assets by `Content-Type`. Enable it in your service's Settings tab under Networking. It's the thing that most closes the gap between single-container and the two-service topology — even serving `web/dist` from the same process as your api, static assets still get edge-cached.
+Railway's CDN is per-service, free on all plans, and caches static assets by
+`Content-Type`. Enable it in your service's Settings tab under Networking. It's
+the thing that most closes the gap between single-container and the two-service
+topology — even serving `web/dist` from the same process as your api, static
+assets still get edge-cached.
 
 ## Scaling up: two services
 
-To split into the [recommended topology](./introduction.md#two-topologies-and-which-to-pick):
+To split into the
+[recommended topology](./introduction.md#two-topologies-and-which-to-pick):
 
 1. Add a second service from the same repo.
 2. On the api service, set the start command to `yarn start:api`.
 3. On the web service, set the start command to `yarn start:web`.
-4. Wire the web service's api proxy target at the api service's Railway-provided domain (public networking), or its private network address if you want internal traffic to stay off the public internet.
+4. Wire the web service's api proxy target at the api service's Railway-provided
+   domain (public networking), or its private network address if you want
+   internal traffic to stay off the public internet.
 
 ## Config as code
 
-Railway supports config-as-code via `railway.json` or `railway.toml` in your repo. There's no JSONC support, so if you want comments in your config, use `railway.toml`.
+Railway supports config-as-code via `railway.json` or `railway.toml` in your
+repo. There's no JSONC support, so if you want comments in your config, use
+`railway.toml`.
 
 ## Private networking
 
-Railway's private network is IPv6-native. Cedar's servers default to binding `::` (dual-stack — both IPv4 and IPv6), so the two-service topology's internal service-to-service traffic works with no host configuration on your part.
+Railway's private network is IPv6-native. Cedar's servers default to binding
+`::` (dual-stack — both IPv4 and IPv6), so the two-service topology's internal
+service-to-service traffic works with no host configuration on your part.

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -51,10 +51,19 @@ To split into the
 
 1. Add a second service from the same repo.
 2. On the api service, set the start command to `yarn start:api`.
-3. On the web service, set the start command to `yarn start:web`.
-4. Wire the web service's api proxy target at the api service's Railway-provided
-   domain (public networking), or its private network address if you want
-   internal traffic to stay off the public internet.
+3. On the web service, set the start command to pass `--api-proxy-target`, a
+   fully-qualified URL (scheme required) pointing at the api service:
+
+   ```shell
+   yarn start:web --api-proxy-target=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
+   ```
+
+   Swap in `${{api.RAILWAY_PRIVATE_DOMAIN}}` (with `http://`, since Railway's
+   private network doesn't terminate TLS) to keep this traffic off the public
+   internet. Either way, replace `api` with your api service's actual name —
+   Railway resolves `${{<service>.<VAR>}}` at deploy time. A missing or
+   schemeless `apiProxyTarget` leaves `apiUrl` requests unhandled and Cedar
+   returns a Bad Gateway error.
 
 ## Config as code
 

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -1,0 +1,46 @@
+---
+description: Deploy to Railway, single-service or split into api/web services
+---
+
+# Deploy to Railway
+
+Railway builds with [Railpack](https://railpack.com) by default (Nixpacks is deprecated), and it handles Cedar's Yarn 4 workspaces and `engines.node` correctly with no configuration. Cedar needs nothing beyond the conventions described in [any container host](./any-container-host.md) to deploy there.
+
+## Single-service (start here)
+
+1. Create a new Railway project, and add a service from your Cedar repo.
+2. Add a Postgres database from Railway's plugin catalog. Railway sets `DATABASE_URL` on services in the same project automatically — check your service's Variables tab to reference it (usually `${{Postgres.DATABASE_URL}}`).
+3. Push. Railpack finds `build` and `start` in `package.json` and runs them — no build or start command configuration needed.
+
+That's the whole setup: create service, add Postgres, reference `DATABASE_URL`, push. This runs the [single-container topology](./introduction.md#two-topologies-and-which-to-pick) — one service serving both sides.
+
+## Migrations
+
+Set your service's **Pre-Deploy Command** (in the service's Settings tab) to run migrations before the new deploy goes live:
+
+```shell
+yarn cedar prisma migrate deploy
+```
+
+Railway runs this once per deploy, before traffic is switched over, which is a better fit than trying to run migrations from inside `start`.
+
+## Enabling Railway's CDN
+
+Railway's CDN is per-service, free on all plans, and caches static assets by `Content-Type`. Enable it in your service's Settings tab under Networking. It's the thing that most closes the gap between single-container and the two-service topology — even serving `web/dist` from the same process as your api, static assets still get edge-cached.
+
+## Scaling up: two services
+
+To split into the [recommended topology](./introduction.md#two-topologies-and-which-to-pick):
+
+1. Add a second service from the same repo.
+2. On the api service, set the start command to `yarn start:api`.
+3. On the web service, set the start command to `yarn start:web`.
+4. Wire the web service's api proxy target at the api service's Railway-provided domain (public networking), or its private network address if you want internal traffic to stay off the public internet.
+
+## Config as code
+
+Railway supports config-as-code via `railway.json` or `railway.toml` in your repo. There's no JSONC support, so if you want comments in your config, use `railway.toml`.
+
+## Private networking
+
+Railway's private network is IPv6-native. Cedar's servers default to binding `::` (dual-stack — both IPv4 and IPv6), so the two-service topology's internal service-to-service traffic works with no host configuration on your part.

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -58,14 +58,18 @@ To split into the
    yarn start:web --api-proxy-target=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
    ```
 
-   Swap in `http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}` to keep this
-   traffic off the public internet instead (Railway's private network doesn't
+   Swap in `http://${{api.RAILWAY_PRIVATE_DOMAIN}}:8911` to keep this traffic
+   off the public internet instead (Railway's private network doesn't
    terminate TLS, so use `http://`). The port is required here —
    `RAILWAY_PRIVATE_DOMAIN` is a bare hostname, and unlike the public domain
    (where Railway's edge proxy forwards to your app's actual port for you),
-   private-network traffic connects to that port directly. Either way, replace
-   `api` with your api service's actual name — Railway resolves
-   `${{<service>.<VAR>}}` at deploy time. A missing or schemeless
+   private-network traffic connects to that port directly. `8911` is Cedar's
+   default api port, not Railway's `PORT` — `start:api` runs `cedarjs-server
+api`, which (unlike `cedar serve api`) doesn't read `PORT`, so it always
+   binds to `CEDAR_API_PORT`/`[api].port` in `cedar.toml`, or `8911` if you
+   haven't set either. Use that value here instead if you've customized it.
+   Either way, replace `api` with your api service's actual name — Railway
+   resolves `${{<service>.<VAR>}}` at deploy time. A missing or schemeless
    `apiProxyTarget` leaves `apiUrl` requests unhandled and Cedar returns a Bad
    Gateway error.
 

--- a/docs/docs/deploy/universal-deploy.md
+++ b/docs/docs/deploy/universal-deploy.md
@@ -32,26 +32,36 @@ Serve it locally to verify everything works before deploying:
 yarn cedar serve --ud
 ```
 
+## Supported production topologies
+
+Universal Deploy supports two production topologies:
+
+1. **Serverless platforms that natively host Fetchables** — Netlify and Vercel. The platform's own adapter wraps the UD entry directly; see below.
+2. **A cloud VM or container, with a reverse proxy in front** — nginx (or your platform's equivalent) serves `web/dist/` static files directly, and proxies API routes to a Node process running the UD entry via [srvx](https://github.com/h3js/srvx):
+
+   ```shell
+   yarn cedar build --ud
+   yarn cedar serve api --ud
+   ```
+
+   `cedar serve api --ud` is the production entry point for the api side — it's what belongs behind your reverse proxy. Use `--api-port` and `--api-host` to configure the listener; `--api-host` defaults to `::` (dual-stack), which works on any container host without configuration.
+
+`yarn cedar serve --ud` (no side specified — both api and web in one process) is **local production-like testing only**, for verifying a `cedar build --ud` output before deploying. It is not one of the two production topologies above — in real production, web assets are always served by a separate process (a CDN, nginx, or the platform's static hosting), not by the UD entry itself.
+
+### Custom server files aren't supported under `--ud`
+
+A custom `api/src/server.ts` is a Fastify concept — Realtime, custom plugins, and custom middleware registered there have no equivalent in the UD entry (a plain Fetchable), so there's no way to honor it. If Cedar detects `api/src/server.ts`, `--ud` refuses to serve rather than silently producing a different app than what's configured:
+
+```
+api/src/server.ts was detected, but a custom server file is not supported
+with --ud. It is a Fastify concept — anything registered there (Realtime,
+custom plugins, custom middleware) would silently be skipped if serving
+continued.
+```
+
 ## Deploying to a provider
 
 Once Universal Deploy is set up, configure your hosting provider:
-
-### Node.js (cloud server, VPS, container)
-
-No additional setup needed. After building, serve directly with:
-
-```shell
-yarn cedar build --ud
-yarn cedar serve --ud
-```
-
-This runs the server using [srvx](https://github.com/h3js/srvx) — a portable HTTP server that wraps the Fetch-native entry. Use `--api-port`, `--api-host`, `--web-port`, and `--web-host` to configure the listeners:
-
-```shell
-yarn cedar serve --ud --api-port 8911 --api-host 0.0.0.0 --web-port 8910 --web-host 0.0.0.0
-```
-
-For production on a cloud VM or container, build once and run `cedar serve --ud` as your process entry point (behind a reverse proxy or load balancer as needed).
 
 ### Netlify
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -117,12 +117,23 @@ module.exports = {
           },
           items: [
             { type: 'doc', label: 'Introduction', id: 'deploy/introduction' },
+            {
+              type: 'doc',
+              label: 'Any Container Host',
+              id: 'deploy/any-container-host',
+            },
+            {
+              type: 'doc',
+              label: 'Universal Deploy',
+              id: 'deploy/universal-deploy',
+            },
             { type: 'doc', label: 'Baremetal', id: 'deploy/baremetal' },
             {
               type: 'doc',
               label: 'GCP or AWS via Coherence',
               id: 'deploy/coherence',
             },
+            { type: 'doc', label: 'Coolify', id: 'deploy/coolify' },
             {
               type: 'doc',
               label: 'AWS via Flightcontrol',
@@ -130,6 +141,7 @@ module.exports = {
             },
             { type: 'doc', label: 'Edgio', id: 'deploy/edgio' },
             { type: 'doc', label: 'Netlify', id: 'deploy/netlify' },
+            { type: 'doc', label: 'Railway', id: 'deploy/railway' },
             { type: 'doc', label: 'Render', id: 'deploy/render' },
             {
               type: 'doc',


### PR DESCRIPTION
Closes #2300 — folds in the deploy-docs work from `docs/implementation-plans/2026-08-03-deploy-simplification.md` (items 1, 2, 3, 4/5, 6, 7 of that issue).

- **`docs/docs/deploy/introduction.md`**: adds the serve-tiers table (`cedar serve api` / `web` / both, plus the `--ud` variants — the `--ud` rows are sourced from `cedar-serve-ud-both-sides-plan.md`'s "Command Roles" table) and explains the two topologies (single-container vs api-process + static/CDN web) and why the latter is recommended once you outgrow the former. Also fixes remaining `yarn rw` → `yarn cedar` spots and drops Edgio/Layer0 (shut down years ago) from the "officially supported" list.
- **New page `any-container-host.md`**: the shared conventions (`build`/`start` scripts, `PORT`/`HOST`) that make Railway, Render, Cloud Run, DigitalOcean App Platform, Heroku, Coolify, Dokku, Dokploy, Koyeb, and Northflank all work with zero Cedar-specific integration, plus the devDependency-pruning caveat for Heroku/DigitalOcean.
- **New page `railway.md`**: single-service setup, migrations via `preDeployCommand`, enabling Railway's CDN, scaling to the two-service topology. Notes that Cedar's dual-stack `::` host default (#2337) already handles Railway's IPv6-native private networking — this was slated to be documented as a gotcha to work around, but landed as an actual fix instead.
- **New page `coolify.md`**: Coolify is the only platform here whose build packs (Nixpacks/Railpack plus a dedicated Static build pack) can natively express the recommended two-service topology without a Dockerfile.
- **`universal-deploy.md`**: replaces an inaccurate claim that `cedar serve --ud` (both sides) is a production entry point with the two topologies UD actually supports in production, per `cedar-serve-ud-both-sides-plan.md`'s decision that the both-sides form is local-testing-only. Also documents the already-implemented refusal to serve when a custom `api/src/server.ts` is present under `--ud`.
- **`sidebars.js`**: registers the three new pages, plus `universal-deploy.md`, which existed but was never added to the nav.
