### PR TITLE
fix(dbAuth): mention PrivateSet in setup post-install notes

### DIFF
--- a/packages/auth-providers/dbAuth/setup/src/setupData.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupData.ts
@@ -129,3 +129,12 @@ export const noteGenerate = [
   '',
   '  yarn cedar generate dbAuth',
 ]
+
+export const notePrivateSet = [
+  '',
+  'Ready to protect a route? Wrap it in `<PrivateSet>` in Routes.tsx:',
+  '',
+  '  <PrivateSet unauthenticated="login">',
+  '    <Route path="/admin" page={AdminPage} name="admin" />',
+  '  </PrivateSet>',
+]

--- a/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
@@ -10,6 +10,7 @@ import {
   notes,
   noteGenerate,
   notesCreatedUserModel,
+  notePrivateSet,
   extraTask,
   createUserModelTask,
 } from './setupData.js'
@@ -68,6 +69,8 @@ export async function handler({
       oneMoreThing.push(...noteGenerate)
     }
   }
+
+  oneMoreThing.push(...notePrivateSet)
 
   let createDbUserModelTask: typeof createUserModelTask | undefined = undefined
 


### PR DESCRIPTION
## Summary

`yarn cedar setup auth dbAuth` generates login/signup infrastructure and prints helpful post-setup notes, but nothing in that flow mentions how to protect routes with `PrivateSet` once auth is set up. This is the natural next step for a developer who just finished auth setup.

## Changes

- Added `notePrivateSet` to `setupData.ts` with a short snippet showing how to wrap a route in `<PrivateSet>`.
- Wired it into `setupHandler.ts` so it's always appended to the post-setup notes, regardless of the `webauthn`, `createUserModel`, or `generateAuthPages` choices (it's relevant in every case).

```
Ready to protect a route? Wrap it in `<PrivateSet>` in Routes.tsx:

  <PrivateSet unauthenticated="login">
    <Route path="/admin" page={AdminPage} name="admin" />
  </PrivateSet>
```

Fixes #2290

## Test plan

- [x] `yarn vitest run packages/auth-providers/dbAuth/setup/src/__tests__/setup.test.ts` — 13/13 passed
- [x] `tsc --noEmit` on the setup package — no errors
- [x] `eslint` on both changed files — clean