### PR TITLE
fix(web): InputVarProps degrading to any when TVariables defaults

### DIFF
--- a/packages/web/src/__typetests__/cellProps.test.tsx
+++ b/packages/web/src/__typetests__/cellProps.test.tsx
@@ -6,7 +6,12 @@ import { gql } from 'graphql-tag'
 import { describe, expect, test } from 'tstyche'
 
 import { createCell } from '@cedarjs/web'
-import type { CellProps, CellSuccessProps } from '@cedarjs/web'
+import type {
+  CellFailureProps,
+  CellLoadingProps,
+  CellProps,
+  CellSuccessProps,
+} from '@cedarjs/web'
 
 type ExampleQueryVariables = {
   category: string
@@ -288,10 +293,22 @@ describe('CellProps mapper type', () => {
   })
 
   describe('what beforeQuery is allowed to return', () => {
+    // These tests are only about the shape `beforeQuery` is allowed to
+    // return, so `Success` is deliberately left at the bare `CellSuccessProps`
+    // type here, rather than reusing `recipeCell.Success` (which is annotated
+    // with `CellSuccessProps<QueryResult>` plus a custom prop). `createCell`
+    // structurally checks `Success` against `CellSuccessProps & Partial<CellProps>`
+    // (see #2366 for why that's a loose check), and a `Success` typed more
+    // specifically than that doesn't satisfy it when passed by reference.
+    const recipeCellForBeforeQuery = {
+      ...recipeCell,
+      Success: (_props: CellSuccessProps) => null,
+    }
+
     test('Just variables', () => {
       expect(
         createCell({
-          ...recipeCell,
+          ...recipeCellForBeforeQuery,
           beforeQuery: ({ word }: { word: string }) => ({
             variables: { category: word, saved: true },
           }),
@@ -302,7 +319,7 @@ describe('CellProps mapper type', () => {
     test('Other query hook options alongside the variables', () => {
       expect(
         createCell({
-          ...recipeCell,
+          ...recipeCellForBeforeQuery,
           beforeQuery: ({ word }: { word: string }) => ({
             variables: { category: word, saved: true },
             fetchPolicy: 'cache-only' as const,
@@ -315,11 +332,59 @@ describe('CellProps mapper type', () => {
     test('skipToken, to not run the query at all', () => {
       expect(
         createCell({
-          ...recipeCell,
+          ...recipeCellForBeforeQuery,
           beforeQuery: ({ word }: { word: string }) =>
             word ? { variables: { category: word, saved: true } } : skipToken,
         }),
       ).type.not.toRaiseError()
+    })
+  })
+
+  describe('InputVarProps does not degrade to any when TVariables is defaulted', () => {
+    // Regression test for https://github.com/cedarjs/cedar/issues/2353
+    //
+    // TVariables defaults to `any` on CellSuccessProps/CellFailureProps/
+    // CellLoadingProps. If InputVarProps doesn't guard against that, the
+    // conditional distributes over `any` and resolves to `any`, which
+    // poisons the whole intersected props type (`X & any` = `any`) --
+    // silently disabling all prop checking.
+    //
+    // Note this can't be caught by redeclaring a custom prop on an
+    // `interface ... extends ...`, since TypeScript keeps an interface's own
+    // explicitly-typed members even when the type it extends is poisoned to
+    // `any`. Instead, these tests lean on excess property checks: TypeScript
+    // only flags unknown properties on an object literal when it's checked
+    // against a real object type, not against `any`, so a bogus property is
+    // a reliable way to tell "properly typed" apart from "poisoned to any".
+
+    test('CellSuccessProps<TData> (single-arg form) rejects unknown properties', () => {
+      expect<CellSuccessProps<QueryResult>>().type.not.toBeAssignableFrom({
+        recipes: [],
+        bogusProp: 'should not be allowed',
+      })
+    })
+
+    test('CellSuccessProps<TData, TVariables> (two-arg form) rejects unknown properties', () => {
+      expect<
+        CellSuccessProps<QueryResult, ExampleQueryVariables>
+      >().type.not.toBeAssignableFrom({
+        recipes: [],
+        category: 'Dinner',
+        saved: true,
+        bogusProp: 'should not be allowed',
+      })
+    })
+
+    test('CellFailureProps (no-arg form) rejects unknown properties', () => {
+      expect<CellFailureProps>().type.not.toBeAssignableFrom({
+        bogusProp: 'should not be allowed',
+      })
+    })
+
+    test('CellLoadingProps (no-arg form) rejects unknown properties', () => {
+      expect<CellLoadingProps>().type.not.toBeAssignableFrom({
+        bogusProp: 'should not be allowed',
+      })
     })
   })
 })

--- a/packages/web/src/__typetests__/cellProps.test.tsx
+++ b/packages/web/src/__typetests__/cellProps.test.tsx
@@ -11,6 +11,7 @@ import type {
   CellLoadingProps,
   CellProps,
   CellSuccessProps,
+  TypedDocumentNode,
 } from '@cedarjs/web'
 
 type ExampleQueryVariables = {
@@ -295,11 +296,10 @@ describe('CellProps mapper type', () => {
   describe('what beforeQuery is allowed to return', () => {
     // These tests are only about the shape `beforeQuery` is allowed to
     // return, so `Success` is deliberately left at the bare `CellSuccessProps`
-    // type here, rather than reusing `recipeCell.Success` (which is annotated
-    // with `CellSuccessProps<QueryResult>` plus a custom prop). `createCell`
-    // structurally checks `Success` against `CellSuccessProps & Partial<CellProps>`
-    // (see #2366 for why that's a loose check), and a `Success` typed more
-    // specifically than that doesn't satisfy it when passed by reference.
+    // type here, rather than reusing `recipeCell.Success`. `recipeCell.Success`
+    // requires a `customProp` that isn't part of these tests' `beforeQuery`
+    // props (just `{ word: string }`), which is an unrelated mismatch to what
+    // these tests are checking, not something #2366 fixed.
     const recipeCellForBeforeQuery = {
       ...recipeCell,
       Success: (_props: CellSuccessProps) => null,
@@ -385,6 +385,57 @@ describe('CellProps mapper type', () => {
       expect<CellLoadingProps>().type.not.toBeAssignableFrom({
         bogusProp: 'should not be allowed',
       })
+    })
+  })
+
+  describe('createCell checks Success/Empty/Failure/Loading against the real QUERY type', () => {
+    // Regression test for https://github.com/cedarjs/cedar/issues/2366
+    //
+    // Real, CLI-generated Cells type QUERY with TypedDocumentNode<TData,
+    // TVariables> and type Success/Failure/Loading with CellSuccessProps<
+    // TData, TVariables> etc, exactly like this fixture does. Before #2366,
+    // CreateCellProps checked those components against the bare, defaulted-
+    // to-`any` CellSuccessProps/CellFailureProps/CellLoadingProps instead of
+    // this Cell's own QUERY type, so a Success reading a field that doesn't
+    // exist on the query result went uncaught.
+    const typedQuery = gql`
+      query ListRecipes {
+        recipes {
+          id
+          name
+        }
+      }
+    ` as TypedDocumentNode<QueryResult, EmptyVariables>
+
+    test('Success typed against the real query result is fine', () => {
+      expect(
+        createCell({
+          QUERY: typedQuery,
+          Success: (props: CellSuccessProps<QueryResult>) => (
+            <ul>{props.recipes.length}</ul>
+          ),
+        }),
+      ).type.not.toRaiseError()
+    })
+
+    // Mirrors the `SuccessProps`/`customProp` fixture near the top of this
+    // file, but requires a prop the query result doesn't provide -- before
+    // #2366, this went unnoticed because `Success` was checked against the
+    // bare, defaulted-to-`any` `CellSuccessProps`, not against this Cell's
+    // own `QUERY` type
+    interface MismatchedSuccessProps extends CellSuccessProps<QueryResult> {
+      totallyWrongProp: number
+    }
+
+    test('Success requiring a prop the query result does not provide raises an error', () => {
+      expect(
+        createCell({
+          QUERY: typedQuery,
+          Success: (props: MismatchedSuccessProps) => (
+            <p>{props.totallyWrongProp}</p>
+          ),
+        }),
+      ).type.toRaiseError()
     })
   })
 })

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -278,11 +278,15 @@ export interface CreateCellProps<
   /**
    * If no data was returned, render this.
    */
-  Empty?: React.FC<CellSuccessProps<GQLResult, CellVariables> & Partial<CellProps>>
+  Empty?: React.FC<
+    CellSuccessProps<GQLResult, CellVariables> & Partial<CellProps>
+  >
   /**
    * If data was returned, render this.
    */
-  Success: React.FC<CellSuccessProps<GQLResult, CellVariables> & Partial<CellProps>>
+  Success: React.FC<
+    CellSuccessProps<GQLResult, CellVariables> & Partial<CellProps>
+  >
   /**
    * What to call the Cell. Defaults to the filename.
    */

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -4,6 +4,7 @@ import type {
   ApolloClient,
   NetworkStatus,
   OperationVariables,
+  TypedDocumentNode,
 } from '@apollo/client'
 import type {
   QueryRef,
@@ -194,15 +195,29 @@ export type CellBeforeQueryResult<CellVariables> =
 
 /**
  * The main interface.
+ *
+ * @param GQLResult - The shape of the data returned by `QUERY` (or, for
+ * fragment Cells, the shape of the fragment's data). This is what
+ * `Success`/`Empty` receive their data as. Defaults to `any` so Cells that
+ * don't -- or can't -- type their `QUERY` with `TypedDocumentNode` (e.g. in
+ * tests, or Cells built from a plain string) keep the pre-existing loose
+ * behavior instead of erroring.
  */
-export interface CreateCellProps<CellProps, CellVariables> {
+export interface CreateCellProps<
+  CellProps,
+  CellVariables extends OperationVariables = OperationVariables,
+  GQLResult = any,
+> {
   /**
    * The GraphQL syntax tree to execute or function to call that returns it.
    * If `QUERY` is a function, it's called with the result of `beforeQuery`.
    *
    * Either `QUERY` or `FRAGMENT` must be provided.
    */
-  QUERY?: DocumentNode | ((variables: Record<string, unknown>) => DocumentNode)
+  QUERY?:
+    | TypedDocumentNode<GQLResult, CellVariables>
+    | DocumentNode
+    | ((variables: Record<string, unknown>) => DocumentNode)
   /**
    * A GraphQL fragment that declares this Cell's data requirements. Fragment
    * Cells don't fire their own query. Instead a parent Cell spreads the
@@ -255,19 +270,19 @@ export interface CreateCellProps<CellProps, CellVariables> {
   /**
    * If the query's in flight and there's no stale data, render this.
    */
-  Loading?: React.FC<CellLoadingProps & Partial<CellProps>>
+  Loading?: React.FC<CellLoadingProps<CellVariables> & Partial<CellProps>>
   /**
    * If something went wrong, render this.
    */
-  Failure?: React.FC<CellFailureProps & Partial<CellProps>>
+  Failure?: React.FC<CellFailureProps<CellVariables> & Partial<CellProps>>
   /**
    * If no data was returned, render this.
    */
-  Empty?: React.FC<CellSuccessProps & Partial<CellProps>>
+  Empty?: React.FC<CellSuccessProps<GQLResult, CellVariables> & Partial<CellProps>>
   /**
    * If data was returned, render this.
    */
-  Success: React.FC<CellSuccessProps & Partial<CellProps>>
+  Success: React.FC<CellSuccessProps<GQLResult, CellVariables> & Partial<CellProps>>
   /**
    * What to call the Cell. Defaults to the filename.
    */

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -69,7 +69,16 @@ export type CellProps<
     CellPropsVariables<CellType, GQLVariables>
 >
 
-type InputVarProps<T> = T extends { [key: string]: never } ? unknown : T
+// `unknown extends T` is only true for `unknown`/`any` and is non-distributive
+// in this position. Without this guard, when `T` is `any` the conditional
+// below distributes over `any`'s implicit `unknown | {}` union, resolving to
+// `unknown | any` = `any` -- which then poisons any intersection it's used
+// in (`X & any` = `any`), silently disabling all prop checking.
+type InputVarProps<T> = unknown extends T
+  ? unknown
+  : T extends { [key: string]: never }
+    ? unknown
+    : T
 
 export type CellLoadingProps<TVariables extends OperationVariables = any> = {
   queryResult?:

--- a/packages/web/src/components/cell/createCell.tsx
+++ b/packages/web/src/components/cell/createCell.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import type { OperationVariables } from '@apollo/client'
 import { CombinedGraphQLErrors } from '@apollo/client'
 import { useQuery } from '@apollo/client/react'
 
@@ -14,9 +15,10 @@ import { isDataEmpty } from './isCellEmpty.js'
 
 export function createCell<
   CellProps extends Record<string, unknown>,
-  CellVariables extends Record<string, unknown>,
+  CellVariables extends OperationVariables = OperationVariables,
+  GQLResult = any,
 >(
-  createCellProps: CreateCellProps<CellProps, CellVariables>,
+  createCellProps: CreateCellProps<CellProps, CellVariables, GQLResult>,
 ): React.FC<CellProps> {
   // Cells that declare their data requirements with a FRAGMENT don't fire
   // queries of their own – they read their slice of a parent Cell's query
@@ -43,10 +45,13 @@ export function createCell<
     // props.
     const suspendingCellProps = createCellProps as CreateCellProps<
       Record<string, unknown>,
-      CellVariables
+      CellVariables,
+      GQLResult
     >
 
-    return createSuspendingCell<CellProps, CellVariables>(suspendingCellProps)
+    return createSuspendingCell<CellProps, CellVariables, GQLResult>(
+      suspendingCellProps,
+    )
   }
 
   return createNonSuspendingCell(createCellProps)
@@ -57,7 +62,8 @@ export function createCell<
  */
 function createNonSuspendingCell<
   CellProps extends Record<string, unknown>,
-  CellVariables extends Record<string, unknown>,
+  CellVariables extends OperationVariables = OperationVariables,
+  GQLResult = any,
 >({
   QUERY,
   beforeQuery = (props) => ({
@@ -79,7 +85,7 @@ function createNonSuspendingCell<
   Empty,
   Success,
   displayName = 'Cell',
-}: CreateCellProps<CellProps, CellVariables>): React.FC<CellProps> {
+}: CreateCellProps<CellProps, CellVariables, GQLResult>): React.FC<CellProps> {
   if (!QUERY) {
     throw new Error(
       `Can't create a Cell (${displayName}) without a QUERY or FRAGMENT export`,
@@ -187,6 +193,16 @@ function createNonSuspendingCell<
       return null
     }
 
+    // `Failure`/`Empty`/`Success`/`Loading` are checked against this Cell's
+    // real `GQLResult` and `CellVariables` at its own call site (that's the
+    // whole point of threading those generics through `CreateCellProps`).
+    // Inside this generic factory function, though, `GQLResult` and
+    // `CellVariables` are still abstract, and the props assembled below are
+    // built from `useQuery<DataObject>`'s untyped result -- there's no way
+    // for TS to verify structurally, at this level, that they line up with
+    // the concrete types each Cell's components declare. The objects below
+    // are exactly what `CellFailureProps`/`CellSuccessProps`/`CellLoadingProps`
+    // describe at runtime, so they're asserted here rather than checked.
     if (error) {
       if (Failure) {
         // errorCode is not part of the type returned by useQuery
@@ -195,21 +211,20 @@ function createNonSuspendingCell<
           errorCode: string
         }
 
-        return (
-          <Failure
-            error={error}
-            errorCode={
-              // Use the ad-hoc QueryResultWithErrorCode type to access the errorCode
-              (queryResult as QueryResultWithErrorCode).errorCode ??
-              (CombinedGraphQLErrors.is(error)
-                ? (error.errors[0]?.extensions?.['code'] as string)
-                : undefined)
-            }
-            {...props}
-            updating={loading}
-            queryResult={queryResult}
-          />
-        )
+        const failureProps = {
+          error,
+          errorCode:
+            // Use the ad-hoc QueryResultWithErrorCode type to access the errorCode
+            (queryResult as QueryResultWithErrorCode).errorCode ??
+            (CombinedGraphQLErrors.is(error)
+              ? (error.errors[0]?.extensions?.['code'] as string)
+              : undefined),
+          ...props,
+          updating: loading,
+          queryResult,
+        }
+
+        return <Failure {...(failureProps as any)} />
       } else {
         // Apollo Client types errors as `ErrorLike`, but at runtime they're
         // `Error` instances
@@ -219,26 +234,28 @@ function createNonSuspendingCell<
       const afterQueryData = afterQuery(data)
 
       if (isEmpty(data, { isDataEmpty }) && Empty) {
-        return (
-          <Empty
-            {...props}
-            {...afterQueryData}
-            updating={loading}
-            queryResult={queryResult}
-          />
-        )
+        const emptyProps = {
+          ...props,
+          ...afterQueryData,
+          updating: loading,
+          queryResult,
+        }
+
+        return <Empty {...(emptyProps as any)} />
       } else {
-        return (
-          <Success
-            {...props}
-            {...afterQueryData}
-            updating={loading}
-            queryResult={queryResult}
-          />
-        )
+        const successProps = {
+          ...props,
+          ...afterQueryData,
+          updating: loading,
+          queryResult,
+        }
+
+        return <Success {...(successProps as any)} />
       }
     } else if (loading) {
-      return <Loading {...props} queryResult={queryResult} />
+      const loadingProps = { ...props, queryResult }
+
+      return <Loading {...(loadingProps as any)} />
     } else {
       /**
        * There really shouldn't be an `else` here, but like any piece of software, GraphQL clients have bugs.

--- a/packages/web/src/components/cell/createCell.tsx
+++ b/packages/web/src/components/cell/createCell.tsx
@@ -194,15 +194,16 @@ function createNonSuspendingCell<
     }
 
     // `Failure`/`Empty`/`Success`/`Loading` are checked against this Cell's
-    // real `GQLResult` and `CellVariables` at its own call site (that's the
-    // whole point of threading those generics through `CreateCellProps`).
+    // real `GQLResult` and `CellVariables` at its own call site (i.e. inside
+    // the developer's own *Cell.ts file).
     // Inside this generic factory function, though, `GQLResult` and
     // `CellVariables` are still abstract, and the props assembled below are
-    // built from `useQuery<DataObject>`'s untyped result -- there's no way
-    // for TS to verify structurally, at this level, that they line up with
-    // the concrete types each Cell's components declare. The objects below
-    // are exactly what `CellFailureProps`/`CellSuccessProps`/`CellLoadingProps`
-    // describe at runtime, so they're asserted here rather than checked.
+    // built from `useQuery<DataObject>`'s untyped result -- there's no way for
+    // TS to verify structurally, at this level, that they line up with the
+    // concrete types each Cell's components declare. The objects below are
+    // exactly what `CellFailureProps`/`CellSuccessProps`/`CellLoadingProps`
+    // describe at runtime, so they're cast to `any` below rather than checked.
+
     if (error) {
       if (Failure) {
         // errorCode is not part of the type returned by useQuery
@@ -224,6 +225,7 @@ function createNonSuspendingCell<
           queryResult,
         }
 
+        // See the long comment around line 200 about why we cast to `any` here
         return <Failure {...(failureProps as any)} />
       } else {
         // Apollo Client types errors as `ErrorLike`, but at runtime they're
@@ -241,6 +243,7 @@ function createNonSuspendingCell<
           queryResult,
         }
 
+        // See the long comment around line 200 about why we cast to `any` here
         return <Empty {...(emptyProps as any)} />
       } else {
         const successProps = {
@@ -250,11 +253,13 @@ function createNonSuspendingCell<
           queryResult,
         }
 
+        // See the long comment around line 200 about why we cast to `any` here
         return <Success {...(successProps as any)} />
       }
     } else if (loading) {
       const loadingProps = { ...props, queryResult }
 
+      // See the long comment around line 200 about why we cast to `any` here
       return <Loading {...(loadingProps as any)} />
     } else {
       /**

--- a/packages/web/src/components/cell/createFragmentCell.tsx
+++ b/packages/web/src/components/cell/createFragmentCell.tsx
@@ -137,11 +137,18 @@ export function createFragmentCell<
 
     const afterQueryData = afterQuery({ [propName]: data })
 
+    // `rest` is typed as `Omit<PropsWithChildren<CellProps>, string>` because
+    // `propName` is only known at runtime, not as a string literal type --
+    // TS can't tell which key was destructured out, so it conservatively
+    // omits every string key. At runtime `rest` does hold the remaining
+    // `CellProps`, so this reflects that.
+    const restProps = rest as Partial<CellProps>
+
     if (isEmpty({ [propName]: data }, { isDataEmpty }) && Empty) {
-      return <Empty {...rest} {...afterQueryData} />
+      return <Empty {...restProps} {...afterQueryData} />
     }
 
-    return <Success {...rest} {...afterQueryData} />
+    return <Success {...restProps} {...afterQueryData} />
   }
 
   NamedCell.displayName = displayName

--- a/packages/web/src/components/cell/createFragmentCell.tsx
+++ b/packages/web/src/components/cell/createFragmentCell.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import type { OperationVariables } from '@apollo/client'
 import type { DocumentNode, FragmentDefinitionNode } from 'graphql'
 import { Kind } from 'graphql'
 
@@ -75,7 +76,8 @@ function isDataRef(value: unknown): value is Record<string, unknown> {
  */
 export function createFragmentCell<
   CellProps extends Record<string, unknown>,
-  CellVariables extends Record<string, unknown>,
+  CellVariables extends OperationVariables = OperationVariables,
+  GQLResult = any,
 >({
   FRAGMENT,
   afterQuery = (data) => data,
@@ -83,7 +85,7 @@ export function createFragmentCell<
   Empty,
   Success,
   displayName = 'Cell',
-}: CreateCellProps<CellProps, CellVariables>): React.FC<CellProps> {
+}: CreateCellProps<CellProps, CellVariables, GQLResult>): React.FC<CellProps> {
   if (!FRAGMENT) {
     throw new Error(
       `createFragmentCell() for ${displayName} requires a FRAGMENT`,
@@ -144,11 +146,19 @@ export function createFragmentCell<
     // `CellProps`, so this reflects that.
     const restProps = rest as Partial<CellProps>
 
+    // `Empty`/`Success` are checked against this Cell's real `GQLResult` and
+    // `CellVariables` at its own call site. Inside this generic factory
+    // function those are still abstract, and there's no way for TS to verify
+    // structurally that `restProps`/`afterQueryData` line up with them, so
+    // the merged props are asserted here rather than checked (see the same
+    // pattern, with more detail, in createCell.tsx)
+    const successProps = { ...restProps, ...afterQueryData }
+
     if (isEmpty({ [propName]: data }, { isDataEmpty }) && Empty) {
-      return <Empty {...restProps} {...afterQueryData} />
+      return <Empty {...(successProps as any)} />
     }
 
-    return <Success {...restProps} {...afterQueryData} />
+    return <Success {...(successProps as any)} />
   }
 
   NamedCell.displayName = displayName

--- a/packages/web/src/components/cell/createServerCell.tsx
+++ b/packages/web/src/components/cell/createServerCell.tsx
@@ -2,6 +2,8 @@
 
 import React, { Suspense } from 'react'
 
+import type { OperationVariables } from '@apollo/client'
+
 // Class components are not supported on the server
 // https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns#when-to-use-server-and-client-components
 // Consider https://github.com/bvaughn/react-error-boundary
@@ -10,10 +12,11 @@ import type { CreateCellProps } from './cellTypes.js'
 import { isDataEmpty } from './isCellEmpty.js'
 
 // TODO(RSC): Clean this type up and consider moving to cellTypes
-type CreateServerCellProps<CellProps, CellVariables> = Omit<
-  CreateCellProps<CellProps, CellVariables>,
-  'QUERY' | 'Failure'
-> & {
+type CreateServerCellProps<
+  CellProps,
+  CellVariables extends OperationVariables = OperationVariables,
+  GQLResult = any,
+> = Omit<CreateCellProps<CellProps, CellVariables, GQLResult>, 'QUERY' | 'Failure'> & {
   data: (variables?: AnyObj) => any
   Failure?: React.ComponentType<{
     error: unknown
@@ -25,9 +28,10 @@ type AnyObj = Record<string, unknown>
 
 export function createServerCell<
   CellProps extends AnyObj,
-  CellVariables extends AnyObj,
+  CellVariables extends OperationVariables = OperationVariables,
+  GQLResult = any,
 >(
-  createCellProps: CreateServerCellProps<CellProps, CellVariables>, // 👈 AnyObj, because using CellProps causes a TS error
+  createCellProps: CreateServerCellProps<CellProps, CellVariables, GQLResult>, // 👈 AnyObj, because using CellProps causes a TS error
 ): React.FC<CellProps> {
   const {
     data: dataFn,
@@ -61,11 +65,19 @@ export function createServerCell<
     try {
       const data = await dataFn(variables)
 
+      // `data` comes from `dataFn`, which is untyped (`(variables?: AnyObj) =>
+      // any`), so the merged props below are already `any` -- no assertion
+      // needed to pass them to `Empty`/`Success`, which are checked against
+      // this Cell's real `GQLResult`/`CellVariables` at its own call site
       if (isEmpty(data, { isDataEmpty }) && Empty) {
-        return <Empty {...props} {...data} />
+        const emptyProps = { ...props, ...data }
+
+        return <Empty {...emptyProps} />
       }
 
-      return <Success {...data} {...props} />
+      const successProps = { ...data, ...props }
+
+      return <Success {...successProps} />
     } catch (error) {
       return <FailureComponent error={error} />
     }
@@ -83,8 +95,12 @@ export function createServerCell<
         return suspendingSuccessElement
       }
 
+      // `Loading` is checked against this Cell's real `CellVariables` at its
+      // own call site. Inside this generic factory function that's still
+      // abstract, so the props object is asserted here rather than checked
+      // (see the same pattern, with more detail, in createCell.tsx)
       return (
-        <Suspense fallback={<LoadingComponent {...props} />}>
+        <Suspense fallback={<LoadingComponent {...(props as any)} />}>
           {suspendingSuccessElement}
         </Suspense>
       )

--- a/packages/web/src/components/cell/createServerCell.tsx
+++ b/packages/web/src/components/cell/createServerCell.tsx
@@ -16,7 +16,10 @@ type CreateServerCellProps<
   CellProps,
   CellVariables extends OperationVariables = OperationVariables,
   GQLResult = any,
-> = Omit<CreateCellProps<CellProps, CellVariables, GQLResult>, 'QUERY' | 'Failure'> & {
+> = Omit<
+  CreateCellProps<CellProps, CellVariables, GQLResult>,
+  'QUERY' | 'Failure'
+> & {
   data: (variables?: AnyObj) => any
   Failure?: React.ComponentType<{
     error: unknown

--- a/packages/web/src/components/cell/createSuspendingCell.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.tsx
@@ -28,9 +28,10 @@ type AnyObj = Record<string, unknown>
  */
 export function createSuspendingCell<
   CellProps extends AnyObj,
-  CellVariables extends AnyObj,
+  CellVariables extends OperationVariables = OperationVariables,
+  GQLResult = any,
 >(
-  createCellProps: CreateCellProps<AnyObj, CellVariables>, // 👈 AnyObj, because using CellProps causes a TS error
+  createCellProps: CreateCellProps<AnyObj, CellVariables, GQLResult>, // 👈 AnyObj, because using CellProps causes a TS error
 ): React.FC<CellProps> {
   const {
     QUERY,
@@ -85,23 +86,29 @@ export function createSuspendingCell<
       networkStatus,
     }
 
+    // `Empty`/`Success` are checked against this Cell's real `GQLResult` and
+    // `CellVariables` at its own call site. Inside this generic factory
+    // function those are still abstract, and there's no way for TS to verify
+    // structurally that `userProps`/`afterQueryData` line up with them, so
+    // the merged props are asserted here rather than checked (see the same
+    // pattern, with more detail, in createCell.tsx)
     if (isEmpty(data, { isDataEmpty }) && Empty) {
-      return (
-        <Empty
-          {...userProps}
-          {...afterQueryData}
-          queryResult={queryResultWithNetworkStatus}
-        />
-      )
+      const emptyProps = {
+        ...userProps,
+        ...afterQueryData,
+        queryResult: queryResultWithNetworkStatus,
+      }
+
+      return <Empty {...(emptyProps as any)} />
     }
 
-    return (
-      <Success
-        {...afterQueryData}
-        {...userProps}
-        queryResult={queryResultWithNetworkStatus}
-      />
-    )
+    const successProps = {
+      ...afterQueryData,
+      ...userProps,
+      queryResult: queryResultWithNetworkStatus,
+    }
+
+    return <Success {...(successProps as any)} />
   }
 
   SuspendingSuccess.displayName = displayName
@@ -187,17 +194,19 @@ export function createSuspendingCell<
         },
       }
 
-      return (
-        <Failure
-          error={error}
-          errorCode={
-            CombinedGraphQLErrors.is(error)
-              ? (error.errors[0]?.extensions?.['code'] as string)
-              : undefined
-          }
-          queryResult={queryResultWithErrorReset}
-        />
-      )
+      // `Failure` is checked against this Cell's real `CellVariables` at its
+      // own call site. Inside this generic factory function that's still
+      // abstract, so the props object is asserted here rather than checked
+      // (see the same pattern, with more detail, in createCell.tsx)
+      const failureProps = {
+        error,
+        errorCode: CombinedGraphQLErrors.is(error)
+          ? (error.errors[0]?.extensions?.['code'] as string)
+          : undefined,
+        queryResult: queryResultWithErrorReset,
+      }
+
+      return <Failure {...(failureProps as any)} />
     }
 
     const wrapInSuspenseIfLoadingPresent = (
@@ -208,11 +217,15 @@ export function createSuspendingCell<
         return suspendingSuccessElement
       }
 
+      // `Loading` is checked against this Cell's real `CellVariables` at its
+      // own call site. Inside this generic factory function that's still
+      // abstract, so the props object is asserted here rather than checked
+      // (see the same pattern, with more detail, in createCell.tsx)
+      const loadingProps = { ...props, queryResult: suspenseQueryResult }
+
       return (
         <Suspense
-          fallback={
-            <LoadingComponent {...props} queryResult={suspenseQueryResult} />
-          }
+          fallback={<LoadingComponent {...(loadingProps as any)} />}
         >
           {suspendingSuccessElement}
         </Suspense>

--- a/packages/web/src/components/cell/createSuspendingCell.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.tsx
@@ -224,9 +224,7 @@ export function createSuspendingCell<
       const loadingProps = { ...props, queryResult: suspenseQueryResult }
 
       return (
-        <Suspense
-          fallback={<LoadingComponent {...(loadingProps as any)} />}
-        >
+        <Suspense fallback={<LoadingComponent {...(loadingProps as any)} />}>
           {suspendingSuccessElement}
         </Suspense>
       )


### PR DESCRIPTION
## Summary

Fixes #2353. Fixes #2366.

`InputVarProps<T>`'s conditional (`T extends { [key: string]: never } ? unknown : T`) distributes over `any`'s implicit `unknown | {}` union when `T` is `any`, resolving to `any` itself. Since `TVariables` defaults to `any` on `CellSuccessProps`, `CellFailureProps`, and `CellLoadingProps`, this poisoned the whole intersected props type (`X & any` = `any`), silently disabling prop checking on affected Cell components.

Guarded with `unknown extends T` first, which is only true for `unknown`/`any` and isn't distributive in this position (as suggested in the issue).

## Also fixed

Rebuilding `@cedarjs/web` with the fix applied surfaced a real, previously-masked bug in `createFragmentCell.tsx`: the destructured `rest` variable is typed as `Omit<PropsWithChildren<CellProps>, string>` (TS can't know which key `[propName]` destructured out, since it's a runtime string, not a literal type, so it conservatively drops every string key). That no longer satisfied `Partial<CellProps>` once `InputVarProps` stopped resolving to `any`. Fixed with a documented cast, since `rest` genuinely does hold the remaining `CellProps` at runtime.

## #2366: CreateCellProps typed Success/Empty/Failure/Loading against bare, defaulted-to-`any` props

Rebuilding also surfaced a larger, independent gap: `CreateCellProps.Success/Empty/Failure/Loading` were typed against *bare* `CellSuccessProps`/`CellFailureProps`/`CellLoadingProps` (no `GQLResult`/`CellVariables` threaded through at all), and were previously only "working" for normal Cells because the bug this PR fixes poisoned that bare type to `any`, silently disabling the check entirely. Fixing the `InputVarProps` bug alone wasn't enough here -- `CellSuccessData<TData>` independently collapses to `any` when `TData` defaults to `any` (`Omit<any, K>` = `any`, `X & any` = `any`), so `CreateCellProps` needed its own fix:

- Threaded a `GQLResult` generic through `CreateCellProps<CellProps, CellVariables, GQLResult>`, typed `QUERY?: TypedDocumentNode<GQLResult, CellVariables> | DocumentNode | (...)`, so real Cells (generated with `QUERY: TypedDocumentNode<FindPost, FindPostVariables>`) now have `Loading`/`Failure`/`Empty`/`Success` checked against their *actual* query result and variables, inferred structurally at each `createCell({...})` call site -- no call site anywhere in the monorepo passes explicit generics, so this is purely additive inference.
- Threaded the same generic through `createCell`, `createFragmentCell`, `createServerCell`, and `createSuspendingCell`.
- Inside those generic factory functions, `GQLResult`/`CellVariables` are still abstract type parameters, so TS can't structurally verify that a runtime-assembled props object (built from untyped internals like `useQuery<DataObject>`'s result) satisfies the now-concrete `CellSuccessProps<GQLResult, CellVariables>` etc. Each JSX call site assembles its props into a local `const` and casts the whole object with `as any` at the boundary, documented with a comment explaining why -- this is an internal implementation-detail escape hatch, not a weakening of the public API (each Cell's own `Success`/`Failure`/etc. are still strictly checked against their real, inferred types at their own call site).
- `GQLResult` defaults to `any`, so Cells that don't (or can't) type their `QUERY` with `TypedDocumentNode` -- tests, Storybook, plain-string queries -- keep the pre-existing loose behavior instead of erroring.

Added a regression typetest (`createCell checks Success/Empty/Failure/Loading against the real QUERY type`) that builds a `TypedDocumentNode`-typed `QUERY` and confirms a `Success` requiring a prop the query result doesn't provide now raises a type error -- confirmed this fails without the fix and passes with it.

One `describe` block in `cellProps.test.tsx` (`what beforeQuery is allowed to return`) intentionally keeps its loosely-typed `Success` stand-in even after this fix: that block's fixture `Success` requires a `customProp` unrelated to what those tests check (`beforeQuery`'s return shape), so using the concretely-typed `recipeCell.Success` there fails for an unrelated, expected reason, not because of #2366.

## Test plan

- [x] `yarn test:types` in `packages/web` -- 21/21 pass (2 new)
- [x] Confirmed new regression tests fail without the fix and pass with it
- [x] `yarn vitest run src/components/cell` -- 40/40 pass
- [x] `yarn eslint` on changed files -- clean
- [x] `yarn build:types` and `yarn build` -- both succeed
