### PR TITLE
feat(cell-generator): add --before-query, --after-query, --is-empty flags

### DIFF
--- a/docs/docs/cells.md
+++ b/docs/docs/cells.md
@@ -130,6 +130,12 @@ This means you can think backwards about your Cell's props from your SDL: whatev
 
 `beforeQuery` is a lifecycle hook. The best way to think about it is as a chance to configure [Apollo Client's `useQuery` hook](https://www.apollographql.com/docs/react/api/react/hooks#options).
 
+You can scaffold a typed `beforeQuery` stub with the cell generator's `--before-query` flag (`isEmpty` and `afterQuery` have `--is-empty` and `--after-query` equivalents):
+
+```bash
+yarn cedar generate cell Post --before-query
+```
+
 By default, `beforeQuery` gives any props passed from the parent component to `QUERY` so that they're available as variables for it. It'll also set the fetch policy to `'cache-and-network'` since we felt it matched the behavior users want most of the time:
 
 ```jsx

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -474,6 +474,9 @@ Cells are signature to Cedar. We think they provide a simpler and more declarati
 | `--typescript, --ts` | Generate TypeScript files Enabled by default if we detect your project is TypeScript                                                                             |
 | `--query`            | Use this flag to specify a specific name for the GraphQL query. The query name must be unique                                                                    |
 | `--list`             | Use this flag to generate a list cell. This flag is needed when dealing with irregular words whose plural and singular is identical such as equipment or pokemon |
+| `--before-query`     | Include a typed `beforeQuery` stub for configuring the query (e.g. variables, fetch policy)                                                                      |
+| `--after-query`      | Include a typed `afterQuery` stub for sanitizing data returned from the query                                                                                    |
+| `--is-empty`         | Include a typed `isEmpty` stub for overriding the default check for the Empty component                                                                          |
 | `--tests`            | Generate test files [default: true]                                                                                                                              |
 | `--stories`          | Generate Storybook files [default: true]                                                                                                                         |
 | `--rollback`         | Rollback changes if an error occurs [default: true]                                                                                                              |

--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.ts.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.ts.snap
@@ -419,6 +419,265 @@ describe('UserProfileCell', () => {
 "
 `;
 
+exports[`Lifecycle hook flags > includes a typed afterQuery stub when --after-query is passed 1`] = `
+"import type { FindUserQuery, FindUserQueryVariables } from 'types/graphql'
+
+import type {
+  CellSuccessProps,
+  CellFailureProps,
+  TypedDocumentNode,
+  DataObject,
+} from '@cedarjs/web'
+
+export const QUERY: TypedDocumentNode<FindUserQuery, FindUserQueryVariables> =
+  gql\`
+    query FindUserQuery($id: Int!) {
+      user: user(id: $id) {
+        id
+      }
+    }
+  \`
+
+export const afterQuery = (data: DataObject): DataObject => {
+  return data
+}
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({
+  error,
+}: CellFailureProps<FindUserQueryVariables>) => (
+  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+)
+
+export const Success = ({
+  user,
+}: CellSuccessProps<FindUserQuery, FindUserQueryVariables>) => {
+  return <div>{JSON.stringify(user)}</div>
+}
+"
+`;
+
+exports[`Lifecycle hook flags > includes a typed beforeQuery stub when --before-query is passed 1`] = `
+"import type { FindUserQuery, FindUserQueryVariables } from 'types/graphql'
+
+import type {
+  CellSuccessProps,
+  CellFailureProps,
+  TypedDocumentNode,
+  CellBeforeQueryResult,
+} from '@cedarjs/web'
+
+export const QUERY: TypedDocumentNode<FindUserQuery, FindUserQueryVariables> =
+  gql\`
+    query FindUserQuery($id: Int!) {
+      user: user(id: $id) {
+        id
+      }
+    }
+  \`
+
+export const beforeQuery = (
+  props: FindUserQueryVariables
+): CellBeforeQueryResult<FindUserQueryVariables> => {
+  return { variables: props }
+}
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({
+  error,
+}: CellFailureProps<FindUserQueryVariables>) => (
+  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+)
+
+export const Success = ({
+  user,
+}: CellSuccessProps<FindUserQuery, FindUserQueryVariables>) => {
+  return <div>{JSON.stringify(user)}</div>
+}
+"
+`;
+
+exports[`Lifecycle hook flags > includes a typed isEmpty stub when --is-empty is passed 1`] = `
+"import type { FindUserQuery, FindUserQueryVariables } from 'types/graphql'
+
+import type {
+  CellSuccessProps,
+  CellFailureProps,
+  TypedDocumentNode,
+  DataObject,
+} from '@cedarjs/web'
+
+export const QUERY: TypedDocumentNode<FindUserQuery, FindUserQueryVariables> =
+  gql\`
+    query FindUserQuery($id: Int!) {
+      user: user(id: $id) {
+        id
+      }
+    }
+  \`
+
+export const isEmpty = (
+  data: DataObject,
+  { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }
+) => {
+  return isDataEmpty(data)
+}
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({
+  error,
+}: CellFailureProps<FindUserQueryVariables>) => (
+  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+)
+
+export const Success = ({
+  user,
+}: CellSuccessProps<FindUserQuery, FindUserQueryVariables>) => {
+  return <div>{JSON.stringify(user)}</div>
+}
+"
+`;
+
+exports[`Lifecycle hook flags > includes all three stubs when all flags are passed 1`] = `
+"import type { FindUserQuery, FindUserQueryVariables } from 'types/graphql'
+
+import type {
+  CellSuccessProps,
+  CellFailureProps,
+  TypedDocumentNode,
+  CellBeforeQueryResult,
+  DataObject,
+} from '@cedarjs/web'
+
+export const QUERY: TypedDocumentNode<FindUserQuery, FindUserQueryVariables> =
+  gql\`
+    query FindUserQuery($id: Int!) {
+      user: user(id: $id) {
+        id
+      }
+    }
+  \`
+
+export const beforeQuery = (
+  props: FindUserQueryVariables
+): CellBeforeQueryResult<FindUserQueryVariables> => {
+  return { variables: props }
+}
+
+export const isEmpty = (
+  data: DataObject,
+  { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }
+) => {
+  return isDataEmpty(data)
+}
+
+export const afterQuery = (data: DataObject): DataObject => {
+  return data
+}
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({
+  error,
+}: CellFailureProps<FindUserQueryVariables>) => (
+  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+)
+
+export const Success = ({
+  user,
+}: CellSuccessProps<FindUserQuery, FindUserQueryVariables>) => {
+  return <div>{JSON.stringify(user)}</div>
+}
+"
+`;
+
+exports[`Lifecycle hook flags > strips types from stubs when generating JavaScript 1`] = `
+"export const QUERY = gql\`
+  query FindUserQuery($id: Int!) {
+    user: user(id: $id) {
+      id
+    }
+  }
+\`
+
+export const beforeQuery = (props) => {
+  return { variables: props }
+}
+
+export const isEmpty = (data, { isDataEmpty }) => {
+  return isDataEmpty(data)
+}
+
+export const afterQuery = (data) => {
+  return data
+}
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({ error }) => (
+  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+)
+
+export const Success = ({ user }) => {
+  return <div>{JSON.stringify(user)}</div>
+}
+"
+`;
+
+exports[`Lifecycle hook flags > works for list cells too 1`] = `
+"export const QUERY = gql\`
+  query UsersQuery {
+    users {
+      id
+    }
+  }
+\`
+
+export const beforeQuery = (props) => {
+  return { variables: props }
+}
+
+export const isEmpty = (data, { isDataEmpty }) => {
+  return isDataEmpty(data)
+}
+
+export const afterQuery = (data) => {
+  return data
+}
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({ error }) => (
+  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+)
+
+export const Success = ({ users }) => {
+  return (
+    <ul>
+      {users.map((item) => {
+        return <li key={item.id}>{JSON.stringify(item)}</li>
+      })}
+    </ul>
+  )
+}
+"
+`;
+
 exports[`Multiword files > creates a cell component with a multi word name 1`] = `
 "export const QUERY = gql\`
   query FindUserProfileQuery($id: Int!) {

--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.ts.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.ts.snap
@@ -482,7 +482,7 @@ export const QUERY: TypedDocumentNode<FindUserQuery, FindUserQueryVariables> =
 export const beforeQuery = (
   props: FindUserQueryVariables
 ): CellBeforeQueryResult<FindUserQueryVariables> => {
-  return { variables: props }
+  return { variables: props, fetchPolicy: 'cache-and-network' }
 }
 
 export const Loading = () => <div>Loading...</div>
@@ -570,7 +570,7 @@ export const QUERY: TypedDocumentNode<FindUserQuery, FindUserQueryVariables> =
 export const beforeQuery = (
   props: FindUserQueryVariables
 ): CellBeforeQueryResult<FindUserQueryVariables> => {
-  return { variables: props }
+  return { variables: props, fetchPolicy: 'cache-and-network' }
 }
 
 export const isEmpty = (
@@ -612,7 +612,7 @@ exports[`Lifecycle hook flags > strips types from stubs when generating JavaScri
 \`
 
 export const beforeQuery = (props) => {
-  return { variables: props }
+  return { variables: props, fetchPolicy: 'cache-and-network' }
 }
 
 export const isEmpty = (data, { isDataEmpty }) => {
@@ -647,7 +647,7 @@ exports[`Lifecycle hook flags > works for list cells too 1`] = `
 \`
 
 export const beforeQuery = (props) => {
-  return { variables: props }
+  return { variables: props, fetchPolicy: 'cache-and-network' }
 }
 
 export const isEmpty = (data, { isDataEmpty }) => {

--- a/packages/cli/src/commands/generate/cell/__tests__/cell.test.ts
+++ b/packages/cli/src/commands/generate/cell/__tests__/cell.test.ts
@@ -690,6 +690,115 @@ describe('Custom query names', () => {
   })
 })
 
+describe('Lifecycle hook flags', () => {
+  const CELL_PATH = path.normalize(
+    '/path/to/project/web/src/components/UserCell/UserCell.jsx',
+  )
+
+  const CELL_PATH_TS = path.normalize(
+    '/path/to/project/web/src/components/UserCell/UserCell.tsx',
+  )
+
+  const LIST_CELL_PATH = path.normalize(
+    '/path/to/project/web/src/components/UsersCell/UsersCell.jsx',
+  )
+
+  test('does not include beforeQuery, afterQuery or isEmpty by default', async () => {
+    const files = await cellHandler.files({
+      name: 'User',
+      tests: false,
+      stories: false,
+      list: false,
+    })
+
+    expect(files[CELL_PATH]).not.toContain('beforeQuery')
+    expect(files[CELL_PATH]).not.toContain('afterQuery')
+    expect(files[CELL_PATH]).not.toContain('isEmpty')
+  })
+
+  test('includes a typed beforeQuery stub when --before-query is passed', async () => {
+    const files = await cellHandler.files({
+      name: 'User',
+      tests: false,
+      stories: false,
+      list: false,
+      typescript: true,
+      beforeQuery: true,
+    })
+
+    expect(files[CELL_PATH_TS]).toMatchSnapshot()
+  })
+
+  test('includes a typed afterQuery stub when --after-query is passed', async () => {
+    const files = await cellHandler.files({
+      name: 'User',
+      tests: false,
+      stories: false,
+      list: false,
+      typescript: true,
+      afterQuery: true,
+    })
+
+    expect(files[CELL_PATH_TS]).toMatchSnapshot()
+  })
+
+  test('includes a typed isEmpty stub when --is-empty is passed', async () => {
+    const files = await cellHandler.files({
+      name: 'User',
+      tests: false,
+      stories: false,
+      list: false,
+      typescript: true,
+      isEmpty: true,
+    })
+
+    expect(files[CELL_PATH_TS]).toMatchSnapshot()
+  })
+
+  test('includes all three stubs when all flags are passed', async () => {
+    const files = await cellHandler.files({
+      name: 'User',
+      tests: false,
+      stories: false,
+      list: false,
+      typescript: true,
+      beforeQuery: true,
+      afterQuery: true,
+      isEmpty: true,
+    })
+
+    expect(files[CELL_PATH_TS]).toMatchSnapshot()
+  })
+
+  test('strips types from stubs when generating JavaScript', async () => {
+    const files = await cellHandler.files({
+      name: 'User',
+      tests: false,
+      stories: false,
+      list: false,
+      beforeQuery: true,
+      afterQuery: true,
+      isEmpty: true,
+    })
+
+    expect(files[CELL_PATH]).toMatchSnapshot()
+  })
+
+  test('works for list cells too', async () => {
+    const files = await cellHandler.files({
+      name: 'Users',
+      tests: false,
+      stories: false,
+      list: true,
+      beforeQuery: true,
+      afterQuery: true,
+      isEmpty: true,
+    })
+
+    expect(files[LIST_CELL_PATH]).toMatchSnapshot()
+  })
+})
+
 describe('Custom Id Field files', () => {
   let customIdFieldFiles: Record<string, string>
   let customIdFieldListFiles: Record<string, string>

--- a/packages/cli/src/commands/generate/cell/cell.ts
+++ b/packages/cli/src/commands/generate/cell/cell.ts
@@ -28,6 +28,24 @@ export const builder = createBuilder({
           'Use to enforce a specific query name within the generated cell - must be unique.',
         type: 'string',
       },
+      beforeQuery: {
+        default: false,
+        description:
+          'Include a typed `beforeQuery` stub for configuring the query (e.g. variables, fetch policy).',
+        type: 'boolean',
+      },
+      afterQuery: {
+        default: false,
+        description:
+          'Include a typed `afterQuery` stub for sanitizing data returned from the query.',
+        type: 'boolean',
+      },
+      isEmpty: {
+        default: false,
+        description:
+          'Include a typed `isEmpty` stub for overriding the default check for the Empty component.',
+        type: 'boolean',
+      },
     }
   },
 })

--- a/packages/cli/src/commands/generate/cell/cellHandler.ts
+++ b/packages/cli/src/commands/generate/cell/cellHandler.ts
@@ -30,6 +30,9 @@ const CEDAR_WEB_PATH_NAME = 'components'
 type CellArgv = TypescriptHandlerArgv & {
   list?: boolean
   query?: string
+  beforeQuery?: boolean
+  afterQuery?: boolean
+  isEmpty?: boolean
 }
 
 export const files = async ({
@@ -39,6 +42,9 @@ export const files = async ({
   query,
   stories,
   tests,
+  beforeQuery = false,
+  afterQuery = false,
+  isEmpty = false,
 }: CellArgv): Promise<Record<string, string>> => {
   let cellName = removeGeneratorName(name, 'cell')
   let idName: string | undefined = 'id'
@@ -103,6 +109,9 @@ export const files = async ({
       operationName,
       idName,
       idType,
+      beforeQuery,
+      afterQuery,
+      isEmpty,
     },
   })
 

--- a/packages/cli/src/commands/generate/cell/templates/cell.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cell.tsx.template
@@ -6,7 +6,9 @@ import type {
 import type {
   CellSuccessProps,
   CellFailureProps,
-  TypedDocumentNode,
+  TypedDocumentNode,<% if (beforeQuery) { %>
+  CellBeforeQueryResult,<% } %><% if (afterQuery || isEmpty) { %>
+  DataObject,<% } %>
 } from '@cedarjs/web'
 
 export const QUERY: TypedDocumentNode<
@@ -19,7 +21,24 @@ export const QUERY: TypedDocumentNode<
     }
   }
 `
-
+<% if (beforeQuery) { %>
+export const beforeQuery = (
+  props: ${operationName}Variables,
+): CellBeforeQueryResult<${operationName}Variables> => {
+  return { variables: props }
+}
+<% } %><% if (isEmpty) { %>
+export const isEmpty = (
+  data: DataObject,
+  { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean },
+) => {
+  return isDataEmpty(data)
+}
+<% } %><% if (afterQuery) { %>
+export const afterQuery = (data: DataObject): DataObject => {
+  return data
+}
+<% } %>
 export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>

--- a/packages/cli/src/commands/generate/cell/templates/cell.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cell.tsx.template
@@ -25,7 +25,7 @@ export const QUERY: TypedDocumentNode<
 export const beforeQuery = (
   props: ${operationName}Variables,
 ): CellBeforeQueryResult<${operationName}Variables> => {
-  return { variables: props }
+  return { variables: props, fetchPolicy: 'cache-and-network' }
 }
 <% } %><% if (isEmpty) { %>
 export const isEmpty = (

--- a/packages/cli/src/commands/generate/cell/templates/cellList.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cellList.tsx.template
@@ -22,7 +22,7 @@ export const QUERY: TypedDocumentNode<
 export const beforeQuery = (
   props: ${operationName}Variables,
 ): CellBeforeQueryResult<${operationName}Variables> => {
-  return { variables: props }
+  return { variables: props, fetchPolicy: 'cache-and-network' }
 }
 <% } %><% if (isEmpty) { %>
 export const isEmpty = (

--- a/packages/cli/src/commands/generate/cell/templates/cellList.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cellList.tsx.template
@@ -3,7 +3,9 @@ import type { ${operationName}, ${operationName}Variables  } from 'types/graphql
 import type {
   CellSuccessProps,
   CellFailureProps,
-  TypedDocumentNode,
+  TypedDocumentNode,<% if (beforeQuery) { %>
+  CellBeforeQueryResult,<% } %><% if (afterQuery || isEmpty) { %>
+  DataObject,<% } %>
 } from '@cedarjs/web'
 
 export const QUERY: TypedDocumentNode<
@@ -16,7 +18,24 @@ export const QUERY: TypedDocumentNode<
     }
   }
 `
-
+<% if (beforeQuery) { %>
+export const beforeQuery = (
+  props: ${operationName}Variables,
+): CellBeforeQueryResult<${operationName}Variables> => {
+  return { variables: props }
+}
+<% } %><% if (isEmpty) { %>
+export const isEmpty = (
+  data: DataObject,
+  { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean },
+) => {
+  return isDataEmpty(data)
+}
+<% } %><% if (afterQuery) { %>
+export const afterQuery = (data: DataObject): DataObject => {
+  return data
+}
+<% } %>
 export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -27,6 +27,7 @@ export type {
   CellSuccessData,
   CellBeforeQueryOptions,
   CellBeforeQueryResult,
+  DataObject,
 } from './components/cell/cellTypes.js'
 
 export * from './graphql.js'


### PR DESCRIPTION
## What

Adds three opt-in flags to `yarn cedar generate cell`:

- `--before-query` — scaffolds a typed `beforeQuery` stub
- `--after-query` — scaffolds a typed `afterQuery` stub
- `--is-empty` — scaffolds a typed `isEmpty` stub

All three are `false` by default, so existing/default cell generation output is unchanged.

## Why

Fixes #2349. That issue asked for an opt-in `--before-query` flag rather than always including commented-out boilerplate (deemed too noisy). Since `beforeQuery` is only one of three documented Cell lifecycle hooks (see the ["Cell exports" table](https://github.com/cedarjs/cedar/blob/main/docs/docs/cells.md)), this PR adds equivalent flags for `afterQuery` and `isEmpty` too, so the generator covers all three consistently.

## Details

- `packages/cli/src/commands/generate/cell/cell.ts` — new yargs boolean options
- `packages/cli/src/commands/generate/cell/cellHandler.ts` — plumbs the flags through to template rendering
- `packages/cli/src/commands/generate/cell/templates/{cell,cellList}.tsx.template` — conditional typed imports + stub exports, gated by lodash `<% if %>` tags
- `packages/web/src/index.ts` — exports `DataObject` (previously internal-only) so the generated `afterQuery`/`isEmpty` stubs type-check without reaching into internal paths
- `docs/docs/cells.md`, `docs/docs/cli-commands.md` — document the new flags
- 7 new tests covering each flag individually, all three combined, JS type-stripping, and list cells

## Test plan

- [x] `yarn vitest run packages/cli/src/commands/generate/cell/__tests__/cell.test.ts` — 52/52 passing (7 new)
- [x] `yarn vitest run src/components/cell` (from `packages/web`) — 40/40 passing
- [x] `yarn tsc --build --verbose ./tsconfig.build.json` (packages/web) — clean
- [x] `yarn eslint` on all touched source files — clean
- [x] Manually inspected generated snapshots for correct import stripping in JS mode and declaration ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)