### PR TITLE
fix(web): Make Cell props reflect beforeQuery's annotated parameter type

### DIFF
--- a/packages/web/src/__typetests__/cellProps.test.tsx
+++ b/packages/web/src/__typetests__/cellProps.test.tsx
@@ -60,6 +60,23 @@ const recipeCell = {
   },
 }
 
+// Like real generated Cells, this fixture's Success is annotated with both
+// the query result and the query variables. (`recipeCell` above leaves
+// `TVariables` at its default.)
+interface SuccessWithVariablesProps extends CellSuccessProps<
+  QueryResult,
+  ExampleQueryVariables
+> {
+  customProp: number
+}
+
+const recipeCellWithVariables = {
+  ...recipeCell,
+  Success: (props: SuccessWithVariablesProps) => {
+    return <h1>{props.recipes.length}</h1>
+  },
+}
+
 describe('CellProps mapper type', () => {
   describe('when beforeQuery does not exist', () => {
     test('Inputs expect props outside cell', () => {
@@ -120,6 +137,73 @@ describe('CellProps mapper type', () => {
       })
     })
 
+    test('Inputs reject beforeQuery args that are missing or of the wrong type', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const cellWithBeforeQuery = {
+        ...recipeCellWithVariables,
+        beforeQuery: ({ word }: { word: string }) => {
+          return {
+            variables: {
+              category: word,
+              saved: !!word,
+            },
+          }
+        },
+      }
+
+      type CellWithBeforeQueryInputs = CellProps<
+        typeof cellWithBeforeQuery.Success,
+        QueryResult,
+        typeof cellWithBeforeQuery,
+        ExampleQueryVariables
+      >
+
+      // `word` is missing
+      expect<CellWithBeforeQueryInputs>().type.not.toBeAssignableFrom({
+        customProp: 99,
+      })
+
+      // `word` has the wrong type
+      expect<CellWithBeforeQueryInputs>().type.not.toBeAssignableFrom({
+        word: 42,
+        customProp: 99,
+      })
+
+      // `customProp` is missing
+      expect<CellWithBeforeQueryInputs>().type.not.toBeAssignableFrom({
+        word: 'abracadabra',
+      })
+    })
+
+    test('Inputs do not require the query variables when beforeQuery computes them', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const cellWithBeforeQuery = {
+        ...recipeCellWithVariables,
+        beforeQuery: ({ word }: { word: string }) => {
+          return {
+            variables: {
+              category: word,
+              saved: !!word,
+            },
+          }
+        },
+      }
+
+      type CellWithBeforeQueryInputs = CellProps<
+        typeof cellWithBeforeQuery.Success,
+        QueryResult,
+        typeof cellWithBeforeQuery,
+        ExampleQueryVariables
+      >
+
+      // Even though `Success` is annotated with the query's variables
+      // (`category` and `saved`), the Cell's caller only provides `word`
+      expect<CellWithBeforeQueryInputs>().type.toBeAssignableFrom({
+        word: 'abracadabra',
+        customProp: 99,
+      })
+    })
+
     test('Inputs still expect custom props when query does not take variables', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const cellWithBeforeQuery = {
@@ -170,6 +254,12 @@ describe('CellProps mapper type', () => {
       // Note that the gql variables are no longer required here
       expect<CellWithBeforeQueryInputs>().type.toBeAssignableFrom({
         customProp: 99,
+      })
+
+      // A zero-arg beforeQuery accepts any props, including none at all
+      expect<CellWithBeforeQueryInputs>().type.toBeAssignableFrom({})
+      expect<CellWithBeforeQueryInputs>().type.toBeAssignableFrom({
+        anything: 'goes',
       })
     })
 

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -16,7 +16,9 @@ import type { A, L, O, U } from 'ts-toolbelt'
 
 /**
  * If the Cell has a `beforeQuery` function, then the variables are not required,
- * but instead the arguments of the `beforeQuery` function are required.
+ * but instead the arguments of the `beforeQuery` function are required. If
+ * `beforeQuery` takes no arguments, or its first argument is untyped, any
+ * props are accepted.
  *
  * If the Cell does not have a `beforeQuery` function, then the variables are required.
  *
@@ -27,9 +29,13 @@ import type { A, L, O, U } from 'ts-toolbelt'
 type CellPropsVariables<Cell, GQLVariables> = Cell extends {
   beforeQuery: (...args: any[]) => any
 }
-  ? Parameters<Cell['beforeQuery']>[0] extends unknown
-    ? Record<string, unknown>
-    : Parameters<Cell['beforeQuery']>[0]
+  ? Parameters<Cell['beforeQuery']> extends [infer FirstArg, ...any[]]
+    ? // `unknown extends T` is only true for `unknown` and `any`, i.e. an
+      // untyped first argument
+      unknown extends FirstArg
+      ? Record<string, unknown>
+      : FirstArg
+    : Record<string, unknown>
   : GQLVariables extends Record<string, never>
     ? unknown
     : GQLVariables
@@ -46,6 +52,16 @@ export type CellProps<
   Omit<
     ComponentProps<CellSuccess>,
     | keyof CellPropsVariables<CellType, GQLVariables>
+    // Success components are typically annotated with the query's variables
+    // (via `CellSuccessProps<TData, TVariables>`). When a `beforeQuery`
+    // computes the variables from different props, the variables must not
+    // leak into the props required at the Cell's call site, so they're
+    // omitted here. Without a `beforeQuery` this is a no-op since
+    // `CellPropsVariables` already equals the variables. `keyof unknown` is
+    // `never`, so queries without variables are unaffected.
+    | keyof (GQLVariables extends Record<string, never>
+        ? unknown
+        : GQLVariables)
     | keyof GQLResult
     | 'updating'
     | 'queryResult'


### PR DESCRIPTION
Fixes a long-standing type bug (inherited from Redwood) where a Cell's `beforeQuery` parameter annotation was silently erased at the Cell's call site. Surfaced by a Greptile review comment on #2350.

## The bug

`CellPropsVariables` contained a tautological conditional:

```ts
? Parameters<Cell['beforeQuery']>[0] extends unknown  // true for EVERY type
  ? Record<string, unknown>
  : Parameters<Cell['beforeQuery']>[0]                // dead branch
```

Every type extends `unknown`, so whenever a Cell had a `beforeQuery`, its external props collapsed to `Record<string, unknown>` — and since `keyof Record<string, unknown>` is `string`, the `Omit` in `CellProps` then wiped *all* remaining prop requirements, including custom `Success` props. A Cell with any `beforeQuery` accepted `<Cell />` with nothing at all, no matter how the hook's parameter was annotated. The operands were simply reversed: the intended check was `unknown extends T` ("is the param untyped?"), which is only true for `unknown`/`any`.

## The fix

- `CellPropsVariables` now matches the parameter list against `[infer FirstArg, ...any[]]` and uses `FirstArg` when it's typed. Zero-arg and untyped-param hooks keep today's permissive `Record<string, unknown>` behavior.
- `CellProps` additionally omits `keyof GQLVariables` from the `Success` component's contribution. Generated Cells annotate `Success` with the query variables (`CellSuccessProps<TData, TVariables>`); without this, fixing the erasure would have made those variables required at the call site even though a transforming `beforeQuery` computes them. It's a no-op for Cells without `beforeQuery` (the keys were already omitted) and for queries without variables (`keyof unknown` is `never`).

## Tests

The existing typetests were all positive `toBeAssignableFrom` assertions, which pass under both the broken and the fixed behavior. Added negative assertions that pin the fix: missing hook args rejected, wrongly-typed args rejected, missing custom `Success` props rejected, query variables *not* required when `beforeQuery` computes them, and zero-arg hooks still accepting any props. The new fixture types `Success` with concrete variables, mirroring real generated code.

## Behavior change

This tightens type checking: call sites that were under-passing props to Cells with a `beforeQuery` will now (correctly) error. That's the docs' long-documented behavior — "the Cell will automatically change the type of its props to match the first argument of the function" — finally holding true.

## Testing notes

- `yarn workspace @cedarjs/web build && yarn test:types` (19 assertions, including 3 that fail against the pre-fix types)
- `yarn vitest run src/components/cell` in `packages/web` (40 tests)
- `yarn vitest run src/__tests__/typeDefinitions.test.ts` in `packages/internal` (13 tests)
