### PR TITLE
fix(cca): use CedarLoggerOptions in template comments

### DIFF
--- a/__fixtures__/empty-project/api/src/lib/logger.ts
+++ b/__fixtures__/empty-project/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/__fixtures__/rsc-caching/api/src/lib/logger.ts
+++ b/__fixtures__/rsc-caching/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/__fixtures__/test-project-esm/api/src/lib/logger.ts
+++ b/__fixtures__/test-project-esm/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/__fixtures__/test-project-live/api/src/lib/logger.ts
+++ b/__fixtures__/test-project-live/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/__fixtures__/test-project-pnpm/api/src/lib/logger.ts
+++ b/__fixtures__/test-project-pnpm/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/__fixtures__/test-project-rsa/api/src/lib/logger.ts
+++ b/__fixtures__/test-project-rsa/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/__fixtures__/test-project-rsc-kitchen-sink/api/src/lib/logger.ts
+++ b/__fixtures__/test-project-rsc-kitchen-sink/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/__fixtures__/test-project/api/src/lib/logger.ts
+++ b/__fixtures__/test-project/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/local-testing-project-live/api/src/lib/logger.ts
+++ b/local-testing-project-live/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/local-testing-project/api/src/lib/logger.ts
+++ b/local-testing-project/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/packages/create-cedar-app/templates/esm-js/api/src/lib/logger.js
+++ b/packages/create-cedar-app/templates/esm-js/api/src/lib/logger.js
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/packages/create-cedar-app/templates/esm-ts/api/src/lib/logger.ts
+++ b/packages/create-cedar-app/templates/esm-ts/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/packages/create-cedar-app/templates/js/api/src/lib/logger.js
+++ b/packages/create-cedar-app/templates/js/api/src/lib/logger.js
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/packages/create-cedar-app/templates/ts/api/src/lib/logger.ts
+++ b/packages/create-cedar-app/templates/ts/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization

--- a/packages/prerender/src/graphql/__tests__/__fixtures__/node-runner/cedar-app/api/src/lib/logger.ts
+++ b/packages/prerender/src/graphql/__tests__/__fixtures__/node-runner/cedar-app/api/src/lib/logger.ts
@@ -1,15 +1,15 @@
 import { createLogger } from '@cedarjs/api/logger'
 
 /**
- * Creates a logger with RedwoodLoggerOptions
+ * Creates a logger with CedarLoggerOptions
  *
  * These extend and override default LoggerOptions,
  * can define a destination like a file or other supported pino log transport stream,
  * and sets whether or not to show the logger configuration settings (defaults to false)
  *
- * @param RedwoodLoggerOptions
+ * @param CedarLoggerOptions
  *
- * RedwoodLoggerOptions have
+ * CedarLoggerOptions have
  * @param {options} LoggerOptions - defines how to log, such as redaction and format
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization


### PR DESCRIPTION
- Updates the JSDoc comments in the create-cedar-app `api/src/lib/logger.{js,ts}` templates (js, ts, esm-js, esm-ts) to reference `CedarLoggerOptions` instead of the deprecated `RedwoodLoggerOptions`.
- `CedarLoggerOptions` is already the canonical exported type in `@cedarjs/api`'s logger module; `RedwoodLoggerOptions` is kept only as a deprecated alias. These templates were just lagging behind in their comments — no code/type changes, doc-only.