### PR TITLE
chore(framework-tools): retry package.json rename on Windows EPERM

### DIFF
--- a/packages/framework-tools/src/generateTypes.ts
+++ b/packages/framework-tools/src/generateTypes.ts
@@ -27,9 +27,14 @@ function renameSyncWithRetry(
       renameSync(oldPath, newPath)
       return
     } catch (e) {
-      const code = (e as NodeJS.ErrnoException).code
+      const isRetryableFsError =
+        typeof e === 'object' &&
+        e !== null &&
+        'code' in e &&
+        (e.code === 'EPERM' || e.code === 'EBUSY')
+
       if (
-        (code !== 'EPERM' && code !== 'EBUSY') ||
+        !isRetryableFsError ||
         attempt >= retries ||
         process.platform !== 'win32'
       ) {

--- a/packages/framework-tools/src/generateTypes.ts
+++ b/packages/framework-tools/src/generateTypes.ts
@@ -6,6 +6,49 @@ import execa from 'execa'
 import type { PackageJson } from 'type-fest'
 
 /**
+ * `nx run-many -t build` runs every package's build script in parallel, and
+ * several of them (this file included) spawn their own `yarn` child process,
+ * which parses every workspace's package.json on startup. On Windows,
+ * renaming over a file that another process momentarily has open for reading
+ * throws EPERM (unlike POSIX, where that's always safe). That makes this
+ * rename transient and worth a few retries rather than a hard failure.
+ *
+ * See: https://github.com/cedarjs/cedar/issues/2146
+ */
+function renameSyncWithRetry(
+  oldPath: string,
+  newPath: string,
+  retries = 5,
+  delayMs = 50,
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      renameSync(oldPath, newPath)
+      return
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code
+      if (
+        (code !== 'EPERM' && code !== 'EBUSY') ||
+        attempt >= retries ||
+        process.platform !== 'win32'
+      ) {
+        throw e
+      }
+
+      // Retries are blocking on purpose: this only ever runs on Windows CI,
+      // where the delay is a few tens of ms, and the callers are synchronous
+      // build scripts with nothing else to do in the meantime.
+      Atomics.wait(
+        new Int32Array(new SharedArrayBuffer(4)),
+        0,
+        0,
+        delayMs * attempt,
+      )
+    }
+  }
+}
+
+/**
  * This function will run `yarn build:types-cjs` to generate the CJS type
  * definitions.
  *
@@ -29,7 +72,7 @@ export async function generateTypesCjs() {
   // manifest during setup) read a partially written file and crash with a
   // JSON syntax error.
   writeFileSync('./package.json.tmp', JSON.stringify(packageJson, null, 2))
-  renameSync('./package.json.tmp', './package.json')
+  renameSyncWithRetry('./package.json.tmp', './package.json')
 
   try {
     await execa('yarn', ['build:types-cjs'], { stdio: 'inherit' })
@@ -38,7 +81,7 @@ export async function generateTypesCjs() {
     process.exitCode = getExitCode(e) ?? 1
     throw e
   } finally {
-    renameSync('package.json.bak', 'package.json')
+    renameSyncWithRetry('package.json.bak', 'package.json')
   }
 }
 

--- a/packages/framework-tools/src/generateTypes.ts
+++ b/packages/framework-tools/src/generateTypes.ts
@@ -13,7 +13,8 @@ import type { PackageJson } from 'type-fest'
  * throws EPERM (unlike POSIX, where that's always safe). That makes this
  * rename transient and worth a few retries rather than a hard failure.
  *
- * See: https://github.com/cedarjs/cedar/issues/2146
+ * See: https://github.com/cedarjs/cedar/issues/2146 and specifically
+ * https://github.com/cedarjs/cedar/actions/runs/31239552284
  */
 function renameSyncWithRetry(
   oldPath: string,

--- a/packages/framework-tools/src/generateTypes.ts
+++ b/packages/framework-tools/src/generateTypes.ts
@@ -27,14 +27,10 @@ function renameSyncWithRetry(
       renameSync(oldPath, newPath)
       return
     } catch (e) {
-      const isRetryableFsError =
-        typeof e === 'object' &&
-        e !== null &&
-        'code' in e &&
-        (e.code === 'EPERM' || e.code === 'EBUSY')
+      const code = getErrorCode(e)
 
       if (
-        !isRetryableFsError ||
+        (code !== 'EPERM' && code !== 'EBUSY') ||
         attempt >= retries ||
         process.platform !== 'win32'
       ) {
@@ -111,6 +107,18 @@ function getExitCode(e: unknown): number | undefined {
 
     if (typeof exitCode === 'number') {
       return exitCode
+    }
+  }
+
+  return undefined
+}
+
+function getErrorCode(e: unknown): string | undefined {
+  if (typeof e === 'object' && e !== null && 'code' in e) {
+    const code = e.code
+
+    if (typeof code === 'string') {
+      return code
     }
   }
 


### PR DESCRIPTION
Fixes the `EPERM: operation not permitted, rename ... package.json.tmp -> package.json` failures seen on nightly Windows CI (#2146).

`generateTypesCjs()` atomically flips `package.json` to `"type": "commonjs"` via a temp-file-then-rename, specifically to avoid a concurrently-running `yarn` process reading a half-written manifest. `nx run-many -t build` runs packages in parallel, and both `packages/testing` and `packages/prerender` call `generateTypesCjs`, each spawning its own `yarn build:types-cjs` child process — and every `yarn` invocation parses *all* workspace manifests on startup, not just its own package's.

On POSIX, renaming over a file that's open elsewhere for reading is safe. On Windows it isn't — if another process's `yarn` subprocess happens to have `package.json` open for reading at that instant, the rename throws `EPERM`. This isn't a Windows Defender issue (already disabled for these runners in `set-up-job/action.yml`); it's a distinct race between concurrent build processes.

## Changes

- Add `renameSyncWithRetry` in `packages/framework-tools/src/generateTypes.ts`: retries `EPERM`/`EBUSY` a few times with linear backoff, Windows-only (no-op behavior change on other platforms — errors still throw immediately there).
- Apply it to both `renameSync` calls in `generateTypesCjs` (the initial `.tmp` swap and the `finally` restore from `.bak`).