### PR TITLE
docs(overview): mention fragment Cells

### DIFF
--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -380,7 +380,8 @@ It's GraphQL-only because:
 - Auto-imports (Vite plugin): `gql` from graphql-tag, `context` from @cedarjs/context, `React` from react
 - Page auto-loading: `cedar-routes-auto-loader` (Vite plugin for dev/build; Babel plugin for Jest/prerender) scans `src/pages/` and auto-imports page components in `Routes.tsx`
 - Components/services: manual imports
-- `*Cell.tsx` → Vite plugin wraps in createCell() (exports QUERY+Loading+Success+Failure+Empty)
+- `*Cell.tsx` → Vite plugin wraps in createCell() (exports QUERY+Loading+Success+Failure+Empty,
+  or FRAGMENT+Success+Empty for fragment Cells — createCell() dispatches to createFragmentCell())
 - `*.sdl.ts` → GraphQL schema ONLY (types, queries, mutations, inputs). Resolvers live in services/.
 - `*.ts` in services/ → business logic (api/src/services/)
 - `*.routeHooks.ts` → exports `routeParameters()` (prerendering: expands params for dynamic routes)


### PR DESCRIPTION
## Summary
- `docs/implementation-docs/2026-03-26-cedarjs-project-overview.md`'s Cell convention bullet only described `QUERY`-exporting Cells (`createCell()` → `QUERY+Loading+Success+Failure+Empty`), which has been stale since fragment Cells (`FRAGMENT` export, `Success`/`Empty` only) landed in #2107.
- Small follow-up flagged by Greptile during review of #2424 (the `--fragment` cell generator PR) — declined there as out of scope since it predates that PR, doing it here instead.

## Test plan
- [x] `yarn prettier --check` on the changed file