### PR TITLE
docs(deploy): Clarify start:web's role and apiUrl vs apiProxyTarget

### DIFF
--- a/docs/docs/deploy/introduction.md
+++ b/docs/docs/deploy/introduction.md
@@ -38,19 +38,73 @@ There are examples of deploying CedarJS on other providers such as Google Cloud 
 | Command                | Role                                                                                                                                                                 |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cedar serve api`      | Production. Web side served separately — by nginx, a CDN, or a static host.                                                                                          |
-| `cedar serve web`      | Production, behind a CDN or reverse proxy. Proxies API requests to `cedar serve api`.                                                                                |
+| `cedar serve web`      | Local production-like testing of the web side. Not a recommended production topology on its own — see below.                                                         |
 | `cedar serve`          | Single-container: both sides in one process. Also useful for local production-like testing.                                                                          |
 | `cedar serve api --ud` | Production, using [Universal Deploy](./universal-deploy.md). Runs `api/dist/ud/index.js` via [srvx](https://github.com/h3js/srvx), behind a reverse proxy.           |
 | `cedar serve --ud`     | Local production-like testing only, for a Universal Deploy build. Not a production topology — see [Universal Deploy](./universal-deploy.md#deploying-to-a-provider). |
 
 The generated `package.json` scripts map onto these: `start` is `cedar serve` (single-container), `start:api` is `cedar serve api`, `start:web` is `cedar serve web`.
 
+`cedar serve web` / `yarn start:web` is primarily a local tool — it lets you run
+the web side standalone to test how it behaves in production mode before
+deploying. Reach for it in production only as a fallback: if your platform has
+no way to host `web/dist` as static files (no CDN, no static build pack),
+running it as a Fastify process via `start:web` is the way to get the
+two-service topology working there anyway — see
+[Railway](./railway.md#scaling-up-two-services), which does exactly this.
+
+When you do run it against a separate api process, point it there with
+`--apiProxyTarget`, a fully-qualified URL:
+
+```shell
+yarn start:web --apiProxyTarget=https://api.example.com
+```
+
+This is a CLI-flag-only option — there's no `cedar.toml` or environment variable
+equivalent. It's required whenever `apiUrl` is a relative path (the default):
+without it, `apiUrl` has nothing to proxy through and API calls get a 502 Bad
+Gateway response. The alternative is to skip the proxy entirely — set `apiUrl`
+in `cedar.toml` to a fully-qualified URL pointing directly at the api service,
+so the browser calls it directly instead of routing through the web process.
+That's what static-hosting setups do, since there's no Fastify process there to
+pass `--apiProxyTarget` to — see
+[Coolify](./coolify.md#scaling-up-two-services-the-coolify-way) for that
+approach.
+
+### Relative `apiUrl` + proxy, or absolute `apiUrl` + CORS?
+
+`apiUrl` and `apiProxyTarget` aren't two competing ways to do the same thing —
+`apiUrl` always determines what URL the browser calls (it's baked into the web
+bundle at build time, so changing it means rebuilding); `apiProxyTarget` only
+matters if you keep `apiUrl` relative, since then something has to be
+listening on that path to forward the request to the api process. The actual
+choice is between two setups:
+
+|                | Relative `apiUrl` + `start:web` proxy | Absolute `apiUrl`, no proxy                                                                                                                                                                          |
+| -------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Requires       | Running web as a Node process         | Nothing extra — works with pure static/CDN hosting                                                                                                                                                   |
+| Browser sees   | Same-origin                           | Cross-origin                                                                                                                                                                                         |
+| CORS / cookies | None needed                           | Required — see [CORS](../cors.md): GraphQL and auth-function `cors`, cookie `SameSite: 'None'` + `Secure`, and `credentials: 'include'` on both the Apollo and dbAuth clients if you're using dbAuth |
+
+Prefer absolute `apiUrl` when your platform can serve static files (a CDN,
+Coolify's Static build pack, Netlify, etc.) — you avoid running a Node process
+just to serve static assets, and you get real edge caching, at the one-time
+cost of the CORS/cookie setup above. Prefer the relative `apiUrl` + proxy setup
+when your platform can't do static hosting (Railway, for example) — you're
+already running `start:web` as a Node process there, so the proxy is free and
+you skip the CORS/cookie configuration entirely.
+
 ## Two topologies, and which to pick
 
 Once you're past `cedar dev`, there are two ways to run Cedar in production:
 
 - **Single-container** (`yarn start`) — one process serves both sides; the web server proxies API requests to the API in-process. This is the **convenient** path: no service-to-service wiring, so it works with zero configuration on any container host — see [any container host](./any-container-host.md).
-- **api process + static/CDN web** (`yarn start:api`, with the web side served separately) — this is the **recommended** path, and what the generated Dockerfile, the baremetal nginx setup, and the Render blueprint all use.
+- **api process + static/CDN web** (`yarn start:api`, with the web side served
+  separately) — this is the **recommended** path, and what the generated
+  Dockerfile, the baremetal nginx setup, and the Render blueprint all use.
+  "Served separately" usually means static/CDN hosting rather than a Node
+  process; reach for `yarn start:web` there only if your platform doesn't offer
+  static hosting — see the note on `cedar serve web` above.
 
 Start with single-container — it's the fastest way to get a working deploy, and for small apps or early-stage projects it's often all you need. Move to the two-part topology when you want your web assets served from a CDN edge (rather than round-tripping through your api process), or when you want to scale the api and web sides independently. The reason this needs to be stated explicitly: without it, it's easy to land on single-container, get a working app, and never learn why the split is worth doing later.
 

--- a/docs/docs/deploy/introduction.md
+++ b/docs/docs/deploy/introduction.md
@@ -82,10 +82,10 @@ matters if you keep `apiUrl` relative, since then something has to be
 listening on that path to forward the request to the api process. The actual
 choice is between two setups:
 
-|                | Relative `apiUrl` + `start:web` proxy | Absolute `apiUrl`, no proxy                                                                                                                                                                          |
-| -------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Requires       | Running web as a Node process         | Nothing extra — works with pure static/CDN hosting                                                                                                                                                   |
-| Browser sees   | Same-origin                           | Cross-origin                                                                                                                                                                                         |
+|                | Relative `apiUrl` + `start:web` proxy | Absolute `apiUrl`, no proxy                                                                                                                                                                                                                                   |
+| -------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Requires       | Running web as a Node process         | Nothing extra — works with pure static/CDN hosting                                                                                                                                                                                                            |
+| Browser sees   | Same-origin                           | Cross-origin                                                                                                                                                                                                                                                  |
 | CORS / cookies | None needed                           | Required if the web and api origins differ (the common case here) — see [CORS](../cors.md): GraphQL and auth-function `cors`, cookie `SameSite: 'None'` + `Secure`, and `credentials: 'include'` on both the Apollo and dbAuth clients if you're using dbAuth |
 
 Prefer absolute `apiUrl` when your platform can reliably serve `web/dist` as

--- a/docs/docs/deploy/introduction.md
+++ b/docs/docs/deploy/introduction.md
@@ -47,10 +47,12 @@ The generated `package.json` scripts map onto these: `start` is `cedar serve` (s
 
 `cedar serve web` / `yarn start:web` is primarily a local tool — it lets you run
 the web side standalone to test how it behaves in production mode before
-deploying. Reach for it in production only as a fallback: if your platform has
-no way to host `web/dist` as static files (no CDN, no static build pack),
-running it as a Fastify process via `start:web` is the way to get the
-two-service topology working there anyway — see
+deploying. In production it's the documented Cedar path for the two-service
+topology, but not a hard requirement everywhere — if your platform can reliably
+serve `web/dist` as static files (a CDN, a static build pack, or your own
+Caddy/nginx/Dockerfile service), that's leaner than running a Node process just
+to serve static assets. Where that isn't practical, running `start:web` gets
+you the two-service topology anyway — see
 [Railway](./railway.md#scaling-up-two-services), which does exactly this.
 
 When you do run it against a separate api process, point it there with
@@ -84,15 +86,18 @@ choice is between two setups:
 | -------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Requires       | Running web as a Node process         | Nothing extra — works with pure static/CDN hosting                                                                                                                                                   |
 | Browser sees   | Same-origin                           | Cross-origin                                                                                                                                                                                         |
-| CORS / cookies | None needed                           | Required — see [CORS](../cors.md): GraphQL and auth-function `cors`, cookie `SameSite: 'None'` + `Secure`, and `credentials: 'include'` on both the Apollo and dbAuth clients if you're using dbAuth |
+| CORS / cookies | None needed                           | Required if the web and api origins differ (the common case here) — see [CORS](../cors.md): GraphQL and auth-function `cors`, cookie `SameSite: 'None'` + `Secure`, and `credentials: 'include'` on both the Apollo and dbAuth clients if you're using dbAuth |
 
-Prefer absolute `apiUrl` when your platform can serve static files (a CDN,
-Coolify's Static build pack, Netlify, etc.) — you avoid running a Node process
-just to serve static assets, and you get real edge caching, at the one-time
-cost of the CORS/cookie setup above. Prefer the relative `apiUrl` + proxy setup
-when your platform can't do static hosting (Railway, for example) — you're
-already running `start:web` as a Node process there, so the proxy is free and
-you skip the CORS/cookie configuration entirely.
+Prefer absolute `apiUrl` when your platform can reliably serve `web/dist` as
+static files (a CDN, Coolify's Static build pack, Netlify, etc.) — you avoid
+running a Node process just to serve static assets, and you get real edge
+caching, at the one-time cost of the CORS/cookie setup above. Prefer the
+relative `apiUrl` + proxy setup when static hosting for your build output isn't
+a reliable option on your platform (Railway's monorepo subdirectory support is
+flaky enough that its own guides recommend a hand-rolled Caddy/Dockerfile setup
+instead — see [Railway](./railway.md#scaling-up-two-services)) — you're already
+running `start:web` as a Node process there, so the proxy is free and you skip
+the CORS/cookie configuration entirely.
 
 ## Two topologies, and which to pick
 

--- a/docs/docs/deploy/introduction.md
+++ b/docs/docs/deploy/introduction.md
@@ -45,42 +45,27 @@ There are examples of deploying CedarJS on other providers such as Google Cloud 
 
 The generated `package.json` scripts map onto these: `start` is `cedar serve` (single-container), `start:api` is `cedar serve api`, `start:web` is `cedar serve web`.
 
-`cedar serve web` / `yarn start:web` is primarily a local tool — it lets you run
-the web side standalone to test how it behaves in production mode before
-deploying. In production it's the documented Cedar path for the two-service
-topology, but not a hard requirement everywhere — if your platform can reliably
-serve `web/dist` as static files (a CDN, a static build pack, or your own
-Caddy/nginx/Dockerfile service), that's leaner than running a Node process just
-to serve static assets. Where that isn't practical, running `start:web` gets
-you the two-service topology anyway — see
-[Railway](./railway.md#scaling-up-two-services), which does exactly this.
+`cedar serve web` / `yarn start:web` is primarily a local tool, for testing
+the web side in production mode before deploying. In production, use it only
+if your platform can't reliably serve `web/dist` as static files — see
+[Railway](./railway.md#scaling-up-two-services).
 
-When you do run it against a separate api process, point it there with
-`--apiProxyTarget`, a fully-qualified URL:
+Point it at a separate api process with `--apiProxyTarget`, a fully-qualified
+URL (CLI-flag only — no `cedar.toml` or environment variable equivalent):
 
 ```shell
 yarn start:web --apiProxyTarget=https://api.example.com
 ```
 
-This is a CLI-flag-only option — there's no `cedar.toml` or environment variable
-equivalent. It's required whenever `apiUrl` is a relative path (the default):
-without it, `apiUrl` has nothing to proxy through and API calls get a 502 Bad
-Gateway response. The alternative is to skip the proxy entirely — set `apiUrl`
-in `cedar.toml` to a fully-qualified URL pointing directly at the api service,
-so the browser calls it directly instead of routing through the web process.
-That's what static-hosting setups do, since there's no Fastify process there to
-pass `--apiProxyTarget` to — see
-[Coolify](./coolify.md#scaling-up-two-services-the-coolify-way) for that
-approach.
+Required whenever `apiUrl` is relative (the default); otherwise API calls get
+a 502. The alternative is an absolute `apiUrl` with no proxy — see
+[Coolify](./coolify.md#scaling-up-two-services-the-coolify-way).
 
 ### Relative `apiUrl` + proxy, or absolute `apiUrl` + CORS?
 
-`apiUrl` and `apiProxyTarget` aren't two competing ways to do the same thing —
-`apiUrl` always determines what URL the browser calls (it's baked into the web
-bundle at build time, so changing it means rebuilding); `apiProxyTarget` only
-matters if you keep `apiUrl` relative, since then something has to be
-listening on that path to forward the request to the api process. The actual
-choice is between two setups:
+`apiUrl` (baked into the web bundle at build time) always determines what URL
+the browser calls; `apiProxyTarget` only matters if you keep `apiUrl`
+relative. The choice is between two setups:
 
 |                | Relative `apiUrl` + `start:web` proxy | Absolute `apiUrl`, no proxy                                                                                                                                                                                                                                   |
 | -------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -89,27 +74,16 @@ choice is between two setups:
 | CORS / cookies | None needed                           | Required if the web and api origins differ (the common case here) — see [CORS](../cors.md): GraphQL and auth-function `cors`, cookie `SameSite: 'None'` + `Secure`, and `credentials: 'include'` on both the Apollo and dbAuth clients if you're using dbAuth |
 
 Prefer absolute `apiUrl` when your platform can reliably serve `web/dist` as
-static files (a CDN, Coolify's Static build pack, Netlify, etc.) — you avoid
-running a Node process just to serve static assets, and you get real edge
-caching, at the one-time cost of the CORS/cookie setup above. Prefer the
-relative `apiUrl` + proxy setup when static hosting for your build output isn't
-a reliable option on your platform (Railway's monorepo subdirectory support is
-flaky enough that its own guides recommend a hand-rolled Caddy/Dockerfile setup
-instead — see [Railway](./railway.md#scaling-up-two-services)) — you're already
-running `start:web` as a Node process there, so the proxy is free and you skip
-the CORS/cookie configuration entirely.
+static files (a CDN, Coolify's Static build pack, Netlify, etc.). Prefer the
+relative `apiUrl` + proxy setup when it can't — see
+[Railway](./railway.md#scaling-up-two-services).
 
 ## Two topologies, and which to pick
 
 Once you're past `cedar dev`, there are two ways to run Cedar in production:
 
 - **Single-container** (`yarn start`) — one process serves both sides; the web server proxies API requests to the API in-process. This is the **convenient** path: no service-to-service wiring, so it works with zero configuration on any container host — see [any container host](./any-container-host.md).
-- **api process + static/CDN web** (`yarn start:api`, with the web side served
-  separately) — this is the **recommended** path, and what the generated
-  Dockerfile, the baremetal nginx setup, and the Render blueprint all use.
-  "Served separately" usually means static/CDN hosting rather than a Node
-  process; reach for `yarn start:web` there only if your platform doesn't offer
-  static hosting — see the note on `cedar serve web` above.
+- **api process + static/CDN web** (`yarn start:api`, with the web side served separately) — this is the **recommended** path, and what the generated Dockerfile, the baremetal nginx setup, and the Render blueprint all use.
 
 Start with single-container — it's the fastest way to get a working deploy, and for small apps or early-stage projects it's often all you need. Move to the two-part topology when you want your web assets served from a CDN edge (rather than round-tripping through your api process), or when you want to scale the api and web sides independently. The reason this needs to be stated explicitly: without it, it's easy to land on single-container, get a working app, and never learn why the split is worth doing later.
 

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -78,6 +78,10 @@ To split into the
    start commands already run in a shell, so `$VAR` expansion works with no
    extra wrapping):
 
+   `RAILWAY_PUBLIC_DOMAIN` only exists for a service once it has a public
+   domain — Railway doesn't assign one automatically. On the api service, go
+   to **Settings → Networking** and generate a domain first.
+
    - Web service **Variables** tab: `API_PROXY_TARGET=${{api.RAILWAY_PUBLIC_DOMAIN}}`
    - Web service start command:
 

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -99,9 +99,14 @@ To split into the
      ```
 
    For private networking instead — keeps this traffic off the public
-   internet, at the cost of needing `http://` since Railway's private network
-   doesn't terminate TLS — reference the api service's private domain and
-   port the same way:
+   internet, and off the public domain's TLS termination too, since Railway
+   doesn't provision TLS certs for `*.railway.internal` domains. That's not a
+   security downside: Railway's private network is already encrypted in
+   transit at the WireGuard layer, so app-level TLS on top would be
+   redundant — Railway's own docs recommend `http://` here for exactly that
+   reason. The practical cost is just that you can't reuse an `https://` URL
+   — reference the api service's private domain and port the same way, using
+   `http://`:
 
    - Api service **Variables** tab: add a fixed `PORT` (e.g. `8911`). Cedar's
      api server binds to whatever `PORT` is set to, and Railway's automatic

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -68,24 +68,47 @@ To split into the
    Caddyfile or a Node-build/Caddy-serve Dockerfile instead of relying on it.
    `start:web` is the documented Cedar path here (unlike
    [Coolify](./coolify.md), which has a dedicated Static build pack that
-   handles this cleanly): set the web service's start command to pass
-   `--api-proxy-target`, a fully-qualified URL (scheme required) pointing at
-   the api service.
+   handles this cleanly): point it at the api service with
+   `--api-proxy-target`, a fully-qualified URL (scheme required).
 
-   ```shell
-   yarn start:web --api-proxy-target=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
-   ```
+   Railway's `${{Service.VAR}}` reference syntax only resolves inside a
+   service's **Variables** tab — it isn't substituted if you paste it directly
+   into the Start Command field. So define the target as a variable first,
+   then read it from the start command as a normal shell variable (Railpack
+   start commands already run in a shell, so `$VAR` expansion works with no
+   extra wrapping):
 
-   Swap in `http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}` to keep this
-   traffic off the public internet instead (Railway's private network doesn't
-   terminate TLS, so use `http://`). The port is required here —
+   - Web service **Variables** tab: `API_PROXY_TARGET=${{api.RAILWAY_PUBLIC_DOMAIN}}`
+   - Web service start command:
+
+     ```shell
+     yarn start:web --api-proxy-target="https://$API_PROXY_TARGET"
+     ```
+
+   For private networking instead — keeps this traffic off the public
+   internet, at the cost of needing `http://` since Railway's private network
+   doesn't terminate TLS — reference the api service's private domain and
+   port the same way:
+
+   - Api service **Variables** tab: add a fixed `PORT` (e.g. `8911`). Cedar's
+     api server binds to whatever `PORT` is set to, and Railway's automatic
+     runtime port assignment isn't itself referenceable from another
+     service — `${{api.PORT}}` only resolves to a variable explicitly
+     declared in the api service's Variables tab.
+   - Web service **Variables** tab:
+     `API_PROXY_TARGET=${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}`
+   - Web service start command:
+
+     ```shell
+     yarn start:web --api-proxy-target="http://$API_PROXY_TARGET"
+     ```
+
    `RAILWAY_PRIVATE_DOMAIN` is a bare hostname, and unlike the public domain
    (where Railway's edge proxy forwards to your app's actual port for you),
-   private-network traffic connects to that port directly. Either way, replace
-   `api` with your api service's actual name — Railway resolves
-   `${{<service>.<VAR>}}` at deploy time. A missing or schemeless
-   `apiProxyTarget` leaves `apiUrl` requests unhandled and Cedar returns a Bad
-   Gateway error.
+   private-network traffic connects to that port directly — hence needing the
+   explicit `PORT` variable above. Either way, replace `api` with your api
+   service's actual name. A missing or schemeless `apiProxyTarget` leaves
+   `apiUrl` requests unhandled and Cedar returns a Bad Gateway error.
 
 ## Config as code
 

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -62,8 +62,10 @@ To split into the
 
 1. Add a second service from the same repo.
 2. On the api service, set the start command to `yarn start:api`.
-3. On the web service, set the start command to pass `--api-proxy-target`, a
-   fully-qualified URL (scheme required) pointing at the api service:
+3. Railway has no static-hosting build pack (unlike [Coolify](./coolify.md)),
+   so the web service also needs to run as a Node process: set its start
+   command to pass `--api-proxy-target`, a fully-qualified URL (scheme
+   required) pointing at the api service.
 
    ```shell
    yarn start:web --api-proxy-target=https://${{api.RAILWAY_PUBLIC_DOMAIN}}

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -62,18 +62,17 @@ To split into the
 
 1. Add a second service from the same repo.
 2. On the api service, set the start command to `yarn start:api`.
-3. Railway's static-file provider isn't reliable for monorepo subdirectories
-   like `web/dist`, so `start:web` is the documented Cedar path here: point it
-   at the api service with `--api-proxy-target`, a fully-qualified URL (scheme
-   required). This needs `apiUrl` in `cedar.toml` to stay relative — see
+3. Set the web service's start command to proxy to the api service with
+   `--api-proxy-target`, a fully-qualified URL (scheme required). Requires
+   `apiUrl` in `cedar.toml` to stay relative — see
    [relative vs. absolute apiUrl](./introduction.md#relative-apiurl--proxy-or-absolute-apiurl--cors).
 
-   Railway's `${{Service.VAR}}` syntax only resolves in a service's
-   **Variables** tab, not in the Start Command field — define it as a
-   variable first, then read it as a shell variable:
+   Define the target as a Variable first, then reference it from the start
+   command (Railway's `${{Service.VAR}}` syntax doesn't resolve directly in
+   the Start Command field):
 
-   - Api service: generate a public domain first (**Settings → Networking**)
-     if it doesn't have one.
+   - Api service: generate a public domain (**Settings → Networking**) if it
+     doesn't have one.
    - Web service **Variables** tab: `API_PROXY_TARGET=${{api.RAILWAY_PUBLIC_DOMAIN}}`
    - Web service start command:
 
@@ -81,9 +80,8 @@ To split into the
      yarn start:web --api-proxy-target="https://$API_PROXY_TARGET"
      ```
 
-   For private networking instead (`http://` — already encrypted via
-   WireGuard, so no TLS needed), the private domain is a bare hostname with no
-   automatic port forwarding, so also give the api service a fixed `PORT`:
+   For private networking instead, use `http://` and give the api service a
+   fixed `PORT`:
 
    - Api service **Variables** tab: `PORT=8911`
    - Web service **Variables** tab:
@@ -95,8 +93,7 @@ To split into the
      ```
 
    Either way, replace `api` with your api service's actual name. A missing
-   or schemeless `apiProxyTarget` leaves `apiUrl` requests unhandled and Cedar
-   returns a Bad Gateway error.
+   or schemeless `apiProxyTarget` returns a Bad Gateway error.
 
 ## Config as code
 

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -62,10 +62,15 @@ To split into the
 
 1. Add a second service from the same repo.
 2. On the api service, set the start command to `yarn start:api`.
-3. Railway has no static-hosting build pack (unlike [Coolify](./coolify.md)),
-   so the web service also needs to run as a Node process: set its start
-   command to pass `--api-proxy-target`, a fully-qualified URL (scheme
-   required) pointing at the api service.
+3. Railway's build system (Railpack) does have a static-file provider, but it's
+   not a reliable one-click option for a monorepo subdirectory like `web/dist`
+   — Railway's own monorepo and SPA-routing guides recommend a hand-rolled
+   Caddyfile or a Node-build/Caddy-serve Dockerfile instead of relying on it.
+   `start:web` is the documented Cedar path here (unlike
+   [Coolify](./coolify.md), which has a dedicated Static build pack that
+   handles this cleanly): set the web service's start command to pass
+   `--api-proxy-target`, a fully-qualified URL (scheme required) pointing at
+   the api service.
 
    ```shell
    yarn start:web --api-proxy-target=https://${{api.RAILWAY_PUBLIC_DOMAIN}}

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -62,35 +62,18 @@ To split into the
 
 1. Add a second service from the same repo.
 2. On the api service, set the start command to `yarn start:api`.
-3. Railway's build system (Railpack) does have a static-file provider, but it's
-   not a reliable one-click option for a monorepo subdirectory like `web/dist`
-   — Railway's own monorepo and SPA-routing guides recommend a hand-rolled
-   Caddyfile or a Node-build/Caddy-serve Dockerfile instead of relying on it.
-   `start:web` is the documented Cedar path here (unlike
-   [Coolify](./coolify.md), which has a dedicated Static build pack that
-   handles this cleanly): point it at the api service with
-   `--api-proxy-target`, a fully-qualified URL (scheme required).
+3. Railway's static-file provider isn't reliable for monorepo subdirectories
+   like `web/dist`, so `start:web` is the documented Cedar path here: point it
+   at the api service with `--api-proxy-target`, a fully-qualified URL (scheme
+   required). This needs `apiUrl` in `cedar.toml` to stay relative — see
+   [relative vs. absolute apiUrl](./introduction.md#relative-apiurl--proxy-or-absolute-apiurl--cors).
 
-   This only works if `apiUrl` in `cedar.toml` is left relative (the
-   default) — that's what makes the web service's Fastify proxy the thing
-   handling API requests in the first place. If you instead set `apiUrl` to
-   an absolute URL, the browser calls the api service directly and bypasses
-   this proxy entirely, `apiProxyTarget` has no effect, and you need the
-   separate CORS/cookie setup described in
-   [Introduction to Deployment](./introduction.md#relative-apiurl--proxy-or-absolute-apiurl--cors)
-   instead.
+   Railway's `${{Service.VAR}}` syntax only resolves in a service's
+   **Variables** tab, not in the Start Command field — define it as a
+   variable first, then read it as a shell variable:
 
-   Railway's `${{Service.VAR}}` reference syntax only resolves inside a
-   service's **Variables** tab — it isn't substituted if you paste it directly
-   into the Start Command field. So define the target as a variable first,
-   then read it from the start command as a normal shell variable (Railpack
-   start commands already run in a shell, so `$VAR` expansion works with no
-   extra wrapping):
-
-   `RAILWAY_PUBLIC_DOMAIN` only exists for a service once it has a public
-   domain — Railway doesn't assign one automatically. On the api service, go
-   to **Settings → Networking** and generate a domain first.
-
+   - Api service: generate a public domain first (**Settings → Networking**)
+     if it doesn't have one.
    - Web service **Variables** tab: `API_PROXY_TARGET=${{api.RAILWAY_PUBLIC_DOMAIN}}`
    - Web service start command:
 
@@ -98,21 +81,11 @@ To split into the
      yarn start:web --api-proxy-target="https://$API_PROXY_TARGET"
      ```
 
-   For private networking instead — keeps this traffic off the public
-   internet, and off the public domain's TLS termination too, since Railway
-   doesn't provision TLS certs for `*.railway.internal` domains. That's not a
-   security downside: Railway's private network is already encrypted in
-   transit at the WireGuard layer, so app-level TLS on top would be
-   redundant — Railway's own docs recommend `http://` here for exactly that
-   reason. The practical cost is just that you can't reuse an `https://` URL
-   — reference the api service's private domain and port the same way, using
-   `http://`:
+   For private networking instead (`http://` — already encrypted via
+   WireGuard, so no TLS needed), the private domain is a bare hostname with no
+   automatic port forwarding, so also give the api service a fixed `PORT`:
 
-   - Api service **Variables** tab: add a fixed `PORT` (e.g. `8911`). Cedar's
-     api server binds to whatever `PORT` is set to, and Railway's automatic
-     runtime port assignment isn't itself referenceable from another
-     service — `${{api.PORT}}` only resolves to a variable explicitly
-     declared in the api service's Variables tab.
+   - Api service **Variables** tab: `PORT=8911`
    - Web service **Variables** tab:
      `API_PROXY_TARGET=${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}`
    - Web service start command:
@@ -121,12 +94,9 @@ To split into the
      yarn start:web --api-proxy-target="http://$API_PROXY_TARGET"
      ```
 
-   `RAILWAY_PRIVATE_DOMAIN` is a bare hostname, and unlike the public domain
-   (where Railway's edge proxy forwards to your app's actual port for you),
-   private-network traffic connects to that port directly — hence needing the
-   explicit `PORT` variable above. Either way, replace `api` with your api
-   service's actual name. A missing or schemeless `apiProxyTarget` leaves
-   `apiUrl` requests unhandled and Cedar returns a Bad Gateway error.
+   Either way, replace `api` with your api service's actual name. A missing
+   or schemeless `apiProxyTarget` leaves `apiUrl` requests unhandled and Cedar
+   returns a Bad Gateway error.
 
 ## Config as code
 

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -71,6 +71,15 @@ To split into the
    handles this cleanly): point it at the api service with
    `--api-proxy-target`, a fully-qualified URL (scheme required).
 
+   This only works if `apiUrl` in `cedar.toml` is left relative (the
+   default) — that's what makes the web service's Fastify proxy the thing
+   handling API requests in the first place. If you instead set `apiUrl` to
+   an absolute URL, the browser calls the api service directly and bypasses
+   this proxy entirely, `apiProxyTarget` has no effect, and you need the
+   separate CORS/cookie setup described in
+   [Introduction to Deployment](./introduction.md#relative-apiurl--proxy-or-absolute-apiurl--cors)
+   instead.
+
    Railway's `${{Service.VAR}}` reference syntax only resolves inside a
    service's **Variables** tab — it isn't substituted if you paste it directly
    into the Start Command field. So define the target as a variable first,


### PR DESCRIPTION
- Reframe `cedar serve web` / `yarn start:web` in the deploy docs as primarily a local production-like testing tool, rather than a standalone production topology — it's only a production fallback for platforms with no static-hosting option (e.g. Railway).
- Explain how `apiUrl` (`cedar.toml`) and `apiProxyTarget` (a `start:web`-only CLI flag, no config-file/env equivalent) relate: they aren't two competing ways to wire up web↔api, but two distinct setups (relative `apiUrl` + proxy vs. absolute `apiUrl` + CORS) with a real trade-off, laid out in a new comparison table.
- Update `railway.md`'s "Scaling up: two services" section to explain *why* Railway needs `start:web` (no static build pack, unlike Coolify).