### PR TITLE
docs(deploy): Add server file note to any-container-host etc docs

### DIFF
--- a/docs/docs/deploy/any-container-host.md
+++ b/docs/docs/deploy/any-container-host.md
@@ -57,6 +57,17 @@ So the setup on any of these platforms is: connect the repo, point the build
 command at `yarn build`, point the start command at `yarn start`, add a
 `DATABASE_URL`. Nothing Cedar-specific beyond that.
 
+## Custom server file caveat
+
+If your app has a custom [server file](../server-file.md)
+(`api/src/server.ts`), `start` won't work on any of these platforms — a
+custom server file is a Fastify concept with no equivalent in the
+single-container in-process server, so it refuses to start rather than
+silently skipping what you configured. You'll need the
+[two-service topology](./introduction.md#two-topologies-and-which-to-pick)
+instead, which means per-platform wiring — see
+[Railway](./railway.md) and [Coolify](./coolify.md).
+
 ## devDependency pruning caveat
 
 Two platforms in the list above strip `devDependencies` after the build step

--- a/docs/docs/deploy/coolify.md
+++ b/docs/docs/deploy/coolify.md
@@ -36,6 +36,17 @@ running container:
 yarn cedar prisma migrate deploy
 ```
 
+## Custom server file
+
+If your app has a custom [server file](../server-file.md) (`api/src/server.ts`),
+single-service won't work — a custom server file is a Fastify concept with no
+equivalent in the single-container in-process server, so `start` refuses to
+start rather than silently skipping what you configured (Realtime, custom
+plugins, custom middleware). Skip straight to
+[scaling up to two services](#scaling-up-two-services-the-coolify-way) below,
+and set the api service's start command to `yarn start:api` — that path does
+run the server file.
+
 ## Scaling up: two services, the Coolify way
 
 This is what sets Coolify apart from the other platforms on the

--- a/docs/docs/deploy/introduction.md
+++ b/docs/docs/deploy/introduction.md
@@ -54,6 +54,14 @@ Once you're past `cedar dev`, there are two ways to run Cedar in production:
 
 Start with single-container — it's the fastest way to get a working deploy, and for small apps or early-stage projects it's often all you need. Move to the two-part topology when you want your web assets served from a CDN edge (rather than round-tripping through your api process), or when you want to scale the api and web sides independently. The reason this needs to be stated explicitly: without it, it's easy to land on single-container, get a working app, and never learn why the split is worth doing later.
 
+:::important
+If your app has a custom [server file](../server-file.md) (`api/src/server.ts`),
+single-container isn't an option — it's a Fastify concept with no equivalent in
+the single-container in-process server, so `yarn start` refuses to start rather
+than silently skipping what you configured. Use the two-service topology
+(`yarn start:api` / `yarn start:web`) instead.
+:::
+
 ## General Deployment Setup
 
 Deploying Cedar requires setup for the following four categories.

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -36,6 +36,17 @@ yarn cedar prisma migrate deploy
 Railway runs this once per deploy, before traffic is switched over, which is a
 better fit than trying to run migrations from inside `start`.
 
+## Custom server file
+
+If your app has a custom [server file](../server-file.md) (`api/src/server.ts`),
+single-service won't work — a custom server file is a Fastify concept with no
+equivalent in the single-container in-process server, so `start` refuses to
+start rather than silently skipping what you configured (Realtime, custom
+plugins, custom middleware). Skip straight to
+[scaling up to two services](#scaling-up-two-services) below, and set the api
+service's start command to `yarn start:api` — that path does run the server
+file.
+
 ## Enabling Railway's CDN
 
 Railway's CDN is per-service, free on all plans, and caches static assets by

--- a/docs/docs/server-file.md
+++ b/docs/docs/server-file.md
@@ -40,6 +40,17 @@ With the server file, there's no indirection. Just use `node`:
 yarn node api/dist/server.js
 ```
 
+:::important
+A custom server file is a Fastify concept, and isn't supported when serving
+both sides from one process — the single-container topology (`yarn start` /
+`cedar serve` / `cedarjs-server` with no side argument). If Cedar detects a
+built server file in that mode, it refuses to start rather than silently
+skipping what you configured (Realtime, custom plugins, custom middleware).
+Use the [two-service topology](./deploy/introduction.md#two-topologies-and-which-to-pick)
+instead: run the api and web sides as separate processes with
+`cedarjs-server api` / `cedarjs-server web` (`yarn start:api` / `yarn start:web`).
+:::
+
 ### Building
 
 You can't run the server file directly with Node.js; it has to be built first:


### PR DESCRIPTION
For server-file support you have to deploy using the two containers topology