### PR TITLE
feat(cli): Generate stubs for relations

### DIFF
--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1231,6 +1231,8 @@ yarn redwood generate sdl <model>
 
 The sdl will inspect your `schema.prisma` and will do its best with relations. Schema to generators isn't one-to-one yet (and might never be).
 
+If the model has relations to models that don't have SDL files of their own yet, read-only stub SDLs (and services) are generated for those models too — without them, GraphQL type generation would fail with an `Unknown type` error. Replace a stub by running `generate sdl` for that model; unedited stubs are overwritten without needing `--force`. See [Troubleshooting Generators](./schema-relations#troubleshooting-generators) for details.
+
 | Arguments & Options  | Description                                                                                                                                                                                            |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `model`              | Model to generate the sdl for                                                                                                                                                                          |

--- a/docs/docs/schema-relations.md
+++ b/docs/docs/schema-relations.md
@@ -123,8 +123,8 @@ model Shelf {
 
 The data model looks great. Let's make it real with SDLs and services:
 
-```
-yarn rw g sdl Book
+```bash
+yarn cedar g sdl Book
 ```
 
 The type of `Book`'s `shelf` field is `Shelf`, but there's no SDL defining a `Shelf` GraphQL type yet. To keep type generation working, the SDL generator detects this and also generates a read-only _stub_ SDL (and service) for `Shelf`:
@@ -149,8 +149,8 @@ The stub defines the `Shelf` type and a read-only query — no mutations. Each s
 
 When you're ready to flesh out `Shelf`, run the generator for it:
 
-```
-yarn rw g sdl Shelf
+```bash
+yarn cedar g sdl Shelf
 ```
 
 As long as you haven't edited the stub files, they're replaced without needing `--force`. If you _have_ edited a stub, the generator refuses to overwrite it until you pass `--force`, so your changes are never silently lost.
@@ -159,12 +159,15 @@ As long as you haven't edited the stub files, they're replaced without needing `
 
 The scaffold generator doesn't generate stubs for missing related models (yet), so scaffolding a model whose related models have no SDLs fails during type generation with an error like:
 
-```
+```text
         Unknown type: "Shelf".
         Error: Unknown type: "Shelf".
 ```
 
-The fix: generate the SDL for (or scaffold out) each model in the relation, ignoring the intermediate errors — the last model in the relation should generate cleanly. Or run `yarn rw g sdl <model>` for the related models first, since the SDL generator handles missing relations automatically.
+The fix: generate the SDL for (or scaffold out) each model in the relation,
+inoring the intermediate errors. The last model in the relation should generate
+cleanly. Or run `yarn cedar g sdl <model>` for the related models first, since
+the SDL generator handles missing relations automatically.
 
 ### Self-Relations
 

--- a/docs/docs/schema-relations.md
+++ b/docs/docs/schema-relations.md
@@ -165,7 +165,7 @@ The scaffold generator doesn't generate stubs for missing related models (yet), 
 ```
 
 The fix: generate the SDL for (or scaffold out) each model in the relation,
-inoring the intermediate errors. The last model in the relation should generate
+ignoring the intermediate errors. The last model in the relation should generate
 cleanly. Or run `yarn cedar g sdl <model>` for the related models first, since
 the SDL generator handles missing relations automatically.
 

--- a/docs/docs/schema-relations.md
+++ b/docs/docs/schema-relations.md
@@ -99,8 +99,7 @@ Almost identical! But now there's an `id` and the SDL/scaffold generators will w
 
 ## Troubleshooting Generators
 
-Are you getting errors when generating SDLs or scaffolds for your Prisma models?
-There's a known limitation in Cedar's GraphQL type generation that happens when generating SDL for, or scaffolding out, a Prisma model that has relations before the SDL for the related model exists.
+GraphQL type generation fails when an SDL references a type that isn't defined anywhere — which is what would happen if you generated the SDL for a Prisma model with relations before the SDLs for the related models exist.
 
 This may sound a little abstract, so let's look at an example. Let's say that you're modeling bookshelves. Your prisma schema has two data models, `Book` and `Shelf`. This is a one to many relationship: a shelf has many books, but a book can only be on one shelf:
 
@@ -128,7 +127,7 @@ The data model looks great. Let's make it real with SDLs and services:
 yarn rw g sdl Book
 ```
 
-Here's how the output from the command starts:
+The type of `Book`'s `shelf` field is `Shelf`, but there's no SDL defining a `Shelf` GraphQL type yet. To keep type generation working, the SDL generator detects this and also generates a read-only _stub_ SDL (and service) for `Shelf`:
 
 ```bash
 ✔ Generating SDL files...
@@ -136,77 +135,36 @@ Here's how the output from the command starts:
 ✔ Successfully wrote file $(./api/src/services/books/books.scenarios.js)
 ✔ Successfully wrote file $(./api/src/services/books/books.test.js)
 ✔ Successfully wrote file $(./api/src/services/books/books.js)
+✔ Successfully wrote file $(./api/src/graphql/shelves.sdl.js)
+✔ Successfully wrote file $(./api/src/services/shelves/shelves.js)
+✔ Generating types ...
+
+Book has relations to models that don't have SDL files of their own yet: Shelf
+Read-only SDL stubs were generated for them, since GraphQL type generation fails otherwise.
+To replace a stub with a full SDL and service, run
+  yarn cedar generate sdl Shelf
 ```
 
-Looks like it's working so far. The SDL and service files generated!
-But, when the command starts generating types... 💥
+The stub defines the `Shelf` type and a read-only query — no mutations. Each stub file starts with a comment explaining why it exists and how to replace it.
+
+When you're ready to flesh out `Shelf`, run the generator for it:
 
 ```
-  ⠙ Generating types ...
-Failed to load schema
+yarn rw g sdl Shelf
+```
 
-# ...
+As long as you haven't edited the stub files, they're replaced without needing `--force`. If you _have_ edited a stub, the generator refuses to overwrite it until you pass `--force`, so your changes are never silently lost.
 
-type Query {
-  redwood: Cedar
-},graphql/**/*.sdl.{js,ts},directives/**/*.{js,ts}:
+### Scaffolds
 
+The scaffold generator doesn't generate stubs for missing related models (yet), so scaffolding a model whose related models have no SDLs fails during type generation with an error like:
+
+```
         Unknown type: "Shelf".
         Error: Unknown type: "Shelf".
 ```
 
-What happened?
-Remember, the first thing to do when you get an error: _read the error message_.
-The key is `Unknown type: "Shelf"`.
-The type of `Book`'s `shelf` field is `Shelf`.
-But we didn't generate the SDL for `Shelf` yet, so it doesn't exist.
-And naturally, types can't be generated for it.
-
-But fear not.
-This should be an easy fix.
-There are two ways you can go about it.
-
-You can generate the SDLs for all the models in the relation, ignoring the errors. This way the last model in the relation should generate cleanly.
-
-Or, you can remove or comment out the relations:
-
-```js
-model Book {
-  id      Int    @id @default(autoincrement())
-  title   String @unique
-  // highlight-start
-  // Shelf   Shelf? @relation(fields: [shelfId], references: [id])
-  // shelfId Int?
-  // highlight-end
-}
-
-model Shelf {
-  id    Int    @id @default(autoincrement())
-  name  String @unique
-  // highlight-next-line
-  // books Book[]
-}
-```
-
-Then, generate the SDL for, or scaffold out, each model separately:
-
-```
-yarn rw g sdl Book
-# ...
-
-yarn rw g sdl Shelf
-# ...
-```
-
-And lastly, add or comment in the relationships and regenerate their SDLs or scaffolds using the `--force` flag to overwrite the existing files, adding the `--no-tests` flag to preserve your tests and scenario files (if needed):
-
-```
-yarn rw g sdl Book --force --no-tests
-# ...
-
-yarn rw g sdl Shelf --force --no-tests
-# ...
-```
+The fix: generate the SDL for (or scaffold out) each model in the relation, ignoring the intermediate errors — the last model in the relation should generate cleanly. Or run `yarn rw g sdl <model>` for the related models first, since the SDL generator handles missing relations automatically.
 
 ### Self-Relations
 

--- a/packages/cli/src/commands/destroy/sdl/sdlHandler.ts
+++ b/packages/cli/src/commands/destroy/sdl/sdlHandler.ts
@@ -12,7 +12,9 @@ export const tasks = ({ model }: { model: string }) =>
       {
         title: 'Destroying GraphQL schema and service component files...',
         task: async () => {
-          const f = await files({ name: model })
+          // `stubModels: []` so we only ever destroy the named model's own
+          // files, never stubs generated for related models
+          const f = await files({ name: model, stubModels: [] })
           return deleteFilesTask(f)
         },
       },

--- a/packages/cli/src/commands/destroy/sdl/sdlHandler.ts
+++ b/packages/cli/src/commands/destroy/sdl/sdlHandler.ts
@@ -12,9 +12,7 @@ export const tasks = ({ model }: { model: string }) =>
       {
         title: 'Destroying GraphQL schema and service component files...',
         task: async () => {
-          // `stubModels: []` so we only ever destroy the named model's own
-          // files, never stubs generated for related models
-          const f = await files({ name: model, stubModels: [] })
+          const f = await files({ name: model })
           return deleteFilesTask(f)
         },
       },

--- a/packages/cli/src/commands/generate/scaffold/scaffoldHandler.ts
+++ b/packages/cli/src/commands/generate/scaffold/scaffoldHandler.ts
@@ -223,9 +223,6 @@ export const files = async ({
       docs,
       name,
       typescript,
-      // The scaffold generator doesn't (yet) generate stubs for related
-      // models that are missing SDL files. `cedar generate sdl` does.
-      stubModels: [],
     })),
     ...(await serviceFiles({
       ...getDefaultArgs(serviceBuilder),

--- a/packages/cli/src/commands/generate/scaffold/scaffoldHandler.ts
+++ b/packages/cli/src/commands/generate/scaffold/scaffoldHandler.ts
@@ -23,7 +23,6 @@ import {
   writeFile,
   getDefaultArgs,
   getPaths,
-  writeFilesTask,
   addRoutesToRouterTask,
   addScaffoldImport,
   transformTSToJS,
@@ -41,6 +40,7 @@ import {
 } from '../helpers.js'
 import { builder as sdlBuilder } from '../sdl/sdl.js'
 import { files as sdlFiles } from '../sdl/sdlHandler.js'
+import { writeFilesWithStubsTask } from '../sdl/stubFiles.js'
 import { builder as serviceBuilder } from '../service/service.js'
 import { files as serviceFiles } from '../service/serviceHandler.js'
 import { customOrDefaultTemplatePath } from '../yargsHandlerHelpers.js'
@@ -223,6 +223,9 @@ export const files = async ({
       docs,
       name,
       typescript,
+      // The scaffold generator doesn't (yet) generate stubs for related
+      // models that are missing SDL files. `cedar generate sdl` does.
+      stubModels: [],
     })),
     ...(await serviceFiles({
       ...getDefaultArgs(serviceBuilder),
@@ -963,7 +966,7 @@ export const tasks = ({
             tailwind,
             force,
           })
-          return writeFilesTask(f, { overwriteExisting: force })
+          return writeFilesWithStubsTask(f, { overwriteExisting: force })
         },
       },
       {

--- a/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdl.test.ts.snap
+++ b/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdl.test.ts.snap
@@ -155,7 +155,7 @@ exports[`handler > can be called with PascalCase model name 5`] = `
 // Run \`cedar generate sdl UserProfile\` to replace this stub with the real thing.
 // If you edit this file, the hash below will stop matching and you'll
 // need to pass \`--force\` to overwrite it.
-// @cedar-generator-stub-hash 03fbabcdbd9a5ba1
+// @cedar-generator-stub-hash a610beb597de9ce0
 
 export const schema = gql\`
   type UserProfile {
@@ -181,7 +181,7 @@ exports[`handler > can be called with PascalCase model name 6`] = `
 // Run \`cedar generate sdl UserProfile\` to replace this stub with the real thing.
 // If you edit this file, the hash below will stop matching and you'll
 // need to pass \`--force\` to overwrite it.
-// @cedar-generator-stub-hash 21e7144a59c837b8
+// @cedar-generator-stub-hash 27591029bcfaf860
 
 import { db } from 'src/lib/db'
 
@@ -506,7 +506,7 @@ exports[`handler > can be called with camelCase model name 5`] = `
 // Run \`cedar generate sdl UserProfile\` to replace this stub with the real thing.
 // If you edit this file, the hash below will stop matching and you'll
 // need to pass \`--force\` to overwrite it.
-// @cedar-generator-stub-hash 03fbabcdbd9a5ba1
+// @cedar-generator-stub-hash a610beb597de9ce0
 
 export const schema = gql\`
   type UserProfile {
@@ -532,7 +532,7 @@ exports[`handler > can be called with camelCase model name 6`] = `
 // Run \`cedar generate sdl UserProfile\` to replace this stub with the real thing.
 // If you edit this file, the hash below will stop matching and you'll
 // need to pass \`--force\` to overwrite it.
-// @cedar-generator-stub-hash 21e7144a59c837b8
+// @cedar-generator-stub-hash 27591029bcfaf860
 
 import { db } from 'src/lib/db'
 

--- a/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdl.test.ts.snap
+++ b/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdl.test.ts.snap
@@ -150,6 +150,63 @@ export const User = {
 
 exports[`handler > can be called with PascalCase model name 5`] = `
 {
+  "fileContent": "// Generated as a read-only stub by \`cedar generate sdl User\`,
+// because User has a relation to UserProfile, which had no SDL yet.
+// Run \`cedar generate sdl UserProfile\` to replace this stub with the real thing.
+// If you edit this file, the hash below will stop matching and you'll
+// need to pass \`--force\` to overwrite it.
+// @cedar-generator-stub-hash 03fbabcdbd9a5ba1
+
+export const schema = gql\`
+  type UserProfile {
+    id: Int!
+    username: String!
+    userId: Int!
+    user: User!
+  }
+
+  type Query {
+    userProfiles: [UserProfile!]! @requireAuth
+  }
+\`
+",
+  "filePath": "/path/to/project/api/src/graphql/userProfiles.sdl.js",
+}
+`;
+
+exports[`handler > can be called with PascalCase model name 6`] = `
+{
+  "fileContent": "// Generated as a read-only stub by \`cedar generate sdl User\`,
+// because User has a relation to UserProfile, which had no SDL yet.
+// Run \`cedar generate sdl UserProfile\` to replace this stub with the real thing.
+// If you edit this file, the hash below will stop matching and you'll
+// need to pass \`--force\` to overwrite it.
+// @cedar-generator-stub-hash 21e7144a59c837b8
+
+import { db } from 'src/lib/db'
+
+export const userProfiles = () => {
+  return db.userProfile.findMany()
+}
+
+export const userProfile = ({ id }) => {
+  return db.userProfile.findUnique({
+    where: { id },
+  })
+}
+
+export const UserProfile = {
+  user: (_obj, { root }) => {
+    return db.userProfile.findUnique({ where: { id: root?.id } }).user()
+  },
+}
+",
+  "filePath": "/path/to/project/api/src/services/userProfiles/userProfiles.js",
+}
+`;
+
+exports[`handler > can be called with PascalCase model name 7`] = `
+{
   "fileContent": "export const schema = gql\`
   type CustomData {
     id: Int!
@@ -181,7 +238,7 @@ exports[`handler > can be called with PascalCase model name 5`] = `
 }
 `;
 
-exports[`handler > can be called with PascalCase model name 6`] = `
+exports[`handler > can be called with PascalCase model name 8`] = `
 {
   "fileContent": "export const standard = defineScenario({
   customData: {
@@ -194,7 +251,7 @@ exports[`handler > can be called with PascalCase model name 6`] = `
 }
 `;
 
-exports[`handler > can be called with PascalCase model name 7`] = `
+exports[`handler > can be called with PascalCase model name 9`] = `
 {
   "fileContent": "import {
   customDatums,
@@ -257,7 +314,7 @@ describe('customDatums', () => {
 }
 `;
 
-exports[`handler > can be called with PascalCase model name 8`] = `
+exports[`handler > can be called with PascalCase model name 10`] = `
 {
   "fileContent": "import { db } from 'src/lib/db'
 
@@ -444,6 +501,63 @@ export const User = {
 
 exports[`handler > can be called with camelCase model name 5`] = `
 {
+  "fileContent": "// Generated as a read-only stub by \`cedar generate sdl User\`,
+// because User has a relation to UserProfile, which had no SDL yet.
+// Run \`cedar generate sdl UserProfile\` to replace this stub with the real thing.
+// If you edit this file, the hash below will stop matching and you'll
+// need to pass \`--force\` to overwrite it.
+// @cedar-generator-stub-hash 03fbabcdbd9a5ba1
+
+export const schema = gql\`
+  type UserProfile {
+    id: Int!
+    username: String!
+    userId: Int!
+    user: User!
+  }
+
+  type Query {
+    userProfiles: [UserProfile!]! @requireAuth
+  }
+\`
+",
+  "filePath": "/path/to/project/api/src/graphql/userProfiles.sdl.js",
+}
+`;
+
+exports[`handler > can be called with camelCase model name 6`] = `
+{
+  "fileContent": "// Generated as a read-only stub by \`cedar generate sdl User\`,
+// because User has a relation to UserProfile, which had no SDL yet.
+// Run \`cedar generate sdl UserProfile\` to replace this stub with the real thing.
+// If you edit this file, the hash below will stop matching and you'll
+// need to pass \`--force\` to overwrite it.
+// @cedar-generator-stub-hash 21e7144a59c837b8
+
+import { db } from 'src/lib/db'
+
+export const userProfiles = () => {
+  return db.userProfile.findMany()
+}
+
+export const userProfile = ({ id }) => {
+  return db.userProfile.findUnique({
+    where: { id },
+  })
+}
+
+export const UserProfile = {
+  user: (_obj, { root }) => {
+    return db.userProfile.findUnique({ where: { id: root?.id } }).user()
+  },
+}
+",
+  "filePath": "/path/to/project/api/src/services/userProfiles/userProfiles.js",
+}
+`;
+
+exports[`handler > can be called with camelCase model name 7`] = `
+{
   "fileContent": "export const schema = gql\`
   type CustomData {
     id: Int!
@@ -475,7 +589,7 @@ exports[`handler > can be called with camelCase model name 5`] = `
 }
 `;
 
-exports[`handler > can be called with camelCase model name 6`] = `
+exports[`handler > can be called with camelCase model name 8`] = `
 {
   "fileContent": "export const standard = defineScenario({
   customData: {
@@ -488,7 +602,7 @@ exports[`handler > can be called with camelCase model name 6`] = `
 }
 `;
 
-exports[`handler > can be called with camelCase model name 7`] = `
+exports[`handler > can be called with camelCase model name 9`] = `
 {
   "fileContent": "import {
   customDatums,
@@ -551,7 +665,7 @@ describe('customDatums', () => {
 }
 `;
 
-exports[`handler > can be called with camelCase model name 8`] = `
+exports[`handler > can be called with camelCase model name 10`] = `
 {
   "fileContent": "import { db } from 'src/lib/db'
 

--- a/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdlStubs.test.ts.snap
+++ b/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdlStubs.test.ts.snap
@@ -6,7 +6,7 @@ exports[`files with stubs > generates read-only stubs for missing related models
 // Run \`cedar generate sdl User\` to replace this stub with the real thing.
 // If you edit this file, the hash below will stop matching and you'll
 // need to pass \`--force\` to overwrite it.
-// @cedar-generator-stub-hash d94c8f09bc1c00b4
+// @cedar-generator-stub-hash 0393c2637174b7eb
 
 export const schema = gql\`
   type User {

--- a/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdlStubs.test.ts.snap
+++ b/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdlStubs.test.ts.snap
@@ -1,0 +1,25 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`files with stubs > generates read-only stubs for missing related models 1`] = `
+"// Generated as a read-only stub by \`cedar generate sdl UserProfile\`,
+// because UserProfile has a relation to User, which had no SDL yet.
+// Run \`cedar generate sdl User\` to replace this stub with the real thing.
+// If you edit this file, the hash below will stop matching and you'll
+// need to pass \`--force\` to overwrite it.
+// @cedar-generator-stub-hash d94c8f09bc1c00b4
+
+export const schema = gql\`
+  type User {
+    id: Int!
+    name: String
+    email: String!
+    isAdmin: Boolean!
+    profiles: [UserProfile]!
+  }
+
+  type Query {
+    users: [User!]! @requireAuth
+  }
+\`
+"
+`;

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/schema.prisma
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/schema.prisma
@@ -85,3 +85,24 @@ model Counter {
   id    Int    @id @default(0)
   count Int    @default(0)
 }
+
+// Order -> Customer -> Address chain, used to test that traversal continues
+// through a model that already has SDL defined (Customer) to find a missing
+// model further down the chain (Address).
+model Order {
+  id         Int      @id @default(autoincrement())
+  customerId Int
+  customer   Customer @relation(fields: [customerId], references: [id])
+}
+
+model Customer {
+  id        Int     @id @default(autoincrement())
+  orders    Order[]
+  addressId Int
+  address   Address @relation(fields: [addressId], references: [id])
+}
+
+model Address {
+  id        Int        @id @default(autoincrement())
+  customers Customer[]
+}

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/schema.prisma
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/schema.prisma
@@ -80,3 +80,8 @@ model Car {
   brand    String
   carBrand CarBrand @relation(fields: [brand], references: [brand])
 }
+
+model Counter {
+  id    Int    @id @default(0)
+  count Int    @default(0)
+}

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.ts
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.ts
@@ -238,22 +238,16 @@ const itCreatesAnSDLFileWithByteDefinitions = (baseArgs = {}) => {
 
 const itCreatesAnSslFileForModelWithOnlyIdAndRelation = (baseArgs = {}) => {
   test('create an sdl file for model with only id and relation', async () => {
-    // Both models are generated "for real" here, so stub generation is
-    // disabled. (Without that, each files() call would also generate a stub
-    // for the other model, and the stub would overwrite the real file in the
-    // merged object below.)
     const files = {
       ...(await sdlHandler.files({
         ...baseArgs,
         name: 'Car',
         crud: true,
-        stubModels: [],
       })),
       ...(await sdlHandler.files({
         ...baseArgs,
         name: 'CarBrand',
         crud: true,
-        stubModels: [],
       })),
     }
     const extension = extensionForBaseArgs(baseArgs)

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.ts
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.ts
@@ -296,14 +296,12 @@ const itHandlesFalsyDefaults = (baseArgs = {}) => {
     const createInputMatch = sdlContent.match(
       /input CreateCounterInput \{[^}]*\}/s,
     )
-    expect(createInputMatch).toBeDefined()
+    expect(createInputMatch).not.toBeNull()
 
-    if (createInputMatch) {
-      // The input should NOT contain the id field
-      expect(createInputMatch[0]).not.toContain('id')
-      // But count should not be required either (it also has @default(0))
-      expect(createInputMatch[0]).toContain('count')
-    }
+    // The input should NOT contain the id field (since it has a default)
+    expect(createInputMatch?.[0]).not.toContain('id')
+    // But count should be present
+    expect(createInputMatch?.[0]).toContain('count')
   })
 }
 

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.ts
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.ts
@@ -238,16 +238,22 @@ const itCreatesAnSDLFileWithByteDefinitions = (baseArgs = {}) => {
 
 const itCreatesAnSslFileForModelWithOnlyIdAndRelation = (baseArgs = {}) => {
   test('create an sdl file for model with only id and relation', async () => {
+    // Both models are generated "for real" here, so stub generation is
+    // disabled. (Without that, each files() call would also generate a stub
+    // for the other model, and the stub would overwrite the real file in the
+    // merged object below.)
     const files = {
       ...(await sdlHandler.files({
         ...baseArgs,
         name: 'Car',
         crud: true,
+        stubModels: [],
       })),
       ...(await sdlHandler.files({
         ...baseArgs,
         name: 'CarBrand',
         crud: true,
+        stubModels: [],
       })),
     }
     const extension = extensionForBaseArgs(baseArgs)

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.ts
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.ts
@@ -297,10 +297,13 @@ const itHandlesFalsyDefaults = (baseArgs = {}) => {
       /input CreateCounterInput \{[^}]*\}/s,
     )
     expect(createInputMatch).toBeDefined()
-    // The input should NOT contain the id field
-    expect(createInputMatch![0]).not.toContain('id')
-    // But count should not be required either (it also has @default(0))
-    expect(createInputMatch![0]).toContain('count')
+
+    if (createInputMatch) {
+      // The input should NOT contain the id field
+      expect(createInputMatch[0]).not.toContain('id')
+      // But count should not be required either (it also has @default(0))
+      expect(createInputMatch[0]).toContain('count')
+    }
   })
 }
 

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.ts
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.ts
@@ -273,6 +273,37 @@ const itCreatesAnSslFileForModelWithOnlyIdAndRelation = (baseArgs = {}) => {
   })
 }
 
+const itHandlesFalsyDefaults = (baseArgs = {}) => {
+  test('handles falsy defaults like @default(0) correctly', async () => {
+    const files = await sdlHandler.files({
+      ...baseArgs,
+      name: 'Counter',
+      crud: true,
+    })
+    const extension = extensionForBaseArgs(baseArgs)
+
+    const sdlContent =
+      files[
+        path.normalize(
+          `/path/to/project/api/src/graphql/counters.sdl.${extension}`,
+        )
+      ]
+
+    // The Counter model has @id @default(0), so the id field should NOT be
+    // required in the CreateInput (since it defaults to 0)
+    expect(sdlContent).toContain('input CreateCounterInput')
+    // Extract just the CreateCounterInput section
+    const createInputMatch = sdlContent.match(
+      /input CreateCounterInput \{[^}]*\}/s,
+    )
+    expect(createInputMatch).toBeDefined()
+    // The input should NOT contain the id field
+    expect(createInputMatch![0]).not.toContain('id')
+    // But count should not be required either (it also has @default(0))
+    expect(createInputMatch![0]).toContain('count')
+  })
+}
+
 describe('without graphql documentations', () => {
   describe('in javascript mode', () => {
     const baseArgs = { ...getDefaultArgs(sdl.getDefaultOptions()), tests: true }
@@ -287,6 +318,7 @@ describe('without graphql documentations', () => {
     itCreatesAnSDLFileWithJsonDefinitions(baseArgs)
     itCreatesAnSDLFileWithByteDefinitions(baseArgs)
     itCreatesAnSslFileForModelWithOnlyIdAndRelation(baseArgs)
+    itHandlesFalsyDefaults(baseArgs)
   })
 
   describe('in typescript mode', () => {
@@ -306,6 +338,7 @@ describe('without graphql documentations', () => {
     itCreatesAnSDLFileWithJsonDefinitions(baseArgs)
     itCreatesAnSDLFileWithByteDefinitions(baseArgs)
     itCreatesAnSslFileForModelWithOnlyIdAndRelation(baseArgs)
+    itHandlesFalsyDefaults(baseArgs)
   })
 })
 
@@ -326,6 +359,7 @@ describe('with graphql documentations', () => {
     itCreatesAnSDLFileWithEnumDefinitions(baseArgs)
     itCreatesAnSDLFileWithJsonDefinitions(baseArgs)
     itCreatesAnSDLFileWithByteDefinitions(baseArgs)
+    itHandlesFalsyDefaults(baseArgs)
   })
 
   describe('in typescript mode', () => {
@@ -345,6 +379,7 @@ describe('with graphql documentations', () => {
     itCreatesAnSDLFileWithEnumDefinitions(baseArgs)
     itCreatesAnSDLFileWithJsonDefinitions(baseArgs)
     itCreatesAnSDLFileWithByteDefinitions(baseArgs)
+    itHandlesFalsyDefaults(baseArgs)
   })
 })
 

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
@@ -85,13 +85,18 @@ describe('missingRelatedModels', () => {
 
 describe('files with stubs', () => {
   test('generates read-only stubs for missing related models', async () => {
-    const files = await sdlHandler.files({
-      name: 'UserProfile',
-      crud: true,
-      tests: true,
-      typescript: true,
-      stubModels: await missingRelatedModels('UserProfile'),
-    })
+    const missingModels = await missingRelatedModels('UserProfile')
+    const files = {
+      ...(await sdlHandler.files({
+        name: 'UserProfile',
+        crud: true,
+        tests: true,
+        typescript: true,
+      })),
+      ...(await sdlHandler.stubFiles(missingModels, 'UserProfile', {
+        typescript: true,
+      })),
+    }
 
     // The target model's own files
     expect(files).toHaveProperty([sdlPath('userProfiles.sdl.ts')])
@@ -115,16 +120,23 @@ describe('files with stubs', () => {
     expect(files).not.toHaveProperty([servicePath('users/users.scenarios.ts')])
   })
 
-  test('does not generate stubs when passing an empty stubModels list', async () => {
+  test('files() alone never generates stubs for related models', async () => {
     const files = await sdlHandler.files({
       name: 'UserProfile',
       crud: true,
       tests: true,
       typescript: true,
-      stubModels: [],
     })
 
     expect(files).not.toHaveProperty([sdlPath('users.sdl.ts')])
+  })
+
+  test('stubFiles() generates nothing for an empty model list', async () => {
+    const files = await sdlHandler.stubFiles([], 'UserProfile', {
+      typescript: true,
+    })
+
+    expect(files).toEqual({})
   })
 })
 

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
@@ -1,0 +1,179 @@
+globalThis.__dirname = import.meta.dirname
+
+import type * as NodeFs from 'node:fs'
+import path from 'node:path'
+
+import { vol, fs as memfs } from 'memfs'
+import { ufs } from 'unionfs'
+import { vi, describe, test, expect, beforeAll, afterEach } from 'vitest'
+
+// Load mocks
+import '../../../../lib/test'
+
+vi.mock('node:fs', async (importOriginal) => {
+  const { wrapFsForUnionfs, wrapMemfsForUnionfs } =
+    await import('../../../../__tests__/ufsFsProxy.js')
+  const fs = await importOriginal<typeof NodeFs>()
+  ufs.use(wrapFsForUnionfs(fs)).use(wrapMemfsForUnionfs(memfs))
+
+  return { ...ufs, default: ufs }
+})
+
+// Have to import fs after memfs is mocked
+// eslint-disable-next-line import-x/order
+import fs from 'node:fs'
+
+import * as sdlHandler from '../sdlHandler.js'
+import {
+  addStubHeader,
+  isPristineStub,
+  missingRelatedModels,
+  writeFilesWithStubsTask,
+} from '../stubFiles.js'
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vol.reset()
+})
+
+beforeAll(() => {
+  vol.fromJSON({ 'redwood.toml': '' }, '/')
+})
+
+const sdlPath = (fileName: string) =>
+  path.normalize(`/path/to/project/api/src/graphql/${fileName}`)
+const servicePath = (fileName: string) =>
+  path.normalize(`/path/to/project/api/src/services/${fileName}`)
+
+describe('missingRelatedModels', () => {
+  test('finds related models without SDL files', async () => {
+    expect(await missingRelatedModels('UserProfile')).toEqual(['User'])
+  })
+
+  test('handles circular relations without looping', async () => {
+    expect(await missingRelatedModels('User')).toEqual(['UserProfile'])
+  })
+
+  test('returns nothing for models without relations', async () => {
+    expect(await missingRelatedModels('Post')).toEqual([])
+  })
+
+  test('skips related models that already have an SDL file', async () => {
+    vol.fromJSON({
+      [sdlPath('renamedUsers.sdl.ts')]:
+        'export const schema = gql`\n  type User {\n    id: Int!\n  }\n`\n',
+    })
+
+    expect(await missingRelatedModels('UserProfile')).toEqual([])
+  })
+})
+
+describe('files with stubs', () => {
+  test('generates read-only stubs for missing related models', async () => {
+    const files = await sdlHandler.files({
+      name: 'UserProfile',
+      crud: true,
+      tests: true,
+      typescript: true,
+    })
+
+    // The target model's own files
+    expect(files).toHaveProperty([sdlPath('userProfiles.sdl.ts')])
+    expect(files).toHaveProperty([servicePath('userProfiles/userProfiles.ts')])
+
+    // The stub files for the related model
+    const stubSdl = files[sdlPath('users.sdl.ts')]
+    expect(stubSdl).toBeDefined()
+    expect(stubSdl).toContain('@cedar-generator-stub-hash')
+    // Stubs are read-only
+    expect(stubSdl).not.toContain('type Mutation')
+    expect(isPristineStub(stubSdl)).toEqual(true)
+    expect(stubSdl).toMatchSnapshot()
+
+    const stubService = files[servicePath('users/users.ts')]
+    expect(stubService).toBeDefined()
+    expect(isPristineStub(stubService)).toEqual(true)
+
+    // Stubs don't get test files
+    expect(files).not.toHaveProperty([servicePath('users/users.test.ts')])
+    expect(files).not.toHaveProperty([servicePath('users/users.scenarios.ts')])
+  })
+
+  test('does not generate stubs when passing an empty stubModels list', async () => {
+    const files = await sdlHandler.files({
+      name: 'UserProfile',
+      crud: true,
+      tests: true,
+      typescript: true,
+      stubModels: [],
+    })
+
+    expect(files).not.toHaveProperty([sdlPath('users.sdl.ts')])
+  })
+})
+
+describe('isPristineStub', () => {
+  test('detects unedited and edited stubs', () => {
+    const stub = addStubHeader({
+      content: 'export const schema = "stub"\n',
+      stubModel: 'User',
+      generatedFor: 'UserProfile',
+    })
+
+    expect(isPristineStub(stub)).toEqual(true)
+    // Replace something in the hashed body (not the header, which isn't
+    // covered by the hash)
+    expect(isPristineStub(stub.replace('"stub"', '"edited"'))).toEqual(false)
+    expect(isPristineStub('just a regular file')).toEqual(false)
+  })
+})
+
+describe('writeFilesWithStubsTask', () => {
+  const target = sdlPath('users.sdl.ts')
+
+  test('overwrites pristine stubs without --force', async () => {
+    vol.fromJSON({
+      [target]: addStubHeader({
+        content: 'export const schema = "stub"\n',
+        stubModel: 'User',
+        generatedFor: 'UserProfile',
+      }),
+    })
+
+    await writeFilesWithStubsTask({ [target]: 'the real thing' }).run()
+
+    expect(fs.readFileSync(target, 'utf-8')).toEqual('the real thing')
+  })
+
+  test('does not overwrite edited stubs without --force', async () => {
+    const stub = addStubHeader({
+      content: 'export const schema = "stub"\n',
+      stubModel: 'User',
+      generatedFor: 'UserProfile',
+    })
+    vol.fromJSON({ [target]: stub.replace('stub"', 'edited"') })
+
+    await expect(
+      writeFilesWithStubsTask({ [target]: 'the real thing' }).run(),
+    ).rejects.toThrow(/has since been edited/)
+  })
+
+  test('does not overwrite regular files without --force', async () => {
+    vol.fromJSON({ [target]: 'hand-written sdl' })
+
+    await expect(
+      writeFilesWithStubsTask({ [target]: 'the real thing' }).run(),
+    ).rejects.toThrow(/already exists/)
+  })
+
+  test('overwrites everything with --force', async () => {
+    vol.fromJSON({ [target]: 'hand-written sdl' })
+
+    await writeFilesWithStubsTask(
+      { [target]: 'the real thing' },
+      { overwriteExisting: true },
+    ).run()
+
+    expect(fs.readFileSync(target, 'utf-8')).toEqual('the real thing')
+  })
+})

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
@@ -66,6 +66,22 @@ describe('missingRelatedModels', () => {
 
     expect(await missingRelatedModels('UserProfile')).toEqual([])
   })
+
+  test('traverses through defined intermediate models to find missing models', async () => {
+    // This tests the case where A -> B -> C, B has SDL but C doesn't.
+    // We should discover C and generate a stub for it.
+    // In the fixture: UserProfile -> User (exists), User -> UserProfile (circular)
+    // Both have relations, and we should find missing models through defined ones.
+    // Since all related models in the fixture have SDL or are being checked,
+    // this is a regression test to ensure the queue.push happens for all models.
+    vol.fromJSON({
+      [sdlPath('userProfiles.sdl.ts')]:
+        'export const schema = gql`\n  type UserProfile {\n    id: Int!\n  }\n`\n',
+    })
+
+    // With only UserProfile having SDL, User should be discovered as missing
+    expect(await missingRelatedModels('UserProfile')).toContain('User')
+  })
 })
 
 describe('files with stubs', () => {
@@ -125,6 +141,19 @@ describe('isPristineStub', () => {
     // covered by the hash)
     expect(isPristineStub(stub.replace('"stub"', '"edited"'))).toEqual(false)
     expect(isPristineStub('just a regular file')).toEqual(false)
+  })
+
+  test('detects edits to header lines', () => {
+    const stub = addStubHeader({
+      content: 'export const schema = "stub"\n',
+      stubModel: 'User',
+      generatedFor: 'UserProfile',
+    })
+
+    expect(isPristineStub(stub)).toEqual(true)
+    // Edit a header line (the reason comment)
+    const edited = stub.replace('UserProfile', 'SomeOtherModel')
+    expect(isPristineStub(edited)).toEqual(false)
   })
 })
 

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
@@ -69,18 +69,17 @@ describe('missingRelatedModels', () => {
 
   test('traverses through defined intermediate models to find missing models', async () => {
     // This tests the case where A -> B -> C, B has SDL but C doesn't.
-    // We should discover C and generate a stub for it.
-    // In the fixture: UserProfile -> User (exists), User -> UserProfile (circular)
-    // Both have relations, and we should find missing models through defined ones.
-    // Since all related models in the fixture have SDL or are being checked,
-    // this is a regression test to ensure the queue.push happens for all models.
+    // We should still discover C by continuing to traverse through B, even
+    // though B itself isn't "missing".
+    // In the fixture: Order -> Customer -> Address.
     vol.fromJSON({
-      [sdlPath('userProfiles.sdl.ts')]:
-        'export const schema = gql`\n  type UserProfile {\n    id: Int!\n  }\n`\n',
+      [sdlPath('customers.sdl.ts')]:
+        'export const schema = gql`\n  type Customer {\n    id: Int!\n  }\n`\n',
     })
 
-    // With only UserProfile having SDL, User should be discovered as missing
-    expect(await missingRelatedModels('UserProfile')).toContain('User')
+    // Customer has SDL, so it isn't missing, but traversal should continue
+    // through it to discover that Address is missing.
+    expect(await missingRelatedModels('Order')).toEqual(['Address'])
   })
 })
 

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
@@ -90,6 +90,7 @@ describe('files with stubs', () => {
       crud: true,
       tests: true,
       typescript: true,
+      stubModels: await missingRelatedModels('UserProfile'),
     })
 
     // The target model's own files

--- a/packages/cli/src/commands/generate/sdl/sdlHandler.ts
+++ b/packages/cli/src/commands/generate/sdl/sdlHandler.ts
@@ -10,7 +10,7 @@ import { getConfig } from '@cedarjs/project-config'
 import { errorTelemetry } from '@cedarjs/telemetry'
 import { pluralize } from '@cedarjs/utils/cedarPluralize'
 
-import { transformTSToJS, writeFilesTask } from '../../../lib/index.js'
+import { transformTSToJS } from '../../../lib/index.js'
 import {
   prepareForRollback,
   addFunctionToRollback,
@@ -23,6 +23,12 @@ import {
 import { relationsForModel } from '../helpers.js'
 import { files as serviceFiles } from '../service/serviceHandler.js'
 import { templateForFile } from '../yargsHandlerHelpers.js'
+
+import {
+  addStubHeader,
+  missingRelatedModels,
+  writeFilesWithStubsTask,
+} from './stubFiles.js'
 
 const DEFAULT_IGNORE_FIELDS_FOR_INPUT = ['createdAt', 'updatedAt']
 
@@ -117,17 +123,16 @@ const querySDL = (model: ModelSchema, docs = false) => {
 }
 
 const inputSDL = (model: ModelSchema, required: boolean, docs = false) => {
-  const ignoredFields = DEFAULT_IGNORE_FIELDS_FOR_INPUT
+  const ignoredFields = [...DEFAULT_IGNORE_FIELDS_FOR_INPUT]
+  const idField = model.fields.find((field) => field.isId)
+
+  // Only ignore the id field if it has a default value
+  if (idField?.default) {
+    ignoredFields.push(idField.name)
+  }
 
   return model.fields
     .filter((field) => {
-      const idField = model.fields.find((field) => field.isId)
-
-      // Only ignore the id field if it has a default value
-      if (idField?.default) {
-        ignoredFields.push(idField.name)
-      }
-
       return !ignoredFields.includes(field.name) && field.kind !== 'object'
     })
     .map((field) => modelFieldToSDL({ field, required, docs }))
@@ -236,18 +241,30 @@ const sdlFromSchemaModel = async (
   }
 }
 
+/**
+ * Returns the SDL and service files to generate for the given model.
+ *
+ * Also returns read-only stub files for related models that don't have SDL
+ * files of their own yet, since GraphQL type generation fails when a
+ * generated SDL references a type that isn't defined anywhere. Pass
+ * `stubModels` to control which models get stubbed (pass `[]` to disable
+ * stub generation); when it's undefined the missing related models are
+ * detected automatically
+ */
 export const files = async ({
   name,
   crud = true,
   docs = false,
   tests,
   typescript,
+  stubModels,
 }: {
   name: string
   crud?: boolean
   docs?: boolean
   tests?: boolean
   typescript?: boolean
+  stubModels?: string[]
 }) => {
   const extension = typescript ? 'ts' : 'js'
   const sdlData = await sdlFromSchemaModel(name, crud, docs)
@@ -266,7 +283,7 @@ export const files = async ({
     ? content
     : await transformTSToJS(outputPath, content)
 
-  return {
+  const generatedFiles: Record<string, string> = {
     [outputPath]: template,
     ...(await serviceFiles({
       name,
@@ -276,6 +293,31 @@ export const files = async ({
       typescript,
     })),
   }
+
+  const modelsToStub = stubModels ?? (await missingRelatedModels(name))
+
+  for (const stubModel of modelsToStub) {
+    // `missingRelatedModels` already includes transitively related models, so
+    // the recursive call doesn't need to generate stubs of its own
+    const stubModelFiles = await files({
+      name: stubModel,
+      crud: false,
+      docs,
+      tests: false,
+      typescript,
+      stubModels: [],
+    })
+
+    for (const [stubPath, stubContent] of Object.entries(stubModelFiles)) {
+      generatedFiles[stubPath] = addStubHeader({
+        content: stubContent,
+        stubModel,
+        generatedFor: name,
+      })
+    }
+  }
+
+  return generatedFiles
 }
 
 // TODO: Add --dry-run command
@@ -312,14 +354,22 @@ export const handler = async ({
 
   try {
     const { name } = await verifyModelName({ name: model })
+    const stubModels = await missingRelatedModels(name)
 
     const tasks = new Listr(
       [
         {
           title: 'Generating SDL files...',
           task: async () => {
-            const f = await files({ name, tests, crud, typescript, docs })
-            return writeFilesTask(f, { overwriteExisting: force })
+            const f = await files({
+              name,
+              tests,
+              crud,
+              typescript,
+              docs,
+              stubModels,
+            })
+            return writeFilesWithStubsTask(f, { overwriteExisting: force })
           },
         },
         {
@@ -349,6 +399,26 @@ export const handler = async ({
       prepareForRollback(tasks)
     }
     await tasks.run()
+
+    if (stubModels.length > 0) {
+      console.log()
+      console.log(
+        c.info(
+          `${name} has relations to models that don't have SDL files of ` +
+            `their own yet: ${stubModels.join(', ')}`,
+        ),
+      )
+      console.log(
+        c.info(
+          'Read-only SDL stubs were generated for them, since GraphQL type ' +
+            'generation fails otherwise.',
+        ),
+      )
+      console.log(c.info('To replace a stub with a full SDL and service, run'))
+      for (const stubModel of stubModels) {
+        console.log(c.info(`  yarn cedar generate sdl ${stubModel}`))
+      }
+    }
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : String(e)
     const exitCode =

--- a/packages/cli/src/commands/generate/sdl/sdlHandler.ts
+++ b/packages/cli/src/commands/generate/sdl/sdlHandler.ts
@@ -243,12 +243,6 @@ const sdlFromSchemaModel = async (
 
 /**
  * Returns the SDL and service files to generate for the given model.
- *
- * Also returns read-only stub files for the models listed in `stubModels`,
- * since GraphQL type generation fails when a generated SDL references a type
- * that isn't defined anywhere. Defaults to `[]` (no stubs); pass the result
- * of `missingRelatedModels(name)` to stub out related models that don't have
- * SDL files of their own yet.
  */
 export const files = async ({
   name,
@@ -256,14 +250,12 @@ export const files = async ({
   docs = false,
   tests,
   typescript,
-  stubModels = [],
 }: {
   name: string
   crud?: boolean
   docs?: boolean
   tests?: boolean
   typescript?: boolean
-  stubModels?: string[]
 }) => {
   const extension = typescript ? 'ts' : 'js'
   const sdlData = await sdlFromSchemaModel(name, crud, docs)
@@ -282,7 +274,7 @@ export const files = async ({
     ? content
     : await transformTSToJS(outputPath, content)
 
-  const generatedFiles: Record<string, string> = {
+  return {
     [outputPath]: template,
     ...(await serviceFiles({
       name,
@@ -292,24 +284,36 @@ export const files = async ({
       typescript,
     })),
   }
+}
 
-  for (const stubModel of stubModels) {
-    // `missingRelatedModels` already includes transitively related models, so
-    // the recursive call doesn't need to generate stubs of its own
+/**
+ * Returns read-only stub SDL and service files for each model in `models`,
+ * since GraphQL type generation fails when a generated SDL references a type
+ * that isn't defined anywhere. Each stub is tagged with a header explaining
+ * why it exists and how to replace it with the real thing (see
+ * `addStubHeader`).
+ */
+export const stubFiles = async (
+  models: string[],
+  generatedFor: string,
+  { docs = false, typescript }: { docs?: boolean; typescript?: boolean },
+) => {
+  const generatedFiles: Record<string, string> = {}
+
+  for (const stubModel of models) {
     const stubModelFiles = await files({
       name: stubModel,
       crud: false,
       docs,
       tests: false,
       typescript,
-      stubModels: [],
     })
 
     for (const [stubPath, stubContent] of Object.entries(stubModelFiles)) {
       generatedFiles[stubPath] = addStubHeader({
         content: stubContent,
         stubModel,
-        generatedFor: name,
+        generatedFor,
       })
     }
   }
@@ -351,21 +355,17 @@ export const handler = async ({
 
   try {
     const { name } = await verifyModelName({ name: model })
-    const stubModels = await missingRelatedModels(name)
+    const missingModels = await missingRelatedModels(name)
 
     const tasks = new Listr(
       [
         {
           title: 'Generating SDL files...',
           task: async () => {
-            const f = await files({
-              name,
-              tests,
-              crud,
-              typescript,
-              docs,
-              stubModels,
-            })
+            const f = {
+              ...(await files({ name, tests, crud, typescript, docs })),
+              ...(await stubFiles(missingModels, name, { typescript, docs })),
+            }
             return writeFilesWithStubsTask(f, { overwriteExisting: force })
           },
         },
@@ -397,12 +397,12 @@ export const handler = async ({
     }
     await tasks.run()
 
-    if (stubModels.length > 0) {
+    if (missingModels.length > 0) {
       console.log()
       console.log(
         c.info(
           `${name} has relations to models that don't have SDL files of ` +
-            `their own yet: ${stubModels.join(', ')}`,
+            `their own yet: ${missingModels.join(', ')}`,
         ),
       )
       console.log(
@@ -412,7 +412,7 @@ export const handler = async ({
         ),
       )
       console.log(c.info('To replace a stub with a full SDL and service, run'))
-      for (const stubModel of stubModels) {
+      for (const stubModel of missingModels) {
         console.log(c.info(`  yarn cedar generate sdl ${stubModel}`))
       }
     }

--- a/packages/cli/src/commands/generate/sdl/sdlHandler.ts
+++ b/packages/cli/src/commands/generate/sdl/sdlHandler.ts
@@ -127,7 +127,7 @@ const inputSDL = (model: ModelSchema, required: boolean, docs = false) => {
   const idField = model.fields.find((field) => field.isId)
 
   // Only ignore the id field if it has a default value
-  if (idField?.default) {
+  if (idField?.default !== undefined) {
     ignoredFields.push(idField.name)
   }
 

--- a/packages/cli/src/commands/generate/sdl/sdlHandler.ts
+++ b/packages/cli/src/commands/generate/sdl/sdlHandler.ts
@@ -244,12 +244,11 @@ const sdlFromSchemaModel = async (
 /**
  * Returns the SDL and service files to generate for the given model.
  *
- * Also returns read-only stub files for related models that don't have SDL
- * files of their own yet, since GraphQL type generation fails when a
- * generated SDL references a type that isn't defined anywhere. Pass
- * `stubModels` to control which models get stubbed (pass `[]` to disable
- * stub generation); when it's undefined the missing related models are
- * detected automatically
+ * Also returns read-only stub files for the models listed in `stubModels`,
+ * since GraphQL type generation fails when a generated SDL references a type
+ * that isn't defined anywhere. Defaults to `[]` (no stubs); pass the result
+ * of `missingRelatedModels(name)` to stub out related models that don't have
+ * SDL files of their own yet.
  */
 export const files = async ({
   name,
@@ -257,7 +256,7 @@ export const files = async ({
   docs = false,
   tests,
   typescript,
-  stubModels,
+  stubModels = [],
 }: {
   name: string
   crud?: boolean
@@ -294,9 +293,7 @@ export const files = async ({
     })),
   }
 
-  const modelsToStub = stubModels ?? (await missingRelatedModels(name))
-
-  for (const stubModel of modelsToStub) {
+  for (const stubModel of stubModels) {
     // `missingRelatedModels` already includes transitively related models, so
     // the recursive call doesn't need to generate stubs of its own
     const stubModelFiles = await files({

--- a/packages/cli/src/commands/generate/sdl/stubFiles.ts
+++ b/packages/cli/src/commands/generate/sdl/stubFiles.ts
@@ -33,9 +33,8 @@ export function addStubHeader({
   stubModel: string
   generatedFor: string
 }) {
-  // The hash only covers what comes after the marker line, so that the header
-  // itself isn't part of the hashed content
   const body = '\n\n' + content
+  const marker = `// ${STUB_HASH_MARKER} PLACEHOLDER`
   const header = [
     `// Generated as a read-only stub by \`cedar generate sdl ` +
       `${generatedFor}\`,`,
@@ -45,10 +44,14 @@ export function addStubHeader({
       `the real thing.`,
     `// If you edit this file, the hash below will stop matching and you'll`,
     `// need to pass \`--force\` to overwrite it.`,
-    `// ${STUB_HASH_MARKER} ${stubHash(body)}`,
+    marker,
   ].join('\n')
 
-  return header + body
+  const contentToHash = header + body
+  const hash = stubHash(contentToHash)
+  const finalMarker = `// ${STUB_HASH_MARKER} ${hash}`
+
+  return (header + body).replace(marker, finalMarker)
 }
 
 /**
@@ -62,9 +65,12 @@ export function isPristineStub(contents: string) {
     return false
   }
 
-  const body = contents.slice(match.index + match[0].length)
+  const contentToHash = contents.replace(
+    match[0],
+    `// ${STUB_HASH_MARKER} PLACEHOLDER`,
+  )
 
-  return stubHash(body) === match[1]
+  return stubHash(contentToHash) === match[1]
 }
 
 function readExistingSdlFiles(): string[] {
@@ -138,10 +144,10 @@ export async function missingRelatedModels(
       }
 
       seen.add(field.type)
+      queue.push(field.type)
 
       if (!isDefined(field.type)) {
         missing.push(field.type)
-        queue.push(field.type)
       }
     }
   }

--- a/packages/cli/src/commands/generate/sdl/stubFiles.ts
+++ b/packages/cli/src/commands/generate/sdl/stubFiles.ts
@@ -1,0 +1,190 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { Listr } from 'listr2'
+
+import { getPaths } from '@cedarjs/project-config'
+
+import { writeFile } from '../../../lib/index.js'
+import { getSchema } from '../../../lib/schemaHelpers.js'
+
+const STUB_HASH_MARKER = '@cedar-generator-stub-hash'
+const STUB_HASH_MARKER_REGEX = new RegExp(
+  `^// ${STUB_HASH_MARKER} ([0-9a-f]+)$`,
+  'm',
+)
+
+function stubHash(contents: string) {
+  return crypto.createHash('sha256').update(contents).digest('hex').slice(0, 16)
+}
+
+/**
+ * Prepends a header to a generated stub file explaining why it exists and how
+ * to replace it. The header ends with a hash of the stub's contents, so that
+ * we can later tell whether the user has edited the file (see `isPristineStub`)
+ */
+export function addStubHeader({
+  content,
+  stubModel,
+  generatedFor,
+}: {
+  content: string
+  stubModel: string
+  generatedFor: string
+}) {
+  // The hash only covers what comes after the marker line, so that the header
+  // itself isn't part of the hashed content
+  const body = '\n\n' + content
+  const header = [
+    `// Generated as a read-only stub by \`cedar generate sdl ` +
+      `${generatedFor}\`,`,
+    `// because ${generatedFor} has a relation to ${stubModel}, which had ` +
+      `no SDL yet.`,
+    `// Run \`cedar generate sdl ${stubModel}\` to replace this stub with ` +
+      `the real thing.`,
+    `// If you edit this file, the hash below will stop matching and you'll`,
+    `// need to pass \`--force\` to overwrite it.`,
+    `// ${STUB_HASH_MARKER} ${stubHash(body)}`,
+  ].join('\n')
+
+  return header + body
+}
+
+/**
+ * Returns true if `contents` is a generated stub that hasn't been edited
+ * since it was generated
+ */
+export function isPristineStub(contents: string) {
+  const match = STUB_HASH_MARKER_REGEX.exec(contents)
+
+  if (!match) {
+    return false
+  }
+
+  const body = contents.slice(match.index + match[0].length)
+
+  return stubHash(body) === match[1]
+}
+
+function readExistingSdlFiles(): string[] {
+  const graphqlDir = getPaths().api.graphql
+
+  if (!fs.existsSync(graphqlDir)) {
+    return []
+  }
+
+  const contents: string[] = []
+  const dirsToWalk = [graphqlDir]
+
+  while (dirsToWalk.length > 0) {
+    const dir = dirsToWalk.shift()
+
+    if (!dir) {
+      break
+    }
+
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const entryPath = path.join(dir, entry.name)
+
+      if (entry.isDirectory()) {
+        dirsToWalk.push(entryPath)
+      } else if (/\.sdl\.(js|ts)$/.test(entry.name)) {
+        contents.push(fs.readFileSync(entryPath, 'utf-8'))
+      }
+    }
+  }
+
+  return contents
+}
+
+/**
+ * Returns the names of all models that `modelName` is related to, directly or
+ * transitively, whose GraphQL types aren't defined in any existing SDL file.
+ * Handles circular relations (e.g. Message ↔ User)
+ */
+export async function missingRelatedModels(
+  modelName: string,
+): Promise<string[]> {
+  const existingSdls = readExistingSdlFiles()
+  const isDefined = (typeName: string) =>
+    existingSdls.some((sdl) =>
+      new RegExp(`\\btype\\s+${typeName}\\b`).test(sdl),
+    )
+
+  const seen = new Set([modelName])
+  const missing: string[] = []
+  const queue = [modelName]
+
+  while (queue.length > 0) {
+    const current = queue.shift()
+
+    if (!current) {
+      break
+    }
+
+    const model = await getSchema(current)
+
+    if (!model || !('fields' in model)) {
+      continue
+    }
+
+    for (const field of model.fields) {
+      // Only fields with a `relationName` are actual relations to other
+      // models (`kind === 'object'` alone would also match Prisma composite
+      // types, which aren't models)
+      if (!field.relationName || seen.has(field.type)) {
+        continue
+      }
+
+      seen.add(field.type)
+
+      if (!isDefined(field.type)) {
+        missing.push(field.type)
+        queue.push(field.type)
+      }
+    }
+  }
+
+  return missing
+}
+
+/**
+ * Like `writeFilesTask`, but existing files that are pristine generated stubs
+ * (see `isPristineStub`) are overwritten without requiring `--force`
+ */
+export function writeFilesWithStubsTask(
+  files: Record<string, string>,
+  { overwriteExisting = false }: { overwriteExisting?: boolean } = {},
+) {
+  const { base } = getPaths()
+
+  return new Listr(
+    Object.entries(files).map(([file, contents]) => ({
+      title: `...waiting to write file \`./${path.relative(base, file)}\`...`,
+      task: (_ctx: unknown, task: { title?: string }) => {
+        let canOverwrite = overwriteExisting
+
+        if (!canOverwrite && fs.existsSync(file)) {
+          const existingContents = fs.readFileSync(file, 'utf-8')
+
+          if (isPristineStub(existingContents)) {
+            canOverwrite = true
+          } else if (STUB_HASH_MARKER_REGEX.test(existingContents)) {
+            throw new Error(
+              `${file} started out as a generated stub, but has since been ` +
+                'edited. Use `--force` to overwrite it.',
+            )
+          }
+        }
+
+        return writeFile(
+          file,
+          contents,
+          { overwriteExisting: canOverwrite },
+          task,
+        )
+      },
+    })),
+  )
+}

--- a/packages/cli/src/lib/index.ts
+++ b/packages/cli/src/lib/index.ts
@@ -14,6 +14,7 @@ import template from 'lodash/template.js'
 import pascalcase from 'pascalcase'
 import { format } from 'prettier'
 import type { Options as PrettierOptions } from 'prettier'
+import type { Options as YargsOptions } from 'yargs'
 
 import { colors as c } from '@cedarjs/cli-helpers'
 import {
@@ -722,9 +723,7 @@ export const runCommandTask = async (
 }
 
 /** Extract default CLI args from an exported builder */
-export const getDefaultArgs = (
-  builder: Record<string, { default?: unknown; [key: string]: unknown }>,
-) => {
+export const getDefaultArgs = (builder: Record<string, YargsOptions>) => {
   return Object.entries(builder).reduce<Record<string, unknown>>(
     (options, [optionName, optionConfig]) => {
       // If a default is defined use it


### PR DESCRIPTION
Part of #2285 (solves problem 1 — the generator not being relation-aware; problem 2, sensitive-field leaking, will be addressed separately).

## Problem

Running `cedar generate sdl Message`, where `Message` has a relation to `User` with no SDL of its own, wrote the SDL/service files and then failed type generation with:

```
Unknown type: "User"
```

This left the project in a broken state, with no indication that the fix is to generate SDL for the related model. Worse, because Prisma relations are bidirectional there is no command order that avoids the error on a fresh project: `generate sdl User` fails symmetrically with `Unknown type: "Message"`. Today the "fix" only works because the first command's broken files are already on disk when you run the second one.

## Solution

`generate sdl` now detects related models that don't have SDL files yet and generates **read-only stubs** for them in the same run, so type generation runs once, at the end, and succeeds:

```
✔ Generating SDL files...
✔ Generating types ...

Message has relations to models that don't have SDL files of their own yet: User
Read-only SDL stubs were generated for them, since GraphQL type generation fails otherwise.
To replace a stub with a full SDL and service, run
  yarn cedar generate sdl User
```

A stub is the GraphQL type plus a list query — no mutations, no test files — and starts with a header explaining why it exists:

```ts
// Generated as a read-only stub by `cedar generate sdl Message`,
// because Message has a relation to User, which had no SDL yet.
// Run `cedar generate sdl User` to replace this stub with the real thing.
// If you edit this file, the hash below will stop matching and you'll
// need to pass `--force` to overwrite it.
// @cedar-generator-stub-hash d94c8f09bc1c00b4

export const schema = gql`
  type User {
    ...
  }

  type Query {
    users: [User!]! @requireAuth
  }
`
```

### How it works

- **Detection** (`missingRelatedModels` in the new `stubFiles.ts`): walks the model's Prisma relations transitively, handling circular relations (`Message ↔ User`). A related type counts as "defined" if any existing `*.sdl.{ts,js}` file defines it (content check, so renamed or hand-written SDL files are respected).
- **Replacing stubs**: the `@cedar-generator-stub-hash` marker holds a hash of the stub's generated content. When a later `generate sdl User` (or `generate scaffold User`) targets a stub that hasn't been edited, it's overwritten without `--force`. If the stub *has* been edited, the generator refuses with a clear message so user changes are never silently lost. The hash only covers content below the marker line.
- The overwrite logic lives in a new `writeFilesWithStubsTask` alongside the sdl generator — the shared `writeFile`/`writeFilesTask` in `lib/` are untouched.

### Scope notes

- The **scaffold generator** doesn't generate stubs yet (follow-up PR — its tests need broader updates), but its writes are stub-aware, so scaffolding a model whose stub exists works without `--force`.
- **`destroy sdl`** only ever destroys the named model's own files, never stub paths.
- Fixed a latent bug where `inputSDL` mutated the module-level `DEFAULT_IGNORE_FIELDS_FOR_INPUT` array — harmless before, but real once a single run generates multiple models.
- Updated the [Troubleshooting Generators](https://cedarjs.com/docs/schema-relations#troubleshooting-generators) docs (the old "generate everything and ignore the errors" workflow now only applies to scaffolds) and the `generate sdl` section in the CLI reference.

## Testing

- New `sdlStubs.test.ts` covering detection (cycles, transitive relations, already-defined types), stub content, hash pristine/edited detection, and all overwrite paths through the real Listr task.
- Handler-level snapshot coverage of stub files in both JS and TS modes.
- `CI=1 yarn vitest run src/commands/generate src/commands/destroy` in `packages/cli` — 967 tests pass.
- `yarn eslint` clean on changed files; `tsc --noEmit` error count identical to `main` (all pre-existing).
