### PR TITLE
docs(deploy): Railway does two services by default

### DIFF
--- a/docs/docs/deploy/introduction.md
+++ b/docs/docs/deploy/introduction.md
@@ -48,7 +48,7 @@ The generated `package.json` scripts map onto these: `start` is `cedar serve` (s
 `cedar serve web` / `yarn start:web` is primarily a local tool, for testing
 the web side in production mode before deploying. In production, use it only
 if your platform can't reliably serve `web/dist` as static files — see
-[Railway](./railway.md#scaling-up-two-services).
+[Railway](./railway.md#two-services).
 
 Point it at a separate api process with `--apiProxyTarget`, a fully-qualified
 URL (CLI-flag only — no `cedar.toml` or environment variable equivalent):
@@ -76,7 +76,7 @@ relative. The choice is between two setups:
 Prefer absolute `apiUrl` when your platform can reliably serve `web/dist` as
 static files (a CDN, Coolify's Static build pack, Netlify, etc.). Prefer the
 relative `apiUrl` + proxy setup when it can't — see
-[Railway](./railway.md#scaling-up-two-services).
+[Railway](./railway.md#two-services).
 
 ## Two topologies, and which to pick
 
@@ -85,7 +85,9 @@ Once you're past `cedar dev`, there are two ways to run Cedar in production:
 - **Single-container** (`yarn start`) — one process serves both sides; the web server proxies API requests to the API in-process. This is the **convenient** path: no service-to-service wiring, so it builds and starts with no platform-specific setup on any container host — see [any container host](./any-container-host.md).
 - **api process + static/CDN web** (`yarn start:api`, with the web side served separately) — this is the **recommended** path, and what the generated Dockerfile, the baremetal nginx setup, and the Render blueprint all use.
 
-Start with single-container — it's the fastest way to get a working deploy, and for small apps or early-stage projects it's often all you need. Move to the two-part topology when you want your web assets served from a CDN edge (rather than round-tripping through your api process), or when you want to scale the api and web sides independently. The reason this needs to be stated explicitly: without it, it's easy to land on single-container, get a working app, and never learn why the split is worth doing later.
+For any container host without a dedicated guide, start with single-container — it's the fastest way to get a working deploy, and for small apps or early-stage projects it's often all you need. Move to the two-part topology when you want your web assets served from a CDN edge (rather than round-tripping through your api process), or when you want to scale the api and web sides independently. The reason this needs to be stated explicitly: without it, it's easy to land on single-container, get a working app, and never learn why the split is worth doing later.
+
+Hosts with a dedicated guide ([Railway](./railway.md), [Coolify](./coolify.md)) may recommend starting elsewhere on that gradient — check the provider page first, since platform-specific defaults (e.g. what a GitHub-import wizard sets up for you) can make a different starting point the easier path on that host.
 
 :::important
 If your app has a custom [server file](../server-file.md) (`api/src/server.ts`),

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -25,7 +25,7 @@ production Cedar app. Before your first deploy, follow the steps below.
    - Settings tab, Healthcheck Path: `/graphql/health`.
    - Variables tab: `PORT=8911`
    - Variables tab: reference the database, usually
-     `DATABASE_URL=${{Postgres.DATABASE_URL}}`. Possibly also 
+     `DATABASE_URL=${{Postgres.DATABASE_URL}}`. Possibly also
      `DIRECT_DATABASE_URL`
 4. On the **web** service:
    - Variables tab: whatever database URL(s) `api/prisma.config.cjs` references
@@ -109,7 +109,11 @@ described above, so getting to one means undoing that.
    Neon Postgres setup.
 4. If you kept the **api** service (deleted web), it never had a public
    domain generated — Settings → Networking → Public Networking →
-   **Generate Domain**, same as the web service's step above.
+   **Generate Domain**, same as the web service's step above. Also remove its
+   `PORT=8911` Variable from the two-service setup: the combined server always
+   runs its api side internally on `8911` (Cedar's default `api.port`), so a
+   leftover `PORT=8911` makes the public web side try to bind that same port
+   and fail to start.
 5. Push. Railpack runs the root `build`/`start` scripts, which serve both sides
    from one process.
 

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -1,5 +1,5 @@
 ---
-description: Deploy to Railway, single-service or split into api/web services
+description: Deploy to Railway, split into api/web services (or a single container)
 ---
 
 # Deploy to Railway
@@ -9,77 +9,94 @@ Cedar's Yarn 4 workspaces and `engines.node` correctly with no configuration.
 Cedar needs nothing beyond the conventions described in
 [any container host](./any-container-host.md) to deploy there.
 
-## Single-service (start here)
+## Two services
 
-1. Create a new Railway project, and add a service from your Cedar repo.
-2. Add a Postgres database from Railway's plugin catalog. Railway sets
-   `DATABASE_URL` on services in the same project automatically — check your
-   service's Variables tab to reference it (usually
-   `${{Postgres.DATABASE_URL}}`).
-3. Push. Railpack finds `build` and `start` in `package.json` and runs them — no
-   build or start command configuration needed.
+When you create a new Railway project from a GitHub repo with Yarn workspaces,
+Railway's import detects `api` and `web` as separate deployable services,
+matching Cedar's
+[recommended topology](./introduction.md#two-topologies-and-which-to-pick) for a
+production Cedar app. Before your first deploy, follow the steps below.
 
-That's the whole setup: create service, add Postgres, reference `DATABASE_URL`,
-push. This runs the
-[single-container topology](./introduction.md#two-topologies-and-which-to-pick)
-— one service serving both sides.
+1. Create a new Railway project from your Cedar repo. Railway creates an `api`
+   and a `web` service.
+2. Add a Postgres database from Railway's plugin catalog.
+3. On the **api** service:
+   - Settings tab, Start Command: `yarn start:api`
+   - Settings tab, Healthcheck Path: `/graphql/health`.
+   - Variables tab: `PORT=8911`
+   - Variables tab: reference the database, usually
+     `DATABASE_URL=${{Postgres.DATABASE_URL}}`
+4. On the **web** service:
+   - Variables tab: whatever database URL(s) `api/prisma.config.cjs` references
+     — usually `DATABASE_URL`, plus possibly `DIRECT_DATABASE_URL`.
+   - Variables tab:
+     `API_PROXY_TARGET=${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}`. Define it
+     as a Variable first, since Railway's `${{Service.VAR}}` syntax doesn't
+     resolve directly in the Start Command field.
+   - Settings tab, Start Command:
+
+     ```shell
+     yarn start:web --api-proxy-target="http://$API_PROXY_TARGET"
+     ```
+
+     This requires `apiUrl` in `cedar.toml` to stay relative — see
+     [relative vs. absolute apiUrl](./introduction.md#relative-apiurl--proxy-or-absolute-apiurl--cors).
+
+   - Settings tab → Networking → Public Networking → **Generate Domain**.
+     Railway doesn't expose a public URL by default; this is what gives you one
+     (a free `*.up.railway.app` subdomain, or add your own custom domain here
+     instead).
+
+5. Deploy. Railpack finds each service's `build`/`start` scripts and runs them —
+   no further build configuration needed.
+
+It might seem starange to have to add `DATABASE_URL` to the web service. But
+it's used for prerendering. During build Cedar will execute Cell queries against
+your database to generate the static HTML it serves when prerendering.
+
+This two-services topology is the only one that supports a custom
+[server file](../server-file.md) (`api/src/server.ts`) — it's a Fastify concept
+with no equivalent in the single-container in-process server, so `yarn start`
+refuses to start rather than silently skipping what you configured (Realtime,
+custom plugins, custom middleware).
 
 ## Migrations
 
-Set your service's **Pre-Deploy Command** (in the service's Settings tab) to run
+Set the **api** service's **Pre-Deploy Command** (in its Settings tab) to run
 migrations before the new deploy goes live:
 
 ```shell
 yarn cedar prisma migrate deploy
 ```
 
-Railway runs this once per deploy, before traffic is switched over, which is a
-better fit than trying to run migrations from inside `start`.
-
-## Custom server file
-
-If your app has a custom [server file](../server-file.md) (`api/src/server.ts`),
-single-service won't work — a custom server file is a Fastify concept with no
-equivalent in the single-container in-process server, so `start` refuses to
-start rather than silently skipping what you configured (Realtime, custom
-plugins, custom middleware). Skip straight to
-[scaling up to two services](#scaling-up-two-services) below, and set the api
-service's start command to `yarn start:api` — that path does run the server
-file.
+Railway runs this once per deploy, before traffic is switched over.
 
 ## Enabling Railway's CDN
 
 Railway's CDN is per-service, free on all plans, and caches static assets by
-`Content-Type`. Enable it in your service's Settings tab under Networking. It's
-the thing that most closes the gap between single-container and the two-service
-topology — even serving `web/dist` from the same process as your api, static
-assets still get edge-cached.
+`Content-Type`. Enable it on the **web** service's Settings tab under Networking
+— `yarn start:web` still serves `web/dist` from a Node process, so the CDN is
+what gets static assets edge-cached instead of round-tripping through that
+process on every request.
 
-## Scaling up: two services
+## Single-container (optional)
 
-To split into the
-[recommended topology](./introduction.md#two-topologies-and-which-to-pick):
+If you'd rather run one service instead of two — fewer moving parts, lower cost,
+no proxy wiring — you can consolidate down to Cedar's
+[single-container topology](./introduction.md#two-topologies-and-which-to-pick).
+This isn't Railway's default: its GitHub import creates the two services
+described above, so getting to one means undoing that.
 
-1. Add a second service from the same repo.
-2. On the api service, set the start command to `yarn start:api`.
-3. Set the web service's start command to proxy to the api service with
-   `--api-proxy-target`, a fully-qualified URL (scheme required). Requires
-   `apiUrl` in `cedar.toml` to stay relative — see
-   [relative vs. absolute apiUrl](./introduction.md#relative-apiurl--proxy-or-absolute-apiurl--cors).
+1. Delete one of the two auto-created services, keeping the other.
+2. On the remaining service, check Settings → Source and clear any
+   root-directory override, so it builds from the repo root rather than the
+   `api` or `web` workspace.
+3. Add Postgres and reference `DATABASE_URL` as above.
+4. Push. Railpack runs the root `build`/`start` scripts, which serve both sides
+   from one process.
 
-   Define the target as a Variable first, then reference it from the start
-   command (Railway's `${{Service.VAR}}` syntax doesn't resolve directly in the
-   Start Command field):
-
-   - Api service **Variables** tab: `PORT=8911`
-   - Web service **Variables** tab:
-     `API_PROXY_TARGET=${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}`, replacing
-     `api` with your api service's actual Railway service name
-   - Web service start command:
-
-     ```shell
-     yarn start:web --api-proxy-target="http://$API_PROXY_TARGET"
-     ```
+Single-container doesn't support a custom server file (see above). Railway's CDN
+still applies the same way — enable it on the one remaining service.
 
 ## Config as code
 

--- a/docs/docs/deploy/railway.md
+++ b/docs/docs/deploy/railway.md
@@ -25,7 +25,8 @@ production Cedar app. Before your first deploy, follow the steps below.
    - Settings tab, Healthcheck Path: `/graphql/health`.
    - Variables tab: `PORT=8911`
    - Variables tab: reference the database, usually
-     `DATABASE_URL=${{Postgres.DATABASE_URL}}`
+     `DATABASE_URL=${{Postgres.DATABASE_URL}}`. Possibly also 
+     `DIRECT_DATABASE_URL`
 4. On the **web** service:
    - Variables tab: whatever database URL(s) `api/prisma.config.cjs` references
      — usually `DATABASE_URL`, plus possibly `DIRECT_DATABASE_URL`.
@@ -50,9 +51,18 @@ production Cedar app. Before your first deploy, follow the steps below.
 5. Deploy. Railpack finds each service's `build`/`start` scripts and runs them —
    no further build configuration needed.
 
-It might seem starange to have to add `DATABASE_URL` to the web service. But
+It might seem strange to have to add `DATABASE_URL` to the web service. But
 it's used for prerendering. During build Cedar will execute Cell queries against
 your database to generate the static HTML it serves when prerendering.
+
+This means a schema-changing deploy has an ordering risk: the web service's
+build (and its prerender step) isn't gated on the api service's Pre-Deploy
+Command finishing, only on it being started, so it can run before or during a
+migration. If you use `<Set prerender>` on routes with Cell data and are
+shipping a breaking schema change, run the migration yourself against
+production before pushing (`yarn cedar prisma migrate deploy`), or keep
+changes backward-compatible (expand/contract) so prerendering succeeds
+against both the old and new shape.
 
 This two-services topology is the only one that supports a custom
 [server file](../server-file.md) (`api/src/server.ts`) — it's a Fastify concept
@@ -88,11 +98,19 @@ This isn't Railway's default: its GitHub import creates the two services
 described above, so getting to one means undoing that.
 
 1. Delete one of the two auto-created services, keeping the other.
-2. On the remaining service, check Settings → Source and clear any
-   root-directory override, so it builds from the repo root rather than the
-   `api` or `web` workspace.
-3. Add Postgres and reference `DATABASE_URL` as above.
-4. Push. Railpack runs the root `build`/`start` scripts, which serve both sides
+2. On the remaining service's Settings tab, clear Railway's auto-configured
+   Root Directory, Build Command, Start Command, and Watch Paths. Railway's
+   monorepo import sets these per-workspace (e.g. Start Command
+   `yarn start:api`), and single-container needs the root-level `build`/`start`
+   scripts instead — leaving a workspace-specific Start Command in place just
+   keeps running that one side, not both.
+3. Add Postgres and reference the same database variable(s) as the api
+   service above — `DATABASE_URL`, plus `DIRECT_DATABASE_URL` if you used the
+   Neon Postgres setup.
+4. If you kept the **api** service (deleted web), it never had a public
+   domain generated — Settings → Networking → Public Networking →
+   **Generate Domain**, same as the web service's step above.
+5. Push. Railpack runs the root `build`/`start` scripts, which serve both sides
    from one process.
 
 Single-container doesn't support a custom server file (see above). Railway's CDN


### PR DESCRIPTION
When importing a Cedar app from GitHub Railway detects the two default workspaces (api and web). So doing the two-services deploy is actually the easier option