### PR TITLE
fix(api-server): treat AbortError as client disconnect, return 499

### DIFF
--- a/packages/api-server/src/__tests__/graphqlPlugin.test.ts
+++ b/packages/api-server/src/__tests__/graphqlPlugin.test.ts
@@ -11,11 +11,43 @@ import {
   expect,
 } from 'vitest'
 
+import { createGraphQLYoga } from '@cedarjs/graphql-server'
+import type * as GraphqlServerModule from '@cedarjs/graphql-server'
+import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
+
 import { createFastifyInstance } from '../fastify.js'
 import {
   cedarFastifyGraphQLServer,
   isClientDisconnectError,
 } from '../plugins/graphql.js'
+
+// Delegates to the real implementation by default, so existing tests are
+// unaffected. Individual tests override the resolved value with
+// `mockResolvedValueOnce` to control what `yoga.handle` does without needing
+// a real GraphQL schema.
+vi.mock('@cedarjs/graphql-server', async (importOriginal) => {
+  const actual = await importOriginal<typeof GraphqlServerModule>()
+
+  return {
+    ...actual,
+    createGraphQLYoga: vi.fn(actual.createGraphQLYoga),
+  }
+})
+
+// Test double: `cedarFastifyGraphQLServer` only reads `yoga.graphqlEndpoint`
+// and calls `yoga.handle`, so that's all this fake needs to implement. Safe
+// because it's only ever passed to the mocked `createGraphQLYoga` above.
+function fakeYogaResult(handle: () => Promise<Response>) {
+  return {
+    yoga: { graphqlEndpoint: '/graphql', handle },
+  } as Awaited<ReturnType<typeof createGraphQLYoga>>
+}
+
+// createGraphQLYoga is mocked in these tests, so its input is never actually
+// read — only used to satisfy cedarFastifyGraphQLServer's option type and
+// skip the fixture-based `dist/functions/graphql.js` lookup, which has no
+// `__cedar_graphqlOptions` export.
+const fakeGraphqlOptions = {} as GraphQLYogaOptions
 
 // Set up CEDAR_CWD.
 let original_CEDAR_CWD: string | undefined
@@ -89,5 +121,59 @@ describe('isClientDisconnectError', () => {
     expect(isClientDisconnectError('boom')).toBe(false)
     expect(isClientDisconnectError(null)).toBe(false)
     expect(isClientDisconnectError(undefined)).toBe(false)
+  })
+})
+
+describe('GraphQL route handler client-disconnect handling', () => {
+  afterEach(async () => {
+    vi.mocked(createGraphQLYoga).mockClear()
+  })
+
+  it('responds 499 when yoga.handle throws a recognized disconnect error', async () => {
+    const fastifyInstance = await createFastifyInstance()
+
+    vi.mocked(createGraphQLYoga).mockResolvedValueOnce(
+      fakeYogaResult(() =>
+        Promise.reject(
+          new DOMException('This operation was aborted', 'AbortError'),
+        ),
+      ),
+    )
+
+    await fastifyInstance.register(cedarFastifyGraphQLServer, {
+      cedar: { graphql: fakeGraphqlOptions },
+    })
+    await fastifyInstance.ready()
+
+    const response = await fastifyInstance.inject({
+      method: 'GET',
+      url: '/graphql',
+    })
+
+    expect(response.statusCode).toBe(499)
+
+    await fastifyInstance.close()
+  })
+
+  it('keeps the normal failure path (500) for unrelated errors', async () => {
+    const fastifyInstance = await createFastifyInstance()
+
+    vi.mocked(createGraphQLYoga).mockResolvedValueOnce(
+      fakeYogaResult(() => Promise.reject(new Error('boom'))),
+    )
+
+    await fastifyInstance.register(cedarFastifyGraphQLServer, {
+      cedar: { graphql: fakeGraphqlOptions },
+    })
+    await fastifyInstance.ready()
+
+    const response = await fastifyInstance.inject({
+      method: 'GET',
+      url: '/graphql',
+    })
+
+    expect(response.statusCode).toBe(500)
+
+    await fastifyInstance.close()
   })
 })

--- a/packages/api-server/src/__tests__/graphqlPlugin.test.ts
+++ b/packages/api-server/src/__tests__/graphqlPlugin.test.ts
@@ -125,12 +125,17 @@ describe('isClientDisconnectError', () => {
 })
 
 describe('GraphQL route handler client-disconnect handling', () => {
+  // Tracked so `afterEach` can always close it, even if registration,
+  // injection, or an assertion throws partway through a test.
+  let fastifyInstance: Awaited<ReturnType<typeof createFastifyInstance>>
+
   afterEach(async () => {
     vi.mocked(createGraphQLYoga).mockClear()
+    await fastifyInstance?.close()
   })
 
   it('responds 499 when yoga.handle throws a recognized disconnect error', async () => {
-    const fastifyInstance = await createFastifyInstance()
+    fastifyInstance = await createFastifyInstance()
 
     vi.mocked(createGraphQLYoga).mockResolvedValueOnce(
       fakeYogaResult(() =>
@@ -151,12 +156,10 @@ describe('GraphQL route handler client-disconnect handling', () => {
     })
 
     expect(response.statusCode).toBe(499)
-
-    await fastifyInstance.close()
   })
 
   it('keeps the normal failure path (500) for unrelated errors', async () => {
-    const fastifyInstance = await createFastifyInstance()
+    fastifyInstance = await createFastifyInstance()
 
     vi.mocked(createGraphQLYoga).mockResolvedValueOnce(
       fakeYogaResult(() => Promise.reject(new Error('boom'))),
@@ -173,7 +176,5 @@ describe('GraphQL route handler client-disconnect handling', () => {
     })
 
     expect(response.statusCode).toBe(500)
-
-    await fastifyInstance.close()
   })
 })

--- a/packages/api-server/src/__tests__/graphqlPlugin.test.ts
+++ b/packages/api-server/src/__tests__/graphqlPlugin.test.ts
@@ -79,6 +79,12 @@ describe('isClientDisconnectError', () => {
     expect(isClientDisconnectError(new Error('boom'))).toBe(false)
   })
 
+  it('returns false for a plain Error renamed to AbortError', () => {
+    const e = Object.assign(new Error('boom'), { name: 'AbortError' })
+
+    expect(isClientDisconnectError(e)).toBe(false)
+  })
+
   it('returns false for non-object values', () => {
     expect(isClientDisconnectError('boom')).toBe(false)
     expect(isClientDisconnectError(null)).toBe(false)

--- a/packages/api-server/src/__tests__/graphqlPlugin.test.ts
+++ b/packages/api-server/src/__tests__/graphqlPlugin.test.ts
@@ -12,7 +12,10 @@ import {
 } from 'vitest'
 
 import { createFastifyInstance } from '../fastify.js'
-import { cedarFastifyGraphQLServer } from '../plugins/graphql.js'
+import {
+  cedarFastifyGraphQLServer,
+  isClientDisconnectError,
+} from '../plugins/graphql.js'
 
 // Set up CEDAR_CWD.
 let original_CEDAR_CWD: string | undefined
@@ -55,5 +58,30 @@ describe('CedarFastifyGraphqlServer Fastify Plugin', () => {
     expect(registerSpy).toHaveBeenCalledWith(fastifyMultipart)
 
     await fastifyInstance.close()
+  })
+})
+
+describe('isClientDisconnectError', () => {
+  it('returns true for ERR_STREAM_PREMATURE_CLOSE errors', () => {
+    const e = new Error('premature close')
+    Object.assign(e, { code: 'ERR_STREAM_PREMATURE_CLOSE' })
+
+    expect(isClientDisconnectError(e)).toBe(true)
+  })
+
+  it('returns true for AbortError DOMExceptions', () => {
+    const e = new DOMException('This operation was aborted', 'AbortError')
+
+    expect(isClientDisconnectError(e)).toBe(true)
+  })
+
+  it('returns false for unrelated errors', () => {
+    expect(isClientDisconnectError(new Error('boom'))).toBe(false)
+  })
+
+  it('returns false for non-object values', () => {
+    expect(isClientDisconnectError('boom')).toBe(false)
+    expect(isClientDisconnectError(null)).toBe(false)
+    expect(isClientDisconnectError(undefined)).toBe(false)
   })
 })

--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -116,12 +116,7 @@ export async function cedarFastifyGraphQLServer(
               requestContext: undefined,
             })
           } catch (e) {
-            if (
-              !!e &&
-              typeof e === 'object' &&
-              'code' in e &&
-              e.code === 'ERR_STREAM_PREMATURE_CLOSE'
-            ) {
+            if (isClientDisconnectError(e)) {
               // Client disconnected while the request was being processed
               // (e.g., page navigation, tab close). Return a 499 so Fastify
               // doesn't log this as a 500.
@@ -160,6 +155,31 @@ export async function cedarFastifyGraphQLServer(
 
 function trimSlashes(path: string) {
   return path.replace(/^\/|\/$/g, '')
+}
+
+/**
+ * Detects errors that indicate the client disconnected before the response
+ * finished, rather than a genuine server-side failure.
+ *
+ * `ERR_STREAM_PREMATURE_CLOSE` can surface from the underlying Node stream
+ * closing early. `AbortError` is thrown by Yoga when the AbortSignal wired up
+ * in `createFetchRequest`'s `reply.raw.on('close', ...)` handler is aborted,
+ * which only happens when the client itself has gone away.
+ */
+export function isClientDisconnectError(e: unknown): boolean {
+  if (!e || typeof e !== 'object') {
+    return false
+  }
+
+  if ('code' in e && e.code === 'ERR_STREAM_PREMATURE_CLOSE') {
+    return true
+  }
+
+  if ('name' in e && e.name === 'AbortError') {
+    return true
+  }
+
+  return false
 }
 
 function createFetchRequest(req: FastifyRequest, reply: FastifyReply) {

--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -162,9 +162,15 @@ function trimSlashes(path: string) {
  * finished, rather than a genuine server-side failure.
  *
  * `ERR_STREAM_PREMATURE_CLOSE` can surface from the underlying Node stream
- * closing early. `AbortError` is thrown by Yoga when the AbortSignal wired up
- * in `createFetchRequest`'s `reply.raw.on('close', ...)` handler is aborted,
- * which only happens when the client itself has gone away.
+ * closing early. The `DOMException` named `AbortError` is thrown by Yoga
+ * when the AbortSignal wired up in `createFetchRequest`'s
+ * `reply.raw.on('close', ...)` handler is aborted, which only happens when
+ * the client itself has gone away.
+ *
+ * The `DOMException` check (rather than just `name === 'AbortError'`) is
+ * deliberate: a resolver or hook could throw a plain `Error` renamed to
+ * `AbortError`, which would otherwise be misclassified as a benign
+ * disconnect and hide a real server-side failure behind a 499.
  */
 export function isClientDisconnectError(e: unknown): boolean {
   if (!e || typeof e !== 'object') {
@@ -175,7 +181,7 @@ export function isClientDisconnectError(e: unknown): boolean {
     return true
   }
 
-  if ('name' in e && e.name === 'AbortError') {
+  if (e instanceof DOMException && e.name === 'AbortError') {
     return true
   }
 


### PR DESCRIPTION
- When a client disconnects mid-request, the `AbortController` set up in `createFetchRequest` fires, and `yoga.handle` throws an `AbortError` (`DOMException`). The catch block in `cedarFastifyGraphQLServer` only special-cased `ERR_STREAM_PREMATURE_CLOSE`, so `AbortError` fell through to `throw e`, producing a logged `500` with a full `DOMException` stack dump for what is functionally the same benign disconnect case.
- Extends the disconnect check to also treat `AbortError` as a client disconnect, returning a quiet `499` instead — same behavior already used for `ERR_STREAM_PREMATURE_CLOSE`.
- Extracted the check into an exported `isClientDisconnectError` helper for unit testability.

I ran into this when I had a browser tab open with the app I was building and I just restarted the dev server. No tricky super rare "mid-request" disconnect or anything like that. Just the HMR/fast-refresh thing on the app doing its normal thing.

Fixes #2287