### PR TITLE
feat(cli): generate stubs for missing relations in scaffold

### DIFF
--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1194,10 +1194,14 @@ Notes:
 
 **Troubleshooting**
 
-If you see `Error: Unknown type: ...`, don't panic!
-It's a known limitation with GraphQL type generation.
-It happens when you generate the SDL of a Prisma model that has relations **before the SDL for the related model exists**.
-Please see [Troubleshooting Generators](./schema-relations#troubleshooting-generators) for help.
+If you see `Error: Unknown type: ...`, don't panic! In most cases this is now
+handled automatically: as described above, `generate scaffold` generates
+read-only stub SDLs for any related models that don't have one yet, so type
+generation doesn't fail. If you still hit this error — for example after
+destroying an SDL that another stub still relies on, or with an implicit
+many-to-many relation — see
+[Troubleshooting Generators](./schema-relations#troubleshooting-generators)
+for help.
 
 ### generate script
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1195,11 +1195,10 @@ Notes:
 **Troubleshooting**
 
 As described above, `generate scaffold` generates read-only stub SDLs for any
-related models that don't have one yet, before type generation runs — so in
-the common case you won't see `Error: Unknown type: ...` at all anymore. If
-you still hit it — for example after destroying an SDL that another stub
-still relies on, or with an implicit many-to-many relation, which isn't
-stubbed — see
+related models that don't have one yet, before type generation runs, so in the
+common case you won't run into `Error: Unknown type: ...`. If you do hit
+it — for example after destroying an SDL that another stub still relies on,
+or with an implicit many-to-many relation, which isn't stubbed — see
 [Troubleshooting Generators](./schema-relations#troubleshooting-generators)
 for help.
 
@@ -1402,11 +1401,11 @@ export const User = {
 **Troubleshooting**
 
 As described above, `generate sdl` generates read-only stub SDLs for any
-related models that don't have one yet, before type generation runs — so in
-the common case you won't see `Error: Unknown type: ...` at all anymore. If
-you still hit it — for example after destroying an SDL that another stub
-still relies on, or with an implicit many-to-many relation, which isn't
-stubbed — see [Troubleshooting Generators](./schema-relations#troubleshooting-generators) for help.
+related models that don't have one yet, before type generation runs, so in
+the common case you won't run into `Error: Unknown type: ...`. If you do hit
+it — for example after destroying an SDL that another stub still relies on,
+or with an implicit many-to-many relation, which isn't stubbed — see
+[Troubleshooting Generators](./schema-relations#troubleshooting-generators) for help.
 
 ### generate secret
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1054,6 +1054,15 @@ The content of the generated components is different from what you'd get by runn
 
 Like [generate sdl](#generate-sdl), the scaffold generator never includes dbAuth's sensitive fields (`hashedPassword`, `salt`, `resetToken`, `resetTokenExpiresAt`, `webAuthnChallenge`) in the generated SDL, forms, cells or display pages. As with `generate sdl`, `salt` is only excluded when the model has at least one of the other auth fields too — a standalone `salt` field is kept.
 
+Also like `generate sdl`, if the model has relations to models that don't have
+SDL files of their own yet, read-only stub SDLs (and services) are generated for
+those models too, so GraphQL type generation doesn't fail with an `Unknown type`
+error. Replace a stub by running `generate sdl` (SDL + service only) or
+`generate scaffold` (adds pages, cells, and forms too) for that model; unedited
+stubs are overwritten without needing `--force`. See
+[Troubleshooting Generators](./schema-relations#troubleshooting-generators) for
+details.
+
 | Arguments & Options  | Description                                                                                                                                                                                           |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `model`              | Model to scaffold. You can also use `<path/model>` to nest files by type at the given path directory (or directories). For example, `redwood g scaffold admin/post`                                   |

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1194,12 +1194,12 @@ Notes:
 
 **Troubleshooting**
 
-If you see `Error: Unknown type: ...`, don't panic! In most cases this is now
-handled automatically: as described above, `generate scaffold` generates
-read-only stub SDLs for any related models that don't have one yet, so type
-generation doesn't fail. If you still hit this error — for example after
-destroying an SDL that another stub still relies on, or with an implicit
-many-to-many relation — see
+As described above, `generate scaffold` generates read-only stub SDLs for any
+related models that don't have one yet, before type generation runs — so in
+the common case you won't see `Error: Unknown type: ...` at all anymore. If
+you still hit it — for example after destroying an SDL that another stub
+still relies on, or with an implicit many-to-many relation, which isn't
+stubbed — see
 [Troubleshooting Generators](./schema-relations#troubleshooting-generators)
 for help.
 
@@ -1401,10 +1401,12 @@ export const User = {
 
 **Troubleshooting**
 
-If you see `Error: Unknown type: ...`, don't panic!
-It's a known limitation with GraphQL type generation.
-It happens when you generate the SDL of a Prisma model that has relations **before the SDL for the related model exists**.
-Please see [Troubleshooting Generators](./schema-relations#troubleshooting-generators) for help.
+As described above, `generate sdl` generates read-only stub SDLs for any
+related models that don't have one yet, before type generation runs — so in
+the common case you won't see `Error: Unknown type: ...` at all anymore. If
+you still hit it — for example after destroying an SDL that another stub
+still relies on, or with an implicit many-to-many relation, which isn't
+stubbed — see [Troubleshooting Generators](./schema-relations#troubleshooting-generators) for help.
 
 ### generate secret
 

--- a/docs/docs/schema-relations.md
+++ b/docs/docs/schema-relations.md
@@ -157,17 +157,13 @@ As long as you haven't edited the stub files, they're replaced without needing `
 
 ### Scaffolds
 
-The scaffold generator doesn't generate stubs for missing related models (yet), so scaffolding a model whose related models have no SDLs fails during type generation with an error like:
-
-```text
-        Unknown type: "Shelf".
-        Error: Unknown type: "Shelf".
-```
-
-The fix: generate the SDL for (or scaffold out) each model in the relation,
-ignoring the intermediate errors. The last model in the relation should generate
-cleanly. Or run `yarn cedar g sdl <model>` for the related models first, since
-the SDL generator handles missing relations automatically.
+The scaffold generator generates the same read-only stubs for missing related
+models, so scaffolding `Book` behaves just like generating its SDL: a stub SDL
+and service are generated for `Shelf`, and the same "Read-only SDL stubs were
+generated for them" message is printed once the scaffold finishes. When you're
+ready to flesh out `Shelf`, run `yarn cedar g sdl Shelf` for just the GraphQL
+type and service, or `yarn cedar g scaffold Shelf` if you also want a full
+CRUD UI for it.
 
 ### Self-Relations
 

--- a/docs/docs/schema-relations.md
+++ b/docs/docs/schema-relations.md
@@ -159,11 +159,13 @@ As long as you haven't edited the stub files, they're replaced without needing `
 
 The scaffold generator generates the same read-only stubs for missing related
 models, so scaffolding `Book` behaves just like generating its SDL: a stub SDL
-and service are generated for `Shelf`, and the same "Read-only SDL stubs were
-generated for them" message is printed once the scaffold finishes. When you're
-ready to flesh out `Shelf`, run `yarn cedar g sdl Shelf` for just the GraphQL
-type and service, or `yarn cedar g scaffold Shelf` if you also want a full
-CRUD UI for it.
+and service are generated for `Shelf`, and a corresponding "Read-only SDL
+stubs were generated for them" message is printed once the scaffold finishes.
+Unlike the SDL generator's message, which only offers `yarn cedar generate sdl
+Shelf`, the scaffold generator's message offers both `yarn cedar generate sdl
+Shelf` (just the GraphQL type and service) and `yarn cedar generate scaffold
+Shelf` (adds pages, cells, and forms too), since scaffolding the related model
+is a reasonable next step but not always the desired one.
 
 ### Self-Relations
 

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldStubRoundTrip.test.ts
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldStubRoundTrip.test.ts
@@ -1,0 +1,104 @@
+globalThis.__dirname = import.meta.dirname
+
+import type * as NodeFs from 'node:fs'
+import path from 'node:path'
+
+import { vol, fs as memfs } from 'memfs'
+import { ufs } from 'unionfs'
+import { vi, test, expect, beforeAll } from 'vitest'
+
+// Load mocks
+import '../../../../lib/test'
+
+vi.mock('node:fs', async (importOriginal) => {
+  const { wrapFsForUnionfs, wrapMemfsForUnionfs } =
+    await import('../../../../__tests__/ufsFsProxy.js')
+  const originalFs = await importOriginal<typeof NodeFs>()
+  ufs.use(wrapFsForUnionfs(originalFs)).use(wrapMemfsForUnionfs(memfs))
+  return { ...ufs, default: { ...ufs } }
+})
+
+vi.mock('execa')
+
+import { getDefaultArgs } from '../../../../lib/index.js'
+import { stubFiles as sdlStubFiles } from '../../sdl/sdlHandler.js'
+import {
+  missingRelatedModels,
+  writeFilesWithStubsTask,
+} from '../../sdl/stubFiles.js'
+import { getYargsDefaults } from '../../yargsCommandHelpers.js'
+import * as scaffoldHandler from '../scaffoldHandler.js'
+
+beforeAll(() => {
+  vol.fromJSON({ 'redwood.toml': '' }, '/')
+})
+
+const sdlPath = (fileName: string) =>
+  path.normalize(`/path/to/project/api/src/graphql/${fileName}`)
+const servicePath = (fileName: string) =>
+  path.normalize(`/path/to/project/api/src/services/${fileName}`)
+const usersPagePath = () =>
+  path.normalize('/path/to/project/web/src/pages/User/UsersPage/UsersPage.jsx')
+
+// This mirrors two successive `cedar generate scaffold` runs: first
+// UserProfile (which stubs out User, since User has no SDL yet), then User
+// itself once you're ready to flesh it out for real.
+test('re-scaffolding a stubbed-out model replaces the stub with the real thing', async () => {
+  const upMissing = await missingRelatedModels('UserProfile')
+  const upFiles = {
+    ...(await scaffoldHandler.files({
+      ...getDefaultArgs(getYargsDefaults()),
+      docs: false,
+      model: 'UserProfile',
+      tests: true,
+      nestScaffoldByModel: true,
+    })),
+    ...(await sdlStubFiles(upMissing, 'UserProfile', { typescript: false })),
+  }
+  await writeFilesWithStubsTask(upFiles).run()
+
+  // Sanity check: User's SDL/service are the read-only stub versions on disk,
+  // and no web-side scaffold exists for User yet
+  expect(memfs.readFileSync(sdlPath('users.sdl.js'), 'utf-8')).not.toContain(
+    'type Mutation',
+  )
+  expect(
+    memfs.readFileSync(servicePath('users/users.js'), 'utf-8'),
+  ).not.toContain('createUser')
+  expect(memfs.existsSync(usersPagePath())).toEqual(false)
+
+  // Now scaffold User for real
+  const userMissing = await missingRelatedModels('User')
+  // UserProfile already has SDL from the first scaffold, so nothing is missing
+  expect(userMissing).toEqual([])
+
+  const userFiles = {
+    ...(await scaffoldHandler.files({
+      ...getDefaultArgs(getYargsDefaults()),
+      docs: false,
+      model: 'User',
+      tests: true,
+      nestScaffoldByModel: true,
+    })),
+    ...(await sdlStubFiles(userMissing, 'User', { typescript: false })),
+  }
+
+  // No --force needed: the existing SDL/service are pristine stubs, so
+  // they're recognized and replaced automatically
+  await writeFilesWithStubsTask(userFiles, { overwriteExisting: false }).run()
+
+  const finalSdl = memfs.readFileSync(sdlPath('users.sdl.js'), 'utf-8')
+  const finalService = memfs.readFileSync(
+    servicePath('users/users.js'),
+    'utf-8',
+  )
+
+  expect(finalSdl).toContain('type Mutation')
+  expect(finalSdl).not.toContain('@cedar-generator-stub-hash')
+  expect(finalService).toContain('createUser')
+  expect(finalService).toContain('updateUser')
+  expect(finalService).toContain('deleteUser')
+
+  // And the full web-side scaffold (layout, pages, cells, forms) now exists
+  expect(memfs.existsSync(usersPagePath())).toEqual(true)
+})

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldStubs.test.ts
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldStubs.test.ts
@@ -22,7 +22,11 @@ vi.mock('execa')
 
 import { getDefaultArgs } from '../../../../lib/index.js'
 import { stubFiles as sdlStubFiles } from '../../sdl/sdlHandler.js'
-import { isPristineStub, missingRelatedModels } from '../../sdl/stubFiles.js'
+import {
+  isPristineStub,
+  missingRelatedModels,
+  writeFilesWithStubsTask,
+} from '../../sdl/stubFiles.js'
 import { getYargsDefaults } from '../../yargsCommandHelpers.js'
 import * as scaffoldHandler from '../scaffoldHandler.js'
 
@@ -115,5 +119,38 @@ describe("files() alone never generates stubs (relied on by 'destroy scaffold')"
 
     expect(files).not.toHaveProperty([sdlPath('users.sdl.js')])
     expect(files).not.toHaveProperty([servicePath('users/users.js')])
+  })
+})
+
+// Regression test: `scaffoldHandler.handler()` used to call
+// `missingRelatedModels(name)` *after* running the Listr tasks that write the
+// stub SDL files. By that point the stub SDL already exists on disk, so
+// `missingRelatedModels` no longer sees it as missing, and the "run one of
+// the following" message (and the redacted-fields note for the stubbed
+// model) silently never printed. The fix computes the list once, before
+// anything is written, and threads it through. This test demonstrates why
+// that ordering matters: computed too late, the same list comes back empty.
+describe('missingRelatedModels ordering around the stub write', () => {
+  test('returns [] once the stub SDL for the related model exists on disk', async () => {
+    const missingBeforeWrite = await missingRelatedModels('UserProfile')
+    expect(missingBeforeWrite).toEqual(['User'])
+
+    const files = {
+      ...(await scaffoldHandler.files({
+        ...getDefaultArgs(getYargsDefaults()),
+        docs: false,
+        model: 'UserProfile',
+        tests: true,
+        nestScaffoldByModel: true,
+      })),
+      ...(await sdlStubFiles(missingBeforeWrite, 'UserProfile', {
+        typescript: false,
+      })),
+    }
+    await writeFilesWithStubsTask(files).run()
+
+    // If `handler()` (re-)computed the list at this point, it would
+    // incorrectly conclude nothing is missing
+    expect(await missingRelatedModels('UserProfile')).toEqual([])
   })
 })

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldStubs.test.ts
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldStubs.test.ts
@@ -1,0 +1,119 @@
+globalThis.__dirname = import.meta.dirname
+
+import type * as NodeFs from 'node:fs'
+import path from 'node:path'
+
+import { vol, fs as memfs } from 'memfs'
+import { ufs } from 'unionfs'
+import { vi, describe, test, expect, beforeAll } from 'vitest'
+
+// Load mocks
+import '../../../../lib/test'
+
+vi.mock('node:fs', async (importOriginal) => {
+  const { wrapFsForUnionfs, wrapMemfsForUnionfs } =
+    await import('../../../../__tests__/ufsFsProxy.js')
+  const originalFs = await importOriginal<typeof NodeFs>()
+  ufs.use(wrapFsForUnionfs(originalFs)).use(wrapMemfsForUnionfs(memfs))
+  return { ...ufs, default: { ...ufs } }
+})
+
+vi.mock('execa')
+
+import { getDefaultArgs } from '../../../../lib/index.js'
+import { stubFiles as sdlStubFiles } from '../../sdl/sdlHandler.js'
+import { isPristineStub, missingRelatedModels } from '../../sdl/stubFiles.js'
+import { getYargsDefaults } from '../../yargsCommandHelpers.js'
+import * as scaffoldHandler from '../scaffoldHandler.js'
+
+beforeAll(() => {
+  vol.fromJSON({ 'redwood.toml': '' }, '/')
+})
+
+const sdlPath = (fileName: string) =>
+  path.normalize(`/path/to/project/api/src/graphql/${fileName}`)
+const servicePath = (fileName: string) =>
+  path.normalize(`/path/to/project/api/src/services/${fileName}`)
+
+// This mirrors how `scaffoldHandler.tasks()` combines the two: `files()`
+// alone never generates stubs for related models (same contract as the SDL
+// generator), so `cedar destroy scaffold` — which calls `files()` directly —
+// doesn't delete stub files that other models may still depend on.
+describe('scaffolding a model with a relation to a model without SDL', () => {
+  let files: Record<string, string>
+
+  beforeAll(async () => {
+    // UserProfile has a relation to User, which has no SDL file in the
+    // fixture schema
+    const missingModels = await missingRelatedModels('UserProfile')
+
+    files = {
+      ...(await scaffoldHandler.files({
+        ...getDefaultArgs(getYargsDefaults()),
+        docs: false,
+        model: 'UserProfile',
+        tests: true,
+        nestScaffoldByModel: true,
+      })),
+      ...(await sdlStubFiles(missingModels, 'UserProfile', {
+        typescript: false,
+      })),
+    }
+  })
+
+  test('generates the scaffold, SDL, and service for the target model', () => {
+    expect(files).toHaveProperty([sdlPath('userProfiles.sdl.js')])
+    expect(files).toHaveProperty([servicePath('userProfiles/userProfiles.js')])
+  })
+
+  test('generates a read-only SDL stub for the missing related model', () => {
+    const stubSdl = files[sdlPath('users.sdl.js')]
+
+    expect(stubSdl).toBeDefined()
+    expect(stubSdl).toContain('@cedar-generator-stub-hash')
+    expect(isPristineStub(stubSdl)).toEqual(true)
+  })
+
+  test('generates a read-only service stub for the missing related model', () => {
+    const stubService = files[servicePath('users/users.js')]
+
+    expect(stubService).toBeDefined()
+    expect(isPristineStub(stubService)).toEqual(true)
+  })
+
+  test('does not generate test files for the stub', () => {
+    expect(files).not.toHaveProperty([servicePath('users/users.test.js')])
+    expect(files).not.toHaveProperty([servicePath('users/users.scenarios.js')])
+  })
+
+  test('does not generate web-side scaffold files for the stub model', () => {
+    const webFiles = Object.keys(files).filter((filePath) =>
+      filePath.includes(path.normalize('/web/')),
+    )
+
+    expect(webFiles.every((filePath) => !filePath.includes('User/'))).toEqual(
+      true,
+    )
+  })
+})
+
+describe('scaffolding a model with no relations', () => {
+  test('finds no missing related models', async () => {
+    expect(await missingRelatedModels('CustomIdField')).toEqual([])
+  })
+})
+
+describe("files() alone never generates stubs (relied on by 'destroy scaffold')", () => {
+  test('files() does not include stubs for a model with a missing relation', async () => {
+    const files = await scaffoldHandler.files({
+      ...getDefaultArgs(getYargsDefaults()),
+      docs: false,
+      model: 'UserProfile',
+      tests: true,
+      nestScaffoldByModel: true,
+    })
+
+    expect(files).not.toHaveProperty([sdlPath('users.sdl.js')])
+    expect(files).not.toHaveProperty([servicePath('users/users.js')])
+  })
+})

--- a/packages/cli/src/commands/generate/scaffold/scaffoldHandler.ts
+++ b/packages/cli/src/commands/generate/scaffold/scaffoldHandler.ts
@@ -9,6 +9,7 @@ import type { ListrTaskWrapper } from 'listr2'
 import pascalcase from 'pascalcase'
 
 import { recordTelemetryAttributes, colors as c } from '@cedarjs/cli-helpers'
+import { formatCedarCommand } from '@cedarjs/cli-helpers/packageManager/display'
 import {
   addWorkspacePackages,
   removeWorkspacePackages,
@@ -42,10 +43,14 @@ import {
 import { builder as sdlBuilder } from '../sdl/sdl.js'
 import {
   files as sdlFiles,
+  stubFiles as sdlStubFiles,
   printRedactedFieldsNote,
   redactedSensitiveFields,
 } from '../sdl/sdlHandler.js'
-import { writeFilesWithStubsTask } from '../sdl/stubFiles.js'
+import {
+  missingRelatedModels,
+  writeFilesWithStubsTask,
+} from '../sdl/stubFiles.js'
 import { builder as serviceBuilder } from '../service/service.js'
 import { files as serviceFiles } from '../service/serviceHandler.js'
 import { customOrDefaultTemplatePath } from '../yargsHandlerHelpers.js'
@@ -966,15 +971,19 @@ export const tasks = ({
       {
         title: 'Generating scaffold files...',
         task: async () => {
-          const f = await files({
-            docs,
-            model,
-            path,
-            tests,
-            typescript,
-            tailwind,
-            force,
-          })
+          const missingModels = await missingRelatedModels(model)
+          const f = {
+            ...(await files({
+              docs,
+              model,
+              path,
+              tests,
+              typescript,
+              tailwind,
+              force,
+            })),
+            ...(await sdlStubFiles(missingModels, model, { docs, typescript })),
+          }
           return writeFilesWithStubsTask(f, { overwriteExisting: force })
         },
       },
@@ -1070,7 +1079,42 @@ export const handler = async ({
     }
     await t.run()
 
-    printRedactedFieldsNote(await redactedSensitiveFields([name]))
+    const missingModels = await missingRelatedModels(name)
+
+    if (missingModels.length > 0) {
+      console.log()
+      console.log(
+        c.info(
+          `${name} has relations to models that don't have SDL files of ` +
+            `their own yet: ${missingModels.join(', ')}`,
+        ),
+      )
+      console.log(
+        c.info(
+          'Read-only SDL stubs were generated for them, since GraphQL type ' +
+            'generation fails otherwise.',
+        ),
+      )
+      console.log(
+        c.info('To replace a stub, run one of the following for each model:'),
+      )
+      for (const stubModel of missingModels) {
+        console.log(
+          c.info(
+            `  ${formatCedarCommand(['generate', 'sdl', stubModel])} (SDL + service only)`,
+          ),
+        )
+        console.log(
+          c.info(
+            `  ${formatCedarCommand(['generate', 'scaffold', stubModel])} (adds pages, cells, and forms too)`,
+          ),
+        )
+      }
+    }
+
+    printRedactedFieldsNote(
+      await redactedSensitiveFields([name, ...missingModels]),
+    )
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e)
     const exitCode =

--- a/packages/cli/src/commands/generate/scaffold/scaffoldHandler.ts
+++ b/packages/cli/src/commands/generate/scaffold/scaffoldHandler.ts
@@ -954,6 +954,7 @@ interface TasksOptions {
   typescript: boolean
   javascript?: boolean
   tailwind: boolean
+  missingModels: string[]
 }
 
 export const tasks = ({
@@ -965,13 +966,13 @@ export const tasks = ({
   typescript,
   javascript: _javascript,
   tailwind,
+  missingModels,
 }: TasksOptions) => {
   return new Listr(
     [
       {
         title: 'Generating scaffold files...',
         task: async () => {
-          const missingModels = await missingRelatedModels(model)
           const f = {
             ...(await files({
               docs,
@@ -1065,6 +1066,9 @@ export const handler = async ({
 
   try {
     const { name } = await verifyModelName({ name: model })
+    // Computed before `t.run()` writes the stub SDL files: once those exist
+    // on disk, `missingRelatedModels` would no longer see them as missing
+    const missingModels = await missingRelatedModels(name)
     const t = tasks({
       docs,
       model: name,
@@ -1073,13 +1077,12 @@ export const handler = async ({
       tests,
       typescript,
       tailwind,
+      missingModels,
     })
     if (rollback && !force) {
       prepareForRollback(t)
     }
     await t.run()
-
-    const missingModels = await missingRelatedModels(name)
 
     if (missingModels.length > 0) {
       console.log()


### PR DESCRIPTION
## Summary

- Extends the read-only SDL/service stub generation added for the SDL generator (#2365) to `generate scaffold`, so scaffolding a model with a relation to a model that has no SDL yet no longer breaks GraphQL type generation.
- `files()` itself stays stub-free — `destroy scaffold` reuses it and must not delete stub files that other models may still depend on. The stub merging happens only in the write step of `tasks()`, mirroring how `destroy sdl` also uses the stub-free `sdlHandler.files()`.
- Once the scaffold finishes, the CLI prints two ways to replace a stub: `generate sdl` (SDL + service only) and `generate scaffold` (adds pages, cells, and forms too) — since scaffolding the related model is a reasonable next step, but not always the desired one. `generate sdl`'s own equivalent message is left as-is (single option), since a user working with SDL alone is likely to want to continue that way.
- Docs (`schema-relations.md`, `cli-commands.md`) updated to match; the old "scaffold doesn't support this yet" caveat is removed.

## Test plan

- Added `scaffoldStubs.test.ts`: verifies stub generation for a model with a missing relation, confirms stubs are read-only/untested, confirms `files()` alone stays stub-free (protecting the `destroy scaffold` contract), and confirms models without relations produce no stubs.
- Added `scaffoldStubRoundTrip.test.ts`: scaffolds a model that stubs out a related model, then scaffolds that related model for real, and confirms the stub SDL/service are replaced with the full CRUD versions (without `--force`) and the web-side files are created.
- `yarn vitest run src/commands/generate/scaffold src/commands/generate/sdl src/commands/destroy` — 667 tests pass.
- `yarn eslint` / `yarn prettier --check` on all touched files — clean.
- `yarn build` (via pre-push hook) — succeeds.