### PR TITLE
docs(tutorial): Update yarn commands to `yarn cedar`

### DIFF
--- a/docs/docs/tutorial/chapter5/first-test.md
+++ b/docs/docs/tutorial/chapter5/first-test.md
@@ -7,7 +7,7 @@ If you've never done any kind of testing before this may be a little hard to fol
 If you still have the test process running from the previous page then then you can just press `a` to run **a**ll tests. If you stopped your test process, you can start it again with:
 
 ```bash
-yarn rw test
+yarn cedar test
 ```
 
 Can you guess what broke in this test?

--- a/docs/docs/tutorial/chapter5/storybook.md
+++ b/docs/docs/tutorial/chapter5/storybook.md
@@ -3,7 +3,7 @@
 Let's see what this Storybook thing is all about. Run this command to start up the Storybook server (you could stop your dev or test runners and then run this, or start another new terminal instance):
 
 ```bash
-yarn rw storybook
+yarn cedar storybook
 ```
 
 After some compiling you should get a message saying that Storybook has started and it's available at [http://localhost:7910](http://localhost:7910)

--- a/docs/docs/tutorial/chapter5/testing.md
+++ b/docs/docs/tutorial/chapter5/testing.md
@@ -3,7 +3,7 @@
 Let's run the test suite to make sure everything is working as expected (you can keep the dev server running and start this in a new terminal window):
 
 ```bash
-yarn rw test
+yarn cedar test
 ```
 
 The `test` command starts a persistent process which watches for file changes and automatically runs any tests associated with the changed file(s) (changing a component _or_ its tests will trigger a test run).
@@ -21,7 +21,7 @@ If you cloned the example repo during the intermission and followed along with t
 If you decided to keep your codebase from the first part of the tutorial, then you'll get the following error after running
 
 ```bash
-yarn rw test
+yarn cedar test
 
 Error: Get config: Schema Parsing P1012
 
@@ -49,8 +49,8 @@ Note that the summary on the bottom indicates that there was 1 test that failed.
 
 If you continued with your own repo from chapters 1-4, you may see some other failures here or none at all: we made a lot of changes to the pages, components and cells we generated, but didn't update the tests to reflect the changes we made. (Another reason to start with the [example repo](../intermission.md#using-the-example-repo-recommended)!)
 
-To switch back to the default mode where test are **only** run for changed files, press `o` now (or quit and restart `yarn rw test`).
+To switch back to the default mode where test are **only** run for changed files, press `o` now (or quit and restart `yarn cedar test`).
 
 What we want to aim for is all green in that left column and no failed tests. In fact best practices tell us you should not even commit any code to your repo unless the test suite passes locally. Not everyone adheres to this policy quite as strictly as others..._&lt;cough, cough&gt;_
 
-We've got an excellent document on [Testing](../../testing.md) which you should definitely read if you're brand new to testing, especially the [Terminology](../../testing.md#terminology) and [Cedar and Testing](../../testing.md#redwood-and-testing) sections. For now though, proceed to the next section and we'll go over our approach to getting that last failed test passing.
+We've got an excellent document on [Testing](../../testing.md) which you should definitely read if you're brand new to testing, especially the [Terminology](../../testing.md#terminology) and [Cedar and Testing](../../testing.md#cedar-and-testing) sections. For now though, proceed to the next section and we'll go over our approach to getting that last failed test passing.

--- a/docs/docs/tutorial/chapter6/comment-form.md
+++ b/docs/docs/tutorial/chapter6/comment-form.md
@@ -3,13 +3,13 @@
 Let's generate a component to house our new comment form, build it out and integrate it via Storybook, then add some tests:
 
 ```bash
-yarn rw g component CommentForm
+yarn cedar g component CommentForm
 ```
 
 And startup Storybook again if it isn't still running:
 
 ```bash
-yarn rw storybook
+yarn cedar storybook
 ```
 
 You'll see that there's a **CommentForm** entry in Storybook now, ready for us to get started.
@@ -1155,7 +1155,7 @@ It would be nice if we could try out sending some arguments to our Prisma calls 
 That's where the Cedar Console comes in! In a new terminal instance, try this:
 
 ```bash
-yarn rw console
+yarn cedar console
 ```
 
 You'll see a standard Node console but with most of Cedar's internals already imported and ready to go! Most importantly, that includes the database. Try it out:
@@ -1563,7 +1563,7 @@ Now if you try refreshing the real site in dev mode you'll see an error where th
 
 ![image](https://user-images.githubusercontent.com/300/198095941-bbd07ede-2006-422a-8635-ea8fe57dd403.png)
 
-For security reasons we don't show the internal error message here, but if you check the terminal window where `yarn rw dev` is running you'll see the real message:
+For security reasons we don't show the internal error message here, but if you check the terminal window where `yarn cedar dev` is running you'll see the real message:
 
 ```text
 Field "comments" argument "postId" of type "Int!" is required, but it was not provided.

--- a/docs/docs/tutorial/chapter6/comments-schema.md
+++ b/docs/docs/tutorial/chapter6/comments-schema.md
@@ -7,7 +7,7 @@ Unfortunately, even with all of this flexibility there's still no such thing as 
 If you went through the first part of the tutorial you should be somewhat familiar with this flow:
 
 1. Add a model to `schema.prisma`
-2. Run a `yarn cedar prisma migrate dev` commands to create a migration and apply it to the database
+2. Run the `yarn cedar prisma migrate dev` command to create a migration and apply it to the database
 3. Generate an SDL and service
 
 ### Adding the Comment model

--- a/docs/docs/tutorial/chapter6/comments-schema.md
+++ b/docs/docs/tutorial/chapter6/comments-schema.md
@@ -7,7 +7,7 @@ Unfortunately, even with all of this flexibility there's still no such thing as 
 If you went through the first part of the tutorial you should be somewhat familiar with this flow:
 
 1. Add a model to `schema.prisma`
-2. Run a `yarn rw prisma migrate dev` commands to create a migration and apply it to the database
+2. Run a `yarn cedar prisma migrate dev` commands to create a migration and apply it to the database
 3. Generate an SDL and service
 
 ### Adding the Comment model
@@ -102,14 +102,14 @@ db.post.findUnique({ where: { id: 1 } }).comments()
 This one is easy enough: we'll create a new migration with a name and then run it:
 
 ```bash
-yarn rw prisma migrate dev
+yarn cedar prisma migrate dev
 ```
 
 When prompted, give this one a name something like "create comment".
 
 :::tip
 
-You'll need to restart the test suite runner at this point if it's still running. You can do a Ctrl-C or just press `q`. Cedar creates a second, test database for you to run your tests against (it is at `.redwood/test.db` by default). The database migrations are run against that test database whenever the test suite is _started_, not while it's running, so you'll need to restart it to test against the new database structure.
+You'll need to restart the test suite runner at this point if it's still running. You can do a Ctrl-C or just press `q`. Cedar creates a second, test database for you to run your tests against (it is at `.cedar/test.db` by default). The database migrations are run against that test database whenever the test suite is _started_, not while it's running, so you'll need to restart it to test against the new database structure.
 
 :::
 
@@ -118,7 +118,7 @@ You'll need to restart the test suite runner at this point if it's still running
 Next we'll create the SDL (that defines the GraphQL interface) and a service (to get the records out of the database) with a generator call:
 
 ```bash
-yarn rw g sdl Comment --no-crud
+yarn cedar g sdl Comment --no-crud
 ```
 
 Note the `--no-crud` flag here. This gives us bare-bones functionality to start with (read-only access to our model) that we can build on. We got all the CRUD endpoints for free when we created the Post section of our site, so let's do the opposite here and see how to add functionality from scratch.

--- a/docs/docs/tutorial/chapter6/multiple-comments.md
+++ b/docs/docs/tutorial/chapter6/multiple-comments.md
@@ -27,7 +27,7 @@ Look, we gotta end this sidebar and get back to building this thing. You can ask
 Let's generate a **CommentsCell**:
 
 ```bash
-yarn rw g cell Comments
+yarn cedar g cell Comments
 ```
 
 Storybook updates with a new **CommentsCell** under the **Cells** folder, and it's actually showing something:

--- a/docs/docs/tutorial/chapter6/the-redwood-way.md
+++ b/docs/docs/tutorial/chapter6/the-redwood-way.md
@@ -16,7 +16,7 @@ Which order we build them in is up to us. To ease into things, let's start with 
 Let's create a component for the display of a single comment. First up, the generator:
 
 ```bash
-yarn rw g component Comment
+yarn cedar g component Comment
 ```
 
 Storybook should refresh and our "Generated" Comment story will be ready to go:
@@ -306,7 +306,7 @@ Here we're testing for both elements of the output `createdAt` timestamp: the ac
 If your tests aren't already running in another terminal window, you can start them now:
 
 ```bash
-yarn rw test
+yarn cedar test
 ```
 
 :::info[What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?]

--- a/docs/docs/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/docs/tutorial/chapter7/api-side-currentuser.md
@@ -158,7 +158,7 @@ yarn cedar prisma migrate dev
 
 And then the seed:
 
-```
+```bash
 yarn cedar prisma db seed
 ```
 

--- a/docs/docs/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/docs/tutorial/chapter7/api-side-currentuser.md
@@ -63,7 +63,7 @@ We created a User model in Chapter 4 when we set up authentication for our blog.
 If you followed our recommendation in the Intermission to use the Example repo, the User SDL and service is already added for you. If not, you'll need to add it yourself:
 
 ```bash
-yarn rw g sdl User --no-crud
+yarn cedar g sdl User --no-crud
 ```
 
 We'll comment out the sensitive fields of our GraphQL User type so there's no chance of them leaking:
@@ -103,7 +103,7 @@ We'll comment out the sensitive fields of our GraphQL User type so there's no ch
 Next, migrate the database to apply the changes (when given the option, name the migration something like "add userId to post"):
 
 ```
-yarn rw prisma migrate dev
+yarn cedar prisma migrate dev
 ```
 
 Whoops!
@@ -125,7 +125,7 @@ This would get us past this problem, but could cause hard-to-track-down bugs in 
 Since we're in development, let's just blow away the database and start over:
 
 ```
-yarn rw prisma migrate reset
+yarn cedar prisma migrate reset
 ```
 
 :::info[Database Seeds]
@@ -144,7 +144,7 @@ If you started the second half the tutorial from the [Cedar Tutorial repo](https
 },
 ```
 
-Now run `yarn rw prisma migrate reset` and and...you'll get a different error. But that's okay, read on...
+Now run `yarn cedar prisma migrate reset` and and...you'll get a different error. But that's okay, read on...
 
 :::
 
@@ -153,13 +153,13 @@ We've got an error here because running a database `reset` doesn't also apply pe
 It may feel like we're stuck, but note that the database did reset successfully, it's just the seed that failed. So now let's migrate the database to add the new `userId` to `Post`, and then re-run the seed to populate the database, naming it something like "add userId to post":
 
 ```
-yarn rw prisma migrate dev
+yarn cedar prisma migrate dev
 ```
 
 And then the seed:
 
 ```
-yarn rw prisma db seed
+yarn cedar prisma db seed
 ```
 
 :::info

--- a/docs/docs/tutorial/chapter7/rbac.md
+++ b/docs/docs/tutorial/chapter7/rbac.md
@@ -27,7 +27,7 @@ model User {
 Next we'll (try) to migrate the database:
 
 ```bash
-yarn rw prisma migrate dev
+yarn cedar prisma migrate dev
 ```
 
 But that will fail with an error:
@@ -57,7 +57,7 @@ model User {
 Now the migration should be able to be applied:
 
 ```bash
-yarn rw prisma migrate dev
+yarn cedar prisma migrate dev
 ```
 
 And you can name it something like "add roles to user".
@@ -211,7 +211,7 @@ Now if you browse to [http://localhost:8910/admin/posts](http://localhost:8910/a
 Let's use the Cedar console again to quickly update our admin user to actually have the `admin` role:
 
 ```bash
-yarn rw c
+yarn cedar c
 ```
 
 :::tip
@@ -921,7 +921,7 @@ We moved the default `comment` object to a constant `COMMENT` and then used that
 We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 
 ```bash
-yarn rw test
+yarn cedar test
 ```
 
 The suite should automatically run the tests for `Comment` and `CommentCell` at the very least, and maybe a few more if you haven't committed your code to git in a while.

--- a/docs/docs/tutorial/intermission.md
+++ b/docs/docs/tutorial/intermission.md
@@ -17,7 +17,7 @@ If you've been through the tutorial so far, you can pick up where you left off a
 If you want to use the same CSS classes we use in the following examples you'll need to add Tailwind to your repo:
 
 ```bash
-yarn rw setup ui tailwindcss
+yarn cedar setup ui tailwindcss
 ```
 
 However, none of the screenshots that follow will come anywhere close to what you're seeing in your browser (except for those isolated components you build in Storybook) so you may want to just start with the [example repo](https://github.com/cedarjs/cedar-tutorial). You'll also be missing out on a good starting test suite that we've added!
@@ -27,7 +27,7 @@ If you're _still_ set on continuing with your own repo, and you deployed to a se
 Once you're ready, start up the dev server:
 
 ```bash
-yarn rw dev
+yarn cedar dev
 ```
 
 ### Using the Example Repo (Recommended)


### PR DESCRIPTION
- Replace `yarn rw`/`yarn redwood` command examples with `yarn cedar` across the tutorial pages.
- Update the immediately surrounding prose where it referenced stale Redwood-era details tied to those commands: the `.redwood/test.db` generated-data path (now `.cedar/test.db`) and a broken `#redwood-and-testing` anchor link (now `#cedar-and-testing`).

This intentionally does *not* do a full Redwood → Cedar audit of the tutorial — just the actual commands and the text directly around them where leaving "Redwood" would be confusing or incorrect.