### PR TITLE
fix(eslint-plugin): drop return-type checks from cell-type-annotations

### DIFF
--- a/packages/eslint-plugin/src/__tests__/cell-type-annotations.test.ts
+++ b/packages/eslint-plugin/src/__tests__/cell-type-annotations.test.ts
@@ -119,6 +119,23 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
         )
       `,
     },
+    {
+      // afterQuery/isEmpty's return types aren't checked -- fully typed
+      // params with an untyped return is valid.
+      filename: CELL_FILENAME,
+      code: `
+        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+        export const afterQuery = (data: DataObject) => data
+        export const isEmpty = (response: DataObject, { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }) => {
+          return isDataEmpty(response)
+        }
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+    },
   ],
   invalid: [
     {
@@ -271,8 +288,8 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
       ],
     },
     {
-      // afterQuery -- both param and return type are always `DataObject`.
-      // A single report covers both missing pieces.
+      // afterQuery -- only the param is checked. Its return type isn't
+      // load-bearing for anything downstream, so it's left alone.
       filename: CELL_FILENAME,
       code: `
         import type { CellSuccessProps } from '@cedarjs/web'
@@ -287,7 +304,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
         import type { CellSuccessProps, DataObject } from '@cedarjs/web'
 
         export const QUERY = gql\`query { blogPosts { id } }\`
-        export const afterQuery = (data: DataObject): DataObject => data
+        export const afterQuery = (data: DataObject) => data
         export const Success = ({ blogPosts }: CellSuccessProps) => (
           <div>{blogPosts.length}</div>
         )
@@ -299,44 +316,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
             name: 'afterQuery',
             typeName: 'DataObject',
             kind: 'function',
-            location: 'parameter and return type',
-          },
-        },
-      ],
-    },
-    {
-      // isEmpty's return type is always `boolean` -- no import needed.
-      filename: CELL_FILENAME,
-      code: `
-        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
-
-        export const QUERY = gql\`query { blogPosts { id } }\`
-        export const isEmpty = (response: DataObject, { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }) => {
-          return isDataEmpty(response)
-        }
-        export const Success = ({ blogPosts }: CellSuccessProps) => (
-          <div>{blogPosts.length}</div>
-        )
-      `,
-      output: `
-        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
-
-        export const QUERY = gql\`query { blogPosts { id } }\`
-        export const isEmpty = (response: DataObject, { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }): boolean => {
-          return isDataEmpty(response)
-        }
-        export const Success = ({ blogPosts }: CellSuccessProps) => (
-          <div>{blogPosts.length}</div>
-        )
-      `,
-      errors: [
-        {
-          messageId: 'needsTypeAnnotation',
-          data: {
-            name: 'isEmpty',
-            typeName: 'boolean',
-            kind: 'function',
-            location: 'return type',
+            location: 'parameter',
           },
         },
       ],
@@ -431,9 +411,8 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
       ],
     },
     {
-      // Unparenthesized single-param arrow: both the param and return type are
-      // missing, so the fix has to wrap the param in parens itself rather than
-      // anchoring on an existing `)`.
+      // Unparenthesized single-param arrow: the fix has to wrap the param in
+      // parens itself rather than anchoring on an existing `)`.
       filename: CELL_FILENAME,
       code: `
         export const QUERY = gql\`query { blogPosts { id } }\`
@@ -446,7 +425,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
 
         export const QUERY = gql\`query { blogPosts { id } }\`
 
-        export const afterQuery = (data: DataObject): DataObject => data
+        export const afterQuery = (data: DataObject) => data
 
         export const Success = () => <div>Success</div>
       `,
@@ -457,7 +436,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
             name: 'afterQuery',
             typeName: 'DataObject',
             kind: 'function',
-            location: 'parameter and return type',
+            location: 'parameter',
           },
         },
       ],
@@ -681,7 +660,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
           }
         \`
 
-        export const afterQuery = (data: DataObject): DataObject => data
+        export const afterQuery = (data: DataObject) => data
 
         export const Success = ({ post }: CellSuccessProps) => (
           <div>{post.title}</div>
@@ -694,7 +673,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
             name: 'afterQuery',
             typeName: 'DataObject',
             kind: 'function',
-            location: 'parameter and return type',
+            location: 'parameter',
           },
         },
       ],

--- a/packages/eslint-plugin/src/cell-type-annotations.ts
+++ b/packages/eslint-plugin/src/cell-type-annotations.ts
@@ -12,8 +12,11 @@ type FunctionLikeNode =
 
 type ParamNode = TSESTree.Parameter
 
-// `beforeQuery`/`afterQuery`/`isEmpty` are lifecycle hooks (return-type led);
-// `Loading`/`Failure`/`Success` are components (props-param led).
+// `beforeQuery`/`afterQuery`/`isEmpty` are lifecycle hooks; `Loading`/
+// `Failure`/`Success` are components. Both groups are checked param-first --
+// only `beforeQuery` also requires an explicit return type, since its return
+// type isn't otherwise checked anywhere (unlike its first param, which is
+// load-bearing for `CellPropsVariables`).
 const LIFECYCLE_EXPORTS = new Set(['beforeQuery', 'afterQuery', 'isEmpty'])
 const RENDER_PROP_EXPORTS = new Set(['Loading', 'Failure', 'Success'])
 
@@ -157,9 +160,9 @@ export const cellTypeAnnotations = createRule({
 
     // Names already given an insertion fix earlier in this same lint pass.
     // Two reports that both need a brand-new `@cedarjs/web` import (e.g.
-    // `afterQuery`'s param and return type both needing `DataObject`) would
-    // otherwise each independently insert the same import text at the same
-    // position, producing a duplicate/conflicting fix.
+    // `isEmpty`'s response and options params both needing `DataObject`)
+    // would otherwise each independently insert the same import text at the
+    // same position, producing a duplicate/conflicting fix.
     const claimedImportNames = new Set<string>()
 
     function needsImportEdit(importName: string | null): importName is string {
@@ -251,21 +254,20 @@ export const cellTypeAnnotations = createRule({
     }
 
     function checkAfterQuery(fn: FunctionLikeNode, reportNode: TSESTree.Node) {
-      const missingReturn = !fn.returnType
+      // Only the param is checked. `afterQuery`'s return type isn't fed into
+      // any other type via `Parameters<>`/`ReturnType<>` the way
+      // `beforeQuery`'s first param is (see `CellPropsVariables` in
+      // `@cedarjs/web`'s cellTypes.ts) -- nothing downstream ever inspects
+      // it, so annotating it doesn't add any checking that isn't already
+      // happening (or not happening) locally in this function body.
       const firstParam = fn.params[0]
       const missingParam = !!firstParam && !paramHasTypeAnnotation(firstParam)
 
-      if (!missingReturn && !missingParam) {
+      if (!missingParam) {
         return
       }
 
       const shouldImport = needsImportEdit('DataObject')
-      const location =
-        missingReturn && missingParam
-          ? 'parameter and return type'
-          : missingReturn
-            ? 'return type'
-            : 'parameter'
 
       context.report({
         node: reportNode,
@@ -274,7 +276,7 @@ export const cellTypeAnnotations = createRule({
           name: 'afterQuery',
           typeName: 'DataObject',
           kind: 'function',
-          location,
+          location: 'parameter',
         },
         *fix(fixer) {
           if (
@@ -284,22 +286,14 @@ export const cellTypeAnnotations = createRule({
             yield* insertWrappedAnnotations(
               fixer,
               firstParam,
-              missingParam ? 'DataObject' : null,
-              missingReturn ? 'DataObject' : null,
+              'DataObject',
+              null,
             )
-          } else {
-            if (missingParam && firstParam) {
-              yield fixer.insertTextAfter(
-                getParamPattern(firstParam),
-                ': DataObject',
-              )
-            }
-            if (missingReturn) {
-              const closingParen = getParamsClosingParen(sourceCode, fn)
-              if (closingParen) {
-                yield fixer.insertTextAfter(closingParen, ': DataObject')
-              }
-            }
+          } else if (firstParam) {
+            yield fixer.insertTextAfter(
+              getParamPattern(firstParam),
+              ': DataObject',
+            )
           }
           if (shouldImport) {
             yield* importEdit(fixer, 'DataObject')
@@ -309,37 +303,28 @@ export const cellTypeAnnotations = createRule({
     }
 
     function checkIsEmpty(fn: FunctionLikeNode, reportNode: TSESTree.Node) {
-      const missingReturn = !fn.returnType
+      // Only the params are checked; see the comment in `checkAfterQuery` --
+      // the same reasoning applies to `isEmpty`'s return type.
       const [responseParam, optionsParam] = fn.params
       const missingResponseType =
         !!responseParam && !paramHasTypeAnnotation(responseParam)
       const missingOptionsType =
         !!optionsParam && !paramHasTypeAnnotation(optionsParam)
 
-      if (!missingReturn && !missingResponseType && !missingOptionsType) {
+      if (!missingResponseType && !missingOptionsType) {
         return
       }
 
-      // `boolean` needs no import; the option param's inline type references
-      // `DataObject`, so that's the only name that might need importing.
-      const missingParams = missingResponseType || missingOptionsType
-      const shouldImport = missingParams && needsImportEdit('DataObject')
-
-      const location =
-        missingReturn && missingParams
-          ? 'parameters and return type'
-          : missingReturn
-            ? 'return type'
-            : 'parameters'
+      const shouldImport = needsImportEdit('DataObject')
 
       context.report({
         node: reportNode,
         messageId: 'needsTypeAnnotation',
         data: {
           name: 'isEmpty',
-          typeName: missingReturn ? 'boolean' : 'DataObject',
+          typeName: 'DataObject',
           kind: 'function',
-          location,
+          location: 'parameters',
         },
         *fix(fixer) {
           if (
@@ -350,7 +335,7 @@ export const cellTypeAnnotations = createRule({
               fixer,
               responseParam,
               missingResponseType ? 'DataObject' : null,
-              missingReturn ? 'boolean' : null,
+              null,
             )
           } else {
             if (missingResponseType && responseParam) {
@@ -364,12 +349,6 @@ export const cellTypeAnnotations = createRule({
                 getParamPattern(optionsParam),
                 ': { isDataEmpty: (data: DataObject) => boolean }',
               )
-            }
-            if (missingReturn) {
-              const closingParen = getParamsClosingParen(sourceCode, fn)
-              if (closingParen) {
-                yield fixer.insertTextAfter(closingParen, ': boolean')
-              }
             }
           }
           if (shouldImport) {


### PR DESCRIPTION
Follow-up to #2391. `cell-type-annotations` no longer requires explicit return-type annotations on `afterQuery`/`isEmpty` — only their parameter types are still checked.

Why: neither return type is load-bearing anywhere.

- Cell exports get wired into `createCell()` by AST-transform plugins (`packages/vite/src/plugins/vite-plugin-cedar-cell.ts` for Vite, plus Babel/Rollup equivalents for Jest and prerendering) that synthesize the call from export *names* only, at the AST level — never as real TypeScript source. `tsc` never sees it, so it can never check `afterQuery`'s or `isEmpty`'s return value against `CreateCellProps`.
- The one generated artifact `tsc` genuinely does check — the mirror `.d.ts` from `generateMirrorCell` — only derives the Cell's external prop type from `beforeQuery`'s param and `Success`'s props. It doesn't touch `afterQuery`/`isEmpty` at all.
- `isEmpty`'s return value is only ever consumed via `isEmpty(...) && Empty` (plain JS truthiness — see `createCell.tsx`, `createFragmentCell.tsx`, `createServerCell.tsx`, `createSuspendingCell.tsx`), not a strict boolean comparison, so nothing at runtime requires it to literally be a `boolean` either.

`beforeQuery` is unchanged: its param annotation is the one genuinely load-bearing check, since `CellPropsVariables` in `@cedarjs/web`'s `cellTypes.ts` does `Parameters<Cell['beforeQuery']>` to derive the Cell's caller-facing prop type, and that reflection does land in the mirror `.d.ts` `tsc` sees.

Net effect: the rule now only requires annotations that either feed real type inference (`beforeQuery`'s param) or catch an implicit `any` locally (the remaining param checks on `afterQuery`/`isEmpty`) — not annotations whose only value would be self-documentation.