### PR TITLE
feat(eslint-plugin): add cell-type-annotations rule

### DIFF
--- a/.changesets/release_notes_major.md
+++ b/.changesets/release_notes_major.md
@@ -59,9 +59,7 @@ are missing type annotations, and autofixes most of them using the types from
 `CellFailureProps`, `CellSuccessProps`). `beforeQuery`'s parameter type is
 flagged but never autofixed — Cedar can't safely guess your props shape — but
 it's worth annotating by hand, since it drives Cedar's prop-type inference for
-the rest of the Cell. It only applies to `.tsx` Cells — `.jsx` Cells are plain
-JavaScript-project output with no build step to strip the annotations back
-out.
+the rest of the Cell. 
 
 Like `service-type-annotations`, it's off by default. Enable it in your
 project's `eslint.config.mjs`:
@@ -174,6 +172,10 @@ code:
   the flag is also no longer hidden. `cedar dev` also now defaults to
   `open: false` when there's no interactive TTY (CI, AI agents), regardless
   of `[browser] open` in `cedar.toml`.
+- **The new `cell-type-annotations` ESLint rule catches untyped Cells.**
+  Cells generated (or hand-edited) without their `beforeQuery`/`afterQuery`/
+  `isEmpty` and `Loading`/`Failure`/`Success` type annotations now get flagged
+  and mostly autofixed. See the Highlights section above for how to enable it.
 
 ### `postcss-loader` is no longer installed
 

--- a/.changesets/release_notes_major.md
+++ b/.changesets/release_notes_major.md
@@ -49,6 +49,37 @@ the fragment selects the type's `id`, the Cell reads its data live from the
 Apollo cache and re-renders when mutations update the entity. See the new
 "Fragment Cells: Aggregating Queries" section in the Cells docs.
 
+### New `cell-type-annotations` ESLint rule
+
+`@cedarjs/eslint-plugin` has a new `cell-type-annotations` rule, mirroring the
+existing `service-type-annotations` rule but for Cells. It flags Cell exports
+(`beforeQuery`, `afterQuery`, `isEmpty`, `Loading`, `Failure`, `Success`) that
+are missing type annotations, and autofixes most of them using the types from
+`@cedarjs/web` (`CellBeforeQueryResult`, `DataObject`, `CellLoadingProps`,
+`CellFailureProps`, `CellSuccessProps`). `beforeQuery`'s parameter type is
+flagged but never autofixed — Cedar can't safely guess your props shape — but
+it's worth annotating by hand, since it drives Cedar's prop-type inference for
+the rest of the Cell. It only applies to `.tsx` Cells — `.jsx` Cells are plain
+JavaScript-project output with no build step to strip the annotations back
+out.
+
+Like `service-type-annotations`, it's off by default. Enable it in your
+project's `eslint.config.mjs`:
+
+```js
+import cedarConfig from '@cedarjs/eslint-config'
+
+export default [
+  ...(await cedarConfig()),
+  {
+    files: ['web/src/components/**/*Cell.tsx'],
+    rules: {
+      '@cedarjs/cell-type-annotations': 'error',
+    },
+  },
+]
+```
+
 ### CedarApolloProvider
 
 Continuing the move from Redwood to Cedar naming, `RedwoodApolloProvider` is

--- a/.changesets/release_notes_major.md
+++ b/.changesets/release_notes_major.md
@@ -59,7 +59,7 @@ are missing type annotations, and autofixes most of them using the types from
 `CellFailureProps`, `CellSuccessProps`). `beforeQuery`'s parameter type is
 flagged but never autofixed — Cedar can't safely guess your props shape — but
 it's worth annotating by hand, since it drives Cedar's prop-type inference for
-the rest of the Cell. 
+the rest of the Cell.
 
 Like `service-type-annotations`, it's off by default. Enable it in your
 project's `eslint.config.mjs`:

--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -158,6 +158,21 @@ export default async function createConfig() {
     },
   })
 
+  // Cell type annotations. The rule requires both the `*Cell.tsx` filename
+  // convention and a QUERY/FRAGMENT export alongside a Success export before
+  // it treats a file as a Cell. `.jsx` is excluded: it's plain
+  // JavaScript-project output with no build step that strips TypeScript
+  // syntax, so the rule's fixes don't apply there.
+  configs.push({
+    files: ['web/src/**/*Cell.tsx'],
+    plugins: {
+      '@cedarjs': cedarjsPlugin,
+    },
+    rules: {
+      '@cedarjs/cell-type-annotations': 'off',
+    },
+  })
+
   // Test, stories, scenarios, and mock files
   configs.push({
     files: [

--- a/packages/eslint-plugin/src/__tests__/cell-type-annotations.test.ts
+++ b/packages/eslint-plugin/src/__tests__/cell-type-annotations.test.ts
@@ -430,5 +430,274 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
         },
       ],
     },
+    {
+      // Unparenthesized single-param arrow: both the param and return type are
+      // missing, so the fix has to wrap the param in parens itself rather than
+      // anchoring on an existing `)`.
+      filename: CELL_FILENAME,
+      code: `
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const afterQuery = data => data
+
+        export const Success = () => <div>Success</div>
+      `,
+      output: `import type { DataObject } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const afterQuery = (data: DataObject): DataObject => data
+
+        export const Success = () => <div>Success</div>
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'afterQuery',
+            typeName: 'DataObject',
+            kind: 'function',
+            location: 'parameter and return type',
+          },
+        },
+      ],
+    },
+    {
+      // Unparenthesized single-param arrow on a render prop: only the param
+      // needs wrapping (no return type involved).
+      filename: CELL_FILENAME,
+      code: `
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const Success = props => <div>{props.blogPosts.length}</div>
+      `,
+      output: `import type { CellSuccessProps } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const Success = (props: CellSuccessProps) => <div>{props.blogPosts.length}</div>
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'Success',
+            typeName: 'CellSuccessProps',
+            kind: 'component',
+            location: 'parameter',
+          },
+        },
+      ],
+    },
+    {
+      // Inline `import { type X }` specifiers count as already imported --
+      // the fix must not add a second, duplicate import for the same name.
+      filename: CELL_FILENAME,
+      code: `
+        import { type CellSuccessProps } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const Success = ({ blogPosts }) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+      output: `
+        import { type CellSuccessProps } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'Success',
+            typeName: 'CellSuccessProps',
+            kind: 'component',
+            location: 'parameter',
+          },
+        },
+      ],
+    },
+    {
+      // A `@cedarjs/web` type import with no named specifier (a namespace
+      // import here) has nothing to append to -- the fix must fall back to
+      // inserting a new `import type` line instead of crashing.
+      filename: CELL_FILENAME,
+      code: `
+        import type * as Web from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const Success = ({ blogPosts }) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+      output: `import type { CellSuccessProps } from '@cedarjs/web'
+
+        import type * as Web from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'Success',
+            typeName: 'CellSuccessProps',
+            kind: 'component',
+            location: 'parameter',
+          },
+        },
+      ],
+    },
+    {
+      // `Loading`'s props type, derived from QUERY's variables type.
+      filename: CELL_FILENAME,
+      code: `
+        import type { CellSuccessProps } from '@cedarjs/web'
+        import type { FindBlogPost, FindBlogPostVariables } from 'types/graphql'
+
+        export const QUERY: TypedDocumentNode<
+          FindBlogPost,
+          FindBlogPostVariables
+        > = gql\`
+          query FindBlogPost($id: Int!) {
+            blogPost(id: $id) {
+              id
+            }
+          }
+        \`
+
+        export const Loading = ({ id }) => <div>Loading {id}...</div>
+        export const Success = ({ blogPost }: CellSuccessProps) => (
+          <div>{blogPost.id}</div>
+        )
+      `,
+      output: `
+        import type { CellSuccessProps, CellLoadingProps } from '@cedarjs/web'
+        import type { FindBlogPost, FindBlogPostVariables } from 'types/graphql'
+
+        export const QUERY: TypedDocumentNode<
+          FindBlogPost,
+          FindBlogPostVariables
+        > = gql\`
+          query FindBlogPost($id: Int!) {
+            blogPost(id: $id) {
+              id
+            }
+          }
+        \`
+
+        export const Loading = ({ id }: CellLoadingProps<FindBlogPostVariables>) => <div>Loading {id}...</div>
+        export const Success = ({ blogPost }: CellSuccessProps) => (
+          <div>{blogPost.id}</div>
+        )
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'Loading',
+            typeName: 'CellLoadingProps<FindBlogPostVariables>',
+            kind: 'component',
+            location: 'parameter',
+          },
+        },
+      ],
+    },
+    {
+      // isEmpty with untyped response and options params but an already
+      // typed return -- the message and fix should only cover the params.
+      filename: CELL_FILENAME,
+      code: `
+        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+        export const isEmpty = (response, { isDataEmpty }): boolean => {
+          return isDataEmpty(response)
+        }
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+      output: `
+        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+        export const isEmpty = (response: DataObject, { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }): boolean => {
+          return isDataEmpty(response)
+        }
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'isEmpty',
+            typeName: 'DataObject',
+            kind: 'function',
+            location: 'parameters',
+          },
+        },
+      ],
+    },
+    {
+      // Cell detection via a `FRAGMENT` export instead of `QUERY`.
+      filename: CELL_FILENAME,
+      code: `
+        import type { CellSuccessProps } from '@cedarjs/web'
+
+        export const FRAGMENT = gql\`
+          fragment BlogPostCell_post on Post {
+            id
+            title
+          }
+        \`
+
+        export const afterQuery = (data) => data
+
+        export const Success = ({ post }: CellSuccessProps) => (
+          <div>{post.title}</div>
+        )
+      `,
+      output: `
+        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
+
+        export const FRAGMENT = gql\`
+          fragment BlogPostCell_post on Post {
+            id
+            title
+          }
+        \`
+
+        export const afterQuery = (data: DataObject): DataObject => data
+
+        export const Success = ({ post }: CellSuccessProps) => (
+          <div>{post.title}</div>
+        )
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'afterQuery',
+            typeName: 'DataObject',
+            kind: 'function',
+            location: 'parameter and return type',
+          },
+        },
+      ],
+    },
   ],
 })

--- a/packages/eslint-plugin/src/__tests__/cell-type-annotations.test.ts
+++ b/packages/eslint-plugin/src/__tests__/cell-type-annotations.test.ts
@@ -1,0 +1,434 @@
+import tsEslintParser from '@typescript-eslint/parser'
+import { RuleTester } from '@typescript-eslint/rule-tester'
+
+import { cellTypeAnnotations } from '../cell-type-annotations.js'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tsEslintParser,
+    parserOptions: {
+      ecmaVersion: 'latest',
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+})
+
+const CELL_FILENAME = '/app/web/src/components/BlogPostCell/BlogPostCell.tsx'
+
+ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
+  valid: [
+    {
+      // Not a Cell file (no `Cell` filename suffix, no QUERY/FRAGMENT +
+      // Success exports), so unannotated exports are ignored.
+      filename: '/app/web/src/components/BlogPostForm/BlogPostForm.tsx',
+      code: `
+        export const beforeQuery = (props) => {
+          return { variables: props }
+        }
+      `,
+    },
+    {
+      // Has QUERY + Success exports, but the filename doesn't end in
+      // `Cell.tsx` -- both signals are required, so this isn't treated as a
+      // Cell and unannotated exports are ignored.
+      filename: '/app/web/src/components/BlogPostsList/BlogPostsList.tsx',
+      code: `
+        import type { CellSuccessProps } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const beforeQuery = (props) => {
+          return { variables: props }
+        }
+
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+    },
+    {
+      // `.jsx` Cells are plain JavaScript-project output with no build step
+      // that strips TypeScript syntax, so they're never treated as Cells by
+      // this rule, even with the filename suffix and both exports present.
+      filename: '/app/web/src/components/BlogPostCell/BlogPostCell.jsx',
+      code: `
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const beforeQuery = (props) => {
+          return { variables: props }
+        }
+
+        export const Success = ({ blogPosts }) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+    },
+    {
+      filename: CELL_FILENAME,
+      code: `
+        import type {
+          CellBeforeQueryResult,
+          CellFailureProps,
+          CellSuccessProps,
+          TypedDocumentNode,
+        } from '@cedarjs/web'
+        import type { FindBlogPost, FindBlogPostVariables } from 'types/graphql'
+
+        export const QUERY: TypedDocumentNode<
+          FindBlogPost,
+          FindBlogPostVariables
+        > = gql\`
+          query FindBlogPost($id: Int!) {
+            blogPost(id: $id) {
+              id
+            }
+          }
+        \`
+
+        export const beforeQuery = (
+          props: FindBlogPostVariables,
+        ): CellBeforeQueryResult<FindBlogPostVariables> => {
+          return { variables: props }
+        }
+
+        export const Failure = ({
+          error,
+        }: CellFailureProps<FindBlogPostVariables>) => (
+          <div>{error?.message}</div>
+        )
+
+        export const Success = ({
+          blogPost,
+        }: CellSuccessProps<FindBlogPost, FindBlogPostVariables>) => {
+          return <div>{blogPost.id}</div>
+        }
+      `,
+    },
+    {
+      // `Loading` with no props at all doesn't need annotating.
+      filename: CELL_FILENAME,
+      code: `
+        import type { CellSuccessProps } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+        export const Loading = () => <div>Loading...</div>
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+    },
+  ],
+  invalid: [
+    {
+      // beforeQuery's return type is derived from QUERY's TypedDocumentNode
+      // variables type, and there's no existing `@cedarjs/web` type import.
+      filename: CELL_FILENAME,
+      code: `
+        import type { FindBlogPost, FindBlogPostVariables } from 'types/graphql'
+
+        export const QUERY: TypedDocumentNode<
+          FindBlogPost,
+          FindBlogPostVariables
+        > = gql\`
+          query FindBlogPost($id: Int!) {
+            blogPost(id: $id) {
+              id
+            }
+          }
+        \`
+
+        export const beforeQuery = (props: FindBlogPostVariables) => {
+          return { variables: props }
+        }
+
+        export const Success = () => <div>Success</div>
+      `,
+      output: `import type { CellBeforeQueryResult } from '@cedarjs/web'
+
+        import type { FindBlogPost, FindBlogPostVariables } from 'types/graphql'
+
+        export const QUERY: TypedDocumentNode<
+          FindBlogPost,
+          FindBlogPostVariables
+        > = gql\`
+          query FindBlogPost($id: Int!) {
+            blogPost(id: $id) {
+              id
+            }
+          }
+        \`
+
+        export const beforeQuery = (props: FindBlogPostVariables): CellBeforeQueryResult<FindBlogPostVariables> => {
+          return { variables: props }
+        }
+
+        export const Success = () => <div>Success</div>
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'beforeQuery',
+            typeName: 'CellBeforeQueryResult<FindBlogPostVariables>',
+            kind: 'function',
+            location: 'return type',
+          },
+        },
+      ],
+    },
+    {
+      // No QUERY typing to derive from -- falls back to a safe default.
+      filename: CELL_FILENAME,
+      code: `
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const beforeQuery = (props) => {
+          return { variables: props }
+        }
+
+        export const Success = () => <div>Success</div>
+      `,
+      output: `import type { CellBeforeQueryResult } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const beforeQuery = (props): CellBeforeQueryResult<Record<string, unknown>> => {
+          return { variables: props }
+        }
+
+        export const Success = () => <div>Success</div>
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'beforeQuery',
+            typeName: 'CellBeforeQueryResult<Record<string, unknown>>',
+            kind: 'function',
+            location: 'return type',
+          },
+        },
+        { messageId: 'beforeQueryParamNeedsType' },
+      ],
+    },
+    {
+      // Return type present, but the (load-bearing) param type is missing --
+      // reported without an autofix.
+      filename: CELL_FILENAME,
+      code: `
+        import type { CellBeforeQueryResult } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export const beforeQuery = (props): CellBeforeQueryResult<Record<string, unknown>> => {
+          return { variables: props }
+        }
+
+        export const Success = () => <div>Success</div>
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: 'beforeQueryParamNeedsType',
+        },
+      ],
+    },
+    {
+      // `export function beforeQuery(...)` declaration form.
+      filename: CELL_FILENAME,
+      code: `
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export function beforeQuery(props) {
+          return { variables: props }
+        }
+
+        export const Success = () => <div>Success</div>
+      `,
+      output: `import type { CellBeforeQueryResult } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export function beforeQuery(props): CellBeforeQueryResult<Record<string, unknown>> {
+          return { variables: props }
+        }
+
+        export const Success = () => <div>Success</div>
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'beforeQuery',
+            typeName: 'CellBeforeQueryResult<Record<string, unknown>>',
+            kind: 'function',
+            location: 'return type',
+          },
+        },
+        { messageId: 'beforeQueryParamNeedsType' },
+      ],
+    },
+    {
+      // afterQuery -- both param and return type are always `DataObject`.
+      // A single report covers both missing pieces.
+      filename: CELL_FILENAME,
+      code: `
+        import type { CellSuccessProps } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+        export const afterQuery = (data) => data
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+      output: `
+        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+        export const afterQuery = (data: DataObject): DataObject => data
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'afterQuery',
+            typeName: 'DataObject',
+            kind: 'function',
+            location: 'parameter and return type',
+          },
+        },
+      ],
+    },
+    {
+      // isEmpty's return type is always `boolean` -- no import needed.
+      filename: CELL_FILENAME,
+      code: `
+        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+        export const isEmpty = (response: DataObject, { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }) => {
+          return isDataEmpty(response)
+        }
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+      output: `
+        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+        export const isEmpty = (response: DataObject, { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }): boolean => {
+          return isDataEmpty(response)
+        }
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'isEmpty',
+            typeName: 'boolean',
+            kind: 'function',
+            location: 'return type',
+          },
+        },
+      ],
+    },
+    {
+      // Failure's props type, derived from QUERY's variables type.
+      filename: CELL_FILENAME,
+      code: `
+        import type { CellSuccessProps } from '@cedarjs/web'
+        import type { FindBlogPost, FindBlogPostVariables } from 'types/graphql'
+
+        export const QUERY: TypedDocumentNode<
+          FindBlogPost,
+          FindBlogPostVariables
+        > = gql\`
+          query FindBlogPost($id: Int!) {
+            blogPost(id: $id) {
+              id
+            }
+          }
+        \`
+
+        export const Failure = ({ error }) => <div>{error?.message}</div>
+        export const Success = ({ blogPost }: CellSuccessProps) => (
+          <div>{blogPost.id}</div>
+        )
+      `,
+      output: `
+        import type { CellSuccessProps, CellFailureProps } from '@cedarjs/web'
+        import type { FindBlogPost, FindBlogPostVariables } from 'types/graphql'
+
+        export const QUERY: TypedDocumentNode<
+          FindBlogPost,
+          FindBlogPostVariables
+        > = gql\`
+          query FindBlogPost($id: Int!) {
+            blogPost(id: $id) {
+              id
+            }
+          }
+        \`
+
+        export const Failure = ({ error }: CellFailureProps<FindBlogPostVariables>) => <div>{error?.message}</div>
+        export const Success = ({ blogPost }: CellSuccessProps) => (
+          <div>{blogPost.id}</div>
+        )
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'Failure',
+            typeName: 'CellFailureProps<FindBlogPostVariables>',
+            kind: 'component',
+            location: 'parameter',
+          },
+        },
+      ],
+    },
+    {
+      // `export function Success(...)` declaration form, and an existing
+      // `@cedarjs/web` type import that the fix appends to.
+      filename: CELL_FILENAME,
+      code: `
+        import type { CellFailureProps } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export function Success({ blogPosts }) {
+          return <div>{blogPosts.length}</div>
+        }
+      `,
+      output: `
+        import type { CellFailureProps, CellSuccessProps } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+
+        export function Success({ blogPosts }: CellSuccessProps) {
+          return <div>{blogPosts.length}</div>
+        }
+      `,
+      errors: [
+        {
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'Success',
+            typeName: 'CellSuccessProps',
+            kind: 'component',
+            location: 'parameter',
+          },
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin/src/cell-type-annotations.ts
+++ b/packages/eslint-plugin/src/cell-type-annotations.ts
@@ -1,0 +1,451 @@
+import { basename } from 'node:path'
+
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils'
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils'
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs
+
+type FunctionLikeNode =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression
+
+type ParamNode = TSESTree.Parameter
+
+// `beforeQuery`/`afterQuery`/`isEmpty` are lifecycle hooks (return-type led);
+// `Loading`/`Failure`/`Success` are components (props-param led).
+const LIFECYCLE_EXPORTS = new Set(['beforeQuery', 'afterQuery', 'isEmpty'])
+const RENDER_PROP_EXPORTS = new Set(['Loading', 'Failure', 'Success'])
+
+interface DerivedQueryTypes {
+  data: string
+  variables: string
+}
+
+function getParamPattern(param: ParamNode): TSESTree.Node {
+  return param.type === AST_NODE_TYPES.AssignmentPattern ? param.left : param
+}
+
+function paramHasTypeAnnotation(param: ParamNode): boolean {
+  const pattern = getParamPattern(param)
+  return 'typeAnnotation' in pattern && !!pattern.typeAnnotation
+}
+
+// Finds the `)` that closes the function's parameter list, so a missing
+// return type can be inserted right after it regardless of function form
+// (arrow, function expression, or function declaration).
+function getParamsClosingParen(
+  sourceCode: TSESLint.SourceCode,
+  fn: FunctionLikeNode,
+) {
+  if (fn.params.length > 0) {
+    const lastParam = fn.params[fn.params.length - 1]
+    return sourceCode.getTokenAfter(lastParam, (token) => token.value === ')')
+  }
+
+  return sourceCode.getFirstToken(fn, (token) => token.value === ')')
+}
+
+function extractTypedDocumentNodeArgs(
+  typeAnnotation: TSESTree.TSTypeAnnotation | undefined,
+  sourceCode: TSESLint.SourceCode,
+): DerivedQueryTypes | null {
+  const type = typeAnnotation?.typeAnnotation
+  if (type?.type !== AST_NODE_TYPES.TSTypeReference) {
+    return null
+  }
+
+  if (
+    type.typeName.type !== AST_NODE_TYPES.Identifier ||
+    type.typeName.name !== 'TypedDocumentNode'
+  ) {
+    return null
+  }
+
+  const args = type.typeArguments?.params
+  if (!args || args.length < 2) {
+    return null
+  }
+
+  return {
+    data: sourceCode.getText(args[0]),
+    variables: sourceCode.getText(args[1]),
+  }
+}
+
+function isImportSpecifier(
+  specifier: TSESTree.ImportClause,
+): specifier is TSESTree.ImportSpecifier {
+  return specifier.type === AST_NODE_TYPES.ImportSpecifier
+}
+
+export const cellTypeAnnotations = createRule({
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        "Sets the types on a Cell file's lifecycle hooks and render props to the correct @cedarjs/web Cell types",
+    },
+    messages: {
+      needsTypeAnnotation:
+        'The `{{name}}` {{kind}} needs a type annotation of `{{typeName}}` ({{location}}).',
+      beforeQueryParamNeedsType:
+        "`beforeQuery`'s first parameter needs a type annotation. Cedar infers the Cell's external props from it, so leaving it untyped degrades type checking at every call site of this Cell.",
+    },
+    fixable: 'code',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const sourceCode = context.sourceCode
+    const filename = basename(context.filename)
+    // `.jsx` is intentionally excluded: it's plain JavaScript-project output
+    // (see `transformTSToJS` in `@cedarjs/cli`), so there's no build step
+    // that would strip the TypeScript syntax this rule inserts.
+    const filenameIndicatesCell = filename.endsWith('Cell.tsx')
+
+    let hasQueryOrFragment = false
+    let hasSuccessExport = false
+    let derivedQueryTypes: DerivedQueryTypes | null = null
+
+    let webTypeImport: TSESTree.ImportDeclaration | null = null
+
+    const checks: (() => void)[] = []
+
+    // Names already given an insertion fix earlier in this same lint pass.
+    // Two reports that both need a brand-new `@cedarjs/web` import (e.g.
+    // `afterQuery`'s param and return type both needing `DataObject`) would
+    // otherwise each independently insert the same import text at the same
+    // position, producing a duplicate/conflicting fix.
+    const claimedImportNames = new Set<string>()
+
+    function needsImportEdit(importName: string | null): importName is string {
+      if (!importName) {
+        return false
+      }
+
+      if (webTypeImport) {
+        const alreadyImported = webTypeImport.specifiers
+          .filter(isImportSpecifier)
+          .some((s) => s.local.name === importName)
+        if (alreadyImported) {
+          return false
+        }
+      }
+
+      if (claimedImportNames.has(importName)) {
+        return false
+      }
+
+      claimedImportNames.add(importName)
+      return true
+    }
+
+    function* importEdit(fixer: TSESLint.RuleFixer, importName: string) {
+      if (webTypeImport) {
+        const specifiers = webTypeImport.specifiers.filter(isImportSpecifier)
+        const lastSpecifier = specifiers[specifiers.length - 1]
+        yield fixer.insertTextAfter(lastSpecifier, `, ${importName}`)
+        return
+      }
+
+      yield fixer.insertTextBeforeRange(
+        [0, 0],
+        `import type { ${importName} } from '@cedarjs/web'\n`,
+      )
+    }
+
+    function checkBeforeQuery(fn: FunctionLikeNode, reportNode: TSESTree.Node) {
+      const variablesType =
+        derivedQueryTypes?.variables ?? 'Record<string, unknown>'
+
+      if (!fn.returnType) {
+        const typeName = `CellBeforeQueryResult<${variablesType}>`
+        const shouldImport = needsImportEdit('CellBeforeQueryResult')
+
+        context.report({
+          node: reportNode,
+          messageId: 'needsTypeAnnotation',
+          data: {
+            name: 'beforeQuery',
+            typeName,
+            kind: 'function',
+            location: 'return type',
+          },
+          *fix(fixer) {
+            const closingParen = getParamsClosingParen(sourceCode, fn)
+            if (!closingParen) {
+              return
+            }
+            yield fixer.insertTextAfter(closingParen, `: ${typeName}`)
+            if (shouldImport) {
+              yield* importEdit(fixer, 'CellBeforeQueryResult')
+            }
+          },
+        })
+      }
+
+      const [firstParam] = fn.params
+      if (firstParam && !paramHasTypeAnnotation(firstParam)) {
+        // The shape of `beforeQuery`'s first argument can't be safely
+        // inferred from the QUERY's variables type (it may only partially
+        // overlap), so this is surfaced without an autofix.
+        context.report({
+          node: reportNode,
+          messageId: 'beforeQueryParamNeedsType',
+        })
+      }
+    }
+
+    function checkAfterQuery(fn: FunctionLikeNode, reportNode: TSESTree.Node) {
+      const missingReturn = !fn.returnType
+      const [firstParam] = fn.params
+      const missingParam = !!firstParam && !paramHasTypeAnnotation(firstParam)
+
+      if (!missingReturn && !missingParam) {
+        return
+      }
+
+      const shouldImport = needsImportEdit('DataObject')
+      const location =
+        missingReturn && missingParam
+          ? 'parameter and return type'
+          : missingReturn
+            ? 'return type'
+            : 'parameter'
+
+      context.report({
+        node: reportNode,
+        messageId: 'needsTypeAnnotation',
+        data: {
+          name: 'afterQuery',
+          typeName: 'DataObject',
+          kind: 'function',
+          location,
+        },
+        *fix(fixer) {
+          if (missingParam && firstParam) {
+            yield fixer.insertTextAfter(
+              getParamPattern(firstParam),
+              ': DataObject',
+            )
+          }
+          if (missingReturn) {
+            const closingParen = getParamsClosingParen(sourceCode, fn)
+            if (closingParen) {
+              yield fixer.insertTextAfter(closingParen, ': DataObject')
+            }
+          }
+          if (shouldImport) {
+            yield* importEdit(fixer, 'DataObject')
+          }
+        },
+      })
+    }
+
+    function checkIsEmpty(fn: FunctionLikeNode, reportNode: TSESTree.Node) {
+      const missingReturn = !fn.returnType
+      const [responseParam, optionsParam] = fn.params
+      const missingResponseType =
+        !!responseParam && !paramHasTypeAnnotation(responseParam)
+      const missingOptionsType =
+        !!optionsParam && !paramHasTypeAnnotation(optionsParam)
+
+      if (!missingReturn && !missingResponseType && !missingOptionsType) {
+        return
+      }
+
+      // `boolean` needs no import; the option param's inline type references
+      // `DataObject`, so that's the only name that might need importing.
+      const shouldImport =
+        (missingResponseType || missingOptionsType) &&
+        needsImportEdit('DataObject')
+
+      context.report({
+        node: reportNode,
+        messageId: 'needsTypeAnnotation',
+        data: {
+          name: 'isEmpty',
+          typeName: 'boolean',
+          kind: 'function',
+          location: missingReturn ? 'return type' : 'parameters',
+        },
+        *fix(fixer) {
+          if (missingResponseType && responseParam) {
+            yield fixer.insertTextAfter(
+              getParamPattern(responseParam),
+              ': DataObject',
+            )
+          }
+          if (missingOptionsType && optionsParam) {
+            yield fixer.insertTextAfter(
+              getParamPattern(optionsParam),
+              ': { isDataEmpty: (data: DataObject) => boolean }',
+            )
+          }
+          if (missingReturn) {
+            const closingParen = getParamsClosingParen(sourceCode, fn)
+            if (closingParen) {
+              yield fixer.insertTextAfter(closingParen, ': boolean')
+            }
+          }
+          if (shouldImport) {
+            yield* importEdit(fixer, 'DataObject')
+          }
+        },
+      })
+    }
+
+    function checkRenderProp(
+      name: string,
+      fn: FunctionLikeNode,
+      reportNode: TSESTree.Node,
+    ) {
+      const [propsParam] = fn.params
+      if (!propsParam || paramHasTypeAnnotation(propsParam)) {
+        return
+      }
+
+      const variablesType = derivedQueryTypes?.variables
+
+      let insertText: string
+      if (name === 'Success') {
+        insertText = derivedQueryTypes
+          ? `CellSuccessProps<${derivedQueryTypes.data}, ${derivedQueryTypes.variables}>`
+          : 'CellSuccessProps'
+      } else if (name === 'Failure') {
+        insertText = variablesType
+          ? `CellFailureProps<${variablesType}>`
+          : 'CellFailureProps'
+      } else {
+        insertText = variablesType
+          ? `CellLoadingProps<${variablesType}>`
+          : 'CellLoadingProps'
+      }
+
+      const importName = `Cell${name}Props`
+      const shouldImport = needsImportEdit(importName)
+
+      context.report({
+        node: reportNode,
+        messageId: 'needsTypeAnnotation',
+        data: {
+          name,
+          typeName: insertText,
+          kind: 'component',
+          location: 'parameter',
+        },
+        *fix(fixer) {
+          yield fixer.insertTextAfter(
+            getParamPattern(propsParam),
+            `: ${insertText}`,
+          )
+          if (shouldImport) {
+            yield* importEdit(fixer, importName)
+          }
+        },
+      })
+    }
+
+    function checkExport(
+      name: string,
+      fn: FunctionLikeNode,
+      reportNode: TSESTree.Node,
+    ) {
+      if (name === 'beforeQuery') {
+        checkBeforeQuery(fn, reportNode)
+      } else if (name === 'afterQuery') {
+        checkAfterQuery(fn, reportNode)
+      } else if (name === 'isEmpty') {
+        checkIsEmpty(fn, reportNode)
+      } else if (RENDER_PROP_EXPORTS.has(name)) {
+        checkRenderProp(name, fn, reportNode)
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        if (
+          node.source.value === '@cedarjs/web' &&
+          node.importKind === 'type'
+        ) {
+          webTypeImport = node
+        }
+      },
+
+      ExportNamedDeclaration(node) {
+        if (node.declaration?.type === AST_NODE_TYPES.FunctionDeclaration) {
+          const fn = node.declaration
+          const idNode = fn.id
+          if (!idNode) {
+            return
+          }
+          const name = idNode.name
+
+          if (name === 'Success') {
+            hasSuccessExport = true
+          }
+
+          if (LIFECYCLE_EXPORTS.has(name) || RENDER_PROP_EXPORTS.has(name)) {
+            checks.push(() => checkExport(name, fn, idNode))
+          }
+
+          return
+        }
+
+        if (node.declaration?.type !== AST_NODE_TYPES.VariableDeclaration) {
+          return
+        }
+
+        node.declaration.declarations.forEach((vd) => {
+          if (
+            vd.type !== AST_NODE_TYPES.VariableDeclarator ||
+            vd.id.type !== AST_NODE_TYPES.Identifier
+          ) {
+            return
+          }
+
+          const name = vd.id.name
+
+          if (name === 'QUERY') {
+            derivedQueryTypes ||= extractTypedDocumentNodeArgs(
+              vd.id.typeAnnotation,
+              sourceCode,
+            )
+            hasQueryOrFragment = true
+            return
+          }
+
+          if (name === 'FRAGMENT') {
+            hasQueryOrFragment = true
+            return
+          }
+
+          if (name === 'Success') {
+            hasSuccessExport = true
+          }
+
+          if (
+            (LIFECYCLE_EXPORTS.has(name) || RENDER_PROP_EXPORTS.has(name)) &&
+            (vd.init?.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+              vd.init?.type === AST_NODE_TYPES.FunctionExpression)
+          ) {
+            const fn = vd.init
+            checks.push(() => checkExport(name, fn, vd.id))
+          }
+        })
+      },
+
+      'Program:exit'() {
+        const isCellFile =
+          filenameIndicatesCell && hasQueryOrFragment && hasSuccessExport
+
+        if (!isCellFile) {
+          return
+        }
+
+        checks.forEach((check) => check())
+      },
+    }
+  },
+})

--- a/packages/eslint-plugin/src/cell-type-annotations.ts
+++ b/packages/eslint-plugin/src/cell-type-annotations.ts
@@ -31,9 +31,10 @@ function paramHasTypeAnnotation(param: ParamNode): boolean {
   return 'typeAnnotation' in pattern && !!pattern.typeAnnotation
 }
 
-// Finds the `)` that closes the function's parameter list, so a missing
-// return type can be inserted right after it regardless of function form
-// (arrow, function expression, or function declaration).
+// Finds the `)` that closes the function's parameter list, so a missing return
+// type can be inserted right after it regardless of function form (arrow,
+// function expression, or function declaration). Only valid to call when the
+// params are actually parenthesized -- see `isUnparenthesizedArrowParam`.
 function getParamsClosingParen(
   sourceCode: TSESLint.SourceCode,
   fn: FunctionLikeNode,
@@ -44,6 +45,43 @@ function getParamsClosingParen(
   }
 
   return sourceCode.getFirstToken(fn, (token) => token.value === ')')
+}
+
+// A single-identifier arrow param (`x => ...`) is the one case where a
+// param/return type can't just be inserted next to the existing tokens: there's
+// no `)` to anchor on (searching forward for one risks landing on an unrelated
+// `)` inside the function body), and TypeScript requires parens as soon as
+// either the param or the return type is annotated. Destructured, defaulted,
+// and multi-param arrows are always parenthesized already, and function
+// declarations/expressions always require parens, so this can only be true for
+// a bare identifier arrow param.
+function isUnparenthesizedArrowParam(
+  fn: FunctionLikeNode,
+  param: ParamNode,
+  sourceCode: TSESLint.SourceCode,
+): boolean {
+  if (fn.type !== AST_NODE_TYPES.ArrowFunctionExpression) {
+    return false
+  }
+  if (fn.params.length !== 1 || fn.params[0] !== param) {
+    return false
+  }
+  return sourceCode.getTokenBefore(param)?.value !== '('
+}
+
+// Wraps a bare identifier arrow param in parens while inserting its annotation
+// and/or the function's return type, e.g. `data => data` becomes
+// `(data: DataObject): DataObject => data`.
+function* insertWrappedAnnotations(
+  fixer: TSESLint.RuleFixer,
+  param: ParamNode,
+  paramTypeText: string | null,
+  returnTypeText: string | null,
+) {
+  yield fixer.insertTextBefore(param, '(')
+  const paramPart = paramTypeText ? `: ${paramTypeText}` : ''
+  const returnPart = returnTypeText ? `: ${returnTypeText}` : ''
+  yield fixer.insertTextAfter(param, `${paramPart})${returnPart}`)
 }
 
 function extractTypedDocumentNodeArgs(
@@ -110,6 +148,11 @@ export const cellTypeAnnotations = createRule({
 
     let webTypeImport: TSESTree.ImportDeclaration | null = null
 
+    // Names already imported as types from `@cedarjs/web`, either via
+    // `import type { X } from '@cedarjs/web'` or the inline modifier
+    // (`import { type X } from '@cedarjs/web'`).
+    const importedWebTypeNames = new Set<string>()
+
     const checks: (() => void)[] = []
 
     // Names already given an insertion fix earlier in this same lint pass.
@@ -124,13 +167,8 @@ export const cellTypeAnnotations = createRule({
         return false
       }
 
-      if (webTypeImport) {
-        const alreadyImported = webTypeImport.specifiers
-          .filter(isImportSpecifier)
-          .some((s) => s.local.name === importName)
-        if (alreadyImported) {
-          return false
-        }
+      if (importedWebTypeNames.has(importName)) {
+        return false
       }
 
       if (claimedImportNames.has(importName)) {
@@ -142,9 +180,11 @@ export const cellTypeAnnotations = createRule({
     }
 
     function* importEdit(fixer: TSESLint.RuleFixer, importName: string) {
-      if (webTypeImport) {
-        const specifiers = webTypeImport.specifiers.filter(isImportSpecifier)
-        const lastSpecifier = specifiers[specifiers.length - 1]
+      const specifiers =
+        webTypeImport?.specifiers.filter(isImportSpecifier) ?? []
+      const lastSpecifier = specifiers[specifiers.length - 1]
+
+      if (lastSpecifier) {
         yield fixer.insertTextAfter(lastSpecifier, `, ${importName}`)
         return
       }
@@ -173,11 +213,23 @@ export const cellTypeAnnotations = createRule({
             location: 'return type',
           },
           *fix(fixer) {
-            const closingParen = getParamsClosingParen(sourceCode, fn)
-            if (!closingParen) {
-              return
+            const [firstParam] = fn.params
+
+            if (
+              firstParam &&
+              isUnparenthesizedArrowParam(fn, firstParam, sourceCode)
+            ) {
+              yield* insertWrappedAnnotations(fixer, firstParam, null, typeName)
+            } else {
+              const closingParen = getParamsClosingParen(sourceCode, fn)
+
+              if (!closingParen) {
+                return
+              }
+
+              yield fixer.insertTextAfter(closingParen, `: ${typeName}`)
             }
-            yield fixer.insertTextAfter(closingParen, `: ${typeName}`)
+
             if (shouldImport) {
               yield* importEdit(fixer, 'CellBeforeQueryResult')
             }
@@ -185,7 +237,8 @@ export const cellTypeAnnotations = createRule({
         })
       }
 
-      const [firstParam] = fn.params
+      const firstParam = fn.params[0]
+
       if (firstParam && !paramHasTypeAnnotation(firstParam)) {
         // The shape of `beforeQuery`'s first argument can't be safely
         // inferred from the QUERY's variables type (it may only partially
@@ -199,7 +252,7 @@ export const cellTypeAnnotations = createRule({
 
     function checkAfterQuery(fn: FunctionLikeNode, reportNode: TSESTree.Node) {
       const missingReturn = !fn.returnType
-      const [firstParam] = fn.params
+      const firstParam = fn.params[0]
       const missingParam = !!firstParam && !paramHasTypeAnnotation(firstParam)
 
       if (!missingReturn && !missingParam) {
@@ -224,16 +277,28 @@ export const cellTypeAnnotations = createRule({
           location,
         },
         *fix(fixer) {
-          if (missingParam && firstParam) {
-            yield fixer.insertTextAfter(
-              getParamPattern(firstParam),
-              ': DataObject',
+          if (
+            firstParam &&
+            isUnparenthesizedArrowParam(fn, firstParam, sourceCode)
+          ) {
+            yield* insertWrappedAnnotations(
+              fixer,
+              firstParam,
+              missingParam ? 'DataObject' : null,
+              missingReturn ? 'DataObject' : null,
             )
-          }
-          if (missingReturn) {
-            const closingParen = getParamsClosingParen(sourceCode, fn)
-            if (closingParen) {
-              yield fixer.insertTextAfter(closingParen, ': DataObject')
+          } else {
+            if (missingParam && firstParam) {
+              yield fixer.insertTextAfter(
+                getParamPattern(firstParam),
+                ': DataObject',
+              )
+            }
+            if (missingReturn) {
+              const closingParen = getParamsClosingParen(sourceCode, fn)
+              if (closingParen) {
+                yield fixer.insertTextAfter(closingParen, ': DataObject')
+              }
             }
           }
           if (shouldImport) {
@@ -257,36 +322,54 @@ export const cellTypeAnnotations = createRule({
 
       // `boolean` needs no import; the option param's inline type references
       // `DataObject`, so that's the only name that might need importing.
-      const shouldImport =
-        (missingResponseType || missingOptionsType) &&
-        needsImportEdit('DataObject')
+      const missingParams = missingResponseType || missingOptionsType
+      const shouldImport = missingParams && needsImportEdit('DataObject')
+
+      const location =
+        missingReturn && missingParams
+          ? 'parameters and return type'
+          : missingReturn
+            ? 'return type'
+            : 'parameters'
 
       context.report({
         node: reportNode,
         messageId: 'needsTypeAnnotation',
         data: {
           name: 'isEmpty',
-          typeName: 'boolean',
+          typeName: missingReturn ? 'boolean' : 'DataObject',
           kind: 'function',
-          location: missingReturn ? 'return type' : 'parameters',
+          location,
         },
         *fix(fixer) {
-          if (missingResponseType && responseParam) {
-            yield fixer.insertTextAfter(
-              getParamPattern(responseParam),
-              ': DataObject',
+          if (
+            responseParam &&
+            isUnparenthesizedArrowParam(fn, responseParam, sourceCode)
+          ) {
+            yield* insertWrappedAnnotations(
+              fixer,
+              responseParam,
+              missingResponseType ? 'DataObject' : null,
+              missingReturn ? 'boolean' : null,
             )
-          }
-          if (missingOptionsType && optionsParam) {
-            yield fixer.insertTextAfter(
-              getParamPattern(optionsParam),
-              ': { isDataEmpty: (data: DataObject) => boolean }',
-            )
-          }
-          if (missingReturn) {
-            const closingParen = getParamsClosingParen(sourceCode, fn)
-            if (closingParen) {
-              yield fixer.insertTextAfter(closingParen, ': boolean')
+          } else {
+            if (missingResponseType && responseParam) {
+              yield fixer.insertTextAfter(
+                getParamPattern(responseParam),
+                ': DataObject',
+              )
+            }
+            if (missingOptionsType && optionsParam) {
+              yield fixer.insertTextAfter(
+                getParamPattern(optionsParam),
+                ': { isDataEmpty: (data: DataObject) => boolean }',
+              )
+            }
+            if (missingReturn) {
+              const closingParen = getParamsClosingParen(sourceCode, fn)
+              if (closingParen) {
+                yield fixer.insertTextAfter(closingParen, ': boolean')
+              }
             }
           }
           if (shouldImport) {
@@ -336,10 +419,14 @@ export const cellTypeAnnotations = createRule({
           location: 'parameter',
         },
         *fix(fixer) {
-          yield fixer.insertTextAfter(
-            getParamPattern(propsParam),
-            `: ${insertText}`,
-          )
+          if (isUnparenthesizedArrowParam(fn, propsParam, sourceCode)) {
+            yield* insertWrappedAnnotations(fixer, propsParam, insertText, null)
+          } else {
+            yield fixer.insertTextAfter(
+              getParamPattern(propsParam),
+              `: ${insertText}`,
+            )
+          }
           if (shouldImport) {
             yield* importEdit(fixer, importName)
           }
@@ -365,12 +452,19 @@ export const cellTypeAnnotations = createRule({
 
     return {
       ImportDeclaration(node) {
-        if (
-          node.source.value === '@cedarjs/web' &&
-          node.importKind === 'type'
-        ) {
+        if (node.source.value !== '@cedarjs/web') {
+          return
+        }
+
+        if (node.importKind === 'type') {
           webTypeImport = node
         }
+
+        node.specifiers.filter(isImportSpecifier).forEach((specifier) => {
+          if (node.importKind === 'type' || specifier.importKind === 'type') {
+            importedWebTypeNames.add(specifier.local.name)
+          }
+        })
       },
 
       ExportNamedDeclaration(node) {

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -2,6 +2,7 @@ import type { ESLintUtils } from '@typescript-eslint/utils'
 
 import pkgJson from '../package.json' with { type: 'json' }
 
+import { cellTypeAnnotations } from './cell-type-annotations.js'
 import { processEnvComputedRule } from './process-env-computed.js'
 import { serviceTypeAnnotations } from './service-type-annotations.js'
 import { unsupportedRouteComponents } from './unsupported-route-components.js'
@@ -12,6 +13,7 @@ export const meta = {
 }
 
 export const rules = {
+  'cell-type-annotations': cellTypeAnnotations,
   'process-env-computed': processEnvComputedRule,
   'service-type-annotations': serviceTypeAnnotations,
   'unsupported-route-components': unsupportedRouteComponents,


### PR DESCRIPTION
- Adds a `cell-type-annotations` ESLint rule, mirroring `service-type-annotations` but for Cells. It flags (and mostly autofixes) missing type annotations on `beforeQuery`, `afterQuery`, `isEmpty`, and the `Loading`/`Failure`/`Success` render props, using the types from `@cedarjs/web` (`CellBeforeQueryResult`, `DataObject`, `CellLoadingProps`, `CellFailureProps`, `CellSuccessProps`).
- `beforeQuery`'s first parameter is flagged but never autofixed — its shape can't be safely inferred from the QUERY typing — even though it's load-bearing for Cedar's prop-type inference across the rest of the Cell.
- A file is only treated as a Cell when it both ends in `Cell.tsx` and exports `QUERY`/`FRAGMENT` alongside `Success`. `.jsx` is intentionally excluded: it's plain JavaScript-project generator output (`transformTSToJS` strips all TS syntax at generation time) with no build step that could strip annotations this rule would insert.
- Registered in `@cedarjs/eslint-plugin` and wired into the shared config (`web/src/**/*Cell.tsx`), off by default — same adoption pattern as `service-type-annotations`.
- Added a release note under `.changesets/release_notes_major.md` explaining the rule and how to enable it.

Closes #2348