### PR TITLE
docs(cells): Add Cell Types Reference section

### DIFF
--- a/docs/docs/cells.md
+++ b/docs/docs/cells.md
@@ -178,8 +178,14 @@ export const beforeQuery = ({ word }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx
+import type { CellBeforeQueryResult } from '@cedarjs/web'
+
 // The cell will take 1 prop named "word" that is a string: <Cell word="abc">
-export const beforeQuery = ({ word }: { word: string }) => {
+export const beforeQuery = ({
+  word,
+}: {
+  word: string
+}): CellBeforeQueryResult<{ magicWord: string }> => {
   return {
     variables: { magicWord: word },
   }

--- a/docs/docs/cells.md
+++ b/docs/docs/cells.md
@@ -425,6 +425,23 @@ We also don't think it's an anti-pattern to do so. Far from it—your cells migh
 
 It's also important to remember that, besides exporting certain things with certain names, there aren't many rules around Cells&mdash;everything you can do in a regular component still goes.
 
+## Cell Types Reference
+
+All Cell-related types are exported from `@cedarjs/web` and share the `Cell` prefix. A nice side effect of the shared prefix is that typing `Cell` inside an `import type { ... } from '@cedarjs/web'` statement makes your editor's autocomplete list the whole family.
+
+| Type                                   | What it types                                                                                                                                       |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CellSuccessProps<TData, TVariables>`  | Props of the `Success` and `Empty` components: the query's data (spread as individual props), plus `queryResult` and `updating`                     |
+| `CellFailureProps<TVariables>`         | Props of the `Failure` component: `error`, `errorCode`, `queryResult` and `updating`                                                                |
+| `CellLoadingProps<TVariables>`         | Props of the `Loading` component                                                                                                                    |
+| `CellSuccessData<TData>`               | Just the data part of `CellSuccessProps`, useful when passing the query result on to other functions or components                                  |
+| `CellBeforeQueryResult<TVariables>`    | Return type of [`beforeQuery`](#beforequery): the query options, or `skipToken` to [skip the query](#skipping-the-query)                            |
+| `CellBeforeQueryOptions<TVariables>`   | The options object variant of `CellBeforeQueryResult`: `variables` plus any other option Apollo Client's `useQuery` hook accepts                    |
+| `TypedDocumentNode<TData, TVariables>` | The `QUERY` document. Annotating `QUERY` with it flows the query's data and variable types through to the rest of the Cell                          |
+| `CellProps<...>`                       | The complete prop interface of a Cell as seen by the components rendering it. Used by Cedar's generated types&mdash;you'll rarely write it yourself |
+
+For worked examples of `CellSuccessProps`, `CellFailureProps`, and `CellLoadingProps`, see the [Utility Types](typescript/utility-types.md#cells) doc. For `CellBeforeQueryResult`, see the [`beforeQuery`](#beforequery) section above.
+
 ## Fragment Cells: Aggregating Queries
 
 Nesting a Cell inside another Cell's `Success` component works, but it creates a

--- a/docs/docs/cells.md
+++ b/docs/docs/cells.md
@@ -180,12 +180,14 @@ export const beforeQuery = ({ word }) => {
 ```tsx
 import type { CellBeforeQueryResult } from '@cedarjs/web'
 
-// The cell will take 1 prop named "word" that is a string: <Cell word="abc">
-export const beforeQuery = ({
-  word,
-}: {
+interface BeforeQueryProps {
   word: string
-}): CellBeforeQueryResult<{ magicWord: string }> => {
+}
+
+type BeforeQueryResult = CellBeforeQueryResult<{ magicWord: string }>
+
+// The cell will take 1 prop named "word" that is a string: <Cell word="abc">
+export const beforeQuery = ({ word }: BeforeQueryProps): BeforeQueryResult => {
   return {
     variables: { magicWord: word },
   }

--- a/docs/docs/how-to/pagination.md
+++ b/docs/docs/how-to/pagination.md
@@ -229,15 +229,16 @@ export const beforeQuery = ({ page }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/BlogPostsCell/BlogPostsCell.tsx"
+import type { CellBeforeQueryResult } from '@cedarjs/web'
+
 export const beforeQuery = ({
   page,
-}: FindBlogPostQueryVariables): GraphQLQueryHookOptions<
-  FindBlogPostQuery,
-  FindBlogPostQueryVariables
-> => {
-  page = page ? parseInt(page, 10) : 1
+}: {
+  page?: number | string
+}): CellBeforeQueryResult<BlogPostsQueryVariables> => {
+  const pageNumber = page ? parseInt(page.toString(), 10) : 1
 
-  return { variables: { page } }
+  return { variables: { page: pageNumber } }
 }
 ```
 

--- a/docs/docs/how-to/pagination.md
+++ b/docs/docs/how-to/pagination.md
@@ -231,11 +231,13 @@ export const beforeQuery = ({ page }) => {
 ```tsx title="web/src/components/BlogPostsCell/BlogPostsCell.tsx"
 import type { CellBeforeQueryResult } from '@cedarjs/web'
 
-export const beforeQuery = ({
-  page,
-}: {
+interface BeforeQueryProps {
   page?: number | string
-}): CellBeforeQueryResult<BlogPostsQueryVariables> => {
+}
+
+type BeforeQueryResult = CellBeforeQueryResult<BlogPostsQueryVariables>
+
+export const beforeQuery = ({ page }: BeforeQueryProps): BeforeQueryResult => {
   const pageNumber = page ? parseInt(page.toString(), 10) : 1
 
   return { variables: { page: pageNumber } }

--- a/docs/implementation-plans/2026-08-08-cell-export-function-style.md
+++ b/docs/implementation-plans/2026-08-08-cell-export-function-style.md
@@ -1,0 +1,169 @@
+# Cell exports: migrate to `export function` style
+
+Plan for changing all Cell exports — `Loading`, `Empty`, `Failure`, `Success`,
+`beforeQuery`, `afterQuery`, `isEmpty` — from const arrow functions to function
+declarations in generator templates, docs, and fixtures. This document also
+records the typing reasoning that led here, because the style decision and the
+type-annotation strategy constrain each other.
+
+## Motivation
+
+The larger React ecosystem has moved away from
+
+```tsx
+export const MyComponent: React.FC<Props> = ({ myProp }) => {
+```
+
+toward
+
+```tsx
+export function MyComponent({ myProp }: Props) {
+```
+
+Cedar's Cell files still use the const arrow form everywhere. Since the
+components in a Cell file should follow the ecosystem, and a generated Cell
+reads better when every export uses the same form, the non-component exports
+(`beforeQuery` et al.) should move too.
+
+This intersects with an ongoing effort to make Cell types discoverable (see
+#2348, #2349, and the `CellBeforeQueryResult` docs work on the
+`tobbe-docs-cells-before-query` branch): whichever style we standardize on
+determines which annotation patterns we can document and lint toward.
+
+## The typing question
+
+The readability problem that started this thread:
+
+```ts
+// TypeScript, annotated inline — hard to read
+export const beforeQuery = ({
+  page,
+}: {
+  page?: number | string
+}): CellBeforeQueryResult<BlogPostsQueryVariables> => {
+
+// The JS version it competes with
+export const beforeQuery = ({ page }) => {
+```
+
+Options considered:
+
+### 1. Function type on the const (rejected)
+
+Annotate the const with a framework-exported function type and let contextual
+typing handle params and return:
+
+```ts
+export const beforeQuery: CellBeforeQuery<BlogPostsQueryVariables> = (
+  props,
+) => {
+```
+
+This is the cleanest arrow-style option (the arrow itself stays identical to
+JS), and would have meant adding a `CellBeforeQuery<CellVariables, CellProps>`
+function type to `@cedarjs/web`. Rejected for two reasons:
+
+- It is **arrow-only**. A function declaration has no expression to hang a
+  function type on, so this pattern dies the moment we migrate to
+  `export function`.
+- It is the `React.FC` / `GetServerSideProps`-era pattern the ecosystem has been
+  walking away from (see precedents below).
+
+Do **not** add `CellBeforeQuery` to `@cedarjs/web`.
+
+### 2. `satisfies` (rejected)
+
+Astro-style `(fn) satisfies GetStaticPaths` only works on expressions. For a
+declaration you'd need a separate `beforeQuery satisfies CellBeforeQuery<...>`
+statement after the function: errors get reported at the `satisfies` line
+instead of inside the function, the inferred return loses excess-property
+checking and option autocomplete in the body, and a bare expression statement
+looks like a mistake.
+
+### 3. Inline annotations with framework "piece" types (chosen)
+
+Annotate the parameter and return individually, with the framework exporting
+types for the pieces (`CellBeforeQueryResult`, `CellSuccessProps`, ...), and
+local aliases as the escape hatch when a signature outgrows one line:
+
+```ts
+interface BeforeQueryProps {
+  page?: number | string
+}
+
+type BeforeQueryResult = CellBeforeQueryResult<BlogPostsQueryVariables>
+
+export function beforeQuery({ page }: BeforeQueryProps): BeforeQueryResult {
+```
+
+That signature line is 76 characters — under Prettier's 80. The same aliases and
+annotations work identically for the const arrow form, so docs written this way
+survive the migration untouched. This is what the docs on the
+`tobbe-docs-cells-before-query` branch use.
+
+Style note: use `interface` for object shapes and reserve `type` for genuine
+aliases (like `BeforeQueryResult` above) — `type` only where `interface` can't
+express it (unions, mapped types, aliases of existing types).
+
+## Ecosystem precedents
+
+The closest analogs to `beforeQuery` are the file-convention exports in other
+React meta-frameworks, and their trajectory all points the same way:
+
+- **Remix / React Router**: `loader`/`action` are exactly `beforeQuery`-shaped
+  (named exports the framework calls with args it defines). Documented style is
+  `export async function loader({ request }: LoaderFunctionArgs) {...}`. Remix
+  used to push `export const loader: LoaderFunction = ...` and moved away from
+  it — for readability, and because inline typing keeps the return type
+  inferable (needed by `useLoaderData<typeof loader>`).
+- **Next.js**: Pages-era
+  `export const getServerSideProps: GetServerSideProps = async (ctx) => {...}`
+  was replaced in the App Router by declarations like
+  `export async function generateMetadata(props): Promise<Metadata>`.
+- **Astro**: went with `satisfies GetStaticPaths` — expression-based, doesn't
+  carry over to declarations.
+
+Conclusion: function declaration + inline annotations using framework-exported
+piece types is both the ecosystem-consistent and file-consistent choice. Cedar
+mirrors Remix by exporting the pieces (`CellBeforeQueryResult`, analogous to
+`LoaderFunctionArgs`) rather than whole function types.
+
+## Cedar-specific caveat: the param annotation is load-bearing
+
+Unlike Remix's `loader`, Cedar infers a Cell's **external props** from
+`beforeQuery`'s first parameter (`CellPropsVariables` in
+`packages/web/src/components/cell/cellTypes.ts` uses
+`Parameters<Cell['beforeQuery']>[0]`). So annotating the parameter isn't just
+local hygiene — it's what makes `<BlogPostsCell page={1} />` type-check. Docs
+and the #2348 lint rule should nudge people toward annotating the parameter even
+when they'd otherwise let it slide as implicit-`any`-with-destructuring.
+
+## Work items
+
+1. **Generator templates** (`packages/cli/src/commands/generate/cell/templates/`
+   and the list-cell variants): convert `Loading`, `Empty`, `Failure`, `Success`
+   to `export function` with inline `CellSuccessProps` / `CellFailureProps`
+   annotations. Check the component, page, and scaffold generators for the same
+   pattern while at it (separate PRs if scope grows).
+2. **Verify the Cell build pipeline handles declarations.** The Babel cell
+   transform collects named exports to assemble `createCell(...)`; confirm it
+   treats `export function Success() {}` the same as
+   `export const Success = () => {}`. Same check for web typegen's mirror
+   `.d.ts` generation and the `CellProps` inference chain. Add tests for the
+   declaration form where missing.
+3. **Docs**: update Cell examples (`cells.md`, `how-to/pagination.md`, tutorial
+   chapters, `typescript/utility-types.md`) to the declaration style. The
+   beforeQuery examples already use form-agnostic annotations, so they only need
+   the `const ... =>` → `function` swap.
+4. **Fixtures and test projects**: `__fixtures__/test-project*`,
+   `tasks/test-project/`, and any Cell fixtures in package tests.
+5. **Lint rule #2348**: must recognize both forms — existing apps keep the arrow
+   style indefinitely (this migration is templates/docs only, not breaking). The
+   autofix inserts inline param/return annotations, which works on both forms;
+   issue updated accordingly.
+6. **Generator flag #2349**: the `--before-query` stub should be generated in
+   declaration style from the start.
+
+Existing user code in either style keeps working; no codemod is required. An
+optional codemod for apps that want to convert wholesale can be considered
+later.


### PR DESCRIPTION
Improves the discoverability and readability of Cell-related TypeScript types in the docs.

## What's in here

**`beforeQuery` typing examples** (`cells.md`, `how-to/pagination.md`)
The TypeScript tabs now show how to type `beforeQuery` with `CellBeforeQueryResult`, using local aliases so the signature stays as readable as possible

```ts
interface BeforeQueryProps {
  page?: number | string
}

type BeforeQueryResult = CellBeforeQueryResult<BlogPostsQueryVariables>

export const beforeQuery = ({ page }: BeforeQueryProps): BeforeQueryResult => {
```

**New "Cell Types Reference" section** (`cells.md`)
A table of every public Cell type exported from `@cedarjs/web` (`CellSuccessProps`, `CellFailureProps`, `CellLoadingProps`, `CellSuccessData`, `CellBeforeQueryResult`, `CellBeforeQueryOptions`, `TypedDocumentNode`, `CellProps`) with one-line descriptions and links to the detailed docs. There was previously no single place that enumerated the family.

## Related

- #2348 (ESLint `cell-type-annotations` rule) and #2349 (`--before-query` generator flag) — follow-up work on the same discoverability problem; not closed by this PR.