### PR TITLE
fix(cli): Improve neon setup DATABASE_URL handling

### DIFF
--- a/packages/cli/src/commands/setup/neon/__tests__/neonHandler.test.ts
+++ b/packages/cli/src/commands/setup/neon/__tests__/neonHandler.test.ts
@@ -262,6 +262,10 @@ describe('neon handler', () => {
     expect(envContent).toContain(
       'DATABASE_URL=postgresql://user:pass@ep-abc-pooler.neon.tech/db',
     )
+    // The stale `file:` entry must be replaced, not left in place alongside
+    // the new one — otherwise the next run would match it again and
+    // provision yet another database.
+    expect(envContent.match(/^DATABASE_URL=/gm)).toHaveLength(1)
   })
 
   it('provisions when the existing DATABASE_URL is blank', async () => {
@@ -282,6 +286,53 @@ describe('neon handler', () => {
     expect(envContent).toContain(
       'DATABASE_URL=postgresql://user:pass@ep-abc-pooler.neon.tech/db',
     )
+    expect(envContent.match(/^DATABASE_URL=/gm)).toHaveLength(1)
+  })
+
+  it('provisions when the existing DATABASE_URL is protocol-only with no host', async () => {
+    // `postgres://` and `postgresql://` alone parse as valid URLs (per
+    // `new URL()`) but have no host, so they're not usable connection
+    // strings — this must not be mistaken for "already configured".
+    seedSqliteProject()
+    memfsFs.writeFileSync(
+      path.join(BASE_PATH, '.env'),
+      'DATABASE_URL=postgres://\n',
+    )
+
+    await handler({ force: false })
+
+    expect(global.fetch).toHaveBeenCalled()
+    expect(Listr2Mock.skippedTaskTitles).not.toContain(
+      'Provisioning Neon database',
+    )
+
+    const envContent = memfsFs.readFileSync(
+      path.join(BASE_PATH, '.env'),
+      'utf-8',
+    )
+    expect(envContent).toContain(
+      'DATABASE_URL=postgresql://user:pass@ep-abc-pooler.neon.tech/db',
+    )
+    expect(envContent.match(/^DATABASE_URL=/gm)).toHaveLength(1)
+  })
+
+  it('skips provisioning when the existing DATABASE_URL is quoted', async () => {
+    // `readEnvVar` (used by the generic Postgres setup path) treats a
+    // quoted value as set without stripping the quotes, so the Neon
+    // detection needs to recognize the same shape rather than rejecting it
+    // on the leading `"`.
+    seedSqliteProject()
+    memfsFs.writeFileSync(
+      path.join(BASE_PATH, '.env'),
+      'DATABASE_URL="postgresql://existing/db"\n',
+    )
+
+    global.fetch = vi.fn()
+
+    await handler({ force: false })
+
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(Listr2Mock.skippedTaskTitles).toContain('Provisioning Neon database')
   })
 
   it('provisions again with --force even when DATABASE_URL is already set', async () => {

--- a/packages/cli/src/commands/setup/neon/__tests__/neonHandler.test.ts
+++ b/packages/cli/src/commands/setup/neon/__tests__/neonHandler.test.ts
@@ -238,6 +238,52 @@ describe('neon handler', () => {
     ).toContain("env('DATABASE_URL')")
   })
 
+  it('provisions when the existing DATABASE_URL is a SQLite file: path', async () => {
+    // A `file:` DATABASE_URL (e.g. carried over from .env.defaults) is not
+    // an already-configured Postgres connection string, so it must not
+    // trip the "already set" skip.
+    seedSqliteProject()
+    memfsFs.writeFileSync(
+      path.join(BASE_PATH, '.env'),
+      'DATABASE_URL=file:./db/dev.db\n',
+    )
+
+    await handler({ force: false })
+
+    expect(global.fetch).toHaveBeenCalled()
+    expect(Listr2Mock.skippedTaskTitles).not.toContain(
+      'Provisioning Neon database',
+    )
+
+    const envContent = memfsFs.readFileSync(
+      path.join(BASE_PATH, '.env'),
+      'utf-8',
+    )
+    expect(envContent).toContain(
+      'DATABASE_URL=postgresql://user:pass@ep-abc-pooler.neon.tech/db',
+    )
+  })
+
+  it('provisions when the existing DATABASE_URL is blank', async () => {
+    seedSqliteProject()
+    memfsFs.writeFileSync(path.join(BASE_PATH, '.env'), 'DATABASE_URL=\n')
+
+    await handler({ force: false })
+
+    expect(global.fetch).toHaveBeenCalled()
+    expect(Listr2Mock.skippedTaskTitles).not.toContain(
+      'Provisioning Neon database',
+    )
+
+    const envContent = memfsFs.readFileSync(
+      path.join(BASE_PATH, '.env'),
+      'utf-8',
+    )
+    expect(envContent).toContain(
+      'DATABASE_URL=postgresql://user:pass@ep-abc-pooler.neon.tech/db',
+    )
+  })
+
   it('provisions again with --force even when DATABASE_URL is already set', async () => {
     seedSqliteProject()
     memfsFs.writeFileSync(

--- a/packages/cli/src/commands/setup/neon/neonHandler.ts
+++ b/packages/cli/src/commands/setup/neon/neonHandler.ts
@@ -45,11 +45,17 @@ export async function handler({ force }: Args) {
   // `process.env` on every CLI invocation regardless of whether Postgres
   // has been configured. Checking `process.env` would make this guard
   // permanently true and skip provisioning on every fresh project.
+  //
+  // The value is inspected too, not just the key's presence — a `file:`
+  // SQLite path (e.g. from `.env.defaults`) or a blank value must not be
+  // mistaken for an already-configured Postgres connection string.
   let hasExistingDatabaseUrl = false
   if (fs.existsSync(envPath)) {
-    hasExistingDatabaseUrl = /^DATABASE_URL=/m.test(
-      fs.readFileSync(envPath, 'utf-8'),
-    )
+    const match = fs
+      .readFileSync(envPath, 'utf-8')
+      .match(/^DATABASE_URL=(.*)$/m)
+    hasExistingDatabaseUrl =
+      !!match?.[1] && /^postgres(ql)?:\/\//.test(match[1].trim())
   }
 
   // Provisioning a new database when one is already configured would orphan

--- a/packages/cli/src/commands/setup/neon/neonHandler.ts
+++ b/packages/cli/src/commands/setup/neon/neonHandler.ts
@@ -23,6 +23,33 @@ interface NeonCtx {
   directDatabaseUrlNotSet?: boolean
 }
 
+// Mirrors how dotenv-style tooling (and `readEnvVar` in postgresHandler.ts)
+// treats a single layer of matching quotes around a value, then requires
+// what's left to actually parse as a Postgres URL with a host — rejecting
+// protocol-only values like `postgres://` that `new URL()` accepts but
+// Neon/Prisma can't connect with.
+function isPostgresConnectionString(rawValue: string): boolean {
+  let value = rawValue.trim()
+  const quoted = value.match(/^(['"])(.*)\1$/)
+  if (quoted) {
+    value = quoted[2]
+  }
+
+  if (!value) {
+    return false
+  }
+
+  try {
+    const url = new URL(value)
+    return (
+      (url.protocol === 'postgres:' || url.protocol === 'postgresql:') &&
+      !!url.hostname
+    )
+  } catch {
+    return false
+  }
+}
+
 export async function handler({ force }: Args) {
   const cedarPaths = getPaths()
 
@@ -47,15 +74,16 @@ export async function handler({ force }: Args) {
   // permanently true and skip provisioning on every fresh project.
   //
   // The value is inspected too, not just the key's presence — a `file:`
-  // SQLite path (e.g. from `.env.defaults`) or a blank value must not be
-  // mistaken for an already-configured Postgres connection string.
+  // SQLite path (e.g. from `.env.defaults`), a blank value, or a malformed
+  // one (e.g. `postgres://` with no host) must not be mistaken for an
+  // already-configured Postgres connection string.
   let hasExistingDatabaseUrl = false
   if (fs.existsSync(envPath)) {
     const match = fs
       .readFileSync(envPath, 'utf-8')
       .match(/^DATABASE_URL=(.*)$/m)
     hasExistingDatabaseUrl =
-      !!match?.[1] && /^postgres(ql)?:\/\//.test(match[1].trim())
+      !!match?.[1] && isPostgresConnectionString(match[1])
   }
 
   // Provisioning a new database when one is already configured would orphan
@@ -225,16 +253,18 @@ export async function handler({ force }: Args) {
           if (fs.existsSync(envPath)) {
             envContent = fs.readFileSync(envPath, 'utf-8')
 
-            if (force) {
-              // Filter out existing DATABASE_URL and DIRECT_DATABASE_URL lines
-              const lines = envContent.split('\n')
-              const filtered = lines.filter(
-                (line) =>
-                  !line.startsWith('DATABASE_URL=') &&
-                  !line.startsWith('DIRECT_DATABASE_URL='),
-              )
-              envContent = filtered.join('\n').trimEnd()
-            }
+            // This task only runs when provisioning wasn't skipped — either
+            // --force was passed, or there was no usable DATABASE_URL to
+            // begin with (absent, blank, SQLite, or malformed). In every
+            // case any existing DATABASE_URL/DIRECT_DATABASE_URL lines are
+            // stale and must be replaced, not appended alongside.
+            const lines = envContent.split('\n')
+            const filtered = lines.filter(
+              (line) =>
+                !line.startsWith('DATABASE_URL=') &&
+                !line.startsWith('DIRECT_DATABASE_URL='),
+            )
+            envContent = filtered.join('\n').trimEnd()
 
             if (envContent && !envContent.endsWith('\n')) {
               envContent += '\n'


### PR DESCRIPTION
Fixes #2336

Provision a new neon db when the existing `DATABASE_URL` is sqlite or blank