### PR TITLE
feat(cli): --fragment cell generator

### DIFF
--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.ts.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.ts.snap
@@ -302,6 +302,178 @@ describe('CustomIdFieldCell', () => {
 "
 `;
 
+exports[`Fragment cells > generates a FRAGMENT cell for the given GraphQL type 1`] = `
+"import type { AuthorBioCell_user } from 'types/graphql'
+
+import type { CellSuccessProps } from '@cedarjs/web'
+
+// A parent Cell spreads this fragment by name in its own QUERY, and passes
+// the matching field down as the \`user\` prop - no import needed,
+// just render <AuthorBioCell />:
+//
+//   query FindSomething($id: Int!) {
+//     something(id: $id) {
+//       id
+//       ...AuthorBioCell_user
+//     }
+//   }
+//
+//   <AuthorBioCell user={something.user} />
+export const FRAGMENT = gql\`
+  fragment AuthorBioCell_user on User {
+    id
+  }
+\`
+
+export const Empty = () => <div>Empty</div>
+
+export const Success = ({ user }: CellSuccessProps<AuthorBioCell_user>) => {
+  return <div>{JSON.stringify(user)}</div>
+}
+"
+`;
+
+exports[`Fragment cells > generates a FRAGMENT cell for the given GraphQL type 2`] = `
+"import { render } from '@cedarjs/testing/web'
+
+import { Empty, Success } from './AuthorBioCell'
+import { standard } from './AuthorBioCell.mock'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float and DateTime types.
+//           Please refer to the RedwoodJS Testing Docs:
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
+
+describe('AuthorBioCell', () => {
+  it('renders Empty successfully', async () => {
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
+  })
+
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  // 1. import { screen } from '@cedarjs/testing/web'
+  // 2. Add test: expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
+  it('renders Success successfully', async () => {
+    expect(() => {
+      render(<Success user={standard().user} />)
+    }).not.toThrow()
+  })
+})
+"
+`;
+
+exports[`Fragment cells > generates a FRAGMENT cell for the given GraphQL type 3`] = `
+"import type { Meta, StoryObj } from '@storybook/react'
+
+import { Empty, Success } from './AuthorBioCell'
+import { standard } from './AuthorBioCell.mock'
+
+const meta: Meta = {
+  title: 'Cells/AuthorBioCell',
+  tags: ['autodocs'],
+}
+
+export default meta
+
+export const empty: StoryObj<typeof Empty> = {
+  render: () => {
+    return Empty ? <Empty /> : <></>
+  },
+}
+
+export const success: StoryObj<typeof Success> = {
+  render: (args) => {
+    return Success ? <Success {...standard()} {...args} /> : <></>
+  },
+}
+"
+`;
+
+exports[`Fragment cells > generates a FRAGMENT cell for the given GraphQL type 4`] = `
+"// Define your own mock data here:
+export const standard = (/* vars, { ctx, req } */) => ({
+  user: {
+    __typename: 'User' as const,
+    id: 42,
+  },
+})
+"
+`;
+
+exports[`Fragment cells > includes afterQuery and isEmpty stubs when passed 1`] = `
+"import type { AuthorBioCell_user } from 'types/graphql'
+
+import type { CellSuccessProps, DataObject } from '@cedarjs/web'
+
+// A parent Cell spreads this fragment by name in its own QUERY, and passes
+// the matching field down as the \`user\` prop - no import needed,
+// just render <AuthorBioCell />:
+//
+//   query FindSomething($id: Int!) {
+//     something(id: $id) {
+//       id
+//       ...AuthorBioCell_user
+//     }
+//   }
+//
+//   <AuthorBioCell user={something.user} />
+export const FRAGMENT = gql\`
+  fragment AuthorBioCell_user on User {
+    id
+  }
+\`
+
+export const isEmpty = (
+  data: DataObject,
+  { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean }
+) => {
+  return isDataEmpty(data)
+}
+
+export const afterQuery = (data: DataObject): DataObject => {
+  return data
+}
+
+export const Empty = () => <div>Empty</div>
+
+export const Success = ({ user }: CellSuccessProps<AuthorBioCell_user>) => {
+  return <div>{JSON.stringify(user)}</div>
+}
+"
+`;
+
+exports[`Fragment cells > strips types from a FRAGMENT cell when generating JavaScript 1`] = `
+"// A parent Cell spreads this fragment by name in its own QUERY, and passes
+// the matching field down as the \`user\` prop - no import needed,
+// just render <AuthorBioCell />:
+//
+//   query FindSomething($id: Int!) {
+//     something(id: $id) {
+//       id
+//       ...AuthorBioCell_user
+//     }
+//   }
+//
+//   <AuthorBioCell user={something.user} />
+export const FRAGMENT = gql\`
+  fragment AuthorBioCell_user on User {
+    id
+  }
+\`
+
+export const Empty = () => <div>Empty</div>
+
+export const Success = ({ user }) => {
+  return <div>{JSON.stringify(user)}</div>
+}
+"
+`;
+
 exports[`Kebab case words > creates a cell component with a kebabCase word name 1`] = `
 "export const QUERY = gql\`
   query FindUserProfileQuery($id: Int!) {

--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.ts.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.ts.snap
@@ -318,7 +318,7 @@ import type { CellSuccessProps } from '@cedarjs/web'
 //     }
 //   }
 //
-//   <AuthorBioCell user={something.user} />
+//   <AuthorBioCell user={something} />
 export const FRAGMENT = gql\`
   fragment AuthorBioCell_user on User {
     id
@@ -327,7 +327,9 @@ export const FRAGMENT = gql\`
 
 export const Empty = () => <div>Empty</div>
 
-export const Success = ({ user }: CellSuccessProps<AuthorBioCell_user>) => {
+export const Success = ({
+  user,
+}: CellSuccessProps<{ user: AuthorBioCell_user }>) => {
   return <div>{JSON.stringify(user)}</div>
 }
 "
@@ -421,7 +423,7 @@ import type { CellSuccessProps, DataObject } from '@cedarjs/web'
 //     }
 //   }
 //
-//   <AuthorBioCell user={something.user} />
+//   <AuthorBioCell user={something} />
 export const FRAGMENT = gql\`
   fragment AuthorBioCell_user on User {
     id
@@ -441,7 +443,9 @@ export const afterQuery = (data: DataObject): DataObject => {
 
 export const Empty = () => <div>Empty</div>
 
-export const Success = ({ user }: CellSuccessProps<AuthorBioCell_user>) => {
+export const Success = ({
+  user,
+}: CellSuccessProps<{ user: AuthorBioCell_user }>) => {
   return <div>{JSON.stringify(user)}</div>
 }
 "
@@ -459,7 +463,7 @@ exports[`Fragment cells > strips types from a FRAGMENT cell when generating Java
 //     }
 //   }
 //
-//   <AuthorBioCell user={something.user} />
+//   <AuthorBioCell user={something} />
 export const FRAGMENT = gql\`
   fragment AuthorBioCell_user on User {
     id

--- a/packages/cli/src/commands/generate/cell/__tests__/cell.test.ts
+++ b/packages/cli/src/commands/generate/cell/__tests__/cell.test.ts
@@ -799,6 +799,111 @@ describe('Lifecycle hook flags', () => {
   })
 })
 
+describe('Fragment cells', () => {
+  const CELL_PATH = path.normalize(
+    '/path/to/project/web/src/components/AuthorBioCell/AuthorBioCell.tsx',
+  )
+
+  const TEST_PATH = path.normalize(
+    '/path/to/project/web/src/components/AuthorBioCell/AuthorBioCell.test.tsx',
+  )
+
+  const STORY_PATH = path.normalize(
+    '/path/to/project/web/src/components/AuthorBioCell/AuthorBioCell.stories.tsx',
+  )
+
+  const MOCK_PATH = path.normalize(
+    '/path/to/project/web/src/components/AuthorBioCell/AuthorBioCell.mock.ts',
+  )
+
+  test('generates a FRAGMENT cell for the given GraphQL type', async () => {
+    const generatedFiles = await cellHandler.files({
+      name: 'AuthorBio',
+      typescript: true,
+      tests: true,
+      stories: true,
+      fragment: 'User',
+    })
+
+    expect(Object.keys(generatedFiles)).toEqual([
+      MOCK_PATH,
+      TEST_PATH,
+      STORY_PATH,
+      CELL_PATH,
+    ])
+
+    expect(generatedFiles[CELL_PATH]).toMatchSnapshot()
+    expect(generatedFiles[TEST_PATH]).toMatchSnapshot()
+    expect(generatedFiles[STORY_PATH]).toMatchSnapshot()
+    expect(generatedFiles[MOCK_PATH]).toMatchSnapshot()
+  })
+
+  test('strips types from a FRAGMENT cell when generating JavaScript', async () => {
+    const generatedFiles = await cellHandler.files({
+      name: 'AuthorBio',
+      tests: false,
+      stories: false,
+      fragment: 'User',
+    })
+
+    const jsCellPath = path.normalize(
+      '/path/to/project/web/src/components/AuthorBioCell/AuthorBioCell.jsx',
+    )
+
+    expect(generatedFiles[jsCellPath]).toMatchSnapshot()
+  })
+
+  test('includes afterQuery and isEmpty stubs when passed', async () => {
+    const generatedFiles = await cellHandler.files({
+      name: 'AuthorBio',
+      typescript: true,
+      tests: false,
+      stories: false,
+      fragment: 'User',
+      afterQuery: true,
+      isEmpty: true,
+    })
+
+    expect(generatedFiles[CELL_PATH]).toMatchSnapshot()
+  })
+
+  test('throws when combined with --list', async () => {
+    await expect(
+      cellHandler.files({
+        name: 'AuthorBio',
+        tests: false,
+        stories: false,
+        fragment: 'User',
+        list: true,
+      }),
+    ).rejects.toThrow('--list flag cannot be combined with --fragment')
+  })
+
+  test('throws when combined with --before-query', async () => {
+    await expect(
+      cellHandler.files({
+        name: 'AuthorBio',
+        tests: false,
+        stories: false,
+        fragment: 'User',
+        beforeQuery: true,
+      }),
+    ).rejects.toThrow('--before-query flag cannot be combined with --fragment')
+  })
+
+  test('throws when combined with --query', async () => {
+    await expect(
+      cellHandler.files({
+        name: 'AuthorBio',
+        tests: false,
+        stories: false,
+        fragment: 'User',
+        query: 'FindAuthorBio',
+      }),
+    ).rejects.toThrow('--query flag cannot be combined with --fragment')
+  })
+})
+
 describe('Custom Id Field files', () => {
   let customIdFieldFiles: Record<string, string>
   let customIdFieldListFiles: Record<string, string>

--- a/packages/cli/src/commands/generate/cell/cell.ts
+++ b/packages/cli/src/commands/generate/cell/cell.ts
@@ -46,6 +46,12 @@ export const builder = createBuilder({
           'Include a typed `isEmpty` stub for overriding the default check for the Empty component.',
         type: 'boolean',
       },
+      fragment: {
+        default: '',
+        description:
+          'Generate a fragment cell (exports FRAGMENT instead of QUERY) that reads its data from a parent Cell, given the GraphQL type it selects from - e.g. --fragment User.',
+        type: 'string',
+      },
     }
   },
 })

--- a/packages/cli/src/commands/generate/cell/cellHandler.ts
+++ b/packages/cli/src/commands/generate/cell/cellHandler.ts
@@ -33,6 +33,7 @@ type CellArgv = TypescriptHandlerArgv & {
   beforeQuery?: boolean
   afterQuery?: boolean
   isEmpty?: boolean
+  fragment?: string
 }
 
 export const files = async ({
@@ -45,6 +46,7 @@ export const files = async ({
   beforeQuery = false,
   afterQuery = false,
   isEmpty = false,
+  fragment = '',
 }: CellArgv): Promise<Record<string, string>> => {
   let cellName = removeGeneratorName(name, 'cell')
   let idName: string | undefined = 'id'
@@ -55,26 +57,47 @@ export const files = async ({
   let typeName = cellName
   // Create a unique operation name.
 
+  if (fragment) {
+    if (list) {
+      throw new Error(
+        'The --list flag cannot be combined with --fragment; fragment cells always render a single item.',
+      )
+    }
+    if (beforeQuery) {
+      throw new Error(
+        'The --before-query flag cannot be combined with --fragment; fragment cells never fire a query of their own.',
+      )
+    }
+    if (query) {
+      throw new Error(
+        "The --query flag cannot be combined with --fragment; fragment cells don't have an operation name.",
+      )
+    }
+  }
+
   const shouldGenerateList =
-    (isWordPluralizable(cellName) ? isPlural(cellName) : list) || list
+    !fragment &&
+    ((isWordPluralizable(cellName) ? isPlural(cellName) : list) || list)
 
   // needed for the singular cell GQL query find by id case
-  try {
-    // todo should pull from graphql schema rather than prisma!
-    model = await getSchema(pascalcase(singularize(cellName)))
-    idName = getIdName(model)
-    idType = getIdType(model)
-    typeName = model.name
-    mockIdValues =
-      idType === 'String'
-        ? mockIdValues.map((value) => `'${value}'`)
-        : mockIdValues
-  } catch {
-    // Eat error so that the destroy cell generator doesn't raise an error
-    // when trying to find prisma query engine in test runs.
+  if (!fragment) {
+    try {
+      // todo should pull from graphql schema rather than prisma!
+      model = await getSchema(pascalcase(singularize(cellName)))
+      idName = getIdName(model)
+      idType = getIdType(model)
+      typeName = model.name
+      mockIdValues =
+        idType === 'String'
+          ? mockIdValues.map((value) => `'${value}'`)
+          : mockIdValues
+    } catch {
+      // Eat error so that the destroy cell generator doesn't raise an error
+      // when trying to find prisma query engine in test runs.
 
-    // Assume id will be Int, otherwise generated cell will keep throwing
-    idType = 'Int'
+      // Assume id will be Int, otherwise generated cell will keep throwing
+      idType = 'Int'
+    }
   }
 
   if (shouldGenerateList) {
@@ -84,7 +107,19 @@ export const files = async ({
   }
 
   let operationName: string | undefined = query
-  if (operationName) {
+  let fragmentName: string | undefined
+  let fragmentOnType: string | undefined
+  let fragmentPropName: string | undefined
+
+  if (fragment) {
+    // The data prop (and fragment name suffix) is derived from the GraphQL
+    // type the fragment selects from, matching createFragmentCell's own
+    // fallback naming (see getFragmentPropName in createFragmentCell.tsx).
+    const fragmentTypeVariants = nameVariants(fragment)
+    fragmentOnType = fragmentTypeVariants.pascalName
+    fragmentPropName = fragmentTypeVariants.camelName
+    fragmentName = `${nameVariants(cellName).pascalName}Cell_${fragmentPropName}`
+  } else if (operationName) {
     const userSpecifiedOperationNameIsUnique =
       await operationNameIsUnique(operationName)
 
@@ -104,15 +139,25 @@ export const files = async ({
     extension,
     webPathSection: CEDAR_WEB_PATH_NAME,
     generator: 'cell',
-    templatePath: `cell${templateNameSuffix}.tsx.template`,
-    templateVars: {
-      operationName,
-      idName,
-      idType,
-      beforeQuery,
-      afterQuery,
-      isEmpty,
-    },
+    templatePath: fragment
+      ? 'cellFragment.tsx.template'
+      : `cell${templateNameSuffix}.tsx.template`,
+    templateVars: fragment
+      ? {
+          fragmentName,
+          fragmentOnType,
+          camelName: fragmentPropName,
+          afterQuery,
+          isEmpty,
+        }
+      : {
+          operationName,
+          idName,
+          idType,
+          beforeQuery,
+          afterQuery,
+          isEmpty,
+        },
   })
 
   const testFile = await templateForComponentFile({
@@ -121,11 +166,13 @@ export const files = async ({
     extension: `.test${extension}`,
     webPathSection: CEDAR_WEB_PATH_NAME,
     generator: 'cell',
-    templatePath: 'test.js.template',
-    templateVars: {
-      idName: shouldGenerateList ? undefined : idName,
-      mockIdValues: shouldGenerateList ? undefined : mockIdValues,
-    },
+    templatePath: fragment ? 'testFragment.js.template' : 'test.js.template',
+    templateVars: fragment
+      ? { camelName: fragmentPropName }
+      : {
+          idName: shouldGenerateList ? undefined : idName,
+          mockIdValues: shouldGenerateList ? undefined : mockIdValues,
+        },
   })
 
   const storiesFile = await templateForComponentFile({
@@ -134,7 +181,9 @@ export const files = async ({
     extension: `.stories${extension}`,
     webPathSection: CEDAR_WEB_PATH_NAME,
     generator: 'cell',
-    templatePath: 'stories.tsx.template',
+    templatePath: fragment
+      ? 'storiesFragment.tsx.template'
+      : 'stories.tsx.template',
   })
 
   const mockFile = await templateForComponentFile({
@@ -144,11 +193,18 @@ export const files = async ({
     webPathSection: CEDAR_WEB_PATH_NAME,
     generator: 'cell',
     templatePath: `mock${templateNameSuffix}.ts.template`,
-    templateVars: {
-      idName,
-      mockIdValues,
-      typeName,
-    },
+    templateVars: fragment
+      ? {
+          idName,
+          mockIdValues,
+          typeName: fragmentOnType,
+          camelName: fragmentPropName,
+        }
+      : {
+          idName,
+          mockIdValues,
+          typeName,
+        },
   })
 
   const files = [cellFile]
@@ -171,7 +227,13 @@ export const files = async ({
 export const handler = createHandler({
   componentName: 'cell',
   filesFn: files,
-  includeAdditionalTasks: ({ name: cellName }: { name: string }) => {
+  includeAdditionalTasks: ({
+    name: cellName,
+    fragment,
+  }: {
+    name: string
+    fragment?: string
+  }) => {
     return [
       {
         title: `Generating types ...`,
@@ -179,7 +241,11 @@ export const handler = createHandler({
           const queryFieldName = nameVariants(
             removeGeneratorName(cellName, 'cell'),
           ).camelName
-          const projectHasSdl = await checkProjectForQueryField(queryFieldName)
+          // Fragment cells aren't backed by a query field on the Query type,
+          // so there's no SDL field to check for - always generate types.
+          const projectHasSdl =
+            Boolean(fragment) ||
+            (await checkProjectForQueryField(queryFieldName))
 
           if (projectHasSdl) {
             const { errors } = await generateTypes()

--- a/packages/cli/src/commands/generate/cell/templates/cellFragment.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cellFragment.tsx.template
@@ -1,0 +1,43 @@
+import type { ${fragmentName} } from 'types/graphql'
+
+import type {
+  CellSuccessProps,<% if (afterQuery || isEmpty) { %>
+  DataObject,<% } %>
+} from '@cedarjs/web'
+
+// A parent Cell spreads this fragment by name in its own QUERY, and passes
+// the matching field down as the `${camelName}` prop - no import needed,
+// just render <${pascalName}Cell />:
+//
+//   query FindSomething($id: Int!) {
+//     something(id: $id) {
+//       id
+//       ...${fragmentName}
+//     }
+//   }
+//
+//   <${pascalName}Cell ${camelName}={something.${camelName}} />
+export const FRAGMENT = gql`
+  fragment ${fragmentName} on ${fragmentOnType} {
+    id
+  }
+`
+<% if (isEmpty) { %>
+export const isEmpty = (
+  data: DataObject,
+  { isDataEmpty }: { isDataEmpty: (data: DataObject) => boolean },
+) => {
+  return isDataEmpty(data)
+}
+<% } %><% if (afterQuery) { %>
+export const afterQuery = (data: DataObject): DataObject => {
+  return data
+}
+<% } %>
+export const Empty = () => <div>Empty</div>
+
+export const Success = ({
+  ${camelName},
+}: CellSuccessProps<${fragmentName}>) => {
+  return <div>{JSON.stringify(${camelName})}</div>
+}

--- a/packages/cli/src/commands/generate/cell/templates/cellFragment.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cellFragment.tsx.template
@@ -16,7 +16,7 @@ import type {
 //     }
 //   }
 //
-//   <${pascalName}Cell ${camelName}={something.${camelName}} />
+//   <${pascalName}Cell ${camelName}={something} />
 export const FRAGMENT = gql`
   fragment ${fragmentName} on ${fragmentOnType} {
     id
@@ -38,6 +38,6 @@ export const Empty = () => <div>Empty</div>
 
 export const Success = ({
   ${camelName},
-}: CellSuccessProps<${fragmentName}>) => {
+}: CellSuccessProps<{ ${camelName}: ${fragmentName} }>) => {
   return <div>{JSON.stringify(${camelName})}</div>
 }

--- a/packages/cli/src/commands/generate/cell/templates/storiesFragment.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/storiesFragment.tsx.template
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Empty, Success } from './${pascalName}Cell'
+import { standard } from './${pascalName}Cell.mock'
+
+const meta: Meta = {
+  title: 'Cells/${pascalName}Cell',
+  tags: ['autodocs']
+}
+
+export default meta
+
+export const empty: StoryObj<typeof Empty> = {
+  render: () => {
+    return Empty ? <Empty /> : <></>
+  }
+}
+
+export const success: StoryObj<typeof Success> = {
+  render: (args) => {
+    return Success ? <Success {...standard()} {...args} /> : <></>
+  }
+}

--- a/packages/cli/src/commands/generate/cell/templates/testFragment.js.template
+++ b/packages/cli/src/commands/generate/cell/templates/testFragment.js.template
@@ -1,0 +1,30 @@
+import { render } from '@cedarjs/testing/web'
+
+import { Empty, Success } from './${pascalName}Cell'
+import { standard } from './${pascalName}Cell.mock'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float and DateTime types.
+//           Please refer to the RedwoodJS Testing Docs:
+//        https://cedarjs.com/docs/testing#testing-cells
+// https://cedarjs.com/docs/testing#jest-expect-type-considerations
+
+describe('${pascalName}Cell', () => {
+  it('renders Empty successfully', async () => {
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
+  })
+
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  // 1. import { screen } from '@cedarjs/testing/web'
+  // 2. Add test: expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
+  it('renders Success successfully', async () => {
+    expect(() => {
+      render(<Success ${camelName}={standard().${camelName}} />)
+    }).not.toThrow()
+  })
+})


### PR DESCRIPTION
- Adds a `--fragment <TypeName>` flag to `yarn cedar generate cell` that emits a fragment Cell (`FRAGMENT` export instead of `QUERY`, `Success`/`Empty` only) following the `<Name>Cell_<prop>` naming convention, with the codegen'd fragment type wired into `Success`'s `CellSuccessProps`, and a comment showing how a parent Cell spreads the fragment.
- Runtime support for fragment Cells (`createFragmentCell`, the four cell transforms, codegen) already existed; this fills the one missing piece - the generator template.
- Rejects `--list`, `--before-query`, and `--query` when combined with `--fragment`, since none apply to fragment Cells.
- Skips the Prisma model lookup and the SDL-query-field gate on type generation for fragment Cells (they aren't backed by a model or a root query field).