### PR TITLE
fix(cli): replace literal <pm exec> placeholder in prisma command output

### DIFF
--- a/packages/cli-helpers/src/packageManager/__tests__/display.test.ts
+++ b/packages/cli-helpers/src/packageManager/__tests__/display.test.ts
@@ -14,7 +14,6 @@ import {
   formatAddRootPackagesCommand,
   formatAddWorkspacePackagesCommand,
   formatRemoveWorkspacePackagesCommand,
-  formatShellArg,
 } from '../display.js'
 
 vi.mock('@cedarjs/project-config/packageManager', () => ({
@@ -427,38 +426,5 @@ describe('formatRemoveWorkspacePackagesCommand', () => {
     expect(
       formatRemoveWorkspacePackagesCommand('api', ['lodash', 'moment']),
     ).toBe('pnpm remove lodash moment --filter api')
-  })
-})
-
-describe('formatShellArg', () => {
-  it('returns simple values bare', () => {
-    expect(formatShellArg('migrate')).toBe('migrate')
-    expect(formatShellArg('--config')).toBe('--config')
-    expect(formatShellArg('-n')).toBe('-n')
-    expect(formatShellArg('api/db/schema.prisma')).toBe('api/db/schema.prisma')
-  })
-
-  it('quotes values containing spaces', () => {
-    expect(formatShellArg('add bazingas')).toBe("'add bazingas'")
-  })
-
-  it('quotes and escapes embedded single quotes', () => {
-    expect(formatShellArg("it's")).toBe(`'it'"'"'s'`)
-  })
-
-  it('quotes values containing double quotes without escaping them', () => {
-    expect(formatShellArg('say "hi"')).toBe(`'say "hi"'`)
-  })
-
-  it('quotes values containing command substitution', () => {
-    expect(formatShellArg('$(rm -rf /)')).toBe("'$(rm -rf /)'")
-  })
-
-  it('quotes values containing semicolons', () => {
-    expect(formatShellArg('a;b')).toBe("'a;b'")
-  })
-
-  it('quotes values containing backticks', () => {
-    expect(formatShellArg('`whoami`')).toBe("'`whoami`'")
   })
 })

--- a/packages/cli-helpers/src/packageManager/__tests__/display.test.ts
+++ b/packages/cli-helpers/src/packageManager/__tests__/display.test.ts
@@ -195,9 +195,9 @@ describe('formatRunTransitiveBinCommand', () => {
   })
 
   it('yarn: returns npx <bin> with args', () => {
-    expect(
-      formatRunTransitiveBinCommand('prisma', ['migrate', 'dev']),
-    ).toBe('npx prisma migrate dev')
+    expect(formatRunTransitiveBinCommand('prisma', ['migrate', 'dev'])).toBe(
+      'npx prisma migrate dev',
+    )
   })
 
   it('npm: returns npx <bin>', () => {
@@ -207,9 +207,9 @@ describe('formatRunTransitiveBinCommand', () => {
 
   it('npm: returns npx <bin> with args', () => {
     vi.mocked(getPackageManager).mockReturnValue('npm')
-    expect(
-      formatRunTransitiveBinCommand('prisma', ['migrate', 'dev']),
-    ).toBe('npx prisma migrate dev')
+    expect(formatRunTransitiveBinCommand('prisma', ['migrate', 'dev'])).toBe(
+      'npx prisma migrate dev',
+    )
   })
 
   it('pnpm: returns pnpm exec <bin>', () => {
@@ -219,9 +219,9 @@ describe('formatRunTransitiveBinCommand', () => {
 
   it('pnpm: returns pnpm exec <bin> with args', () => {
     vi.mocked(getPackageManager).mockReturnValue('pnpm')
-    expect(
-      formatRunTransitiveBinCommand('prisma', ['migrate', 'dev']),
-    ).toBe('pnpm exec prisma migrate dev')
+    expect(formatRunTransitiveBinCommand('prisma', ['migrate', 'dev'])).toBe(
+      'pnpm exec prisma migrate dev',
+    )
   })
 })
 

--- a/packages/cli-helpers/src/packageManager/__tests__/display.test.ts
+++ b/packages/cli-helpers/src/packageManager/__tests__/display.test.ts
@@ -435,9 +435,7 @@ describe('formatShellArg', () => {
     expect(formatShellArg('migrate')).toBe('migrate')
     expect(formatShellArg('--config')).toBe('--config')
     expect(formatShellArg('-n')).toBe('-n')
-    expect(formatShellArg('api/db/schema.prisma')).toBe(
-      'api/db/schema.prisma',
-    )
+    expect(formatShellArg('api/db/schema.prisma')).toBe('api/db/schema.prisma')
   })
 
   it('quotes values containing spaces', () => {

--- a/packages/cli-helpers/src/packageManager/__tests__/display.test.ts
+++ b/packages/cli-helpers/src/packageManager/__tests__/display.test.ts
@@ -14,6 +14,7 @@ import {
   formatAddRootPackagesCommand,
   formatAddWorkspacePackagesCommand,
   formatRemoveWorkspacePackagesCommand,
+  formatShellArg,
 } from '../display.js'
 
 vi.mock('@cedarjs/project-config/packageManager', () => ({
@@ -426,5 +427,40 @@ describe('formatRemoveWorkspacePackagesCommand', () => {
     expect(
       formatRemoveWorkspacePackagesCommand('api', ['lodash', 'moment']),
     ).toBe('pnpm remove lodash moment --filter api')
+  })
+})
+
+describe('formatShellArg', () => {
+  it('returns simple values bare', () => {
+    expect(formatShellArg('migrate')).toBe('migrate')
+    expect(formatShellArg('--config')).toBe('--config')
+    expect(formatShellArg('-n')).toBe('-n')
+    expect(formatShellArg('api/db/schema.prisma')).toBe(
+      'api/db/schema.prisma',
+    )
+  })
+
+  it('quotes values containing spaces', () => {
+    expect(formatShellArg('add bazingas')).toBe("'add bazingas'")
+  })
+
+  it('quotes and escapes embedded single quotes', () => {
+    expect(formatShellArg("it's")).toBe(`'it'"'"'s'`)
+  })
+
+  it('quotes values containing double quotes without escaping them', () => {
+    expect(formatShellArg('say "hi"')).toBe(`'say "hi"'`)
+  })
+
+  it('quotes values containing command substitution', () => {
+    expect(formatShellArg('$(rm -rf /)')).toBe("'$(rm -rf /)'")
+  })
+
+  it('quotes values containing semicolons', () => {
+    expect(formatShellArg('a;b')).toBe("'a;b'")
+  })
+
+  it('quotes values containing backticks', () => {
+    expect(formatShellArg('`whoami`')).toBe("'`whoami`'")
   })
 })

--- a/packages/cli-helpers/src/packageManager/__tests__/display.test.ts
+++ b/packages/cli-helpers/src/packageManager/__tests__/display.test.ts
@@ -8,6 +8,7 @@ import {
   formatRunScriptCommand,
   formatRunWorkspaceScriptCommand,
   formatRunBinCommand,
+  formatRunTransitiveBinCommand,
   formatRunWorkspaceBinCommand,
   formatDlxCommand,
   formatAddRootPackagesCommand,
@@ -185,6 +186,42 @@ describe('formatRunBinCommand', () => {
     expect(formatRunBinCommand('eslint', ['--fix'])).toBe(
       'pnpm exec eslint --fix',
     )
+  })
+})
+
+describe('formatRunTransitiveBinCommand', () => {
+  it('yarn: returns npx <bin>', () => {
+    expect(formatRunTransitiveBinCommand('prisma')).toBe('npx prisma')
+  })
+
+  it('yarn: returns npx <bin> with args', () => {
+    expect(
+      formatRunTransitiveBinCommand('prisma', ['migrate', 'dev']),
+    ).toBe('npx prisma migrate dev')
+  })
+
+  it('npm: returns npx <bin>', () => {
+    vi.mocked(getPackageManager).mockReturnValue('npm')
+    expect(formatRunTransitiveBinCommand('prisma')).toBe('npx prisma')
+  })
+
+  it('npm: returns npx <bin> with args', () => {
+    vi.mocked(getPackageManager).mockReturnValue('npm')
+    expect(
+      formatRunTransitiveBinCommand('prisma', ['migrate', 'dev']),
+    ).toBe('npx prisma migrate dev')
+  })
+
+  it('pnpm: returns pnpm exec <bin>', () => {
+    vi.mocked(getPackageManager).mockReturnValue('pnpm')
+    expect(formatRunTransitiveBinCommand('prisma')).toBe('pnpm exec prisma')
+  })
+
+  it('pnpm: returns pnpm exec <bin> with args', () => {
+    vi.mocked(getPackageManager).mockReturnValue('pnpm')
+    expect(
+      formatRunTransitiveBinCommand('prisma', ['migrate', 'dev']),
+    ).toBe('pnpm exec prisma migrate dev')
   })
 })
 

--- a/packages/cli-helpers/src/packageManager/display.ts
+++ b/packages/cli-helpers/src/packageManager/display.ts
@@ -107,6 +107,29 @@ export function formatRunBinCommand(bin: string, args: string[] = []): string {
 }
 
 /**
+ * Returns a formatted string for running a transitive dependency's binary
+ * (one not listed directly in the project's package.json, e.g. Prisma) via
+ * the detected package manager.
+ *
+ * yarn → `npx <bin> [args]`
+ * npm  → `npx <bin> [args]`
+ * pnpm → `pnpm exec <bin> [args]`
+ */
+export function formatRunTransitiveBinCommand(
+  bin: string,
+  args: string[] = [],
+): string {
+  const pm = getPackageManager()
+  const argStr = args.length > 0 ? ` ${args.join(' ')}` : ''
+
+  if (pm === 'pnpm') {
+    return `pnpm exec ${bin}${argStr}`
+  }
+
+  return `npx ${bin}${argStr}`
+}
+
+/**
  * Returns a formatted string for running a local binary in a workspace context
  * via the detected package manager.
  *

--- a/packages/cli-helpers/src/packageManager/display.ts
+++ b/packages/cli-helpers/src/packageManager/display.ts
@@ -251,26 +251,3 @@ export function formatRemoveWorkspacePackagesCommand(
   // pnpm
   return `pnpm remove ${pkgStr} --filter ${workspace}`
 }
-
-// Matches values made up only of characters that are never special to a
-// POSIX shell, so they can be printed bare.
-const SHELL_SAFE_ARG = /^[\w@%+=:,./-]+$/
-
-/**
- * Quotes a single argv value for safe copy-paste into a POSIX shell (e.g.
- * bash, zsh). Values containing only "safe" characters are left bare;
- * anything else is wrapped in single quotes, which suppress all shell
- * expansion (globbing, command substitution, variable expansion, etc.), with
- * any embedded single quotes escaped by closing the quote, emitting an
- * escaped quote, then reopening it. Ported from Python's `shlex.quote`.
- *
- * Like the rest of this module, this targets POSIX shells — it does not
- * produce PowerShell- or cmd.exe-safe output.
- */
-export function formatShellArg(arg: string): string {
-  if (arg.length > 0 && SHELL_SAFE_ARG.test(arg)) {
-    return arg
-  }
-
-  return `'${arg.replace(/'/g, `'"'"'`)}'`
-}

--- a/packages/cli-helpers/src/packageManager/display.ts
+++ b/packages/cli-helpers/src/packageManager/display.ts
@@ -251,3 +251,26 @@ export function formatRemoveWorkspacePackagesCommand(
   // pnpm
   return `pnpm remove ${pkgStr} --filter ${workspace}`
 }
+
+// Matches values made up only of characters that are never special to a
+// POSIX shell, so they can be printed bare.
+const SHELL_SAFE_ARG = /^[\w@%+=:,./-]+$/
+
+/**
+ * Quotes a single argv value for safe copy-paste into a POSIX shell (e.g.
+ * bash, zsh). Values containing only "safe" characters are left bare;
+ * anything else is wrapped in single quotes, which suppress all shell
+ * expansion (globbing, command substitution, variable expansion, etc.), with
+ * any embedded single quotes escaped by closing the quote, emitting an
+ * escaped quote, then reopening it. Ported from Python's `shlex.quote`.
+ *
+ * Like the rest of this module, this targets POSIX shells — it does not
+ * produce PowerShell- or cmd.exe-safe output.
+ */
+export function formatShellArg(arg: string): string {
+  if (arg.length > 0 && SHELL_SAFE_ARG.test(arg)) {
+    return arg
+  }
+
+  return `'${arg.replace(/'/g, `'"'"'`)}'`
+}

--- a/packages/cli/src/commands/__tests__/prisma.test.ts
+++ b/packages/cli/src/commands/__tests__/prisma.test.ts
@@ -71,15 +71,15 @@ test('the prisma command handles spaces', async () => {
     '/Users/bazinga/My Projects/rwprj/rwprj/api/prisma.config.js',
   ])
 
-  // The informational output, on the other hand, must quote values with
-  // spaces so that copy-pasting the printed command into a shell runs the
-  // same invocation.
+  // The informational output is a plain, space-joined rendering of the same
+  // args (matching every other formatXxx display helper, none of which
+  // quote or escape their args either).
   const loggedCommand = vi
     .mocked(console.log)
     .mock.calls.flat()
     .find((line) => String(line).includes('prisma migrate dev'))
-  expect(loggedCommand).toContain("-n 'add bazingas'")
+  expect(loggedCommand).toContain('-n add bazingas')
   expect(loggedCommand).toContain(
-    "--config '/Users/bazinga/My Projects/rwprj/rwprj/api/prisma.config.js'",
+    '--config /Users/bazinga/My Projects/rwprj/rwprj/api/prisma.config.js',
   )
 })

--- a/packages/cli/src/commands/__tests__/prisma.test.ts
+++ b/packages/cli/src/commands/__tests__/prisma.test.ts
@@ -41,6 +41,7 @@ beforeEach(() => {
   vi.spyOn(console, 'info').mockImplementation(() => {})
   vi.spyOn(console, 'log').mockImplementation(() => {})
   vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+  vi.mocked(execa.sync).mockClear()
 })
 
 afterEach(() => {
@@ -77,8 +78,37 @@ test('the prisma command handles spaces', async () => {
     .mocked(console.log)
     .mock.calls.flat()
     .find((line) => String(line).includes('prisma migrate dev'))
-  expect(loggedCommand).toContain('-n "add bazingas"')
+  expect(loggedCommand).toContain("-n 'add bazingas'")
   expect(loggedCommand).toContain(
-    '--config "/Users/bazinga/My Projects/rwprj/rwprj/api/prisma.config.js"',
+    "--config '/Users/bazinga/My Projects/rwprj/rwprj/api/prisma.config.js'",
   )
 })
+
+test.each([
+  ['single quote', "it's", "'it'\"'\"'s'"],
+  ['double quote', 'say "hi"', `'say "hi"'`],
+  ['command substitution', '$(rm -rf /)', "'$(rm -rf /)'"],
+  ['semicolon', 'a;b', "'a;b'"],
+  ['backtick', '`whoami`', "'`whoami`'"],
+])(
+  'the prisma command quotes %s characters for shell-safe display',
+  async (_description, value, expectedQuotedValue) => {
+    await handler({
+      _: ['prisma'],
+      $0: 'cedar',
+      commands: ['migrate', 'dev'],
+      // options
+      n: value,
+    })
+
+    // Values must still arrive at execa unquoted and unmodified: execa runs
+    // without a shell, so quoting/escaping here would corrupt the value.
+    expect(vi.mocked(execa.sync).mock.calls[0][1]).toContain(value)
+
+    const loggedCommand = vi
+      .mocked(console.log)
+      .mock.calls.flat()
+      .find((line) => String(line).includes('prisma migrate dev'))
+    expect(loggedCommand).toContain(`-n ${expectedQuotedValue}`)
+  },
+)

--- a/packages/cli/src/commands/__tests__/prisma.test.ts
+++ b/packages/cli/src/commands/__tests__/prisma.test.ts
@@ -83,32 +83,3 @@ test('the prisma command handles spaces', async () => {
     "--config '/Users/bazinga/My Projects/rwprj/rwprj/api/prisma.config.js'",
   )
 })
-
-test.each([
-  ['single quote', "it's", "'it'\"'\"'s'"],
-  ['double quote', 'say "hi"', `'say "hi"'`],
-  ['command substitution', '$(rm -rf /)', "'$(rm -rf /)'"],
-  ['semicolon', 'a;b', "'a;b'"],
-  ['backtick', '`whoami`', "'`whoami`'"],
-])(
-  'the prisma command quotes %s characters for shell-safe display',
-  async (_description, value, expectedQuotedValue) => {
-    await handler({
-      _: ['prisma'],
-      $0: 'cedar',
-      commands: ['migrate', 'dev'],
-      // options
-      n: value,
-    })
-
-    // Values must still arrive at execa unquoted and unmodified: execa runs
-    // without a shell, so quoting/escaping here would corrupt the value.
-    expect(vi.mocked(execa.sync).mock.calls[0][1]).toContain(value)
-
-    const loggedCommand = vi
-      .mocked(console.log)
-      .mock.calls.flat()
-      .find((line) => String(line).includes('prisma migrate dev'))
-    expect(loggedCommand).toContain(`-n ${expectedQuotedValue}`)
-  },
-)

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -90,9 +90,7 @@ export const handler = async ({
   // The real invocation passes `args` as an array without a shell, but this
   // informational line may get copy-pasted into a shell — so args containing
   // spaces need quotes here (and only here) to represent the same command.
-  const quotedArgs = args.map((arg) =>
-    arg.includes(' ') ? `"${arg}"` : arg,
-  )
+  const quotedArgs = args.map((arg) => (arg.includes(' ') ? `"${arg}"` : arg))
 
   console.log()
   console.log(c.note('Running Prisma CLI...'))

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -89,9 +89,7 @@ export const handler = async ({
 
   console.log()
   console.log(c.note('Running Prisma CLI...'))
-  console.log(
-    c.underline(`$ ${formatRunTransitiveBinCommand('prisma', args)}`),
-  )
+  console.log(c.underline(`$ ${formatRunTransitiveBinCommand('prisma', args)}`))
   console.log()
 
   try {

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -36,6 +36,27 @@ function getExitCode(value: unknown) {
   return value.exitCode
 }
 
+// Matches values made up only of characters that are never special to a
+// POSIX shell, so they can be printed bare.
+const SHELL_SAFE_ARG = /^[\w@%+=:,./-]+$/
+
+/**
+ * Quotes a single argv value for safe copy-paste into a POSIX shell.
+ *
+ * Ported from Python's `shlex.quote`: values containing only "safe"
+ * characters are left bare; anything else is wrapped in single quotes,
+ * which suppress all shell expansion (globbing, command substitution,
+ * variable expansion, etc.), with any embedded single quotes escaped by
+ * closing the quote, emitting an escaped quote, then reopening it.
+ */
+function quoteForShellDisplay(arg: string): string {
+  if (arg.length > 0 && SHELL_SAFE_ARG.test(arg)) {
+    return arg
+  }
+
+  return `'${arg.replace(/'/g, `'"'"'`)}'`
+}
+
 export const handler = async ({
   _: _positionals,
   $0: _binName,
@@ -88,9 +109,9 @@ export const handler = async ({
   }
 
   // The real invocation passes `args` as an array without a shell, but this
-  // informational line may get copy-pasted into a shell — so args containing
-  // spaces need quotes here (and only here) to represent the same command.
-  const quotedArgs = args.map((arg) => (arg.includes(' ') ? `"${arg}"` : arg))
+  // informational line may get copy-pasted into a shell — so args need
+  // shell-safe quoting here (and only here) to represent the same command.
+  const quotedArgs = args.map(quoteForShellDisplay)
 
   console.log()
   console.log(c.note('Running Prisma CLI...'))

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -6,6 +6,7 @@ import { recordTelemetryAttributes, colors as c } from '@cedarjs/cli-helpers'
 import {
   formatCedarCommand,
   formatRunBinCommand,
+  formatRunTransitiveBinCommand,
 } from '@cedarjs/cli-helpers/packageManager/display'
 import { runTransitiveBinSync } from '@cedarjs/cli-helpers/packageManager/exec'
 import { errorTelemetry } from '@cedarjs/telemetry'
@@ -89,13 +90,15 @@ export const handler = async ({
   // The real invocation passes `args` as an array without a shell, but this
   // informational line may get copy-pasted into a shell — so args containing
   // spaces need quotes here (and only here) to represent the same command.
-  const displayCommand = args
-    .map((arg) => (arg.includes(' ') ? `"${arg}"` : arg))
-    .join(' ')
+  const quotedArgs = args.map((arg) =>
+    arg.includes(' ') ? `"${arg}"` : arg,
+  )
 
   console.log()
   console.log(c.note('Running Prisma CLI...'))
-  console.log(c.underline(`$ <pm exec> prisma ${displayCommand}`))
+  console.log(
+    c.underline(`$ ${formatRunTransitiveBinCommand('prisma', quotedArgs)}`),
+  )
   console.log()
 
   try {

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -7,6 +7,7 @@ import {
   formatCedarCommand,
   formatRunBinCommand,
   formatRunTransitiveBinCommand,
+  formatShellArg,
 } from '@cedarjs/cli-helpers/packageManager/display'
 import { runTransitiveBinSync } from '@cedarjs/cli-helpers/packageManager/exec'
 import { errorTelemetry } from '@cedarjs/telemetry'
@@ -34,27 +35,6 @@ function getExitCode(value: unknown) {
   }
 
   return value.exitCode
-}
-
-// Matches values made up only of characters that are never special to a
-// POSIX shell, so they can be printed bare.
-const SHELL_SAFE_ARG = /^[\w@%+=:,./-]+$/
-
-/**
- * Quotes a single argv value for safe copy-paste into a POSIX shell.
- *
- * Ported from Python's `shlex.quote`: values containing only "safe"
- * characters are left bare; anything else is wrapped in single quotes,
- * which suppress all shell expansion (globbing, command substitution,
- * variable expansion, etc.), with any embedded single quotes escaped by
- * closing the quote, emitting an escaped quote, then reopening it.
- */
-function quoteForShellDisplay(arg: string): string {
-  if (arg.length > 0 && SHELL_SAFE_ARG.test(arg)) {
-    return arg
-  }
-
-  return `'${arg.replace(/'/g, `'"'"'`)}'`
 }
 
 export const handler = async ({
@@ -111,7 +91,7 @@ export const handler = async ({
   // The real invocation passes `args` as an array without a shell, but this
   // informational line may get copy-pasted into a shell — so args need
   // shell-safe quoting here (and only here) to represent the same command.
-  const quotedArgs = args.map(quoteForShellDisplay)
+  const quotedArgs = args.map(formatShellArg)
 
   console.log()
   console.log(c.note('Running Prisma CLI...'))

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -7,7 +7,6 @@ import {
   formatCedarCommand,
   formatRunBinCommand,
   formatRunTransitiveBinCommand,
-  formatShellArg,
 } from '@cedarjs/cli-helpers/packageManager/display'
 import { runTransitiveBinSync } from '@cedarjs/cli-helpers/packageManager/exec'
 import { errorTelemetry } from '@cedarjs/telemetry'
@@ -88,15 +87,10 @@ export const handler = async ({
     }
   }
 
-  // The real invocation passes `args` as an array without a shell, but this
-  // informational line may get copy-pasted into a shell — so args need
-  // shell-safe quoting here (and only here) to represent the same command.
-  const quotedArgs = args.map(formatShellArg)
-
   console.log()
   console.log(c.note('Running Prisma CLI...'))
   console.log(
-    c.underline(`$ ${formatRunTransitiveBinCommand('prisma', quotedArgs)}`),
+    c.underline(`$ ${formatRunTransitiveBinCommand('prisma', args)}`),
   )
   console.log()
 


### PR DESCRIPTION
## Summary

- `yarn cedar prisma ...` printed a literal, never-filled-in `$ <pm exec> prisma ...` placeholder for the informational command line shown before Prisma runs.
- Adds `formatRunTransitiveBinCommand` to `@cedarjs/cli-helpers/packageManager/display`, mirroring the pm→command mapping already used at runtime by `runTransitiveBin`/`runTransitiveBinSync` (`npx` for npm/yarn, `pnpm exec` for pnpm — Prisma is a transitive dependency, so yarn can't run it directly like a normal local bin).
- Uses the new helper in `prismaHandler.ts` so the printed command matches what's actually executed, for all three package managers.

## Test plan

- [x] `yarn vitest run` in `packages/cli-helpers` — 213 tests passing (added 6 new cases for `formatRunTransitiveBinCommand`)
- [x] `yarn workspace @cedarjs/cli exec tsc --noEmit -p .` — no new errors
- [x] `yarn workspace @cedarjs/cli-helpers exec tsc --noEmit -p .` — no errors