### PR TITLE
fix(api-server): Read PORT when the api side is served standalone

### DIFF
--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -243,6 +243,46 @@ describe('createServer', () => {
 
       delete process.env.REDWOOD_API_PORT
     })
+
+    it('falls back to `PORT` — `createServer()` always serves the api on its own', async () => {
+      process.env.PORT = '8922'
+
+      const server = await createServer()
+      await server.start()
+
+      const address = server.server.address()
+
+      if (!address || typeof address === 'string') {
+        throw new Error('No address or address is a string')
+      }
+
+      expect(address.port).toBe(+process.env.PORT)
+
+      await server.close()
+
+      delete process.env.PORT
+    })
+
+    it('the `CEDAR_API_PORT` env var takes precedence over `PORT`', async () => {
+      process.env.CEDAR_API_PORT = '8923'
+      process.env.PORT = '8924'
+
+      const server = await createServer()
+      await server.start()
+
+      const address = server.server.address()
+
+      if (!address || typeof address === 'string') {
+        throw new Error('No address or address is a string')
+      }
+
+      expect(address.port).toBe(+process.env.CEDAR_API_PORT)
+
+      await server.close()
+
+      delete process.env.CEDAR_API_PORT
+      delete process.env.PORT
+    })
   })
 })
 

--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -191,97 +191,96 @@ describe('createServer', () => {
   })
 
   describe('`server.start`', () => {
-    it('starts the server using [api].port in redwood.toml if none is specified', async () => {
-      const server = await createServer()
-      await server.start()
+    // Guaranteed cleanup, even when an assertion above throws — otherwise a
+    // failed assertion leaks the env vars and the still-listening server into
+    // later tests in this file.
+    let startedServer: Awaited<ReturnType<typeof createServer>> | undefined
+    const touchedEnvVars: string[] = []
 
-      const address = server.server.address()
+    function setEnvVar(name: string, value: string) {
+      touchedEnvVars.push(name)
+      process.env[name] = value
+    }
+
+    afterEach(async () => {
+      await startedServer?.close()
+      startedServer = undefined
+
+      touchedEnvVars.splice(0).forEach((name) => delete process.env[name])
+    })
+
+    it('starts the server using [api].port in redwood.toml if none is specified', async () => {
+      startedServer = await createServer()
+      await startedServer.start()
+
+      const address = startedServer.server.address()
 
       if (!address || typeof address === 'string') {
         throw new Error('No address or address is a string')
       }
 
       expect(address.port).toBe(getConfig().api.port)
-
-      await server.close()
     })
 
     it('the `CEDAR_API_PORT` env var takes precedence over [api].port', async () => {
-      process.env.CEDAR_API_PORT = '8920'
+      setEnvVar('CEDAR_API_PORT', '8920')
 
-      const server = await createServer()
-      await server.start()
+      startedServer = await createServer()
+      await startedServer.start()
 
-      const address = server.server.address()
+      const address = startedServer.server.address()
 
       if (!address || typeof address === 'string') {
         throw new Error('No address or address is a string')
       }
 
-      expect(address.port).toBe(+process.env.CEDAR_API_PORT)
-
-      await server.close()
-
-      delete process.env.CEDAR_API_PORT
+      expect(address.port).toBe(8920)
     })
 
     it('the deprecated `REDWOOD_API_PORT` env var still works', async () => {
-      process.env.REDWOOD_API_PORT = '8921'
+      setEnvVar('REDWOOD_API_PORT', '8921')
 
-      const server = await createServer()
-      await server.start()
+      startedServer = await createServer()
+      await startedServer.start()
 
-      const address = server.server.address()
+      const address = startedServer.server.address()
 
       if (!address || typeof address === 'string') {
         throw new Error('No address or address is a string')
       }
 
-      expect(address.port).toBe(+process.env.REDWOOD_API_PORT)
-
-      await server.close()
-
-      delete process.env.REDWOOD_API_PORT
+      expect(address.port).toBe(8921)
     })
 
     it('falls back to `PORT` — `createServer()` always serves the api on its own', async () => {
-      process.env.PORT = '8922'
+      setEnvVar('PORT', '8922')
 
-      const server = await createServer()
-      await server.start()
+      startedServer = await createServer()
+      await startedServer.start()
 
-      const address = server.server.address()
+      const address = startedServer.server.address()
 
       if (!address || typeof address === 'string') {
         throw new Error('No address or address is a string')
       }
 
-      expect(address.port).toBe(+process.env.PORT)
-
-      await server.close()
-
-      delete process.env.PORT
+      expect(address.port).toBe(8922)
     })
 
     it('the `CEDAR_API_PORT` env var takes precedence over `PORT`', async () => {
-      process.env.CEDAR_API_PORT = '8923'
-      process.env.PORT = '8924'
+      setEnvVar('CEDAR_API_PORT', '8923')
+      setEnvVar('PORT', '8924')
 
-      const server = await createServer()
-      await server.start()
+      startedServer = await createServer()
+      await startedServer.start()
 
-      const address = server.server.address()
+      const address = startedServer.server.address()
 
       if (!address || typeof address === 'string') {
         throw new Error('No address or address is a string')
       }
 
-      expect(address.port).toBe(+process.env.CEDAR_API_PORT)
-
-      await server.close()
-
-      delete process.env.CEDAR_API_PORT
-      delete process.env.PORT
+      expect(address.port).toBe(8923)
     })
   })
 })

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -165,11 +165,12 @@ export async function createServer(options: CreateServerOptions = {}) {
   })
 
   /**
-   * A wrapper around `fastify.listen` that handles `--apiPort`, `CEDAR_API_PORT` and [api].port in cedar.toml (and redwood.toml) (same for host)
+   * A wrapper around `fastify.listen` that handles `--apiPort`, `CEDAR_API_PORT`, `PORT`, and [api].port in cedar.toml (and redwood.toml) (same for host)
    *
    * The order of precedence is:
    * - `--apiPort`
    * - `CEDAR_API_PORT`
+   * - `PORT` (the api side is always the one taking public traffic here)
    * - [api].port in cedar.toml (and redwood.toml)
    */
   server.start = (options: StartOptions = {}) => {

--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -74,8 +74,12 @@ export const getDefaultCreateServerOptions: () => DefaultCreateServerOptions =
     discoverFunctionsGlob: 'dist/functions/**/*.{ts,js}',
     configureApiServer: () => {},
     parseArgs: true,
-    apiHost: getAPIHost(),
-    apiPort: getAPIPort(),
+    // `createServer()`'s only callers are `cedarjs-server api` and custom
+    // `api/src/server.ts` files — both only ever run with the api side
+    // serving public traffic on its own, so they get to use the host's
+    // `HOST`/`PORT` env vars.
+    apiHost: getAPIHost({ isPublicSide: true }),
+    apiPort: getAPIPort({ isPublicSide: true }),
   })
 
 type ResolvedOptions = Required<


### PR DESCRIPTION
`@cedarjs/api-server`'s `createServer()`'s default host/port resolution never passed `isPublicSide: true` to `getAPIHost()`/`getAPIPort()`, so it never consulted the platform's `PORT`/`HOST` env vars.

`createServer()` has exactly two callers, and both always serve the api side standalone, taking public traffic directly:
- `cedarjs-server api` (`apiCLIConfigHandler.ts` — what the generated `start:api` script runs)
- custom `api/src/server.ts` files (both the setup template and the fixtures call `createServer({...})` with no explicit host/port)

`cedar serve api` (the CLI-wrapped command) and the single-container `cedarjs-server` (for its web side) already resolve `isPublicSide: true` correctly — this was a gap specific to the standalone api-only path, introduced in #2292.

In practice, this meant a standalone api deployment on any container host that assigns a dynamic `PORT` (Railway, Render, Heroku, Cloud Run, Fly.io, ...) would silently bind to Cedar's default port (8911) instead of the platform's assigned port, so nothing could reach it — surfaced while writing deploy docs for the two-service topology (#2338).

## Changes

- `createServerHelpers.ts`: `getDefaultCreateServerOptions()` now resolves `apiHost`/`apiPort` with `isPublicSide: true`.
- `createServer.ts`: updated the `server.start` precedence-order doc comment to include `PORT`.
- Added two tests covering the `PORT` fallback and `CEDAR_API_PORT` taking precedence over it.