### PR TITLE
feat(web): Add CedarProvider. Deprecate RedwoodProvider

### DIFF
--- a/__fixtures__/cedar-ud-app/web/src/App.tsx
+++ b/__fixtures__/cedar-ud-app/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -6,11 +6,11 @@ import Routes from 'src/Routes'
 
 const App = ({ children }: { children?: React.ReactNode }) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>
         {children ? children : <Routes />}
       </CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/__fixtures__/empty-project/web/src/App.tsx
+++ b/__fixtures__/empty-project/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -8,11 +8,11 @@ import './index.css'
 
 const App = ({ children }) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>
         {children ? children : <Routes />}
       </CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/__fixtures__/example-todo-main-with-errors/web/src/index.js
+++ b/__fixtures__/example-todo-main-with-errors/web/src/index.js
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom'
-import { RedwoodProvider, FatalErrorBoundary } from '@cedarjs/web'
+import { CedarProvider, FatalErrorBoundary } from '@cedarjs/web'
 import FatalErrorPage from 'src/pages/FatalErrorPage'
 
 import Routes from './Routes'
@@ -8,9 +8,9 @@ import './index.css'
 
 ReactDOM.render(
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider>
+    <CedarProvider>
       <Routes />
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>,
   document.getElementById('redwood-app')
 )

--- a/__fixtures__/rsc-caching/web/src/App.tsx
+++ b/__fixtures__/rsc-caching/web/src/App.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from './pages/FatalErrorPage/FatalErrorPage'
@@ -13,9 +13,9 @@ interface AppProps {
 
 const App = ({ children }: AppProps) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>{children}</CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/__fixtures__/test-project-esm/web/src/App.tsx
+++ b/__fixtures__/test-project-esm/web/src/App.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -16,11 +16,11 @@ interface AppProps {
 
 const App = ({ children }: AppProps) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth}>{children}</CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/__fixtures__/test-project-live/web/src/App.tsx
+++ b/__fixtures__/test-project-live/web/src/App.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 
 import { configureGqlorm } from '@cedarjs/gqlorm/setup'
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -21,11 +21,11 @@ interface AppProps {
 
 const App = ({ children }: AppProps) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth}>{children}</CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/__fixtures__/test-project-pnpm/web/src/App.tsx
+++ b/__fixtures__/test-project-pnpm/web/src/App.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -16,11 +16,11 @@ interface AppProps {
 
 const App = ({ children }: AppProps) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth}>{children}</CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/__fixtures__/test-project-rsa/web/src/App.tsx
+++ b/__fixtures__/test-project-rsa/web/src/App.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from './pages/FatalErrorPage/FatalErrorPage'
@@ -13,9 +13,9 @@ interface AppProps {
 
 const App = ({ children }: AppProps) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>{children}</CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/App.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/App.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import { AuthProvider, useAuth } from './auth'
@@ -15,11 +15,11 @@ interface AppProps {
 
 const App = ({ children }: AppProps) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth}>{children}</CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/__fixtures__/test-project/web/src/App.tsx
+++ b/__fixtures__/test-project/web/src/App.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -16,11 +16,11 @@ interface AppProps {
 
 const App = ({ children }: AppProps) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth}>{children}</CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/docs/docs/auth/dbauth.md
+++ b/docs/docs/auth/dbauth.md
@@ -725,7 +725,7 @@ import { AuthProvider } from '@cedarjs/auth'
 // highlight-start
 import WebAuthnClient from '@cedarjs/auth-dbauth-web/webAuthn'
 // highlight-end
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -736,7 +736,7 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       // highlight-start
       <AuthProvider type="dbAuth" client={WebAuthnClient}>
         // highlight-end
@@ -744,7 +744,7 @@ const App = () => (
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/docs/docs/cors.md
+++ b/docs/docs/cors.md
@@ -143,7 +143,7 @@ import { AuthProvider, useAuth } from 'src/auth'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider type="dbAuth">
         <CedarApolloProvider
           useAuth={useAuth}
@@ -154,7 +154,7 @@ const App = () => (
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 ```

--- a/docs/docs/how-to/supabase-auth.md
+++ b/docs/docs/how-to/supabase-auth.md
@@ -53,7 +53,7 @@ yarn cedar setup auth supabase
 By specifying `supabase` as the provider, Cedar automatically added the necessary Supabase config to our app. Let's open up `web/src/App.[js/tsx]` and inspect. You should see:
 
 ```jsx {1-2,12,17} title="web/src/App.[js/tsx]"
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -65,13 +65,13 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth}>
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/docs/docs/seo-head.md
+++ b/docs/docs/seo-head.md
@@ -25,13 +25,13 @@ It will also be used for the title template.
 
 Now that you have the app title set, you probably want some consistence with the page title, that's what the title template is for.
 
-Add `titleTemplate` as a prop for `RedwoodProvider` to have a title template for every page.
+Add `titleTemplate` as a prop for `CedarProvider` to have a title template for every page.
 
 ```diff title=web/src/App.(tsx|jsx)
--  <RedwoodProvider>
-+  <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+-  <CedarProvider>
++  <CedarProvider titleTemplate="%PageTitle | %AppTitle">
     /* ... */
-  <RedwoodProvider />
+  <CedarProvider />
 ```
 
 You can use whatever formatting you'd like in here. Some examples:

--- a/docs/docs/seo-head.md
+++ b/docs/docs/seo-head.md
@@ -31,7 +31,7 @@ Add `titleTemplate` as a prop for `CedarProvider` to have a title template for e
 -  <CedarProvider>
 +  <CedarProvider titleTemplate="%PageTitle | %AppTitle">
     /* ... */
-  <CedarProvider />
+  </CedarProvider>
 ```
 
 You can use whatever formatting you'd like in here. Some examples:

--- a/local-testing-project-live/web/src/App.tsx
+++ b/local-testing-project-live/web/src/App.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 
 import { configureGqlorm } from '@cedarjs/gqlorm/setup'
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -21,11 +21,11 @@ interface AppProps {
 
 const App = ({ children }: AppProps) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth}>{children}</CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/local-testing-project/web/src/App.tsx
+++ b/local-testing-project/web/src/App.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -16,11 +16,11 @@ interface AppProps {
 
 const App = ({ children }: AppProps) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth}>{children}</CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli-helpers/src/auth/__tests__/__snapshots__/authTasks.test.ts.snap
+++ b/packages/cli-helpers/src/auth/__tests__/__snapshots__/authTasks.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`authTasks > Components with props > Should add useAuth on the same line for single line components, and separate line for multiline components 1`] = `
-"import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+"import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -13,13 +13,13 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth} graphQLClientConfig={{ cache }}>
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 
@@ -63,7 +63,7 @@ export default Routes
 `;
 
 exports[`authTasks > Components with props > Should not add useAuth if one already exists 1`] = `
-"import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+"import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -75,13 +75,13 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth} graphQLClientConfig={{ cache }}>
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 
@@ -130,7 +130,7 @@ export default Routes
 
 exports[`authTasks > Customized App.js > Should add auth config when using explicit return 1`] = `
 "import { useEffect } from 'react'
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -149,7 +149,7 @@ const App = (props) => {
 
   return (
     <FatalErrorBoundary page={FatalErrorPage}>
-      <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+      <CedarProvider titleTemplate="%PageTitle | %AppTitle">
         <AuthProvider>
           <CedarApolloProvider useAuth={useAuth}>
             <AnotherProvider>
@@ -157,7 +157,7 @@ const App = (props) => {
             </AnotherProvider>
           </CedarApolloProvider>
         </AuthProvider>
-      </RedwoodProvider>
+      </CedarProvider>
     </FatalErrorBoundary>
   )
 }
@@ -167,7 +167,7 @@ export default App
 `;
 
 exports[`authTasks > Should update App.{jsx,tsx}, Routes.{jsx,tsx} and add auth.ts (Auth0) 1`] = `
-"import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+"import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -179,13 +179,13 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth}>
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 
@@ -248,7 +248,7 @@ export default Routes
 `;
 
 exports[`authTasks > Should update App.{jsx,tsx}, Routes.{jsx,tsx} and add auth.ts (Clerk) 1`] = `
-"import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+"import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -260,13 +260,13 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth}>
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 
@@ -361,7 +361,7 @@ exports[`authTasks > Should update App.tsx for legacy apps 1`] = `
 "import netlifyIdentity from 'netlify-identity-widget'
 
 import { isBrowser } from '@cedarjs/prerender/browserUtils'
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -375,13 +375,13 @@ isBrowser && netlifyIdentity.init()
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth}>
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 
@@ -390,7 +390,7 @@ export default App
 `;
 
 exports[`authTasks > Swapped out GraphQL client > Should add auth config when app is missing CedarApolloProvider 1`] = `
-"import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+"import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
 import Routes from 'src/Routes'
@@ -403,7 +403,7 @@ const queryClient = {}
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <QueryClientProvider client={queryClient}>
           <RedwoodReactQueryProvider>
@@ -411,7 +411,7 @@ const App = () => (
           </RedwoodReactQueryProvider>
         </QueryClientProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli-helpers/src/auth/__tests__/authTasks.test.ts
+++ b/packages/cli-helpers/src/auth/__tests__/authTasks.test.ts
@@ -79,6 +79,7 @@ import {
   graphqlTs,
   legacyApolloProviderAppTsx,
   legacyAuthWebAppTsx,
+  legacyProviderAppTsx,
   nonStandardAuthDecoderGraphqlTs,
   routesTsx,
   useAuthRoutesTsx,
@@ -200,6 +201,27 @@ describe('authTasks', () => {
     addConfigToWebApp().task(ctx, {} as any)
 
     expect(fs.readFileSync(getPaths().web.app, 'utf-8')).toMatchSnapshot()
+  })
+
+  it('Should still add auth config for apps still using the deprecated RedwoodProvider name', () => {
+    vol.fromJSON({
+      ...vol.toJSON(),
+      [getPaths().web.app]: legacyProviderAppTsx,
+    })
+
+    const ctx: AuthGeneratorCtx = {
+      provider: 'clerk',
+      setupMode: 'FORCE',
+      force: false,
+    }
+
+    addConfigToWebApp().task(ctx, {} as any)
+
+    const app = fs.readFileSync(getPaths().web.app, 'utf-8')
+    expect(app).toContain(
+      '<RedwoodProvider titleTemplate="%PageTitle | %AppTitle">',
+    )
+    expect(app).toContain('<AuthProvider>')
   })
 
   describe('Components with props', () => {

--- a/packages/cli-helpers/src/auth/__tests__/mockFsFiles.ts
+++ b/packages/cli-helpers/src/auth/__tests__/mockFsFiles.ts
@@ -1,4 +1,28 @@
 export const webAppTsx =
+  "import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'\n" +
+  `import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
+
+import FatalErrorPage from 'src/pages/FatalErrorPage'
+import Routes from 'src/Routes'
+
+import './index.css'
+
+const App = () => (
+  <FatalErrorBoundary page={FatalErrorPage}>
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
+      <CedarApolloProvider>
+        <Routes />
+      </CedarApolloProvider>
+    </CedarProvider>
+  </FatalErrorBoundary>
+)
+
+export default App
+`
+
+// Same as `webAppTsx`, but still using the deprecated `RedwoodProvider` name,
+// to make sure we still support apps that haven't migrated yet.
+export const legacyProviderAppTsx =
   "import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'\n" +
   `import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
@@ -177,7 +201,7 @@ export const legacyAuthWebAppTsx =
   `
 import { AuthProvider } from '@cedarjs/auth'
 import { isBrowser } from '@cedarjs/prerender/browserUtils'
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -189,13 +213,13 @@ isBrowser && netlifyIdentity.init()
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider client={netlifyIdentity} type="netlify">
         <CedarApolloProvider>
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 
@@ -203,7 +227,7 @@ export default App
 `
 
 export const customApolloAppTsx =
-  "import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'\n" +
+  "import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'\n" +
   `import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -213,11 +237,11 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider graphQLClientConfig={{ cache }}>
         <Routes />
       </CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 
@@ -294,7 +318,7 @@ export default Routes
 
 export const explicitReturnAppTsx =
   "import { useEffect } from 'react'\n" +
-  `import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+  `import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -311,13 +335,13 @@ const App = (props) => {
 
   return (
     <FatalErrorBoundary page={FatalErrorPage}>
-      <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+      <CedarProvider titleTemplate="%PageTitle | %AppTitle">
         <CedarApolloProvider>
           <AnotherProvider>
             <Routes />
           </AnotherProvider>
         </CedarApolloProvider>
-      </RedwoodProvider>
+      </CedarProvider>
     </FatalErrorBoundary>
   )
 }
@@ -326,7 +350,7 @@ export default App
 `
 
 export const withoutApolloProviderAppTsx =
-  "import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'\n" +
+  "import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'\n" +
   `
 import FatalErrorPage from 'src/pages/FatalErrorPage'
 import Routes from 'src/Routes'
@@ -337,13 +361,13 @@ const queryClient = {}
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <QueryClientProvider client={queryClient}>
         <RedwoodReactQueryProvider>
           <Routes />
         </RedwoodReactQueryProvider>
       </QueryClientProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli-helpers/src/auth/authTasks.ts
+++ b/packages/cli-helpers/src/auth/authTasks.ts
@@ -237,12 +237,15 @@ const addAuthProviderToApp = (content: string, setupMode: AuthSetupMode) => {
     content = removeAuthProvider(content)
   }
 
+  // Older projects (created before CedarProvider replaced the deprecated
+  // RedwoodProvider) may still have <RedwoodProvider> in App.{jsx,tsx}, so
+  // both names are matched here.
   const match = content.match(
-    /(\s+)(<RedwoodProvider.*?>)(.*)(<\/RedwoodProvider>)/s,
+    /(\s+)(<(?:Cedar|Redwood)Provider.*?>)(.*)(<\/(?:Cedar|Redwood)Provider>)/s,
   )
 
   if (!match) {
-    throw new Error('Could not find <RedwoodProvider> in App.{jsx,tsx}')
+    throw new Error('Could not find <CedarProvider> in App.{jsx,tsx}')
   }
 
   // If Auth.tsx already contains exactly what we're trying to add there's no
@@ -255,12 +258,12 @@ const addAuthProviderToApp = (content: string, setupMode: AuthSetupMode) => {
   const [
     _,
     newlineAndIndent,
-    redwoodProviderOpen,
-    redwoodProviderChildren,
-    redwoodProviderClose,
+    cedarProviderOpen,
+    cedarProviderChildren,
+    cedarProviderClose,
   ] = match
 
-  const redwoodProviderChildrenLines = redwoodProviderChildren
+  const cedarProviderChildrenLines = cedarProviderChildren
     .split('\n')
     .map((line, index) => {
       return `${index === 0 ? '' : '  '}` + line
@@ -268,17 +271,17 @@ const addAuthProviderToApp = (content: string, setupMode: AuthSetupMode) => {
 
   const renderContent =
     newlineAndIndent +
-    redwoodProviderOpen +
+    cedarProviderOpen +
     newlineAndIndent +
     '  ' +
     `<AuthProvider>` +
-    redwoodProviderChildrenLines.join('\n') +
+    cedarProviderChildrenLines.join('\n') +
     `</AuthProvider>` +
     newlineAndIndent +
-    redwoodProviderClose
+    cedarProviderClose
 
   return content.replace(
-    /\s+<RedwoodProvider.*?>.*<\/RedwoodProvider>/s,
+    /\s+<(?:Cedar|Redwood)Provider.*?>.*<\/(?:Cedar|Redwood)Provider>/s,
     renderContent,
   )
 }

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__codemod_tests__/appGqlConfigTransform.test.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__codemod_tests__/appGqlConfigTransform.test.ts
@@ -75,7 +75,7 @@ describe.skipIf(process.env.CI && process.platform === 'win32')(
         testProjectAppTsx,
         `import type { ReactNode } from 'react'
 
-      import { FatalErrorBoundary, RedwoodProvider } from \"@cedarjs/web\";
+      import { FatalErrorBoundary, CedarProvider } from \"@cedarjs/web\";
       import { CedarApolloProvider } from \"@cedarjs/web/apollo/CedarApolloProvider\";
 
       import FatalErrorPage from \"src/pages/FatalErrorPage\";
@@ -97,7 +97,7 @@ describe.skipIf(process.env.CI && process.platform === 'win32')(
 
       const App = ({ children }: AppProps) => (
         <FatalErrorBoundary page={FatalErrorPage}>
-          <RedwoodProvider titleTemplate=\"%PageTitle | %AppTitle\">
+          <CedarProvider titleTemplate=\"%PageTitle | %AppTitle\">
             <AuthProvider>
               <CedarApolloProvider
                 useAuth={useAuth}
@@ -106,7 +106,7 @@ describe.skipIf(process.env.CI && process.platform === 'win32')(
                 {children}
               </CedarApolloProvider>
             </AuthProvider>
-          </RedwoodProvider>
+          </CedarProvider>
         </FatalErrorBoundary>
       );
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/config-simple/input/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/config-simple/input/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -11,11 +11,11 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>
         <Routes />
       </CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/config-simple/output/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/config-simple/output/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -17,11 +17,11 @@ const graphQLClientConfig = {
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider graphQLClientConfig={graphQLClientConfig}>
         <Routes />
       </CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingImport/input/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingImport/input/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -11,11 +11,11 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>
         <Routes />
       </CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingImport/output/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingImport/output/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -11,11 +11,11 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>
         <Routes />
       </CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropInline/input/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropInline/input/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -13,7 +13,7 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider
           useAuth={useAuth}
@@ -28,7 +28,7 @@ const App = () => (
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropInline/output/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropInline/output/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -22,7 +22,7 @@ const graphQLClientConfig = {
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider
           useAuth={useAuth}
@@ -31,7 +31,7 @@ const App = () => (
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariable/input/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariable/input/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -21,7 +21,7 @@ const graphQLClientConfig = {
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider
           useAuth={useAuth}
@@ -30,7 +30,7 @@ const App = () => (
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariable/output/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariable/output/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -22,7 +22,7 @@ const graphQLClientConfig = {
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider
           useAuth={useAuth}
@@ -31,7 +31,7 @@ const App = () => (
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariableCustomName/input/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariableCustomName/input/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -17,13 +17,13 @@ const config = {
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth} graphQLClientConfig={config}>
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariableCustomName/output/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariableCustomName/output/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -21,13 +21,13 @@ const config = {
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider useAuth={useAuth} graphQLClientConfig={config}>
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariableNoCacheConfig/input/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariableNoCacheConfig/input/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -17,7 +17,7 @@ const graphQLClientConfig = {
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider
           useAuth={useAuth}
@@ -26,7 +26,7 @@ const App = () => (
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariableNoCacheConfig/output/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/existingPropVariableNoCacheConfig/output/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -21,7 +21,7 @@ const graphQLClientConfig = {
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <AuthProvider>
         <CedarApolloProvider
           useAuth={useAuth}
@@ -30,7 +30,7 @@ const App = () => (
           <Routes />
         </CedarApolloProvider>
       </AuthProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/import-simple/input/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/import-simple/input/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -9,11 +9,11 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>
         <Routes />
       </CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/import-simple/output/App.tsx
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__testfixtures__/import-simple/output/App.tsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import possibleTypes from 'src/graphql/possibleTypes'
@@ -11,11 +11,11 @@ import './index.css'
 
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>
         <Routes />
       </CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
+++ b/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
@@ -123,6 +123,11 @@ export const handler = async ({ force }: Args) => {
         const webImportIndex = contentLines.findLastIndex((line) =>
           webImportRe.test(line),
         )
+        if (webImportIndex === -1) {
+          throw new Error(
+            'Could not find "import { FatalErrorBoundary, CedarProvider } from \'@cedarjs/web\'" in web/src/App',
+          )
+        }
         const providerName =
           contentLines[webImportIndex].match(webImportRe)?.[1]
         contentLines.splice(

--- a/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
+++ b/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
@@ -116,15 +116,19 @@ export const handler = async ({ force }: Args) => {
           .toString()
           .split('\n')
 
+        // Older projects (created before CedarProvider replaced the
+        // deprecated RedwoodProvider) may still import RedwoodProvider here.
+        const webImportRe =
+          /^import \{ FatalErrorBoundary, ((?:Cedar|Redwood)Provider) \} from '@cedarjs\/web'$/
         const webImportIndex = contentLines.findLastIndex((line) =>
-          /^import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs\/web'$/.test(
-            line,
-          ),
+          webImportRe.test(line),
         )
+        const providerName =
+          contentLines[webImportIndex].match(webImportRe)?.[1]
         contentLines.splice(
           webImportIndex,
           1,
-          "import { RedwoodProvider } from '@cedarjs/web'",
+          `import { ${providerName} } from '@cedarjs/web'`,
         )
 
         const boundaryOpenIndex = contentLines.findLastIndex((line) =>

--- a/packages/cli/src/commands/setup/ui/libraries/chakra-uiHandler.ts
+++ b/packages/cli/src/commands/setup/ui/libraries/chakra-uiHandler.ts
@@ -67,7 +67,9 @@ export async function handler({
             insertComponent: {
               name: 'ChakraProvider',
               props: { theme: 'extendedTheme' },
-              within: 'RedwoodProvider',
+              // Older projects (created before CedarProvider replaced the
+              // deprecated RedwoodProvider) may still use RedwoodProvider.
+              within: 'CedarProvider|RedwoodProvider',
               insertBefore: '<ColorModeScript />',
             },
             imports: [

--- a/packages/cli/src/commands/setup/ui/libraries/mantineHandler.ts
+++ b/packages/cli/src/commands/setup/ui/libraries/mantineHandler.ts
@@ -97,7 +97,9 @@ export async function handler({
             insertComponent: {
               name: 'MantineProvider',
               props: { theme: 'theme' },
-              within: 'RedwoodProvider',
+              // Older projects (created before CedarProvider replaced the
+              // deprecated RedwoodProvider) may still use RedwoodProvider.
+              within: 'CedarProvider|RedwoodProvider',
             },
             imports: [
               "import { MantineProvider } from '@mantine/core'",

--- a/packages/cli/src/lib/extendFile.ts
+++ b/packages/cli/src/lib/extendFile.ts
@@ -122,7 +122,9 @@ function insertComponent(
     )
   }
 
-  const target = around ?? within
+  // Wrapped in a non-capturing group so callers can pass alternations, e.g.
+  // 'CedarProvider|RedwoodProvider', without it leaking out of the tag match.
+  const target = `(?:${around ?? within})`
   const findTagIndex = (regex: RegExp) =>
     content.findIndex((line) => regex.test(line))
 

--- a/packages/create-cedar-app/templates/esm-js/web/src/App.jsx
+++ b/packages/create-cedar-app/templates/esm-js/web/src/App.jsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -7,9 +7,9 @@ import './index.css'
 
 const App = ({ children }) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>{children}</CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/create-cedar-app/templates/esm-ts/web/src/App.tsx
+++ b/packages/create-cedar-app/templates/esm-ts/web/src/App.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -13,9 +13,9 @@ interface AppProps {
 
 const App = ({ children }: AppProps) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>{children}</CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/create-cedar-app/templates/js/web/src/App.jsx
+++ b/packages/create-cedar-app/templates/js/web/src/App.jsx
@@ -1,4 +1,4 @@
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -7,9 +7,9 @@ import './index.css'
 
 const App = ({ children }) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>{children}</CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/create-cedar-app/templates/ts/web/src/App.tsx
+++ b/packages/create-cedar-app/templates/ts/web/src/App.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'
+import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import FatalErrorPage from 'src/pages/FatalErrorPage'
@@ -13,9 +13,9 @@ interface AppProps {
 
 const App = ({ children }: AppProps) => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider>{children}</CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   </FatalErrorBoundary>
 )
 

--- a/packages/storybook/src/mocks/MockProviders.tsx
+++ b/packages/storybook/src/mocks/MockProviders.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 
 import { LocationProvider } from '@cedarjs/router'
 import { useAuth } from '@cedarjs/testing/auth'
-import { RedwoodProvider } from '@cedarjs/web'
+import { CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import { MockParamsProvider } from './MockParamsProvider.js'
@@ -33,13 +33,13 @@ export const MockProviders: React.FunctionComponent<{
   children: React.ReactNode
 }> = ({ children }) => {
   return (
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider useAuth={useAuth}>
         <UserRoutes />
         <LocationProvider>
           <MockParamsProvider>{children}</MockParamsProvider>
         </LocationProvider>
       </CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   )
 }

--- a/packages/testing/src/web/MockProviders.tsx
+++ b/packages/testing/src/web/MockProviders.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { LocationProvider } from '@cedarjs/router'
-import { RedwoodProvider } from '@cedarjs/web'
+import { CedarProvider } from '@cedarjs/web'
 import { CedarApolloProvider } from '@cedarjs/web/apollo/CedarApolloProvider'
 
 import { UserRoutes as VitestUserRoutes } from './globRoutesImporter.js'
@@ -33,7 +33,7 @@ export const MockProviders: React.FunctionComponent<{
   children: React.ReactNode
 }> = ({ children }) => {
   return (
-    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+    <CedarProvider titleTemplate="%PageTitle | %AppTitle">
       <CedarApolloProvider useAuth={useAuth}>
         <UserRoutes />
         <VitestUserRoutes />
@@ -41,7 +41,7 @@ export const MockProviders: React.FunctionComponent<{
           <MockParamsProvider>{children}</MockParamsProvider>
         </LocationProvider>
       </CedarApolloProvider>
-    </RedwoodProvider>
+    </CedarProvider>
   )
 }
 

--- a/packages/web/src/components/CedarProvider.tsx
+++ b/packages/web/src/components/CedarProvider.tsx
@@ -8,7 +8,7 @@ interface RedwoodProviderProps {
   titleTemplate?: string
 }
 
-export const RedwoodProvider = ({
+export const CedarProvider = ({
   children,
   titleTemplate,
 }: RedwoodProviderProps) => {
@@ -35,5 +35,8 @@ export const RedwoodProvider = ({
     </HelmetProvider>
   )
 }
+
+/** @deprecated Please use CedarProvider instead */
+export const RedwoodProvider = CedarProvider
 
 declare global {}

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -32,7 +32,7 @@ export type {
 
 export * from './graphql.js'
 
-export * from './components/RedwoodProvider.js'
+export * from './components/CedarProvider.tsx'
 
 export * from './components/MetaTags.js'
 export * from './components/Metadata.js'

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -32,7 +32,7 @@ export type {
 
 export * from './graphql.js'
 
-export * from './components/CedarProvider.tsx'
+export * from './components/CedarProvider.js'
 
 export * from './components/MetaTags.js'
 export * from './components/Metadata.js'

--- a/tasks/test-project/base-tasks.mts
+++ b/tasks/test-project/base-tasks.mts
@@ -791,9 +791,9 @@ async function addGqlorm() {
   let appTsxContent = fs.readFileSync(appTsxPath, 'utf8')
 
   appTsxContent = appTsxContent.replace(
-    "import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'",
+    "import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'",
     "import { configureGqlorm } from '@cedarjs/gqlorm/setup'\n" +
-      "import { FatalErrorBoundary, RedwoodProvider } from '@cedarjs/web'",
+      "import { FatalErrorBoundary, CedarProvider } from '@cedarjs/web'",
   )
 
   appTsxContent = appTsxContent.replace(


### PR DESCRIPTION
Continuing the rebranding to Cedar.

This should be a backwards-compatible change. The old provider name is still exported, it's just deprecated