### PR TITLE
fix(render): put sqlite deploy option on a paid plan, not free

### DIFF
--- a/docs/docs/deploy/render.md
+++ b/docs/docs/deploy/render.md
@@ -18,7 +18,11 @@ Postgres or SQLite database, you can do the following:
    commit, and add it as a new repo to GitHub or GitLab
 3. run the command `yarn cedar setup deploy render`, use the flag `--database`
    to select from `postgresql`, `sqlite` or `none` to proceed without a database
-   [default : `postgresql`]
+   [default : `postgresql`]. Note: `sqlite` stores its database file on a
+   persistent disk, which Render's free plan doesn't support — the setup
+   command will prompt you to confirm putting the `api` service on a paid
+   plan before generating `render.yaml`. `postgresql` and `none` stay on the
+   free plan.
 4. commit the generated `render.yaml`, then create a new Blueprint from your
    repo at https://dashboard.render.com/iacs
 5. after the first deploy, replace the `destination` placeholder in

--- a/docs/docs/deploy/render.md
+++ b/docs/docs/deploy/render.md
@@ -21,9 +21,8 @@ Postgres or SQLite database, you can do the following:
    [default : `postgresql`]. Note: `sqlite` stores its database file on a
    persistent disk, which Render's free plan doesn't support — the setup
    command will prompt you to confirm putting the `api` service on a paid
-   plan before generating `render.yaml`. With `postgresql` or `none`, the
-   `api` service itself stays on the free plan (the managed Postgres database
-   that `postgresql` provisions has its own separate plan, set by Render).
+   plan before generating `render.yaml`. `postgresql` and `none` stay on the
+   free plan.
 4. commit the generated `render.yaml`, then create a new Blueprint from your
    repo at https://dashboard.render.com/iacs
 5. after the first deploy, replace the `destination` placeholder in

--- a/docs/docs/deploy/render.md
+++ b/docs/docs/deploy/render.md
@@ -21,8 +21,9 @@ Postgres or SQLite database, you can do the following:
    [default : `postgresql`]. Note: `sqlite` stores its database file on a
    persistent disk, which Render's free plan doesn't support — the setup
    command will prompt you to confirm putting the `api` service on a paid
-   plan before generating `render.yaml`. `postgresql` and `none` stay on the
-   free plan.
+   plan before generating `render.yaml`. With `postgresql` or `none`, the
+   `api` service itself stays on the free plan (the managed Postgres database
+   that `postgresql` provisions has its own separate plan, set by Render).
 4. commit the generated `render.yaml`, then create a new Blueprint from your
    repo at https://dashboard.render.com/iacs
 5. after the first deploy, replace the `destination` placeholder in

--- a/packages/cli/src/commands/setup/deploy/__tests__/render.test.ts
+++ b/packages/cli/src/commands/setup/deploy/__tests__/render.test.ts
@@ -62,6 +62,12 @@ describe('render.yaml', () => {
     expect(yaml).toContain('property: connectionString')
   })
 
+  it('keeps the postgres database itself on the free plan', () => {
+    // Render defaults an omitted `databases[].plan` to a paid plan
+    // (`basic-256mb`), so this has to be set explicitly.
+    expect(POSTGRES_YAML).toContain('plan: free')
+  })
+
   it('mounts a disk instead of a database for sqlite', () => {
     const sqliteYaml = RENDER_YAML(SQLITE_YAML)
 

--- a/packages/cli/src/commands/setup/deploy/__tests__/render.test.ts
+++ b/packages/cli/src/commands/setup/deploy/__tests__/render.test.ts
@@ -68,4 +68,17 @@ describe('render.yaml', () => {
     expect(sqliteYaml).toContain('mountPath:')
     expect(sqliteYaml).not.toContain('fromDatabase:')
   })
+
+  it('defaults the api service to the free plan', () => {
+    expect(yaml).toContain('plan: free')
+  })
+
+  it('lets the caller override the api service plan', () => {
+    // Render's free plan doesn't support persistent disks, so callers using
+    // the sqlite option (which attaches one) need to pass a paid plan here.
+    const paidYaml = RENDER_YAML(SQLITE_YAML, 'starter')
+
+    expect(paidYaml).toContain('plan: starter')
+    expect(paidYaml).not.toContain('plan: free')
+  })
 })

--- a/packages/cli/src/commands/setup/deploy/__tests__/renderHandler.test.ts
+++ b/packages/cli/src/commands/setup/deploy/__tests__/renderHandler.test.ts
@@ -1,0 +1,114 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+const mockWriteFilesTask = vi.fn(() => undefined)
+
+vi.mock('../../../../lib/index.js', async (importOriginal) => {
+  const originalLib = await importOriginal<object>()
+
+  return {
+    ...originalLib,
+    getPaths: () => ({ base: '/mock/project/my-cedar-app' }),
+    writeFilesTask: mockWriteFilesTask,
+    printSetupNotes: () => ({ title: 'notes', task: () => {} }),
+  }
+})
+
+vi.mock('@cedarjs/project-config', async (importOriginal) => {
+  const originalProjectConfig = await importOriginal<object>()
+
+  return {
+    ...originalProjectConfig,
+    getPaths: () => ({ base: '/mock/project/my-cedar-app' }),
+    getPrismaSchemas: async () => ({ schemas: [] }),
+  }
+})
+
+vi.mock('../helpers/index.js', async (importOriginal) => {
+  const originalHelpers = await importOriginal<object>()
+
+  return {
+    ...originalHelpers,
+    getUserApiUrl: () => '/.api/functions',
+  }
+})
+
+const mockGetConfig = vi.fn()
+vi.mock('@prisma/internals', () => ({
+  default: { getConfig: (...args: unknown[]) => mockGetConfig(...args) },
+}))
+
+vi.mock('@cedarjs/telemetry', () => ({
+  errorTelemetry: vi.fn(),
+}))
+
+const mockPrompts = vi.fn()
+vi.mock('prompts', () => ({
+  default: (...args: unknown[]) => mockPrompts(...args),
+}))
+
+const { handler } = await import('../providers/renderHandler.js')
+
+describe('render setup handler', () => {
+  const processExitSpy = vi
+    .spyOn(process, 'exit')
+    .mockImplementation(() => undefined as never)
+
+  beforeEach(() => {
+    mockWriteFilesTask.mockClear()
+    mockGetConfig.mockClear()
+    mockPrompts.mockClear()
+    processExitSpy.mockClear()
+    // Matches whatever `database` the handler asks for, so
+    // getRenderYamlContent's detected/requested provider check passes.
+    mockGetConfig.mockImplementation(async () => ({
+      datasources: [{ activeProvider: 'sqlite' }],
+    }))
+  })
+
+  it('does not write render.yaml when the sqlite paid-plan prompt is declined', async () => {
+    mockPrompts.mockResolvedValue({ confirmed: false })
+
+    await handler({ force: false, database: 'sqlite' })
+
+    expect(mockPrompts).toHaveBeenCalledTimes(1)
+    expect(mockWriteFilesTask).not.toHaveBeenCalled()
+    expect(processExitSpy).not.toHaveBeenCalled()
+  })
+
+  it('writes render.yaml with the paid plan when the sqlite prompt is confirmed', async () => {
+    mockPrompts.mockResolvedValue({ confirmed: true })
+
+    await handler({ force: false, database: 'sqlite' })
+
+    expect(mockPrompts).toHaveBeenCalledTimes(1)
+    expect(mockWriteFilesTask).toHaveBeenCalledTimes(1)
+    const files = mockWriteFilesTask.mock.calls[0][0] as Record<string, string>
+    const content = Object.values(files)[0]
+    expect(content).toContain('plan: starter')
+    expect(content).not.toContain('plan: free')
+  })
+
+  it('does not prompt for postgresql, and keeps the free plan', async () => {
+    mockGetConfig.mockResolvedValue({
+      datasources: [{ activeProvider: 'postgresql' }],
+    })
+
+    await handler({ force: false, database: 'postgresql' })
+
+    expect(mockPrompts).not.toHaveBeenCalled()
+    expect(mockWriteFilesTask).toHaveBeenCalledTimes(1)
+    const files = mockWriteFilesTask.mock.calls[0][0] as Record<string, string>
+    const content = Object.values(files)[0]
+    expect(content).toContain('plan: free')
+  })
+
+  it('does not prompt for none, and keeps the free plan', async () => {
+    await handler({ force: false, database: 'none' })
+
+    expect(mockPrompts).not.toHaveBeenCalled()
+    expect(mockWriteFilesTask).toHaveBeenCalledTimes(1)
+    const files = mockWriteFilesTask.mock.calls[0][0] as Record<string, string>
+    const content = Object.values(files)[0]
+    expect(content).toContain('plan: free')
+  })
+})

--- a/packages/cli/src/commands/setup/deploy/__tests__/renderHandler.test.ts
+++ b/packages/cli/src/commands/setup/deploy/__tests__/renderHandler.test.ts
@@ -1,6 +1,6 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
-const mockWriteFilesTask = vi.fn(() => undefined)
+const mockWriteFilesTask = vi.fn((_files: Record<string, string>) => undefined)
 
 vi.mock('../../../../lib/index.js', async (importOriginal) => {
   const originalLib = await importOriginal<object>()
@@ -49,6 +49,8 @@ vi.mock('prompts', () => ({
 const { handler } = await import('../providers/renderHandler.js')
 
 describe('render setup handler', () => {
+  // `process.exit`'s real signature returns `never`, so the no-op mock has
+  // to lie about its return type to satisfy that signature.
   const processExitSpy = vi
     .spyOn(process, 'exit')
     .mockImplementation(() => undefined as never)
@@ -82,7 +84,7 @@ describe('render setup handler', () => {
 
     expect(mockPrompts).toHaveBeenCalledTimes(1)
     expect(mockWriteFilesTask).toHaveBeenCalledTimes(1)
-    const files = mockWriteFilesTask.mock.calls[0][0] as Record<string, string>
+    const files = mockWriteFilesTask.mock.calls[0][0]
     const content = Object.values(files)[0]
     expect(content).toContain('plan: starter')
     expect(content).not.toContain('plan: free')
@@ -97,7 +99,7 @@ describe('render setup handler', () => {
 
     expect(mockPrompts).not.toHaveBeenCalled()
     expect(mockWriteFilesTask).toHaveBeenCalledTimes(1)
-    const files = mockWriteFilesTask.mock.calls[0][0] as Record<string, string>
+    const files = mockWriteFilesTask.mock.calls[0][0]
     const content = Object.values(files)[0]
     expect(content).toContain('plan: free')
   })
@@ -107,7 +109,7 @@ describe('render setup handler', () => {
 
     expect(mockPrompts).not.toHaveBeenCalled()
     expect(mockWriteFilesTask).toHaveBeenCalledTimes(1)
-    const files = mockWriteFilesTask.mock.calls[0][0] as Record<string, string>
+    const files = mockWriteFilesTask.mock.calls[0][0]
     const content = Object.values(files)[0]
     expect(content).toContain('plan: free')
   })

--- a/packages/cli/src/commands/setup/deploy/providers/renderHandler.ts
+++ b/packages/cli/src/commands/setup/deploy/providers/renderHandler.ts
@@ -2,6 +2,7 @@ import path from 'path'
 
 import prismaInternals from '@prisma/internals'
 import { Listr } from 'listr2'
+import prompts from 'prompts'
 
 import { recordTelemetryAttributes, colors as c } from '@cedarjs/cli-helpers'
 import { getPaths, getPrismaSchemas } from '@cedarjs/project-config'
@@ -11,6 +12,11 @@ import { writeFilesTask, printSetupNotes } from '../../../../lib/index.js'
 import { POSTGRES_YAML, RENDER_YAML, SQLITE_YAML } from '../templates/render.js'
 
 const { getConfig } = prismaInternals
+
+// Persistent disks (which the `sqlite` option attaches to the api service)
+// aren't available on Render's free plan, so that service needs to be on a
+// paid plan for the sqlite deploy option to actually work.
+const SQLITE_API_PLAN = 'starter'
 
 interface RenderFileData {
   path: string
@@ -41,7 +47,7 @@ const getRenderYamlContent = async (
       case 'sqlite':
         return {
           path: path.join(getPaths().base, 'render.yaml'),
-          content: RENDER_YAML(SQLITE_YAML),
+          content: RENDER_YAML(SQLITE_YAML, SQLITE_API_PLAN),
         }
       default:
         throw new Error(`
@@ -81,6 +87,40 @@ export const handler = async ({
     force,
     database,
   })
+
+  // The sqlite option stores its database file on a persistent disk, which
+  // Render's free plan doesn't support. Warn and confirm before generating a
+  // render.yaml that bills the api service, instead of a config that would
+  // silently fail to deploy.
+  if (database === 'sqlite') {
+    console.warn(
+      c.warning(
+        "Render's free plan doesn't support persistent disks, which the " +
+          '`sqlite` deploy option requires for its database file. The ' +
+          `generated render.yaml will set the api service's plan to ` +
+          `"${SQLITE_API_PLAN}" (a paid plan) instead of "free" so the ` +
+          'disk can actually attach.\n\n' +
+          'If you want to stay on the free plan, rerun this command with ' +
+          '`--database postgresql` (a managed database, not a disk) or ' +
+          '`--database none`.',
+      ),
+    )
+    console.log()
+
+    const { confirmed } = await prompts({
+      type: 'confirm',
+      name: 'confirmed',
+      message: `Generate render.yaml with the api service on the "${SQLITE_API_PLAN}" plan?`,
+    })
+
+    if (!confirmed) {
+      console.log('Aborting render setup.')
+      return
+    }
+
+    console.log()
+  }
+
   const tasks = new Listr(
     [
       {

--- a/packages/cli/src/commands/setup/deploy/templates/render.ts
+++ b/packages/cli/src/commands/setup/deploy/templates/render.ts
@@ -74,6 +74,7 @@ export const POSTGRES_YAML = `\
 
 databases:
   - name: ${PROJECT_NAME}-db
+    plan: free
     region: oregon`
 
 export const SQLITE_YAML = `\

--- a/packages/cli/src/commands/setup/deploy/templates/render.ts
+++ b/packages/cli/src/commands/setup/deploy/templates/render.ts
@@ -5,7 +5,7 @@ import { getUserApiUrl } from '../helpers/index.js'
 
 export const PROJECT_NAME = path.basename(getPaths().base)
 
-export const RENDER_YAML = (database: string) => {
+export const RENDER_YAML = (database: string, plan = 'free') => {
   const apiUrl = getUserApiUrl().replace(/\/$/, '')
   return `# Quick links to the docs:
 # - Deploying Cedar: https://cedarjs.com/docs/deploy/render
@@ -44,7 +44,7 @@ services:
 
 - name: ${PROJECT_NAME}-api
   type: web
-  plan: free
+  plan: ${plan}
   runtime: node
   region: oregon
   buildCommand: npm install --global corepack && yarn install && yarn cedar build api
@@ -79,6 +79,8 @@ databases:
 export const SQLITE_YAML = `\
   - key: DATABASE_URL
     value: file:./data/sqlite.db
+  # Persistent disks aren't available on Render's free plan, which is why
+  # the api service above is on a paid plan when SQLite is selected.
   disk:
     name: sqlite-data
     mountPath: /opt/render/project/src/api/db/data


### PR DESCRIPTION
## Summary

Render's free plan doesn't support persistent disks (confirmed via Render's docs at https://render.com/docs/disks — persistent disks are only available on paid web/private services and background workers). Cedar's generated `render.yaml` hardcodes `plan: free` on the `api` service (`packages/cli/src/commands/setup/deploy/templates/render.ts`) regardless of database choice, but the `sqlite` deploy option attaches a persistent disk to that same service for its database file. That combination can't actually deploy on Render today.

Postgres doesn't have this problem — it's a separate managed database, not a disk on the api service — so `--database postgresql` (the default) and `--database none` are unaffected.

## Changes

- `RENDER_YAML` now accepts an optional `plan` override (defaults to `'free'`, unchanged for postgresql/none).
- `renderHandler.ts` passes a paid plan (`starter`) when `--database sqlite` is selected, and warns + prompts for confirmation before generating `render.yaml`, explaining why and offering `postgresql`/`none` as free-plan alternatives.
- `render.md`'s tl;dr walkthrough notes the sqlite caveat.
- Added template tests covering the default free plan and the override.