### PR TITLE
fix(structure): Detect Private/PrivateSet ancestors beyond the immediate parent

### DIFF
--- a/packages/structure/src/model/RWRoute.ts
+++ b/packages/structure/src/model/RWRoute.ts
@@ -30,47 +30,102 @@ export class RWRoute extends BaseNode {
     return LocationLike_toLocation(this.jsxNode)
   }
 
+  /**
+   * All enclosing `<Private>` / `<PrivateSet>` JSX elements, walking up from
+   * this route's `<Route>` tag to (but not including) the `<Router>` tag.
+   * Ordered innermost-first, so `privateAncestors[0]` (if present) is the
+   * nearest wrapper. A route can be nested inside a plain `<Set>` that is
+   * itself inside a `<PrivateSet>`, so we can't just look at the immediate
+   * JSX parent.
+   */
+  @lazy() private get privateAncestors(): tsm.JsxElement[] {
+    const ancestors: tsm.JsxElement[] = []
+    let current: tsm.Node | undefined = this.jsxNode
+
+    let parentElement = current.getParentIfKind(tsm.SyntaxKind.JsxElement)
+    while (parentElement) {
+      const tagName = parentElement
+        .getOpeningElement()
+        .getTagNameNode()
+        .getText()
+
+      // Don't walk past the <Router> tag
+      if (tagName === 'Router') {
+        break
+      }
+
+      if (tagName === 'Private' || tagName === 'PrivateSet') {
+        ancestors.push(parentElement)
+      }
+
+      current = parentElement
+      parentElement = current.getParentIfKind(tsm.SyntaxKind.JsxElement)
+    }
+
+    return ancestors
+  }
+
   @lazy() get isPrivate() {
-    const tagText = this.jsxNode
-      .getParentIfKind(tsm.SyntaxKind.JsxElement)
-      ?.getOpeningElement()
-      ?.getTagNameNode()
-      ?.getText()
-    return tagText === 'Private' || tagText === 'PrivateSet'
+    return this.privateAncestors.length > 0
   }
 
   @lazy() get unauthenticated() {
-    if (!this.isPrivate) {
-      return undefined
-    }
-
-    const a = this.jsxNode
-      .getParentIfKind(tsm.SyntaxKind.JsxElement)
-      ?.getOpeningElement()
-      .getAttribute('unauthenticated')
-
-    if (!a) {
-      return undefined
-    }
-    if (tsm.Node.isJsxAttribute(a)) {
-      const init = a.getInitializer()
-      if (tsm.Node.isStringLiteral(init)) {
-        return init.getLiteralValue()
+    // Use the innermost Private/PrivateSet ancestor that carries the
+    // attribute
+    for (const ancestor of this.privateAncestors) {
+      const a = ancestor.getOpeningElement().getAttribute('unauthenticated')
+      if (!a) {
+        continue
       }
+      if (tsm.Node.isJsxAttribute(a)) {
+        const init = a.getInitializer()
+        if (tsm.Node.isStringLiteral(init)) {
+          return init.getLiteralValue()
+        }
+      }
+      return undefined
     }
     return undefined
   }
 
   @lazy()
   get roles() {
-    if (!this.isPrivate) {
+    // Each Private/PrivateSet wrapper independently guards the route, so the
+    // effective requirement is the union of roles across all of them
+    const rolesPerAncestor = this.privateAncestors
+      .map((ancestor) => this.getRolesAttr(ancestor.getOpeningElement()))
+      .filter((val): val is string | string[] => val !== undefined)
+
+    if (rolesPerAncestor.length === 0) {
       return undefined
     }
 
-    const a = this.jsxNode
-      .getParentIfKind(tsm.SyntaxKind.JsxElement)
-      ?.getOpeningElement()
-      .getAttribute('roles')
+    // Preserve today's single-wrapper behavior (and its return shape)
+    // exactly when there's only one ancestor with roles
+    if (rolesPerAncestor.length === 1) {
+      return rolesPerAncestor[0]
+    }
+
+    const union = new Set<string>()
+    for (const roles of rolesPerAncestor) {
+      if (Array.isArray(roles)) {
+        roles.forEach((role) => union.add(role))
+      } else {
+        union.add(roles)
+      }
+    }
+    return [...union]
+  }
+
+  /**
+   * Reads the `roles` attribute off a `<Private>`/`<PrivateSet>` opening
+   * element, handling the string literal, quasi-JSON string
+   * (e.g. `"['a','b']"`), and JSX array-literal expression forms.
+   */
+  private getRolesAttr(
+    openingElement: tsm.JsxOpeningElement,
+  ): string | string[] | undefined {
+    const a = openingElement.getAttribute('roles')
 
     if (!a) {
       return undefined
@@ -115,7 +170,7 @@ export class RWRoute extends BaseNode {
               }
               return undefined
             })
-            .filter((val) => val !== undefined)
+            .filter((val): val is string => val !== undefined)
         }
       }
     }

--- a/packages/structure/src/model/__tests__/RWRoute.test.ts
+++ b/packages/structure/src/model/__tests__/RWRoute.test.ts
@@ -117,6 +117,24 @@ describe('RWRoute isPrivate/unauthenticated/roles ancestor walk', () => {
     expect(route.unauthenticated).toBe('home')
   })
 
+  it('prefers the inner ancestor when both wrappers set unauthenticated', () => {
+    const src = `
+      const Routes = () => (
+        <Router>
+          <PrivateSet unauthenticated="outer">
+            <PrivateSet unauthenticated="inner">
+              <Route path="/nested" page={NestedPage} name="nestedPage" />
+            </PrivateSet>
+          </PrivateSet>
+        </Router>
+      )
+    `
+    const route = new RWRoute(getRouteNode(src, 'nestedPage'), fakeRouter)
+
+    expect(route.isPrivate).toBe(true)
+    expect(route.unauthenticated).toBe('inner')
+  })
+
   it('unions roles across two nested <PrivateSet> ancestors', () => {
     const src = `
       const Routes = () => (

--- a/packages/structure/src/model/__tests__/RWRoute.test.ts
+++ b/packages/structure/src/model/__tests__/RWRoute.test.ts
@@ -1,0 +1,159 @@
+import * as tsm from 'ts-morph'
+import { describe, it, expect } from 'vitest'
+
+import { createTSMSourceFile } from '../../x/ts-morph.js'
+import { RWRoute } from '../RWRoute.js'
+import type { RWRouter } from '../RWRouter.js'
+
+/**
+ * `RWRoute` only needs its `parent` (an `RWRouter`) for its `id` getter and
+ * for path-collision/page lookups, none of which are exercised by the
+ * `isPrivate`/`unauthenticated`/`roles` getters under test here. A stub
+ * keeps these tests independent of a full `RWProject`/fixture on disk.
+ */
+const fakeRouter = {} as unknown as RWRouter
+
+/**
+ * Parses `src` and returns the `<Route .../>` self-closing element whose
+ * `name` attribute matches `routeName`.
+ */
+function getRouteNode(
+  src: string,
+  routeName: string,
+): tsm.JsxSelfClosingElement {
+  const sf = createTSMSourceFile('/Routes.tsx', src)
+  const routeNode = sf
+    .getDescendantsOfKind(tsm.SyntaxKind.JsxSelfClosingElement)
+    .find((x) => {
+      if (x.getTagNameNode().getText() !== 'Route') {
+        return false
+      }
+      const nameAttr = x.getAttribute('name')
+      if (!nameAttr || !tsm.Node.isJsxAttribute(nameAttr)) {
+        return false
+      }
+      const init = nameAttr.getInitializer()
+      return (
+        tsm.Node.isStringLiteral(init) && init.getLiteralValue() === routeName
+      )
+    })
+
+  if (!routeNode) {
+    throw new Error(`Could not find <Route name="${routeName}" /> in source`)
+  }
+
+  return routeNode
+}
+
+describe('RWRoute isPrivate/unauthenticated/roles ancestor walk', () => {
+  it('is private for a route directly inside <PrivateSet>', () => {
+    const src = `
+      const Routes = () => (
+        <Router>
+          <PrivateSet unauthenticated="home" roles="admin">
+            <Route path="/private" page={PrivatePage} name="privatePage" />
+          </PrivateSet>
+        </Router>
+      )
+    `
+    const route = new RWRoute(getRouteNode(src, 'privatePage'), fakeRouter)
+
+    expect(route.isPrivate).toBe(true)
+    expect(route.unauthenticated).toBe('home')
+    expect(route.roles).toBe('admin')
+  })
+
+  it('is private for a route inside a <Set> nested within <PrivateSet>', () => {
+    const src = `
+      const Routes = () => (
+        <Router>
+          <PrivateSet unauthenticated="home" roles="admin">
+            <Set wrap={SomeLayout}>
+              <Route path="/private" page={PrivatePage} name="privatePage" />
+            </Set>
+          </PrivateSet>
+        </Router>
+      )
+    `
+    const route = new RWRoute(getRouteNode(src, 'privatePage'), fakeRouter)
+
+    expect(route.isPrivate).toBe(true)
+    expect(route.unauthenticated).toBe('home')
+    expect(route.roles).toBe('admin')
+  })
+
+  it('is not private for a route inside a plain <Set>', () => {
+    const src = `
+      const Routes = () => (
+        <Router>
+          <Set wrap={SomeLayout}>
+            <Route path="/foo" page={FooPage} name="fooPage" />
+          </Set>
+        </Router>
+      )
+    `
+    const route = new RWRoute(getRouteNode(src, 'fooPage'), fakeRouter)
+
+    expect(route.isPrivate).toBe(false)
+    expect(route.unauthenticated).toBeUndefined()
+    expect(route.roles).toBeUndefined()
+  })
+
+  it('resolves unauthenticated from the nearest ancestor that has it', () => {
+    const src = `
+      const Routes = () => (
+        <Router>
+          <PrivateSet unauthenticated="home">
+            <PrivateSet roles="admin">
+              <Route path="/nested" page={NestedPage} name="nestedPage" />
+            </PrivateSet>
+          </PrivateSet>
+        </Router>
+      )
+    `
+    const route = new RWRoute(getRouteNode(src, 'nestedPage'), fakeRouter)
+
+    expect(route.isPrivate).toBe(true)
+    expect(route.unauthenticated).toBe('home')
+  })
+
+  it('unions roles across two nested <PrivateSet> ancestors', () => {
+    const src = `
+      const Routes = () => (
+        <Router>
+          <PrivateSet unauthenticated="home" roles="admin">
+            <PrivateSet roles={['owner', 'superuser']}>
+              <Route path="/nested" page={NestedPage} name="nestedPage" />
+            </PrivateSet>
+          </PrivateSet>
+        </Router>
+      )
+    `
+    const route = new RWRoute(getRouteNode(src, 'nestedPage'), fakeRouter)
+
+    expect(route.isPrivate).toBe(true)
+    expect(route.roles).toBeInstanceOf(Array)
+    expect(route.roles).toHaveLength(3)
+    expect(route.roles).toContain('admin')
+    expect(route.roles).toContain('owner')
+    expect(route.roles).toContain('superuser')
+  })
+
+  it('keeps single-wrapper roles as an array when only that ancestor has roles', () => {
+    const src = `
+      const Routes = () => (
+        <Router>
+          <PrivateSet unauthenticated="home" roles={['owner', 'superuser']}>
+            <Route path="/private" page={PrivatePage} name="privatePage" />
+          </PrivateSet>
+        </Router>
+      )
+    `
+    const route = new RWRoute(getRouteNode(src, 'privatePage'), fakeRouter)
+
+    expect(route.isPrivate).toBe(true)
+    expect(route.roles).toBeInstanceOf(Array)
+    expect(route.roles).toContain('owner')
+    expect(route.roles).toContain('superuser')
+  })
+})


### PR DESCRIPTION
## Summary

`RWRoute.isPrivate` only inspected the route's immediate JSX parent tag. A route nested like `<PrivateSet><Set>...<Route/></Set></PrivateSet>` incorrectly reported `isPrivate === false`, and the same bug meant `unauthenticated` and `roles` were silently dropped whenever a route sat inside a plain `<Set>` nested within a `<Private>`/`<PrivateSet>`.

## What changed

- Added a `privateAncestors` getter on `RWRoute` that walks up all enclosing JSX elements (not just the immediate parent) up to, but not past, the `<Router>` tag, collecting every `<Private>`/`<PrivateSet>` ancestor, innermost first.
- `isPrivate` is now true if any ancestor in that list is `Private`/`PrivateSet`.
- `unauthenticated` now returns the value from the innermost ancestor that carries the attribute.
- `roles` now collects roles from all enclosing `Private`/`PrivateSet` ancestors and returns their union (deduplicated), since each wrapper independently guards the route. When only one ancestor supplies roles, the return shape matches today's single-wrapper behavior exactly (string, parsed quasi-JSON array, or array from a JSX array-literal expression).
- Extracted the roles-attribute parsing into a small private helper (`getRolesAttr`) reused per ancestor, to avoid tripling the logic.

No other diagnostics or models were touched. This transitively fixes `packages/internal/src/routes.ts` (`getProjectRoutes()`) and the existing "notfound page cannot be in PrivateSet" diagnostic for nested `<Set>`s, since they consume `RWRoute.isPrivate`/`unauthenticated`/`roles`.

## Testing

- `yarn workspace @cedarjs/structure build`
- `CI=1 yarn workspace @cedarjs/structure test`
- `npx prettier --check packages/structure/src/model/RWRoute.ts packages/structure/src/model/__tests__/RWRoute.test.ts`
- `npx eslint packages/structure/src/model/RWRoute.ts packages/structure/src/model/__tests__/RWRoute.test.ts`

Added `packages/structure/src/model/__tests__/RWRoute.test.ts` with inline JSX sources (no shared fixture edits) covering:
1. Route directly inside `<PrivateSet>` → `isPrivate` true (existing behavior).
2. Route inside `<PrivateSet><Set>...</Set></PrivateSet>` → now true.
3. Route inside a plain `<Set>` only → false.
4. `unauthenticated` resolved through a nested wrapper (innermost-without-attribute falls through to outer).
5. `roles` union across two nested `PrivateSet`s.
6. Single-wrapper array roles still returned as-is.

All existing `@cedarjs/structure` tests (including the ones exercising the shared `example-todo-main` fixture) still pass.

Related to #2291