### PR TITLE
fix(cli): track tsconfig.tsbuildinfo for rollback in package generator

### DIFF
--- a/.changesets/2334.md
+++ b/.changesets/2334.md
@@ -3,7 +3,7 @@
 Fixes #2334, where `cedar generate package <name> --rollback` left
 `tsconfig.tsbuildinfo` behind at the package root when a later step failed.
 `installAndBuild()` runs `tsc` (via the generated `tsconfig.json`'s
-`"composite": true`), which produces this file, but it was never registered
-with `addFileToRollback`. Because it was an untracked leftover, it could also
-prevent `executeRollback`'s empty-parent-directory cleanup from fully removing
-the generated package directory.
+`"composite": true`), which produces this file, but it was never registered with
+`addFileToRollback`. Because it was an untracked leftover, it could also prevent
+`executeRollback`'s empty-parent-directory cleanup from fully removing the
+generated package directory.

--- a/.changesets/2334.md
+++ b/.changesets/2334.md
@@ -1,0 +1,9 @@
+# fix(cli): track tsconfig.tsbuildinfo for rollback in package generator (#2334) by @lisa-assistant
+
+Fixes #2334, where `cedar generate package <name> --rollback` left
+`tsconfig.tsbuildinfo` behind at the package root when a later step failed.
+`installAndBuild()` runs `tsc` (via the generated `tsconfig.json`'s
+`"composite": true`), which produces this file, but it was never registered
+with `addFileToRollback`. Because it was an untracked leftover, it could also
+prevent `executeRollback`'s empty-parent-directory cleanup from fully removing
+the generated package directory.

--- a/packages/cli/src/commands/generate/package/packageHandler.ts
+++ b/packages/cli/src/commands/generate/package/packageHandler.ts
@@ -18,7 +18,7 @@ import { getPackageManager } from '@cedarjs/project-config/packageManager'
 import { errorTelemetry } from '@cedarjs/telemetry'
 
 import { getPaths, writeFilesTask } from '../../../lib/index.js'
-import { prepareForRollback } from '../../../lib/rollback.js'
+import { addFileToRollback, prepareForRollback } from '../../../lib/rollback.js'
 
 import { files } from './filesTask.js'
 
@@ -372,6 +372,12 @@ export function updateWorkspaceTsconfigReferences(
 async function installAndBuild(folderName: string) {
   const packagePath = path.join('packages', folderName)
   await installPackages({ stdio: 'inherit', cwd: getPaths().base })
+  // `tsc` (via the generated tsconfig.json's `"composite": true`) writes a
+  // tsconfig.tsbuildinfo file at the package root. Track it for rollback
+  // before running the build so a later failure cleans it up too.
+  addFileToRollback(
+    path.join(getPaths().base, packagePath, 'tsconfig.tsbuildinfo'),
+  )
   // TODO: `yarn cedar build <packageName>`
   await runScript('build', [], { stdio: 'inherit', cwd: packagePath })
 }

--- a/packages/cli/src/lib/__tests__/rollback.test.ts
+++ b/packages/cli/src/lib/__tests__/rollback.test.ts
@@ -1,11 +1,28 @@
-import fs from 'node:fs'
+import type NodeFs from 'node:fs'
 import path from 'node:path'
 
-vi.mock('node:fs')
-
 import { Listr } from 'listr2'
-import { vol } from 'memfs'
 import { vi, it, expect, beforeEach } from 'vitest'
+
+const { memfs, ufs, vol } = await vi.hoisted(async () => {
+  const { vol, fs: memfs } = await import('memfs')
+  const { ufs } = await import('unionfs')
+  return { memfs, ufs, vol }
+})
+
+vi.mock('node:fs', async (importOriginal) => {
+  const { wrapFsForUnionfs, wrapMemfsForUnionfs } =
+    await import('../../__tests__/ufsFsProxy.js')
+  const originalFs = await importOriginal<typeof NodeFs>()
+  ufs.use(wrapFsForUnionfs(originalFs)).use(wrapMemfsForUnionfs(memfs))
+
+  return {
+    ...ufs,
+    default: ufs,
+  }
+})
+
+const fs = await import('node:fs')
 
 import * as rollback from '../rollback.js'
 
@@ -65,6 +82,46 @@ it('removes empty folders after removing files', async () => {
     fs.existsSync(path.join('fake_dir', 'mock_dir', 'test_dir', 'fake-file')),
   ).toBe(false)
   expect(fs.readdirSync('fake_dir')).toStrictEqual([])
+})
+
+it('removes a build artifact tracked before it was created, e.g. tsconfig.tsbuildinfo', async () => {
+  // Mirrors the package generator's `installAndBuild()`: the build artifact
+  // doesn't exist yet when it's registered for rollback, `tsc` then creates
+  // it, and a later failure should remove it again.
+  const tsBuildInfoPath = path.join(
+    'packages',
+    'my-package',
+    'tsconfig.tsbuildinfo',
+  )
+  vol.fromJSON({
+    [path.join('packages', 'my-package', 'package.json')]: '{}',
+  })
+
+  rollback.addFileToRollback(tsBuildInfoPath)
+  fs.writeFileSync(tsBuildInfoPath, 'fake-tsbuildinfo-content')
+  expect(fs.existsSync(tsBuildInfoPath)).toBe(true)
+
+  await executeRollback()
+  expect(fs.existsSync(tsBuildInfoPath)).toBe(false)
+})
+
+it('restores a pre-existing build artifact tracked before it was overwritten', async () => {
+  const tsBuildInfoPath = path.join(
+    'packages',
+    'my-package',
+    'tsconfig.tsbuildinfo',
+  )
+  vol.fromJSON({
+    [tsBuildInfoPath]: 'original-tsbuildinfo-content',
+  })
+
+  rollback.addFileToRollback(tsBuildInfoPath)
+  fs.writeFileSync(tsBuildInfoPath, 'new-tsbuildinfo-content')
+
+  await executeRollback()
+  expect(fs.readFileSync(tsBuildInfoPath, 'utf-8')).toBe(
+    'original-tsbuildinfo-content',
+  )
 })
 
 it('executes sync functions', async () => {


### PR DESCRIPTION
Fixes #2334.

`cedar generate package <name> --rollback` left `tsconfig.tsbuildinfo` behind at the package root when a later step failed and rollback ran.

`installAndBuild()` runs `tsc` (via the generated `tsconfig.json`'s `"composite": true`), which produces `tsconfig.tsbuildinfo` at the package root — but this file was never registered with `addFileToRollback` (unlike the other scaffolded files, which are tracked via `prepareForRollback`). Because it was an untracked leftover, it could also prevent `executeRollback`'s empty-parent-directory cleanup from fully removing the generated package directory.

## Fix

In `packageHandler.ts`'s `installAndBuild()`, register the expected `tsconfig.tsbuildinfo` path with `addFileToRollback` before running the `tsc` build step, mirroring how other generated files are already tracked.

## Changes

- `packages/cli/src/commands/generate/package/packageHandler.ts` — import `addFileToRollback` alongside `prepareForRollback`; call it in `installAndBuild()` right before the build step.