### PR TITLE
fix(cli): make sdl generate stub hint package-manager agnostic

### DIFF
--- a/packages/cli/src/commands/generate/sdl/sdlHandler.ts
+++ b/packages/cli/src/commands/generate/sdl/sdlHandler.ts
@@ -5,6 +5,7 @@ import camelcase from 'camelcase'
 import { Listr } from 'listr2'
 
 import { recordTelemetryAttributes, colors as c } from '@cedarjs/cli-helpers'
+import { formatCedarCommand } from '@cedarjs/cli-helpers/packageManager/display'
 import { generate as generateTypes } from '@cedarjs/internal/dist/generate/generate'
 import { getConfig } from '@cedarjs/project-config'
 import { errorTelemetry } from '@cedarjs/telemetry'
@@ -475,7 +476,9 @@ export const handler = async ({
       )
       console.log(c.info('To replace a stub with a full SDL and service, run'))
       for (const stubModel of missingModels) {
-        console.log(c.info(`  yarn cedar generate sdl ${stubModel}`))
+        console.log(
+          c.info(`  ${formatCedarCommand(['generate', 'sdl', stubModel])}`),
+        )
       }
     }
 


### PR DESCRIPTION
## Summary

- PR #2365 added a hint for replacing an SDL stub with a full SDL/service, but hard coded the command as `yarn cedar generate sdl <model>`.
- Uses `formatCedarCommand` from `@cedarjs/cli-helpers/packageManager/display` (the same helper used elsewhere in the generate commands, e.g. `cellHandler.ts`, `dbAuthHandler.ts`) so the hint respects the project's detected package manager (npm/pnpm/yarn) instead of always printing `yarn`.

## Test plan

- [x] `yarn workspace @cedarjs/cli exec tsc --noEmit -p .` — no new errors in `sdlHandler.ts`
- [x] `yarn vitest run src/commands/generate/sdl` (in `packages/cli`) — 67 tests passing