### PR TITLE
feat(create-cedar-app): enable cell-type-annotations by default in TS templates

### DIFF
--- a/__fixtures__/test-project-esm/eslint.config.js
+++ b/__fixtures__/test-project-esm/eslint.config.js
@@ -1,3 +1,11 @@
 import cedarConfig from '@cedarjs/eslint-config'
 
-export default await cedarConfig()
+export default [
+  ...(await cedarConfig()),
+  {
+    files: ['web/src/**/*Cell.tsx'],
+    rules: {
+      '@cedarjs/cell-type-annotations': 'error',
+    },
+  },
+]

--- a/__fixtures__/test-project/eslint.config.mjs
+++ b/__fixtures__/test-project/eslint.config.mjs
@@ -1,3 +1,11 @@
 import cedarConfig from '@cedarjs/eslint-config'
 
-export default await cedarConfig()
+export default [
+  ...(await cedarConfig()),
+  {
+    files: ['web/src/**/*Cell.tsx'],
+    rules: {
+      '@cedarjs/cell-type-annotations': 'error',
+    },
+  },
+]

--- a/packages/create-cedar-app/scripts/tsToJS.js
+++ b/packages/create-cedar-app/scripts/tsToJS.js
@@ -140,3 +140,27 @@ const authFile = fs
 fs.writeFileSync(authFilePath, authFile)
 
 console.groupEnd()
+
+console.group(
+  'Removing the cell-type-annotations override from eslint.config.mjs',
+)
+
+// `cell-type-annotations` only matches `.tsx` Cells, so it can never fire in
+// a JS project -- drop the override rather than ship a dead rule reference.
+const eslintConfigFilePath = path.join(JS_TEMPLATE_PATH, 'eslint.config.mjs')
+const eslintConfigFile = fs.readFileSync(eslintConfigFilePath, 'utf-8').replace(
+  `export default [
+  ...(await cedarConfig()),
+  {
+    files: ['web/src/**/*Cell.tsx'],
+    rules: {
+      '@cedarjs/cell-type-annotations': 'error',
+    },
+  },
+]
+`,
+  'export default await cedarConfig()\n',
+)
+fs.writeFileSync(eslintConfigFilePath, eslintConfigFile)
+
+console.groupEnd()

--- a/packages/create-cedar-app/templates/esm-ts/eslint.config.js
+++ b/packages/create-cedar-app/templates/esm-ts/eslint.config.js
@@ -1,3 +1,11 @@
 import cedarConfig from '@cedarjs/eslint-config'
 
-export default await cedarConfig()
+export default [
+  ...(await cedarConfig()),
+  {
+    files: ['web/src/**/*Cell.tsx'],
+    rules: {
+      '@cedarjs/cell-type-annotations': 'error',
+    },
+  },
+]

--- a/packages/create-cedar-app/templates/js/eslint.config.mjs
+++ b/packages/create-cedar-app/templates/js/eslint.config.mjs
@@ -1,3 +1,11 @@
 import cedarConfig from '@cedarjs/eslint-config'
 
-export default await cedarConfig()
+export default [
+  ...(await cedarConfig()),
+  {
+    files: ['web/src/**/*Cell.tsx'],
+    rules: {
+      '@cedarjs/cell-type-annotations': 'error',
+    },
+  },
+]

--- a/packages/create-cedar-app/templates/js/eslint.config.mjs
+++ b/packages/create-cedar-app/templates/js/eslint.config.mjs
@@ -1,11 +1,3 @@
 import cedarConfig from '@cedarjs/eslint-config'
 
-export default [
-  ...(await cedarConfig()),
-  {
-    files: ['web/src/**/*Cell.tsx'],
-    rules: {
-      '@cedarjs/cell-type-annotations': 'error',
-    },
-  },
-]
+export default await cedarConfig()

--- a/packages/create-cedar-app/templates/ts/eslint.config.mjs
+++ b/packages/create-cedar-app/templates/ts/eslint.config.mjs
@@ -1,3 +1,11 @@
 import cedarConfig from '@cedarjs/eslint-config'
 
-export default await cedarConfig()
+export default [
+  ...(await cedarConfig()),
+  {
+    files: ['web/src/**/*Cell.tsx'],
+    rules: {
+      '@cedarjs/cell-type-annotations': 'error',
+    },
+  },
+]

--- a/packages/eslint-plugin/src/__tests__/cell-type-annotations.test.ts
+++ b/packages/eslint-plugin/src/__tests__/cell-type-annotations.test.ts
@@ -119,6 +119,23 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
         )
       `,
     },
+    {
+      // afterQuery/isEmpty's return types aren't checked -- fully typed
+      // params with an untyped return is valid.
+      filename: CELL_FILENAME,
+      code: `
+        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
+
+        export const QUERY = gql\`query { blogPosts { id } }\`
+        export const afterQuery = (data: DataObject) => data
+        export const isEmpty = (response: DataObject, { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }) => {
+          return isDataEmpty(response)
+        }
+        export const Success = ({ blogPosts }: CellSuccessProps) => (
+          <div>{blogPosts.length}</div>
+        )
+      `,
+    },
   ],
   invalid: [
     {
@@ -271,8 +288,8 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
       ],
     },
     {
-      // afterQuery -- both param and return type are always `DataObject`.
-      // A single report covers both missing pieces.
+      // afterQuery -- only the param is checked. Its return type isn't
+      // load-bearing for anything downstream, so it's left alone.
       filename: CELL_FILENAME,
       code: `
         import type { CellSuccessProps } from '@cedarjs/web'
@@ -287,7 +304,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
         import type { CellSuccessProps, DataObject } from '@cedarjs/web'
 
         export const QUERY = gql\`query { blogPosts { id } }\`
-        export const afterQuery = (data: DataObject): DataObject => data
+        export const afterQuery = (data: DataObject) => data
         export const Success = ({ blogPosts }: CellSuccessProps) => (
           <div>{blogPosts.length}</div>
         )
@@ -299,44 +316,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
             name: 'afterQuery',
             typeName: 'DataObject',
             kind: 'function',
-            location: 'parameter and return type',
-          },
-        },
-      ],
-    },
-    {
-      // isEmpty's return type is always `boolean` -- no import needed.
-      filename: CELL_FILENAME,
-      code: `
-        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
-
-        export const QUERY = gql\`query { blogPosts { id } }\`
-        export const isEmpty = (response: DataObject, { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }) => {
-          return isDataEmpty(response)
-        }
-        export const Success = ({ blogPosts }: CellSuccessProps) => (
-          <div>{blogPosts.length}</div>
-        )
-      `,
-      output: `
-        import type { CellSuccessProps, DataObject } from '@cedarjs/web'
-
-        export const QUERY = gql\`query { blogPosts { id } }\`
-        export const isEmpty = (response: DataObject, { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }): boolean => {
-          return isDataEmpty(response)
-        }
-        export const Success = ({ blogPosts }: CellSuccessProps) => (
-          <div>{blogPosts.length}</div>
-        )
-      `,
-      errors: [
-        {
-          messageId: 'needsTypeAnnotation',
-          data: {
-            name: 'isEmpty',
-            typeName: 'boolean',
-            kind: 'function',
-            location: 'return type',
+            location: 'parameter',
           },
         },
       ],
@@ -431,9 +411,8 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
       ],
     },
     {
-      // Unparenthesized single-param arrow: both the param and return type are
-      // missing, so the fix has to wrap the param in parens itself rather than
-      // anchoring on an existing `)`.
+      // Unparenthesized single-param arrow: the fix has to wrap the param in
+      // parens itself rather than anchoring on an existing `)`.
       filename: CELL_FILENAME,
       code: `
         export const QUERY = gql\`query { blogPosts { id } }\`
@@ -446,7 +425,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
 
         export const QUERY = gql\`query { blogPosts { id } }\`
 
-        export const afterQuery = (data: DataObject): DataObject => data
+        export const afterQuery = (data: DataObject) => data
 
         export const Success = () => <div>Success</div>
       `,
@@ -457,7 +436,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
             name: 'afterQuery',
             typeName: 'DataObject',
             kind: 'function',
-            location: 'parameter and return type',
+            location: 'parameter',
           },
         },
       ],
@@ -681,7 +660,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
           }
         \`
 
-        export const afterQuery = (data: DataObject): DataObject => data
+        export const afterQuery = (data: DataObject) => data
 
         export const Success = ({ post }: CellSuccessProps) => (
           <div>{post.title}</div>
@@ -694,7 +673,7 @@ ruleTester.run('cell-type-annotations', cellTypeAnnotations, {
             name: 'afterQuery',
             typeName: 'DataObject',
             kind: 'function',
-            location: 'parameter and return type',
+            location: 'parameter',
           },
         },
       ],

--- a/packages/eslint-plugin/src/cell-type-annotations.ts
+++ b/packages/eslint-plugin/src/cell-type-annotations.ts
@@ -12,8 +12,11 @@ type FunctionLikeNode =
 
 type ParamNode = TSESTree.Parameter
 
-// `beforeQuery`/`afterQuery`/`isEmpty` are lifecycle hooks (return-type led);
-// `Loading`/`Failure`/`Success` are components (props-param led).
+// `beforeQuery`/`afterQuery`/`isEmpty` are lifecycle hooks; `Loading`/
+// `Failure`/`Success` are components. Both groups are checked param-first --
+// only `beforeQuery` also requires an explicit return type, since its return
+// type isn't otherwise checked anywhere (unlike its first param, which is
+// load-bearing for `CellPropsVariables`).
 const LIFECYCLE_EXPORTS = new Set(['beforeQuery', 'afterQuery', 'isEmpty'])
 const RENDER_PROP_EXPORTS = new Set(['Loading', 'Failure', 'Success'])
 
@@ -157,9 +160,9 @@ export const cellTypeAnnotations = createRule({
 
     // Names already given an insertion fix earlier in this same lint pass.
     // Two reports that both need a brand-new `@cedarjs/web` import (e.g.
-    // `afterQuery`'s param and return type both needing `DataObject`) would
-    // otherwise each independently insert the same import text at the same
-    // position, producing a duplicate/conflicting fix.
+    // `isEmpty`'s response and options params both needing `DataObject`)
+    // would otherwise each independently insert the same import text at the
+    // same position, producing a duplicate/conflicting fix.
     const claimedImportNames = new Set<string>()
 
     function needsImportEdit(importName: string | null): importName is string {
@@ -251,21 +254,20 @@ export const cellTypeAnnotations = createRule({
     }
 
     function checkAfterQuery(fn: FunctionLikeNode, reportNode: TSESTree.Node) {
-      const missingReturn = !fn.returnType
+      // Only the param is checked. `afterQuery`'s return type isn't fed into
+      // any other type via `Parameters<>`/`ReturnType<>` the way
+      // `beforeQuery`'s first param is (see `CellPropsVariables` in
+      // `@cedarjs/web`'s cellTypes.ts) -- nothing downstream ever inspects
+      // it, so annotating it doesn't add any checking that isn't already
+      // happening (or not happening) locally in this function body.
       const firstParam = fn.params[0]
       const missingParam = !!firstParam && !paramHasTypeAnnotation(firstParam)
 
-      if (!missingReturn && !missingParam) {
+      if (!missingParam) {
         return
       }
 
       const shouldImport = needsImportEdit('DataObject')
-      const location =
-        missingReturn && missingParam
-          ? 'parameter and return type'
-          : missingReturn
-            ? 'return type'
-            : 'parameter'
 
       context.report({
         node: reportNode,
@@ -274,7 +276,7 @@ export const cellTypeAnnotations = createRule({
           name: 'afterQuery',
           typeName: 'DataObject',
           kind: 'function',
-          location,
+          location: 'parameter',
         },
         *fix(fixer) {
           if (
@@ -284,22 +286,14 @@ export const cellTypeAnnotations = createRule({
             yield* insertWrappedAnnotations(
               fixer,
               firstParam,
-              missingParam ? 'DataObject' : null,
-              missingReturn ? 'DataObject' : null,
+              'DataObject',
+              null,
             )
-          } else {
-            if (missingParam && firstParam) {
-              yield fixer.insertTextAfter(
-                getParamPattern(firstParam),
-                ': DataObject',
-              )
-            }
-            if (missingReturn) {
-              const closingParen = getParamsClosingParen(sourceCode, fn)
-              if (closingParen) {
-                yield fixer.insertTextAfter(closingParen, ': DataObject')
-              }
-            }
+          } else if (firstParam) {
+            yield fixer.insertTextAfter(
+              getParamPattern(firstParam),
+              ': DataObject',
+            )
           }
           if (shouldImport) {
             yield* importEdit(fixer, 'DataObject')
@@ -309,37 +303,28 @@ export const cellTypeAnnotations = createRule({
     }
 
     function checkIsEmpty(fn: FunctionLikeNode, reportNode: TSESTree.Node) {
-      const missingReturn = !fn.returnType
+      // Only the params are checked; see the comment in `checkAfterQuery` --
+      // the same reasoning applies to `isEmpty`'s return type.
       const [responseParam, optionsParam] = fn.params
       const missingResponseType =
         !!responseParam && !paramHasTypeAnnotation(responseParam)
       const missingOptionsType =
         !!optionsParam && !paramHasTypeAnnotation(optionsParam)
 
-      if (!missingReturn && !missingResponseType && !missingOptionsType) {
+      if (!missingResponseType && !missingOptionsType) {
         return
       }
 
-      // `boolean` needs no import; the option param's inline type references
-      // `DataObject`, so that's the only name that might need importing.
-      const missingParams = missingResponseType || missingOptionsType
-      const shouldImport = missingParams && needsImportEdit('DataObject')
-
-      const location =
-        missingReturn && missingParams
-          ? 'parameters and return type'
-          : missingReturn
-            ? 'return type'
-            : 'parameters'
+      const shouldImport = needsImportEdit('DataObject')
 
       context.report({
         node: reportNode,
         messageId: 'needsTypeAnnotation',
         data: {
           name: 'isEmpty',
-          typeName: missingReturn ? 'boolean' : 'DataObject',
+          typeName: 'DataObject',
           kind: 'function',
-          location,
+          location: 'parameters',
         },
         *fix(fixer) {
           if (
@@ -350,7 +335,7 @@ export const cellTypeAnnotations = createRule({
               fixer,
               responseParam,
               missingResponseType ? 'DataObject' : null,
-              missingReturn ? 'boolean' : null,
+              null,
             )
           } else {
             if (missingResponseType && responseParam) {
@@ -364,12 +349,6 @@ export const cellTypeAnnotations = createRule({
                 getParamPattern(optionsParam),
                 ': { isDataEmpty: (data: DataObject) => boolean }',
               )
-            }
-            if (missingReturn) {
-              const closingParen = getParamsClosingParen(sourceCode, fn)
-              if (closingParen) {
-                yield fixer.insertTextAfter(closingParen, ': boolean')
-              }
             }
           }
           if (shouldImport) {


### PR DESCRIPTION
Stacked on #2395 — turns the `@cedarjs/eslint-plugin` `cell-type-annotations` rule on by default (`'error'`) for new TypeScript apps, in the `ts` and `esm-ts` `create-cedar-app` templates:

```js
export default [
  ...(await cedarConfig()),
  {
    files: ['web/src/**/*Cell.tsx'],
    rules: {
      '@cedarjs/cell-type-annotations': 'error',
    },
  },
]
```

`js`/`esm-js` templates are untouched — the rule only ever matches `.tsx`, so enabling it there would be a no-op.

This depends on #2395 (loosening the rule to drop `afterQuery`/`isEmpty`'s return-type requirement): without it, the CLI's default `isEmpty` generator template (which doesn't annotate its return type) would fail lint immediately in any freshly generated Cell, in every new TS app.