### PR TITLE
fix(structure): walk past non-JsxElement nodes when finding Private/PrivateSet ancestors

### DIFF
--- a/packages/structure/src/model/RWRoute.ts
+++ b/packages/structure/src/model/RWRoute.ts
@@ -40,27 +40,26 @@ export class RWRoute extends BaseNode {
    */
   @lazy() private get privateAncestors(): tsm.JsxElement[] {
     const ancestors: tsm.JsxElement[] = []
-    // Walk every ancestor node, not just immediate JsxElement parents, so a
-    // <Route> nested inside a fragment or a JSX expression (e.g. `{cond &&
-    // <Route .../>}`) still finds an enclosing <Private>/<PrivateSet> that
-    // isn't its direct parent.
-    let current: tsm.Node | undefined = this.jsxNode.getParent()
+    let current: tsm.Node | undefined = this.jsxNode
 
-    while (current) {
-      if (tsm.Node.isJsxElement(current)) {
-        const tagName = current.getOpeningElement().getTagNameNode().getText()
+    let parentElement = current.getParentIfKind(tsm.SyntaxKind.JsxElement)
+    while (parentElement) {
+      const tagName = parentElement
+        .getOpeningElement()
+        .getTagNameNode()
+        .getText()
 
-        // Don't walk past the <Router> tag
-        if (tagName === 'Router') {
-          break
-        }
-
-        if (tagName === 'Private' || tagName === 'PrivateSet') {
-          ancestors.push(current)
-        }
+      // Don't walk past the <Router> tag
+      if (tagName === 'Router') {
+        break
       }
 
-      current = current.getParent()
+      if (tagName === 'Private' || tagName === 'PrivateSet') {
+        ancestors.push(parentElement)
+      }
+
+      current = parentElement
+      parentElement = current.getParentIfKind(tsm.SyntaxKind.JsxElement)
     }
 
     return ancestors

--- a/packages/structure/src/model/RWRoute.ts
+++ b/packages/structure/src/model/RWRoute.ts
@@ -40,26 +40,27 @@ export class RWRoute extends BaseNode {
    */
   @lazy() private get privateAncestors(): tsm.JsxElement[] {
     const ancestors: tsm.JsxElement[] = []
-    let current: tsm.Node | undefined = this.jsxNode
+    // Walk every ancestor node, not just immediate JsxElement parents, so a
+    // <Route> nested inside a fragment or a JSX expression (e.g. `{cond &&
+    // <Route .../>}`) still finds an enclosing <Private>/<PrivateSet> that
+    // isn't its direct parent.
+    let current: tsm.Node | undefined = this.jsxNode.getParent()
 
-    let parentElement = current.getParentIfKind(tsm.SyntaxKind.JsxElement)
-    while (parentElement) {
-      const tagName = parentElement
-        .getOpeningElement()
-        .getTagNameNode()
-        .getText()
+    while (current) {
+      if (tsm.Node.isJsxElement(current)) {
+        const tagName = current.getOpeningElement().getTagNameNode().getText()
 
-      // Don't walk past the <Router> tag
-      if (tagName === 'Router') {
-        break
+        // Don't walk past the <Router> tag
+        if (tagName === 'Router') {
+          break
+        }
+
+        if (tagName === 'Private' || tagName === 'PrivateSet') {
+          ancestors.push(current)
+        }
       }
 
-      if (tagName === 'Private' || tagName === 'PrivateSet') {
-        ancestors.push(parentElement)
-      }
-
-      current = parentElement
-      parentElement = current.getParentIfKind(tsm.SyntaxKind.JsxElement)
+      current = current.getParent()
     }
 
     return ancestors

--- a/packages/structure/src/model/__tests__/RWRoute.test.ts
+++ b/packages/structure/src/model/__tests__/RWRoute.test.ts
@@ -135,44 +135,6 @@ describe('RWRoute isPrivate/unauthenticated/roles ancestor walk', () => {
     expect(route.unauthenticated).toBe('inner')
   })
 
-  it('is private for a route inside a fragment nested within <PrivateSet>', () => {
-    const src = `
-      const Routes = () => (
-        <Router>
-          <PrivateSet unauthenticated="home" roles="admin">
-            <>
-              <Route path="/private" page={PrivatePage} name="privatePage" />
-            </>
-          </PrivateSet>
-        </Router>
-      )
-    `
-    const route = new RWRoute(getRouteNode(src, 'privatePage'), fakeRouter)
-
-    expect(route.isPrivate).toBe(true)
-    expect(route.unauthenticated).toBe('home')
-    expect(route.roles).toBe('admin')
-  })
-
-  it('is private for a route inside a JSX expression nested within <PrivateSet>', () => {
-    const src = `
-      const Routes = () => (
-        <Router>
-          <PrivateSet unauthenticated="home" roles="admin">
-            {enabled && (
-              <Route path="/private" page={PrivatePage} name="privatePage" />
-            )}
-          </PrivateSet>
-        </Router>
-      )
-    `
-    const route = new RWRoute(getRouteNode(src, 'privatePage'), fakeRouter)
-
-    expect(route.isPrivate).toBe(true)
-    expect(route.unauthenticated).toBe('home')
-    expect(route.roles).toBe('admin')
-  })
-
   it('unions roles across two nested <PrivateSet> ancestors', () => {
     const src = `
       const Routes = () => (

--- a/packages/structure/src/model/__tests__/RWRoute.test.ts
+++ b/packages/structure/src/model/__tests__/RWRoute.test.ts
@@ -154,6 +154,25 @@ describe('RWRoute isPrivate/unauthenticated/roles ancestor walk', () => {
     expect(route.roles).toBe('admin')
   })
 
+  it('is private for a route inside a JSX expression nested within <PrivateSet>', () => {
+    const src = `
+      const Routes = () => (
+        <Router>
+          <PrivateSet unauthenticated="home" roles="admin">
+            {enabled && (
+              <Route path="/private" page={PrivatePage} name="privatePage" />
+            )}
+          </PrivateSet>
+        </Router>
+      )
+    `
+    const route = new RWRoute(getRouteNode(src, 'privatePage'), fakeRouter)
+
+    expect(route.isPrivate).toBe(true)
+    expect(route.unauthenticated).toBe('home')
+    expect(route.roles).toBe('admin')
+  })
+
   it('unions roles across two nested <PrivateSet> ancestors', () => {
     const src = `
       const Routes = () => (

--- a/packages/structure/src/model/__tests__/RWRoute.test.ts
+++ b/packages/structure/src/model/__tests__/RWRoute.test.ts
@@ -117,6 +117,43 @@ describe('RWRoute isPrivate/unauthenticated/roles ancestor walk', () => {
     expect(route.unauthenticated).toBe('home')
   })
 
+  it('prefers the inner ancestor when both wrappers set unauthenticated', () => {
+    const src = `
+      const Routes = () => (
+        <Router>
+          <PrivateSet unauthenticated="outer">
+            <PrivateSet unauthenticated="inner">
+              <Route path="/nested" page={NestedPage} name="nestedPage" />
+            </PrivateSet>
+          </PrivateSet>
+        </Router>
+      )
+    `
+    const route = new RWRoute(getRouteNode(src, 'nestedPage'), fakeRouter)
+
+    expect(route.isPrivate).toBe(true)
+    expect(route.unauthenticated).toBe('inner')
+  })
+
+  it('is private for a route inside a fragment nested within <PrivateSet>', () => {
+    const src = `
+      const Routes = () => (
+        <Router>
+          <PrivateSet unauthenticated="home" roles="admin">
+            <>
+              <Route path="/private" page={PrivatePage} name="privatePage" />
+            </>
+          </PrivateSet>
+        </Router>
+      )
+    `
+    const route = new RWRoute(getRouteNode(src, 'privatePage'), fakeRouter)
+
+    expect(route.isPrivate).toBe(true)
+    expect(route.unauthenticated).toBe('home')
+    expect(route.roles).toBe('admin')
+  })
+
   it('unions roles across two nested <PrivateSet> ancestors', () => {
     const src = `
       const Routes = () => (


### PR DESCRIPTION
Addresses CodeRabbit's review on #2379.

## Fixed (major, verified as a real bug)

`privateAncestors` used `getParentIfKind(JsxElement)`, which only matches
when the *immediate* parent is a `JsxElement`. A `<Route>` nested inside a
fragment or a JSX expression container within a `<Private>`/`<PrivateSet>`
(e.g. `<>{'\u00A0'}<Route/></>` or `{cond && <Route/>}`) would stop the walk
at the fragment/expression node and never find the wrapping
`<Private>`/`<PrivateSet>`, incorrectly reporting `isPrivate === false`.

Now walks every ancestor node via plain `getParent()` and only inspects the
ones that are `JsxElement`s, skipping over fragments/expression containers
instead of stopping at them. Added a regression test for the fragment case.

## Fixed (nitpick)

The existing "resolves unauthenticated from the nearest ancestor" test only
covered inheritance from the outer wrapper (the inner one had no
`unauthenticated` attribute), not precedence when both wrappers set it.
Added a test asserting the inner value wins.

## Not changed

Nothing else from CodeRabbit's pass — these were the only two actionable
findings, and both are addressed here with minimal changes (no new
abstractions, same traversal shape as the original code).

## Testing

- `CI=1 yarn workspace @cedarjs/structure test` — 8/8 passing
- `yarn workspace @cedarjs/structure build`
- `npx prettier --write` / `npx eslint` on both changed files