### PR TITLE
fix(vite): forward dev server options via --fwd

### DIFF
--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -220,6 +220,8 @@ Using `--forward` (alias `--fwd`), you can pass one or more Vite Dev Server [con
 ~/redwood-app$ yarn redwood dev --fwd="--port=1234 --open=false"
 ```
 
+When there's no interactive terminal attached (CI, AI coding agents, etc.), the dev server defaults to `--open=false` automatically, so you don't need to pass it explicitly in those environments.
+
 You may need to access your dev application from a different host, like your mobile device or an SSH tunnel. To resolve the “Invalid Host Header” message, run the following:
 
 ```bash

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -28,9 +28,6 @@ export const builder = (yargs: Argv) => {
         'String of one or more vite dev server config options, for example: ' +
         '`--fwd="--port=1234 --open=false"`',
       type: 'string',
-      // The reason `forward` is hidden is that it's been broken with Vite and
-      // it's not clear how to fix it.
-      hidden: true,
     })
     .option('generate', {
       type: 'boolean',

--- a/packages/vite/bins/cedar-vite-dev.mjs
+++ b/packages/vite/bins/cedar-vite-dev.mjs
@@ -16,14 +16,27 @@ const startDevServer = async () => {
   // Tries to maintain the same options as vite's dev cli
   // See here: https://github.com/vitejs/vite/blob/main/packages/vite/src/node/cli.ts#L103
   // e.g. yarn cedar dev web --fwd="--force"
+  //
+  // `force` and `debug` aren't Vite server options, so pull those out.
+  // Everything else yargs-parser picks out of argv (e.g. `open`, `port`,
+  // `https`, `strictPort`, `cors`) is a forwarded server option and gets
+  // passed straight through to Vite's `server` config.
   const {
     force: forceOptimize,
-    forwardedServerArgs,
     debug,
+    _: _positional,
+    ...forwardedServerArgs
   } = yargsParser(process.argv.slice(2), {
     boolean: ['https', 'open', 'strictPort', 'force', 'cors', 'debug'],
     number: ['port'],
   })
+
+  // Default to not auto-opening a browser when there's no interactive
+  // terminal attached (CI, AI coding agents, etc.), unless the user
+  // explicitly forwarded --open.
+  if (forwardedServerArgs.open === undefined && !process.stdout.isTTY) {
+    forwardedServerArgs.open = false
+  }
 
   const devServer = await createServer({
     configFile,


### PR DESCRIPTION
- `cedar dev --fwd="..."` silently dropped every forwarded Vite dev server option (`--port`, `--open`, `--https`, `--strictPort`, `--cors`). `packages/vite/bins/cedar-vite-dev.mjs` destructured a `forwardedServerArgs` key that `yargs-parser` never produces — parsed flags come back as top-level keys, not nested under a grouping key, so `server: forwardedServerArgs` was always `undefined`. Fixed by rest-spreading the remaining parsed args instead, mirroring the already-correct pattern in `cedar-unified-dev.ts`.
- Now that `--fwd` actually works, un-hide the `--forward`/`--fwd` option in `packages/cli/src/commands/dev.ts` (it was previously marked `hidden: true` because it was broken).
- Also default to `open: false` when there's no interactive TTY attached (CI, AI coding agents, etc.), unless the user explicitly forwarded `--open`, so those environments don't need to pass the flag manually.
- Added a short docs note about the new automatic no-TTY default.

Fixes #2286