### PR TITLE
feat(api-server): add configureGraphQLServer and configureServer options

### DIFF
--- a/.changesets/2389.md
+++ b/.changesets/2389.md
@@ -1,0 +1,30 @@
+- fix(api-server): add `configureGraphQLServer` and `configureServer` to `createServer` (#2389) by @lisa-assistant
+
+Fixes #2304, where registering `@fastify/compress` via `configureApiServer`
+only compressed api-function responses, not GraphQL responses.
+
+`configureApiServer` and the GraphQL endpoint are registered as sibling
+Fastify plugins, each with their own encapsulation context, so a hook
+registered inside one never applied to the other. Two new options make this
+explicit instead of surprising:
+
+- `configureGraphQLServer` — the GraphQL-only counterpart to
+  `configureApiServer`, scoped to just the GraphQL routes.
+- `configureServer` — runs on the root Fastify instance *before* the api
+  functions and GraphQL plugins register their routes. This is the place for
+  plugins with a "global" mode that hooks Fastify's `onRoute` (e.g.
+  `@fastify/compress`), since those only affect routes registered *after*
+  the plugin itself:
+
+  ```js
+  const server = await createServer({
+    configureServer: (server) => {
+      server.register(compress, { global: true })
+    },
+  })
+  ```
+
+Plain request-lifecycle hooks (`onRequest`, `onSend`, etc.) don't depend on
+registration order and can still be added directly to the `server` instance
+returned by `createServer()` after the fact, applying to both api functions
+and GraphQL.

--- a/.changesets/2389.md
+++ b/.changesets/2389.md
@@ -1,4 +1,4 @@
-- fix(api-server): add `configureGraphQLServer` and `configureServer` to
+- feat(api-server): add `configureGraphQLServer` and `configureServer` to
   `createServer` (#2389) by @lisa-assistant
 
 Fixes #2304, where registering `@fastify/compress` via `configureApiServer` only

--- a/.changesets/2389.md
+++ b/.changesets/2389.md
@@ -1,20 +1,21 @@
-- fix(api-server): add `configureGraphQLServer` and `configureServer` to `createServer` (#2389) by @lisa-assistant
+- fix(api-server): add `configureGraphQLServer` and `configureServer` to
+  `createServer` (#2389) by @lisa-assistant
 
-Fixes #2304, where registering `@fastify/compress` via `configureApiServer`
-only compressed api-function responses, not GraphQL responses.
+Fixes #2304, where registering `@fastify/compress` via `configureApiServer` only
+compressed api-function responses, not GraphQL responses.
 
-`configureApiServer` and the GraphQL endpoint are registered as sibling
-Fastify plugins, each with their own encapsulation context, so a hook
-registered inside one never applied to the other. Two new options make this
-explicit instead of surprising:
+`configureApiServer` and the GraphQL endpoint are registered as sibling Fastify
+plugins, each with their own encapsulation context, so a hook registered inside
+one never applied to the other. Two new options make this explicit instead of
+surprising:
 
 - `configureGraphQLServer` — the GraphQL-only counterpart to
   `configureApiServer`, scoped to just the GraphQL routes.
-- `configureServer` — runs on the root Fastify instance *before* the api
+- `configureServer` — runs on the root Fastify instance _before_ the api
   functions and GraphQL plugins register their routes. This is the place for
   plugins with a "global" mode that hooks Fastify's `onRoute` (e.g.
-  `@fastify/compress`), since those only affect routes registered *after*
-  the plugin itself:
+  `@fastify/compress`), since those only affect routes registered _after_ the
+  plugin itself:
 
   ```js
   const server = await createServer({
@@ -26,5 +27,5 @@ explicit instead of surprising:
 
 Plain request-lifecycle hooks (`onRequest`, `onSend`, etc.) don't depend on
 registration order and can still be added directly to the `server` instance
-returned by `createServer()` after the fact, applying to both api functions
-and GraphQL.
+returned by `createServer()` after the fact, applying to both api functions and
+GraphQL.

--- a/.changesets/2389.md
+++ b/.changesets/2389.md
@@ -1,5 +1,4 @@
-- feat(api-server): add configureGraphQLServer and configureServer options
-  (#2389) by @lisa-assistant
+# feat(api-server): add configureGraphQLServer and configureServer options (#2389) by @lisa-assistant
 
 Fixes #2304, where registering `@fastify/compress` via `configureApiServer` only
 compressed api-function responses, not GraphQL responses.

--- a/.changesets/2389.md
+++ b/.changesets/2389.md
@@ -1,5 +1,5 @@
-- feat(api-server): add `configureGraphQLServer` and `configureServer` to
-  `createServer` (#2389) by @lisa-assistant
+- feat(api-server): add configureGraphQLServer and configureServer options
+  (#2389) by @lisa-assistant
 
 Fixes #2304, where registering `@fastify/compress` via `configureApiServer` only
 compressed api-function responses, not GraphQL responses.

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -114,6 +114,7 @@
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
+    "@fastify/compress": "9.1.1",
     "@types/aws-lambda": "8.10.162",
     "@types/dotenv-defaults": "^5.0.0",
     "@types/split2": "4.2.3",

--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -295,7 +295,9 @@ describe('resolveOptions', () => {
       // Can't really compare functions with toEqual() unless it's the same
       // reference. And when calling `getDefaulCreateServerOptions()` you get a
       // new function, and thus a new reference, each time
+      configureServer: resolvedOptions.configureServer,
       configureApiServer: resolvedOptions.configureApiServer,
+      configureGraphQLServer: resolvedOptions.configureGraphQLServer,
       fastifyServerOptions: {
         requestTimeout: defaults.fastifyServerOptions.requestTimeout,
         logger: defaults.logger,
@@ -306,8 +308,14 @@ describe('resolveOptions', () => {
       apiPort: defaults.apiPort,
     })
 
+    expect(resolvedOptions.configureServer.toString()).toEqual(
+      defaults.configureServer.toString(),
+    )
     expect(resolvedOptions.configureApiServer.toString()).toEqual(
       defaults.configureApiServer.toString(),
+    )
+    expect(resolvedOptions.configureGraphQLServer.toString()).toEqual(
+      defaults.configureGraphQLServer.toString(),
     )
   })
 

--- a/packages/api-server/src/__tests__/graphqlPlugin.test.ts
+++ b/packages/api-server/src/__tests__/graphqlPlugin.test.ts
@@ -1,5 +1,7 @@
 import path from 'path'
+import { gunzipSync } from 'zlib'
 
+import fastifyCompress from '@fastify/compress'
 import fastifyMultipart from '@fastify/multipart'
 import {
   vi,
@@ -15,6 +17,8 @@ import { createGraphQLYoga } from '@cedarjs/graphql-server'
 import type * as GraphqlServerModule from '@cedarjs/graphql-server'
 import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
 
+import type { createServer } from '../createServer.js'
+import type { CreateServerOptions } from '../createServerHelpers.js'
 import { createFastifyInstance } from '../fastify.js'
 import {
   cedarFastifyGraphQLServer,
@@ -179,32 +183,44 @@ describe('GraphQL route handler client-disconnect handling', () => {
   })
 })
 
-// Regression test for https://github.com/cedarjs/cedar/issues/2304
+// Regression tests for https://github.com/cedarjs/cedar/issues/2304
 //
 // `cedarFastifyAPI` and `cedarFastifyGraphQLServer` are registered as
 // *sibling* plugins (see `createServer.ts`), each getting its own Fastify
 // encapsulation context. A hook/plugin registered *inside* one of them
-// (e.g. by running the user's `configureApiServer` callback inside
-// `cedarFastifyAPI`) would never apply to the other sibling's routes. This
-// bit real users using `configureApiServer` to register `@fastify/compress`:
-// it compressed function responses, but not GraphQL responses.
+// (e.g. via `configureApiServer`, which runs inside `cedarFastifyAPI`, or
+// `configureGraphQLServer`, which runs inside `cedarFastifyGraphQLServer`)
+// only applies to that plugin's own routes, never the sibling's. This is
+// intentional: the two are configured independently on purpose (see PR
+// review discussion on #2389).
 //
-// `createServer.ts` now runs `configureApiServer` directly on the root
-// server instance, *before* registering either plugin, so hooks it adds
-// apply to both. This test verifies this by passing a `configureApiServer`
-// callback to `createServer` that adds an `onSend` hook, then asserting
-// it applies to both a function route (served by `cedarFastifyAPI`) and
-// the GraphQL route (served by `cedarFastifyGraphQLServer`).
-describe('root-level hooks apply across sibling plugins (issue #2304)', () => {
+// Real users hit #2304 by registering `@fastify/compress` via
+// `configureApiServer`, expecting it to also compress GraphQL responses.
+//
+// Applying a plugin/hook to *both* function and GraphQL routes has two
+// supported options, depending on what the plugin does:
+//
+// - Plain request-lifecycle hooks (`onRequest`, `onSend`, etc.) can be
+//   registered directly on the `server` instance returned by
+//   `createServer()`. That works because Fastify resolves hooks added to a
+//   parent context against its children's routes at request-dispatch time,
+//   regardless of whether they were added before or after the children were
+//   registered.
+// - Plugins with a "global" mode that works by hooking Fastify's `onRoute`
+//   (e.g. `@fastify/compress`) are different: `onRoute` only fires for
+//   routes registered *after* the plugin itself, so registering them on the
+//   returned `server` (i.e. after `cedarFastifyAPI`/
+//   `cedarFastifyGraphQLServer` already registered their routes) silently
+//   does nothing. These must be registered via the new `configureServer`
+//   option, which runs *before* any routes exist.
+describe('configureApiServer / configureGraphQLServer scoping (issue #2304)', () => {
   let server: Awaited<ReturnType<typeof createServer>>
 
-  afterEach(async () => {
-    vi.mocked(createGraphQLYoga).mockClear()
-    await server?.close()
-  })
-
-  it('a header set by an onSend hook in configureApiServer is present on both api-function and GraphQL responses', async () => {
-    // Import createServer locally to avoid affecting other tests' setup
+  async function createServerWithGraphQL(
+    options: CreateServerOptions,
+    yogaHandle: () => Promise<Response> = () =>
+      Promise.resolve(new Response('{}')),
+  ) {
     const { createServer: createServerFn } = await import('../createServer.js')
 
     // The fixture's graphql.js doesn't export __cedar_graphqlOptions, so
@@ -220,14 +236,20 @@ describe('root-level hooks apply across sibling plugins (issue #2304)', () => {
     )
 
     // Mock the GraphQL Yoga creation so we get a real /graphql route without
-    // needing a full GraphQL schema
-    vi.mocked(createGraphQLYoga).mockResolvedValue(
-      fakeYogaResult(() => Promise.resolve(new Response('{}'))),
-    )
+    // needing a full GraphQL schema. Defaults to a small `{}` response, but
+    // callers (e.g. the compression test below) can override the body.
+    vi.mocked(createGraphQLYoga).mockResolvedValue(fakeYogaResult(yogaHandle))
 
-    // Create the server with a configureApiServer callback that adds a header.
-    // This is what real users do, e.g. `server.register(compress)`.
-    server = await createServerFn({
+    return createServerFn(options)
+  }
+
+  afterEach(async () => {
+    vi.mocked(createGraphQLYoga).mockClear()
+    await server?.close()
+  })
+
+  it('configureApiServer only applies to api-function routes, not GraphQL', async () => {
+    server = await createServerWithGraphQL({
       configureApiServer: async (fastifyServer) => {
         fastifyServer.addHook('onSend', (_req, reply, payload, done) => {
           reply.header('x-configure-api-server', 'applied')
@@ -236,18 +258,110 @@ describe('root-level hooks apply across sibling plugins (issue #2304)', () => {
       },
     })
 
-    // The header should be present on function routes
-    const helloResponse = await server.inject({
-      method: 'GET',
-      url: '/hello',
-    })
+    const helloResponse = await server.inject({ method: 'GET', url: '/hello' })
     expect(helloResponse.headers['x-configure-api-server']).toEqual('applied')
 
-    // And on GraphQL routes
     const graphqlResponse = await server.inject({
       method: 'GET',
       url: '/graphql',
     })
-    expect(graphqlResponse.headers['x-configure-api-server']).toEqual('applied')
+    expect(graphqlResponse.headers['x-configure-api-server']).toBeUndefined()
+  })
+
+  it('configureGraphQLServer only applies to GraphQL routes, not api-functions', async () => {
+    server = await createServerWithGraphQL({
+      configureGraphQLServer: async (fastifyServer) => {
+        fastifyServer.addHook('onSend', (_req, reply, payload, done) => {
+          reply.header('x-configure-graphql-server', 'applied')
+          done(null, payload)
+        })
+      },
+    })
+
+    const graphqlResponse = await server.inject({
+      method: 'GET',
+      url: '/graphql',
+    })
+    expect(graphqlResponse.headers['x-configure-graphql-server']).toEqual(
+      'applied',
+    )
+
+    const helloResponse = await server.inject({ method: 'GET', url: '/hello' })
+    expect(helloResponse.headers['x-configure-graphql-server']).toBeUndefined()
+  })
+
+  it('registering a plugin directly on the returned server applies to both', async () => {
+    server = await createServerWithGraphQL({})
+
+    server.addHook('onSend', (_req, reply, payload, done) => {
+      reply.header('x-root-hook', 'applied')
+      done(null, payload)
+    })
+    await server.ready()
+
+    const helloResponse = await server.inject({ method: 'GET', url: '/hello' })
+    expect(helloResponse.headers['x-root-hook']).toEqual('applied')
+
+    const graphqlResponse = await server.inject({
+      method: 'GET',
+      url: '/graphql',
+    })
+    expect(graphqlResponse.headers['x-root-hook']).toEqual('applied')
+  })
+
+  it('registering @fastify/compress via configureServer actually compresses both api-function and GraphQL responses', async () => {
+    // Use a real (non-mocked) yoga.handle response with a body large enough
+    // that @fastify/compress's default threshold (1024 bytes) kicks in, so
+    // this exercises real gzip compression end to end rather than just
+    // asserting a header was set.
+    const largeJsonBody = JSON.stringify({
+      data: 'x'.repeat(2000),
+    })
+
+    server = await createServerWithGraphQL(
+      {
+        // `configureServer` runs before `cedarFastifyAPI`/
+        // `cedarFastifyGraphQLServer` register their routes, which is
+        // required for `@fastify/compress`'s `onRoute`-based global hook to
+        // catch them. `threshold: 0` forces compression regardless of
+        // payload size, so the tiny `/hello` fixture response (well under
+        // the default 1024-byte threshold) is compressed too, not just the
+        // larger GraphQL response.
+        configureServer: async (fastifyServer) => {
+          await fastifyServer.register(fastifyCompress, {
+            global: true,
+            threshold: 0,
+          })
+        },
+      },
+      () =>
+        Promise.resolve(
+          new Response(largeJsonBody, {
+            headers: { 'content-type': 'application/json' },
+          }),
+        ),
+    )
+
+    const helloResponse = await server.inject({
+      method: 'GET',
+      url: '/hello',
+      headers: { 'accept-encoding': 'gzip' },
+    })
+    expect(helloResponse.headers['content-encoding']).toEqual('gzip')
+
+    const graphqlResponse = await server.inject({
+      method: 'GET',
+      url: '/graphql',
+      headers: { 'accept-encoding': 'gzip' },
+    })
+    expect(graphqlResponse.headers['content-encoding']).toEqual('gzip')
+
+    // Confirm the compressed payload actually decompresses back to the
+    // original body, i.e. this isn't just a header being set with
+    // uncompressed bytes underneath.
+    const decompressed = gunzipSync(graphqlResponse.rawPayload).toString(
+      'utf-8',
+    )
+    expect(decompressed).toEqual(largeJsonBody)
   })
 })

--- a/packages/api-server/src/__tests__/graphqlPlugin.test.ts
+++ b/packages/api-server/src/__tests__/graphqlPlugin.test.ts
@@ -16,6 +16,7 @@ import type * as GraphqlServerModule from '@cedarjs/graphql-server'
 import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
 
 import { createFastifyInstance } from '../fastify.js'
+import { cedarFastifyAPI } from '../plugins/api.js'
 import {
   cedarFastifyGraphQLServer,
   isClientDisconnectError,
@@ -176,5 +177,67 @@ describe('GraphQL route handler client-disconnect handling', () => {
     })
 
     expect(response.statusCode).toBe(500)
+  })
+})
+
+// Regression test for https://github.com/cedarjs/cedar/issues/2304
+//
+// `cedarFastifyAPI` and `cedarFastifyGraphQLServer` are registered as
+// *sibling* plugins (see `createServer.ts`), each getting its own Fastify
+// encapsulation context. A hook/plugin registered *inside* one of them
+// (e.g. by running the user's `configureApiServer` callback inside
+// `cedarFastifyAPI`) would never apply to the other sibling's routes. This
+// bit real users using `configureApiServer` to register `@fastify/compress`:
+// it compressed function responses, but not GraphQL responses.
+//
+// `createServer.ts` now runs `configureApiServer` directly on the root
+// server instance, *before* registering either plugin, so hooks it adds
+// apply to both. This test simulates that by adding an `onSend` hook
+// directly on the root instance, then asserting it applies to both a
+// function route (served by `cedarFastifyAPI`) and the GraphQL route
+// (served by `cedarFastifyGraphQLServer`).
+describe('root-level hooks apply across sibling plugins (issue #2304)', () => {
+  let fastifyInstance: Awaited<ReturnType<typeof createFastifyInstance>>
+
+  afterEach(async () => {
+    vi.mocked(createGraphQLYoga).mockClear()
+    await fastifyInstance?.close()
+  })
+
+  it('a header set by an onSend hook on the root instance is present on both api-function and GraphQL responses', async () => {
+    fastifyInstance = await createFastifyInstance()
+
+    // Stands in for what a user's `configureApiServer` callback might do,
+    // e.g. `server.register(compress)`, which itself adds an `onSend` hook.
+    fastifyInstance.addHook('onSend', (_req, reply, payload, done) => {
+      reply.header('x-configure-api-server', 'applied')
+      done(null, payload)
+    })
+
+    await fastifyInstance.register(cedarFastifyAPI, {
+      cedar: { loadUserConfig: false },
+    })
+
+    vi.mocked(createGraphQLYoga).mockResolvedValueOnce(
+      fakeYogaResult(() => Promise.resolve(new Response('{}'))),
+    )
+
+    await fastifyInstance.register(cedarFastifyGraphQLServer, {
+      cedar: { graphql: fakeGraphqlOptions },
+    })
+
+    await fastifyInstance.ready()
+
+    const helloResponse = await fastifyInstance.inject({
+      method: 'GET',
+      url: '/hello',
+    })
+    expect(helloResponse.headers['x-configure-api-server']).toEqual('applied')
+
+    const graphqlResponse = await fastifyInstance.inject({
+      method: 'GET',
+      url: '/graphql',
+    })
+    expect(graphqlResponse.headers['x-configure-api-server']).toEqual('applied')
   })
 })

--- a/packages/api-server/src/__tests__/graphqlPlugin.test.ts
+++ b/packages/api-server/src/__tests__/graphqlPlugin.test.ts
@@ -16,7 +16,6 @@ import type * as GraphqlServerModule from '@cedarjs/graphql-server'
 import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
 
 import { createFastifyInstance } from '../fastify.js'
-import { cedarFastifyAPI } from '../plugins/api.js'
 import {
   cedarFastifyGraphQLServer,
   isClientDisconnectError,
@@ -192,49 +191,60 @@ describe('GraphQL route handler client-disconnect handling', () => {
 //
 // `createServer.ts` now runs `configureApiServer` directly on the root
 // server instance, *before* registering either plugin, so hooks it adds
-// apply to both. This test simulates that by adding an `onSend` hook
-// directly on the root instance, then asserting it applies to both a
-// function route (served by `cedarFastifyAPI`) and the GraphQL route
-// (served by `cedarFastifyGraphQLServer`).
+// apply to both. This test verifies this by passing a `configureApiServer`
+// callback to `createServer` that adds an `onSend` hook, then asserting
+// it applies to both a function route (served by `cedarFastifyAPI`) and
+// the GraphQL route (served by `cedarFastifyGraphQLServer`).
 describe('root-level hooks apply across sibling plugins (issue #2304)', () => {
-  let fastifyInstance: Awaited<ReturnType<typeof createFastifyInstance>>
+  let server: Awaited<ReturnType<typeof createServer>>
 
   afterEach(async () => {
     vi.mocked(createGraphQLYoga).mockClear()
-    await fastifyInstance?.close()
+    await server?.close()
   })
 
-  it('a header set by an onSend hook on the root instance is present on both api-function and GraphQL responses', async () => {
-    fastifyInstance = await createFastifyInstance()
+  it('a header set by an onSend hook in configureApiServer is present on both api-function and GraphQL responses', async () => {
+    // Import createServer locally to avoid affecting other tests' setup
+    const { createServer: createServerFn } = await import('../createServer.js')
 
-    // Stands in for what a user's `configureApiServer` callback might do,
-    // e.g. `server.register(compress)`, which itself adds an `onSend` hook.
-    fastifyInstance.addHook('onSend', (_req, reply, payload, done) => {
-      reply.header('x-configure-api-server', 'applied')
-      done(null, payload)
-    })
+    // The fixture's graphql.js doesn't export __cedar_graphqlOptions, so
+    // createServer will skip GraphQL setup. We need to mock the dynamic import
+    // to provide proper options so the GraphQL plugin registers.
+    vi.doMock(
+      `file://${path.join(__dirname, './fixtures/graphql/cedar-app/api/dist/functions/graphql.js')}`,
+      () => ({
+        handler: async () => ({}),
+        __cedar_graphqlOptions: fakeGraphqlOptions,
+      }),
+      { virtual: true },
+    )
 
-    await fastifyInstance.register(cedarFastifyAPI, {
-      cedar: { loadUserConfig: false },
-    })
-
-    vi.mocked(createGraphQLYoga).mockResolvedValueOnce(
+    // Mock the GraphQL Yoga creation so we get a real /graphql route without
+    // needing a full GraphQL schema
+    vi.mocked(createGraphQLYoga).mockResolvedValue(
       fakeYogaResult(() => Promise.resolve(new Response('{}'))),
     )
 
-    await fastifyInstance.register(cedarFastifyGraphQLServer, {
-      cedar: { graphql: fakeGraphqlOptions },
+    // Create the server with a configureApiServer callback that adds a header.
+    // This is what real users do, e.g. `server.register(compress)`.
+    server = await createServerFn({
+      configureApiServer: async (fastifyServer) => {
+        fastifyServer.addHook('onSend', (_req, reply, payload, done) => {
+          reply.header('x-configure-api-server', 'applied')
+          done(null, payload)
+        })
+      },
     })
 
-    await fastifyInstance.ready()
-
-    const helloResponse = await fastifyInstance.inject({
+    // The header should be present on function routes
+    const helloResponse = await server.inject({
       method: 'GET',
       url: '/hello',
     })
     expect(helloResponse.headers['x-configure-api-server']).toEqual('applied')
 
-    const graphqlResponse = await fastifyInstance.inject({
+    // And on GraphQL routes
+    const graphqlResponse = await server.inject({
       method: 'GET',
       url: '/graphql',
     })

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -50,13 +50,29 @@ if (!process.env.CEDAR_ENV_FILES_LOADED) {
  *   const server = await createServer({
  *     logger,
  *     apiRootPath: 'api'
+ *     configureServer: (server) => {
+ *       // Runs before the api functions and GraphQL plugins are
+ *       // registered, i.e. before any routes exist. This is the right
+ *       // place for plugins with a "global" mode that hooks `onRoute`
+ *       // (e.g. `@fastify/compress`), since those only affect routes
+ *       // registered *after* the plugin itself — registering them here
+ *       // applies them to *both* api functions and the GraphQL endpoint:
+ *       server.register(compress, { global: true })
+ *     },
  *     configureApiServer: (server) => {
- *       // Configure the API server fastify instance, e.g. add content type parsers
+ *       // Configure just the api functions' fastify instance, e.g. add
+ *       // content type parsers. Doesn't apply to the GraphQL endpoint.
+ *     },
+ *     configureGraphQLServer: (server) => {
+ *       // Configure just the GraphQL fastify instance. Doesn't apply to
+ *       // api function routes.
  *     },
  *   })
  *
- *   // Configure the returned fastify instance:
- *   server.register(myPlugin)
+ *   // Plain request-lifecycle hooks (onRequest, onSend, etc.) don't depend
+ *   // on registration order, so they can also be added to the returned
+ *   // instance after the fact and will still apply to both:
+ *   server.addHook('onRequest', myHook)
  *
  *   // When ready, start the server:
  *   await server.start()
@@ -70,7 +86,9 @@ export async function createServer(options: CreateServerOptions = {}) {
     apiRootPath,
     fastifyServerOptions,
     discoverFunctionsGlob,
+    configureServer,
     configureApiServer,
+    configureGraphQLServer,
     apiPort,
     apiHost,
   } = resolveOptions(options)
@@ -116,19 +134,26 @@ export async function createServer(options: CreateServerOptions = {}) {
     getAsyncStoreInstance().run(new Map<string, GlobalContext>(), done)
   })
 
-  // Run the user's custom server configuration function directly on the root
-  // `server` instance, *before* registering the api/GraphQL plugins.
-  //
-  // `cedarFastifyAPI` and `cedarFastifyGraphQLServer` are registered below as
-  // sibling plugins (each gets its own Fastify encapsulation context), so
-  // anything registered *inside* one of them (e.g. hooks/plugins added via
-  // `configureApiServer` if it ran inside `cedarFastifyAPI`) would not apply
-  // to the other. Running it here, on the root instance, means hooks and
-  // plugins added by `configureApiServer` (e.g. `@fastify/compress`) apply to
-  // both the api functions and the GraphQL endpoint alike.
-  // See: https://github.com/cedarjs/cedar/issues/2304
-  await configureApiServer(server)
+  // Run the user's `configureServer` *before* the api functions and GraphQL
+  // plugins are registered below, i.e. before any routes exist. This matters
+  // for plugins with a "global" mode that works by hooking Fastify's
+  // `onRoute` (e.g. `@fastify/compress`) — those only affect routes
+  // registered *after* the plugin itself, so registering them any later
+  // (including directly on the returned `server` once `createServer()`
+  // resolves) would silently fail to compress api-function/GraphQL
+  // responses. See https://github.com/cedarjs/cedar/issues/2304.
+  if (configureServer) {
+    await configureServer(server)
+  }
 
+  // `cedarFastifyAPI` and `cedarFastifyGraphQLServer` are registered below as
+  // sibling plugins, each getting its own Fastify encapsulation context.
+  // `configureApiServer`/`configureGraphQLServer` are run *inside* their
+  // respective plugin's context, so they're scoped to that plugin's routes
+  // only and don't leak into the other. Plain request-lifecycle hooks
+  // (onRequest, onSend, etc.) don't depend on registration order and can
+  // still be added directly to the `server` instance returned by
+  // `createServer()` — see the example above.
   await server.register(cedarFastifyAPI, {
     cedar: {
       apiRootPath,
@@ -136,6 +161,7 @@ export async function createServer(options: CreateServerOptions = {}) {
         ignore: ['**/dist/functions/graphql.js'],
       },
       discoverFunctionsGlob,
+      configureServer: configureApiServer,
     },
   })
 
@@ -157,6 +183,7 @@ export async function createServer(options: CreateServerOptions = {}) {
       cedar: {
         apiRootPath,
         graphql: __cedar_graphqlOptions,
+        configureServer: configureGraphQLServer,
       },
     })
   }

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -116,6 +116,19 @@ export async function createServer(options: CreateServerOptions = {}) {
     getAsyncStoreInstance().run(new Map<string, GlobalContext>(), done)
   })
 
+  // Run the user's custom server configuration function directly on the root
+  // `server` instance, *before* registering the api/GraphQL plugins.
+  //
+  // `cedarFastifyAPI` and `cedarFastifyGraphQLServer` are registered below as
+  // sibling plugins (each gets its own Fastify encapsulation context), so
+  // anything registered *inside* one of them (e.g. hooks/plugins added via
+  // `configureApiServer` if it ran inside `cedarFastifyAPI`) would not apply
+  // to the other. Running it here, on the root instance, means hooks and
+  // plugins added by `configureApiServer` (e.g. `@fastify/compress`) apply to
+  // both the api functions and the GraphQL endpoint alike.
+  // See: https://github.com/cedarjs/cedar/issues/2304
+  await configureApiServer(server)
+
   await server.register(cedarFastifyAPI, {
     cedar: {
       apiRootPath,
@@ -123,7 +136,6 @@ export async function createServer(options: CreateServerOptions = {}) {
         ignore: ['**/dist/functions/graphql.js'],
       },
       discoverFunctionsGlob,
-      configureServer: configureApiServer,
     },
   })
 

--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -38,8 +38,23 @@ export interface CreateServerOptions {
    */
   discoverFunctionsGlob?: string | string[]
 
-  /** Customise the API server fastify plugin before it is registered */
+  /**
+   * Configure the root fastify instance *before* the api functions and
+   * GraphQL plugins are registered. Use this to register Fastify plugins
+   * that need to run before any routes exist — most notably plugins with a
+   * "global" mode that works by hooking `onRoute` (e.g. `@fastify/compress`),
+   * which only affects routes registered *after* the plugin itself. Simple
+   * request-lifecycle hooks (`onRequest`, `onSend`, etc.) don't have this
+   * restriction and can also be added to the returned server after
+   * `createServer()` resolves.
+   */
+  configureServer?: (server: Server) => void | Promise<void>
+
+  /** Customise the API functions fastify plugin before it is registered */
   configureApiServer?: (server: Server) => void | Promise<void>
+
+  /** Customise the GraphQL fastify plugin before it is registered */
+  configureGraphQLServer?: (server: Server) => void | Promise<void>
 
   /** Whether to parse args or not. Defaults to `true` */
   parseArgs?: boolean
@@ -72,7 +87,9 @@ export const getDefaultCreateServerOptions: () => DefaultCreateServerOptions =
       bodyLimit: 1024 * 1024 * 100, // 100MB
     },
     discoverFunctionsGlob: 'dist/functions/**/*.{ts,js}',
+    configureServer: () => {},
     configureApiServer: () => {},
+    configureGraphQLServer: () => {},
     parseArgs: true,
     // `createServer()`'s only callers are `cedarjs-server api` and custom
     // `api/src/server.ts` files — both only ever run with the api side
@@ -115,8 +132,11 @@ export function resolveOptions(
     },
     discoverFunctionsGlob:
       options.discoverFunctionsGlob ?? defaults.discoverFunctionsGlob,
+    configureServer: options.configureServer ?? defaults.configureServer,
     configureApiServer:
       options.configureApiServer ?? defaults.configureApiServer,
+    configureGraphQLServer:
+      options.configureGraphQLServer ?? defaults.configureGraphQLServer,
     apiHost: options.apiHost ?? defaults.apiHost,
     apiPort: options.apiPort ?? defaults.apiPort,
   }

--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -48,13 +48,13 @@ export interface CreateServerOptions {
    * restriction and can also be added to the returned server after
    * `createServer()` resolves.
    */
-  configureServer?: (server: Server) => void | Promise<void>
+  configureServer?: (server: FastifyInstance) => void | Promise<void>
 
   /** Customise the API functions fastify plugin before it is registered */
-  configureApiServer?: (server: Server) => void | Promise<void>
+  configureApiServer?: (server: FastifyInstance) => void | Promise<void>
 
   /** Customise the GraphQL fastify plugin before it is registered */
-  configureGraphQLServer?: (server: Server) => void | Promise<void>
+  configureGraphQLServer?: (server: FastifyInstance) => void | Promise<void>
 
   /** Whether to parse args or not. Defaults to `true` */
   parseArgs?: boolean

--- a/packages/api-server/src/plugins/api.ts
+++ b/packages/api-server/src/plugins/api.ts
@@ -7,7 +7,6 @@ import type { GlobalContext } from '@cedarjs/context'
 import { getAsyncStoreInstance } from '@cedarjs/context/dist/store'
 import { coerceRootPath } from '@cedarjs/fastify-web/dist/helpers.js'
 
-import type { Server } from '../createServerHelpers.js'
 import { loadFastifyConfig } from '../fastify.js'
 
 import { lambdaRequestHandler, loadFunctionsFromDist } from './lambdaLoader.js'
@@ -18,7 +17,7 @@ export interface CedarFastifyAPIOptions {
     fastGlobOptions?: FastGlobOptions
     discoverFunctionsGlob?: string | string[]
     loadUserConfig?: boolean
-    configureServer?: (server: Server) => void | Promise<void>
+    configureServer?: (server: FastifyInstance) => void | Promise<void>
     // TODO(UD): Future potential integration point. Remove if we don't end up
     // using it
     // onRoutesDiscovered?: (routes: unknown[]) => void | Promise<void>
@@ -66,7 +65,7 @@ export async function cedarFastifyAPI(
   // apply to both, register it directly on the `server` instance returned by
   // `createServer()` instead.
   if (cedarOptions.configureServer) {
-    await cedarOptions.configureServer(fastify as Server)
+    await cedarOptions.configureServer(fastify)
   }
 
   fastify.all(`${cedarOptions.apiRootPath}:routeName`, lambdaRequestHandler)

--- a/packages/api-server/src/plugins/api.ts
+++ b/packages/api-server/src/plugins/api.ts
@@ -7,6 +7,7 @@ import type { GlobalContext } from '@cedarjs/context'
 import { getAsyncStoreInstance } from '@cedarjs/context/dist/store'
 import { coerceRootPath } from '@cedarjs/fastify-web/dist/helpers.js'
 
+import type { Server } from '../createServerHelpers.js'
 import { loadFastifyConfig } from '../fastify.js'
 
 import { lambdaRequestHandler, loadFunctionsFromDist } from './lambdaLoader.js'
@@ -17,6 +18,7 @@ export interface CedarFastifyAPIOptions {
     fastGlobOptions?: FastGlobOptions
     discoverFunctionsGlob?: string | string[]
     loadUserConfig?: boolean
+    configureServer?: (server: Server) => void | Promise<void>
     // TODO(UD): Future potential integration point. Remove if we don't end up
     // using it
     // onRoutesDiscovered?: (routes: unknown[]) => void | Promise<void>
@@ -56,6 +58,15 @@ export async function cedarFastifyAPI(
         apiRootPath: cedarOptions.apiRootPath,
       })
     }
+  }
+
+  // Run the user's custom server configuration function, scoped to this
+  // plugin's own encapsulation context (i.e. it applies to api function
+  // routes only, not to the sibling GraphQL server). For config that should
+  // apply to both, register it directly on the `server` instance returned by
+  // `createServer()` instead.
+  if (cedarOptions.configureServer) {
+    await cedarOptions.configureServer(fastify as Server)
   }
 
   fastify.all(`${cedarOptions.apiRootPath}:routeName`, lambdaRequestHandler)

--- a/packages/api-server/src/plugins/api.ts
+++ b/packages/api-server/src/plugins/api.ts
@@ -7,7 +7,6 @@ import type { GlobalContext } from '@cedarjs/context'
 import { getAsyncStoreInstance } from '@cedarjs/context/dist/store'
 import { coerceRootPath } from '@cedarjs/fastify-web/dist/helpers.js'
 
-import type { Server } from '../createServerHelpers.js'
 import { loadFastifyConfig } from '../fastify.js'
 
 import { lambdaRequestHandler, loadFunctionsFromDist } from './lambdaLoader.js'
@@ -18,7 +17,6 @@ export interface CedarFastifyAPIOptions {
     fastGlobOptions?: FastGlobOptions
     discoverFunctionsGlob?: string | string[]
     loadUserConfig?: boolean
-    configureServer?: (server: Server) => void | Promise<void>
     // TODO(UD): Future potential integration point. Remove if we don't end up
     // using it
     // onRoutesDiscovered?: (routes: unknown[]) => void | Promise<void>
@@ -58,11 +56,6 @@ export async function cedarFastifyAPI(
         apiRootPath: cedarOptions.apiRootPath,
       })
     }
-  }
-
-  // Run users custom server configuration function
-  if (cedarOptions.configureServer) {
-    await cedarOptions.configureServer(fastify as Server)
   }
 
   fastify.all(`${cedarOptions.apiRootPath}:routeName`, lambdaRequestHandler)

--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -18,14 +18,13 @@ import { createGraphQLYoga } from '@cedarjs/graphql-server'
 import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
 import { getPaths } from '@cedarjs/project-config'
 
-import type { Server } from '../createServerHelpers.js'
 import { lambdaEventForFastifyRequest } from '../requestHandlers/awsLambdaFastify.js'
 
 export interface CedarFastifyGraphQLOptions {
   cedar: {
     apiRootPath?: string
     graphql?: GraphQLYogaOptions
-    configureServer?: (server: Server) => void | Promise<void>
+    configureServer?: (server: FastifyInstance) => void | Promise<void>
   }
 }
 
@@ -54,7 +53,7 @@ export async function cedarFastifyGraphQLServer(
   // should apply to both, register it directly on the `server` instance
   // returned by `createServer()` instead.
   if (cedarOptions.configureServer) {
-    await cedarOptions.configureServer(fastify as Server)
+    await cedarOptions.configureServer(fastify)
   }
 
   try {

--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -18,12 +18,14 @@ import { createGraphQLYoga } from '@cedarjs/graphql-server'
 import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
 import { getPaths } from '@cedarjs/project-config'
 
+import type { Server } from '../createServerHelpers.js'
 import { lambdaEventForFastifyRequest } from '../requestHandlers/awsLambdaFastify.js'
 
 export interface CedarFastifyGraphQLOptions {
   cedar: {
     apiRootPath?: string
     graphql?: GraphQLYogaOptions
+    configureServer?: (server: Server) => void | Promise<void>
   }
 }
 
@@ -45,6 +47,15 @@ export async function cedarFastifyGraphQLServer(
   fastify.addHook('onRequest', (_req, _reply, done) => {
     getAsyncStoreInstance().run(new Map<string, GlobalContext>(), done)
   })
+
+  // Run the user's custom server configuration function, scoped to this
+  // plugin's own encapsulation context (i.e. it applies to the GraphQL
+  // routes only, not to the sibling api function routes). For config that
+  // should apply to both, register it directly on the `server` instance
+  // returned by `createServer()` instead.
+  if (cedarOptions.configureServer) {
+    await cedarOptions.configureServer(fastify as Server)
+  }
 
   try {
     // Load the graphql options from the user's graphql function if none are

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,6 +2084,7 @@ __metadata:
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
     "@cedarjs/web-server": "workspace:*"
+    "@fastify/compress": "npm:9.1.1"
     "@fastify/multipart": "npm:9.4.0"
     "@fastify/url-data": "npm:6.0.4"
     "@types/aws-lambda": "npm:8.10.162"


### PR DESCRIPTION
`cedarFastifyAPI` and `cedarFastifyGraphQLServer` are registered as *sibling* Fastify plugins in `createServer.ts`, each getting its own Fastify encapsulation context. Previously, the user's `configureApiServer` callback was invoked *inside* `cedarFastifyAPI`'s own registration — so any hooks/plugins it added (e.g. `@fastify/compress`) never applied to the sibling `cedarFastifyGraphQLServer`'s routes. In practice this meant `@fastify/compress` registered via `configureApiServer` compressed serverless function responses, but not GraphQL responses (#2304).

## Design (updated per review discussion with @Tobbe)

An earlier version of this PR ran `configureApiServer(server)` on the root instance, before either sibling plugin registered — but that widened `configureApiServer`'s scope to also apply to GraphQL routes, which is a behavior change existing users could be relying on *not* happening (they're two separate, independently-configured plugins on purpose).

This version instead keeps `configureApiServer` scoped to api-function routes only (reverting to its original behavior) and adds two new, purpose-built options:

- **`configureGraphQLServer`** — the GraphQL-only counterpart to `configureApiServer`, scoped to just the GraphQL routes via `cedarFastifyGraphQLServer`'s own encapsulation context.
- **`configureServer`** — runs on the root Fastify instance *before* the api-function and GraphQL plugins are registered, i.e. before any routes exist. This turned out to be necessary (not just nice-to-have) for the actual #2304 use case: `@fastify/compress`'s "global" mode works by hooking Fastify's `onRoute`, which only fires for routes registered *after* the plugin itself. Registering it directly on the `server` instance returned by `createServer()` (i.e. after `cedarFastifyAPI`/`cedarFastifyGraphQLServer` already registered their routes internally) silently does nothing — verified empirically with a real (non-mocked) `@fastify/compress` + `gunzipSync` round-trip test.

Plain request-lifecycle hooks (`onRequest`, `onSend`, etc.) don't have this registration-order restriction, since Fastify resolves them against the full encapsulation tree at request-dispatch time. Those can still be added directly to the returned `server` instance after `createServer()` resolves, and will apply to both api functions and GraphQL.

```js
const server = await createServer({
  configureServer: (server) => {
    // Runs before any routes exist — required for onRoute-based global
    // plugins like @fastify/compress to catch both api-function and
    // GraphQL routes.
    server.register(compress, { global: true })
  },
  configureApiServer: (server) => {
    // Api-function routes only.
  },
  configureGraphQLServer: (server) => {
    // GraphQL routes only.
  },
})

// Plain hooks can go here too, and apply to both:
server.addHook('onRequest', myHook)
```

## Changes

- `packages/api-server/src/createServerHelpers.ts` — adds `configureServer` and `configureGraphQLServer` to `CreateServerOptions`, with defaults and resolution.
- `packages/api-server/src/createServer.ts` — calls `configureServer(server)` before registering `cedarFastifyAPI`/`cedarFastifyGraphQLServer`; passes `configureApiServer`/`configureGraphQLServer` through to each plugin's own options (reverted to pre-PR scoping).
- `packages/api-server/src/plugins/api.ts` — `configureServer` option restored (this plugin's `configureApiServer` value is passed through as `configureServer` here), scoped to this plugin's own context.
- `packages/api-server/src/plugins/graphql.ts` — new symmetric `configureServer` option (this plugin's `configureGraphQLServer` value is passed through as `configureServer` here), scoped to this plugin's own context.
- `packages/api-server/src/__tests__/graphqlPlugin.test.ts` — regression tests for: `configureApiServer` only affecting api-function routes, `configureGraphQLServer` only affecting GraphQL routes, plain hooks on the returned server applying to both, and a real `@fastify/compress` + `gunzipSync` round-trip test proving compression actually works end-to-end for both api-function and GraphQL responses via `configureServer`.
- `packages/api-server/src/__tests__/createServer.test.ts` — updated `resolveOptions` defaults test for the new `configureServer`/`configureGraphQLServer` fields.
- `packages/api-server/package.json` — adds `@fastify/compress` as a devDependency for the new compression test.

Fixes #2304
