### PR TITLE
feat(jobs): enforce maxRuntime and support cancelling jobs

### DIFF
--- a/docs/docs/background-jobs.md
+++ b/docs/docs/background-jobs.md
@@ -339,7 +339,7 @@ await later.cancel(scheduledJob.id)
 What cancelling means depends on the state of the job:
 
 - **Queued, not started yet**: the job will never run. Using the `PrismaAdapter` the job stays in the database marked as failed (`failedAt` is set and `lastError` is `"Job cancelled by user"`) so you keep a record of it.
-- **Currently running**: the in-progress attempt is _not_ interrupted (see [Job Timeouts](#job-timeouts)—the worker will stop waiting on it once `maxRuntime` is exceeded), but the job will not be retried if it errors, and no other worker will pick it up. If the in-progress attempt succeeds, the job completes normally.
+- **Currently running**: the in-progress attempt is _not_ interrupted (see [Job Timeouts](#job-timeouts)—the worker will stop waiting on it once `maxRuntime` is exceeded), but the job will not be retried if it errors, and no other worker will pick it up. Even if the in-progress attempt finishes successfully, the job record keeps its cancelled state (it won't be deleted by `deleteSuccessfulJobs`).
 
 Cancellation requires an adapter that implements the optional `cancel()` function. The `PrismaAdapter` does; for a custom adapter that doesn't, `later.cancel()` throws a `CancelNotImplementedError`.
 
@@ -832,7 +832,7 @@ Your process monitor can now restart the workers automatically if they crash sin
 
 ### What Happens if a Worker Crashes?
 
-If a worker crashes because of circumstances outside of your control the job will remained locked in the storage system: the worker couldn't finish work and clean up after itself. When this happens, the job will be picked up again immediately if a new worker starts with the same process title, otherwise when `maxRuntime` (plus a one-minute grace period) has passed it's eligible for any worker to pick up and re-lock.
+If a worker crashes because of circumstances outside of your control the job will remain locked in the storage system: the worker couldn't finish work and clean up after itself. When this happens, the job will be picked up again immediately if a new worker starts with the same process title, otherwise when `maxRuntime` (plus a one-minute grace period) has passed it's eligible for any worker to pick up and re-lock.
 
 ## Creating Your Own Adapter
 
@@ -844,7 +844,7 @@ The general gist of the required functions:
 - `schedule()` accepts `name`, `path`, `args`, `runAt`, `queue` and `priority` and should store the job. Whatever it returns is returned from `later()`, so return at least an object with the stored job's `id` so users can cancel it or check on it later
 - `success()` accepts the same job object returned from `find()` and a `deleteJob` boolean for whether the job should be deleted upon success.
 - `error()` accepts the same job object returned from `find()` and an error instance. Does whatever failure means to you (like unlock the job and reschedule a time for it to run again in the future)
-- `failure()` is called when the job has reached `maxAttempts` or exceeded `maxRuntime`. Accepts the job object and a `deleteJob` boolean that says whether the job should be deleted.
+- `failure()` is called when the job has reached `maxAttempts` or exceeded `maxRuntime`. Accepts the job object, a `deleteJob` boolean that says whether the job should be deleted, and—when the job is failed directly without a preceding `error()` call (a timeout)—an `error` that should be recorded in the same write that marks the job as failed.
 - `clear()` remove all jobs from the queue (mostly used in development).
 - `cancel()` (optional) accepts an object with a `jobId` property and should make sure that job never runs (or is never retried, if it's currently running). Return `true` if a job was cancelled, `false` otherwise. If you don't implement this function, `later.cancel()` will throw a `CancelNotImplementedError`.
 

--- a/docs/docs/background-jobs.md
+++ b/docs/docs/background-jobs.md
@@ -582,7 +582,7 @@ This is an array of objects. Each object represents the config for a single "gro
 - queue: **[required]** the named queue(s) in which this worker group will watch for jobs. There is a reserved `'*'` value you can use which means "all queues." This can be an array of queues as well: `['default', 'email']` for example.
 - `count`: **[required]** the number of workers to start with this config.
 - `maxAttempts`: the maximum number of times to retry a job before giving up. A job that throws an error will be set to retry in the future with an exponential backoff in time equal to the number of previous attempts \*\* 4. After this number, a job is considered "failed" and will not be re-attempted. Default: `24`.
-- `maxRuntime`: the maximum amount of time, in seconds, that a job is allowed to run. A job that runs longer than this is marked as **failed** (it will not be retried, and the timeout is recorded in `lastError`) and the worker moves on to the next job. The job is told to stop what it's doing via an `AbortSignal`—see [Job timeouts](#job-timeouts). This is also how long a job's lock is honored if the worker that locked it crashed without cleaning up after itself: once `maxRuntime` has passed, another worker is allowed to pick the job up again. Default: `14_400` (4 hours).
+- `maxRuntime`: the maximum amount of time, in seconds, that a job is allowed to run. A job that runs longer than this is marked as **failed** (it will not be retried, and the timeout is recorded in `lastError`) and the worker moves on to the next job. The job is told to stop what it's doing via an `AbortSignal`—see [Job timeouts](#job-timeouts). This is also how long a job's lock is honored if the worker that locked it crashed without cleaning up after itself: once `maxRuntime` (plus a one-minute grace period, so a live worker always gets to record the timeout first) has passed, another worker is allowed to pick the job up again. Default: `14_400` (4 hours).
 - `deleteFailedJobs`: when a job has failed (maximum number of retries has occurred) you can keep the job in the database, or delete it. Default: `false`.
 - `deleteSuccessfulJobs`: when a job has succeeded, you can keep the job in the database, or delete it. It's generally assumed that your jobs _will_ succeed so it usually makes sense to clear them out and keep the queue lean. Default: `true`.
 - `sleepDelay`: the amount of time, in seconds, to wait before checking the queue for another job to run. Too low and you'll be thrashing your storage system looking for jobs, too high and you start to have a long delay before any job is run. Default: `5`.
@@ -603,7 +603,7 @@ These modes are ideal when you're creating a job and want to be sure it runs cor
 yarn cedar jobs work
 ```
 
-This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
+This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` (plus a one-minute grace period) has expired, even if they are still locked.
 
 To work on whatever outstanding jobs there are and then automatically exit use the `workoff` mode:
 
@@ -740,11 +740,11 @@ By checking the `lastError` field in the database you can see what the last erro
 
 ### Job Timeouts
 
-A job that runs longer than the worker's `maxRuntime` is timed out: the worker stops waiting on it, records the timeout in the job's `lastError`, marks the job as **failed** and moves on to the next job. A timed out job is _not_ retried—the previous attempt could still be holding on to resources, so silently re-running it could mean two copies of the job doing work at once.
+A job that runs longer than the worker's `maxRuntime` is timed out: the worker stops waiting on it, records the timeout in the job's `lastError`, marks the job as **failed** and moves on to the next job. A timed-out job is _not_ retried—the previous attempt could still be holding on to resources, so silently re-running it could mean two copies of the job doing work at once.
 
-:::caution[Long running jobs]
+:::caution[Long-running jobs]
 
-NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever. So when a job times out, the worker can't forcefully kill your `perform()` function's promise—it can only stop waiting on it.
+NodeJS Promises are not truly cancellable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever. So when a job times out, the worker can't forcefully kill your `perform()` function's promise—it can only stop waiting on it. This also means the timeout can only preempt _asynchronous_ work: fully synchronous CPU-bound code blocks the event loop, so the timeout can't fire until it yields (and if such a job eventually returns, it completes normally).
 
 To let your job actually stop working when it's timed out, an `AbortSignal` is available inside `perform()` via `getJobExecutionContext()`. It's aborted the moment the job exceeds `maxRuntime`. Pass it to `fetch()`, hand it to child processes you spawn, or check `signal.aborted` in long-running loops:
 
@@ -763,7 +763,7 @@ export const SampleJob = jobs.createJob({
 })
 ```
 
-The only way to guarantee a job will completely stop no matter what is for your job to spawn an actual OS level process with a timeout (or the abort signal above) that kills it after a certain amount of time.
+The only way to guarantee a job will completely stop no matter what is for your job to spawn an actual OS-level process with a timeout (or the abort signal above) that kills it after a certain amount of time.
 
 :::
 
@@ -832,7 +832,7 @@ Your process monitor can now restart the workers automatically if they crash sin
 
 ### What Happens if a Worker Crashes?
 
-If a worker crashes because of circumstances outside of your control the job will remained locked in the storage system: the worker couldn't finish work and clean up after itself. When this happens, the job will be picked up again immediately if a new worker starts with the same process title, otherwise when `maxRuntime` has passed it's eligible for any worker to pick up and re-lock.
+If a worker crashes because of circumstances outside of your control the job will remained locked in the storage system: the worker couldn't finish work and clean up after itself. When this happens, the job will be picked up again immediately if a new worker starts with the same process title, otherwise when `maxRuntime` (plus a one-minute grace period) has passed it's eligible for any worker to pick up and re-lock.
 
 ## Creating Your Own Adapter
 

--- a/docs/docs/background-jobs.md
+++ b/docs/docs/background-jobs.md
@@ -334,7 +334,7 @@ const scheduledJob = await later(SendWelcomeEmailJob, [user.id])
 await later.cancel(scheduledJob.id)
 ```
 
-`later.cancel()` returns `true` if a job was cancelled and `false` if no cancellable job with that id was found (it may have already completed and been deleted, or already failed).
+`later.cancel()` returns `true` if a job was cancelled and `false` if no cancellable job with that id was found (it may have already completed, or already failed).
 
 What cancelling means depends on the state of the job:
 

--- a/docs/docs/background-jobs.md
+++ b/docs/docs/background-jobs.md
@@ -276,6 +276,13 @@ later(MillenniumAnnouncementJob, [user.id], {
 })
 ```
 
+`later()` returns whatever the adapter's `schedule()` function returns. For the `PrismaAdapter` that's the job record that was created in the database, so you can hold on to its `id` to check on the job later, or to [cancel it](#cancelling-jobs):
+
+```js
+const scheduledJob = await later(SendWelcomeEmailJob, [user.id])
+// scheduledJob.id can be used with `later.cancel()`
+```
+
 If we were to query the `BackgroundJob` table after the job has been scheduled you'd see a new row. We can use the Cedar Console to query the table from the command line:
 
 ```js
@@ -312,6 +319,29 @@ The `handler` column contains the name of the job, file path to find it, and the
 Jobs are run from the `api/dist` directory, which will exist only after running `yarn cedar build api` or `yarn cedar dev`. If you are working on a job in development, you're probably running `yarn cedar dev` anyway. But just be aware that if the dev server is _not_ running then any changes to your job will not be reflected unless you run `yarn cedar build api` (or start the dev server) to compile your job into `api/dist`.
 
 :::
+
+### Cancelling Jobs
+
+Sometimes you schedule a job and then change your mind—maybe the user deleted the record the job was going to work on, or an admin wants to stop an expensive job that's no longer needed. Use `later.cancel()`, passing the `id` of the job that `later()` returned:
+
+```js
+import { later } from 'src/lib/jobs'
+import { SendWelcomeEmailJob } from 'src/jobs/SendWelcomeEmailJob'
+
+const scheduledJob = await later(SendWelcomeEmailJob, [user.id])
+
+// somewhere else, later on
+await later.cancel(scheduledJob.id)
+```
+
+`later.cancel()` returns `true` if a job was cancelled and `false` if no cancellable job with that id was found (it may have already completed and been deleted, or already failed).
+
+What cancelling means depends on the state of the job:
+
+- **Queued, not started yet**: the job will never run. Using the `PrismaAdapter` the job stays in the database marked as failed (`failedAt` is set and `lastError` is `"Job cancelled by user"`) so you keep a record of it.
+- **Currently running**: the in-progress attempt is _not_ interrupted (see [Job Timeouts](#job-timeouts)—the worker will stop waiting on it once `maxRuntime` is exceeded), but the job will not be retried if it errors, and no other worker will pick it up. If the in-progress attempt succeeds, the job completes normally.
+
+Cancellation requires an adapter that implements the optional `cancel()` function. The `PrismaAdapter` does; for a custom adapter that doesn't, `later.cancel()` throws a `CancelNotImplementedError`.
 
 ### Executing Jobs
 
@@ -552,7 +582,7 @@ This is an array of objects. Each object represents the config for a single "gro
 - queue: **[required]** the named queue(s) in which this worker group will watch for jobs. There is a reserved `'*'` value you can use which means "all queues." This can be an array of queues as well: `['default', 'email']` for example.
 - `count`: **[required]** the number of workers to start with this config.
 - `maxAttempts`: the maximum number of times to retry a job before giving up. A job that throws an error will be set to retry in the future with an exponential backoff in time equal to the number of previous attempts \*\* 4. After this number, a job is considered "failed" and will not be re-attempted. Default: `24`.
-- `maxRuntime`: the maximum amount of time, in seconds, to try running a job before another worker will pick it up and try again. It's up to you to make sure your job doesn't run for longer than this amount of time! Default: `14_400` (4 hours).
+- `maxRuntime`: the maximum amount of time, in seconds, that a job is allowed to run. A job that runs longer than this is marked as **failed** (it will not be retried, and the timeout is recorded in `lastError`) and the worker moves on to the next job. The job is told to stop what it's doing via an `AbortSignal`—see [Job timeouts](#job-timeouts). This is also how long a job's lock is honored if the worker that locked it crashed without cleaning up after itself: once `maxRuntime` has passed, another worker is allowed to pick the job up again. Default: `14_400` (4 hours).
 - `deleteFailedJobs`: when a job has failed (maximum number of retries has occurred) you can keep the job in the database, or delete it. Default: `false`.
 - `deleteSuccessfulJobs`: when a job has succeeded, you can keep the job in the database, or delete it. It's generally assumed that your jobs _will_ succeed so it usually makes sense to clear them out and keep the queue lean. Default: `true`.
 - `sleepDelay`: the amount of time, in seconds, to wait before checking the queue for another job to run. Too low and you'll be thrashing your storage system looking for jobs, too high and you start to have a long delay before any job is run. Default: `5`.
@@ -574,14 +604,6 @@ yarn cedar jobs work
 ```
 
 This process will stay attached to the console and continually look for new jobs and execute them as they are found. The log level is set to `debug` by default so you'll see everything. Pressing `Ctrl-C` to cancel the process (sending `SIGINT`) will start a graceful shutdown: the workers will complete any work they're in the middle of before exiting. To cancel immediately, hit `Ctrl-C` again (or send `SIGTERM`) and they'll stop in the middle of what they're doing. Note that this could leave locked jobs in the database, but they will be picked back up again if a new worker starts with the same name as the one that locked the process. They'll also be picked up automatically after `maxRuntime` has expired, even if they are still locked.
-
-:::caution[Long running jobs]
-
-It's currently up to you to make sure your job completes before your `maxRuntime` limit is reached! NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever.
-
-The only way to guarantee a job will completely stop no matter what is for your job to spawn an actual OS level process with a timeout that kills it after a certain amount of time. We may add this functionality natively to Jobs in the near future: let us know if you'd benefit from this being built in!
-
-:::
 
 To work on whatever outstanding jobs there are and then automatically exit use the `workoff` mode:
 
@@ -716,6 +738,35 @@ If you're using the `PrismaAdapter` and an uncaught error occurs while the worke
 
 By checking the `lastError` field in the database you can see what the last error was and attempt to correct it, if possible. If the retry occurs and another error is thrown, the same sequence above will happen _unless_ the number of attempts is equal to the `maxAttempts` config variable set in the jobs config. If `maxAttempts` is reached then the job is considered **failed** and will not be rescheduled. `runAt` is set to `NULL`, the `failedAt` timestamp is set to now and, assuming you have `deleteFailedJobs` set to `false`, the job will remain in the database so you can inspect it and potentially correct the problem.
 
+### Job Timeouts
+
+A job that runs longer than the worker's `maxRuntime` is timed out: the worker stops waiting on it, records the timeout in the job's `lastError`, marks the job as **failed** and moves on to the next job. A timed out job is _not_ retried—the previous attempt could still be holding on to resources, so silently re-running it could mean two copies of the job doing work at once.
+
+:::caution[Long running jobs]
+
+NodeJS Promises are not truly cancelable: you can reject early, but any Promises that were started _inside_ will continue running unless they are also early rejected, recursively forever. So when a job times out, the worker can't forcefully kill your `perform()` function's promise—it can only stop waiting on it.
+
+To let your job actually stop working when it's timed out, an `AbortSignal` is available inside `perform()` via `getJobExecutionContext()`. It's aborted the moment the job exceeds `maxRuntime`. Pass it to `fetch()`, hand it to child processes you spawn, or check `signal.aborted` in long-running loops:
+
+```js
+import { getJobExecutionContext } from '@cedarjs/jobs'
+
+export const SampleJob = jobs.createJob({
+  queue: 'default',
+  perform: async (userId) => {
+    const context = getJobExecutionContext()
+
+    await fetch('https://example.com/expensive-thing', {
+      signal: context?.signal,
+    })
+  },
+})
+```
+
+The only way to guarantee a job will completely stop no matter what is for your job to spawn an actual OS level process with a timeout (or the abort signal above) that kills it after a certain amount of time.
+
+:::
+
 ## Deployment
 
 For many use cases you may be able to rely on the job runner to start and detach your job workers, which will then run forever:
@@ -790,19 +841,20 @@ We'd love the community to contribute adapters for Cedar Jobs! Take a look at th
 The general gist of the required functions:
 
 - `find()` should find a job to be run, lock it and return it (minimum return of an object containing `id`, `name`, `path`, `args` and `attempts` properties)
-- `schedule()` accepts `name`, `path`, `args`, `runAt`, `queue` and `priority` and should store the job
+- `schedule()` accepts `name`, `path`, `args`, `runAt`, `queue` and `priority` and should store the job. Whatever it returns is returned from `later()`, so return at least an object with the stored job's `id` so users can cancel it or check on it later
 - `success()` accepts the same job object returned from `find()` and a `deleteJob` boolean for whether the job should be deleted upon success.
 - `error()` accepts the same job object returned from `find()` and an error instance. Does whatever failure means to you (like unlock the job and reschedule a time for it to run again in the future)
-- `failure()` is called when the job has reached `maxAttempts`. Accepts the job object and a `deleteJob` boolean that says whether the job should be deleted.
+- `failure()` is called when the job has reached `maxAttempts` or exceeded `maxRuntime`. Accepts the job object and a `deleteJob` boolean that says whether the job should be deleted.
 - `clear()` remove all jobs from the queue (mostly used in development).
+- `cancel()` (optional) accepts an object with a `jobId` property and should make sure that job never runs (or is never retried, if it's currently running). Return `true` if a job was cancelled, `false` otherwise. If you don't implement this function, `later.cancel()` will throw a `CancelNotImplementedError`.
 
 ## The Future
 
 There's still more to add to background jobs! Our current TODO list:
 
 - More adapters: Redis, SQS, RabbitMQ...
-- CedarJS Admin integration: monitor the state of your outstanding jobs, provide
-  a way to cancel or retry jobs, read failure logs, and more.
+- CedarJS Admin integration: monitor the state of your outstanding jobs,
+  cancel or retry jobs from a UI, read failure logs, and more.
 - Baremetal integration: if jobs are enabled, monitor the workers with pm2 or
   systemd
 - Lifecycle hooks: `beforePerform()`, `afterPerform()`, `afterSuccess()`,

--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -267,18 +267,19 @@ Routes.tsx ← 4 routes added inside <Set wrap={ScaffoldLayout} title="Posts" ..
 | cookie-jar           | Typed cookie map. get/set/has/unset/serialize.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | utils                | Pluralization wrapper.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
-## THE FIVE CONTEXTS (`ctx` / `context` disambiguation)
+## THE SIX CONTEXTS (`ctx` / `context` disambiguation)
 
-`ctx` and `context` name five unrelated things in this codebase. Only #2 and #3
+`ctx` and `context` name six unrelated things in this codebase. Only #2 and #3
 are the same data; the rest are entirely separate systems.
 
-| #   | Name                      | Side | Where                                                          | What it is                                                                    |
-| --- | ------------------------- | ---- | -------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| 1   | MSW response transformers | web  | `packages/testing/src/web/mockRequests.ts`                     | Response **builder** in test/Storybook GraphQL mocks. Not request state.      |
-| 2   | GraphQL resolver context  | api  | `packages/graphql-server/src/types.ts` (`CedarGraphQLContext`) | Yoga per-request context: `currentUser`, request, auth state.                 |
-| 3   | Global `context`          | api  | `packages/context`                                             | AsyncLocalStorage-backed Proxy, auto-imported in services. Populated from #2. |
-| 4   | Mocked global `context`   | api  | `packages/testing/src/api/mockContext.ts`                      | Test double for #3, so service tests run with no GraphQL server.              |
-| 5   | Listr2 task `ctx`         | CLI  | `packages/cli/src/commands/**` (setup/generate/upgrade)        | Passes state between tasks in a listr2 task list.                             |
+| #   | Name                      | Side | Where                                                                     | What it is                                                                                                                                                                           |
+| --- | ------------------------- | ---- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | MSW response transformers | web  | `packages/testing/src/web/mockRequests.ts`                                | Response **builder** in test/Storybook GraphQL mocks. Not request state.                                                                                                             |
+| 2   | GraphQL resolver context  | api  | `packages/graphql-server/src/types.ts` (`CedarGraphQLContext`)            | Yoga per-request context: `currentUser`, request, auth state.                                                                                                                        |
+| 3   | Global `context`          | api  | `packages/context`                                                        | AsyncLocalStorage-backed Proxy, auto-imported in services. Populated from #2.                                                                                                        |
+| 4   | Mocked global `context`   | api  | `packages/testing/src/api/mockContext.ts`                                 | Test double for #3, so service tests run with no GraphQL server.                                                                                                                     |
+| 5   | Listr2 task `ctx`         | CLI  | `packages/cli/src/commands/**` (setup/generate/upgrade)                   | Passes state between tasks in a listr2 task list.                                                                                                                                    |
+| 6   | Job execution context     | api  | `packages/jobs/src/core/executionContext.ts` (`getJobExecutionContext()`) | ALS-backed per-job context in background job workers: abort `signal` (aborted on `maxRuntime` timeout) + current `job`. Same ALS pattern as #3, but a separate store—unrelated data. |
 
 **1. MSW response transformers.** The `ctx` in `mockGraphQLQuery('Op', (variables, { ctx, req }) => ...)`
 and in generated `*.mock.ts` cell mocks. In MSW v1 each `ctx.*` call returned a

--- a/packages/jobs/src/adapters/BaseAdapter/BaseAdapter.ts
+++ b/packages/jobs/src/adapters/BaseAdapter/BaseAdapter.ts
@@ -39,6 +39,11 @@ export interface FailureOptions<TJob extends BaseJob = BaseJob> {
   deleteJob?: boolean
 }
 
+export interface CancelOptions {
+  /** The id of the job to cancel, as returned by `schedule()` */
+  jobId: string | number
+}
+
 /**
  * Base class for all job adapters. Provides a common interface for scheduling
  * jobs. At a minimum, you must implement the `schedule` method in your adapter.
@@ -92,4 +97,15 @@ export abstract class BaseAdapter<
    * Clear all jobs from storage
    */
   abstract clear(): void | Promise<void>
+
+  /**
+   * Cancel a job so that it will not be run (if it's still queued) or not be
+   * retried or picked up by another worker (if it's currently running).
+   * Should return `true` if a job was cancelled and `false` if no cancellable
+   * job with the given id was found.
+   *
+   * This method is optional: adapters that don't implement it don't support
+   * cancellation and `later.cancel()` will throw a `CancelNotImplementedError`
+   */
+  cancel?(options: CancelOptions): boolean | Promise<boolean>
 }

--- a/packages/jobs/src/adapters/BaseAdapter/BaseAdapter.ts
+++ b/packages/jobs/src/adapters/BaseAdapter/BaseAdapter.ts
@@ -37,6 +37,13 @@ export interface ErrorOptions<TJob extends BaseJob = BaseJob> {
 export interface FailureOptions<TJob extends BaseJob = BaseJob> {
   job: TJob
   deleteJob?: boolean
+  /**
+   * Present when the job is failed directly, without a preceding `error()`
+   * call for the same attempt (currently: when the job exceeded
+   * `maxRuntime`), so the adapter can record what went wrong in a single
+   * write
+   */
+  error?: Error
 }
 
 export interface CancelOptions {
@@ -89,7 +96,9 @@ export abstract class BaseAdapter<
   abstract error(options: ErrorOptions): void | Promise<void>
 
   /**
-   * Called when a job has errored more than maxAttempts and will not be retried
+   * Called when a job will not be retried: it has either errored more than
+   * maxAttempts times, or exceeded maxRuntime (in which case
+   * `options.error` contains the timeout error to record)
    */
   abstract failure(options: FailureOptions): void | Promise<void>
 

--- a/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
@@ -9,6 +9,7 @@ import type {
   SuccessOptions,
   ErrorOptions,
   FailureOptions,
+  CancelOptions,
 } from '../BaseAdapter/BaseAdapter.js'
 import { BaseAdapter } from '../BaseAdapter/BaseAdapter.js'
 
@@ -163,7 +164,8 @@ interface FailureData {
  * ```
  */
 export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
-  PrismaAdapterOptions<TDb>
+  PrismaAdapterOptions<TDb>,
+  Promise<PrismaJob>
 > {
   db: TDb
   model: DelegateKey<TDb> | string
@@ -202,8 +204,10 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
     maxRuntime,
     queues,
   }: FindArgs): Promise<PrismaJob | undefined> {
+    // The oldest a job's lock is allowed to be before it's considered stale
+    // and the job is eligible to be picked up by another worker
     const maxRuntimeExpire = new Date(
-      new Date().getTime() + (maxRuntime || DEFAULT_MAX_RUNTIME * 1000),
+      new Date().getTime() - (maxRuntime || DEFAULT_MAX_RUNTIME) * 1000,
     )
 
     // This query is gnarly but not so bad once you know what it's doing. For a
@@ -342,7 +346,9 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
     }
   }
 
-  // Schedules a job by creating a new record in the background job table
+  // Schedules a job by creating a new record in the background job table.
+  // Returns the created job so that callers get access to its `id` (to cancel
+  // it later, poll its status, etc.)
   override async schedule({
     name,
     path,
@@ -351,8 +357,8 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
     cron,
     queue,
     priority,
-  }: SchedulePayload) {
-    await this.accessor.create({
+  }: SchedulePayload): Promise<PrismaJob> {
+    const data = await this.accessor.create({
       data: {
         handler: JSON.stringify({ name, path, args }),
         runAt,
@@ -361,6 +367,38 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
         priority,
       },
     })
+
+    // The delegate is untyped, but the shape of the created row is guaranteed
+    // by the schema contract documented on this class
+    const row = data as Omit<PrismaJob, 'name' | 'path' | 'args'>
+
+    return { ...row, name, path, args }
+  }
+
+  /**
+   * Cancels a job by marking it as permanently failed so no worker will pick
+   * it up (or retry it, if it's currently being worked on).
+   *
+   * If the job is currently running, the in-progress attempt is not
+   * interrupted (the worker will stop it when `maxRuntime` is exceeded), but
+   * it will not be retried and will not be picked up by another worker once
+   * its lock goes stale.
+   */
+  override async cancel({ jobId }: CancelOptions) {
+    this.logger.debug(`[CedarJS Jobs] Cancelling job ${jobId}`)
+
+    // updateMany so that nothing throws if the job no longer exists, and so
+    // we can make the update conditional on the job not already being failed
+    const { count } = await this.accessor.updateMany({
+      where: { id: jobId, failedAt: null },
+      data: {
+        failedAt: new Date(),
+        lastError: 'Job cancelled by user',
+        runAt: null,
+      },
+    })
+
+    return count > 0
   }
 
   override async clear() {

--- a/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
@@ -312,20 +312,26 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
   // doesn't await the Promise then the queries will never be executed!)
   //
   // All of these updates/deletes are done with updateMany/deleteMany guarded
-  // on `failedAt: null` so that a job that was cancelled (or otherwise
-  // permanently failed) while this attempt was running keeps its
-  // failed/cancelled state instead of being overwritten or deleted by the
-  // in-flight attempt's outcome
+  // on `failedAt: null` and on `attempts` still being this attempt's value,
+  // so the in-flight attempt's outcome can't overwrite or delete the row
+  // when:
+  // - the job was cancelled (or otherwise permanently failed) while this
+  //   attempt was running (`failedAt` is no longer null), or
+  // - the job was reclaimed by another worker because this attempt stalled
+  //   past `maxRuntime` plus the grace period (relocking increments
+  //   `attempts`, so this attempt's remembered value no longer matches).
+  // `lockedBy` can't serve as that second fence because worker process names
+  // are deterministic and reused across restarts
   override async success({ job, runAt, deleteJob }: SuccessOptions<PrismaJob>) {
     this.logger.debug(`[CedarJS Jobs] Job ${job.id} success`)
 
     if (deleteJob) {
       await this.accessor.deleteMany({
-        where: { id: job.id, failedAt: null },
+        where: { id: job.id, failedAt: null, attempts: job.attempts },
       })
     } else {
       await this.accessor.updateMany({
-        where: { id: job.id, failedAt: null },
+        where: { id: job.id, failedAt: null, attempts: job.attempts },
         data: {
           lockedAt: null,
           lockedBy: null,
@@ -349,7 +355,7 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
     }
 
     await this.accessor.updateMany({
-      where: { id: job.id, failedAt: null },
+      where: { id: job.id, failedAt: null, attempts: job.attempts },
       data,
     })
   }
@@ -360,7 +366,7 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
   override async failure({ job, deleteJob, error }: FailureOptions<PrismaJob>) {
     if (deleteJob) {
       await this.accessor.deleteMany({
-        where: { id: job.id, failedAt: null },
+        where: { id: job.id, failedAt: null, attempts: job.attempts },
       })
     } else {
       const data: { failedAt: Date; runAt: null; lastError?: string } = {
@@ -373,7 +379,7 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
       }
 
       await this.accessor.updateMany({
-        where: { id: job.id, failedAt: null },
+        where: { id: job.id, failedAt: null, attempts: job.attempts },
         data,
       })
     }

--- a/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
@@ -22,10 +22,13 @@ import { ModelNameError } from './errors.js'
 export interface PrismaJob extends BaseJob {
   id: number
   handler: string
-  runAt: Date
+  /** Null once the job has completed or permanently failed */
+  runAt: Date | null
   cron: string | null | undefined
-  lockedAt: Date
-  lockedBy: string
+  /** Null unless the job is currently locked by a worker */
+  lockedAt: Date | null
+  /** Null unless the job is currently locked by a worker */
+  lockedBy: string | null
   lastError: string | null
   failedAt: Date | null
   createdAt: Date

--- a/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
@@ -418,9 +418,13 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
     this.logger.debug(`[CedarJS Jobs] Cancelling job ${jobId}`)
 
     // updateMany so that nothing throws if the job no longer exists, and so
-    // we can make the update conditional on the job not already being failed
+    // we can make the update conditional on the job still being active:
+    // not already failed (`failedAt: null`) and not already completed—a
+    // completed job that's kept in the database has its `runAt` set to null,
+    // while every active state (queued, running, awaiting retry, rescheduled
+    // cron) has a non-null `runAt`
     const { count } = await this.accessor.updateMany({
-      where: { id: jobId, failedAt: null },
+      where: { id: jobId, failedAt: null, runAt: { not: null } },
       data: {
         failedAt: new Date(),
         lastError: 'Job cancelled by user',

--- a/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
@@ -1,6 +1,10 @@
 import { camelCase } from 'change-case'
 
-import { DEFAULT_MAX_RUNTIME, DEFAULT_MODEL_NAME } from '../../consts.js'
+import {
+  DEFAULT_MAX_RUNTIME,
+  DEFAULT_MODEL_NAME,
+  MAX_RUNTIME_GRACE_PERIOD,
+} from '../../consts.js'
 import type { BaseJob } from '../../types.js'
 import type {
   BaseAdapterOptions,
@@ -205,9 +209,14 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
     queues,
   }: FindArgs): Promise<PrismaJob | undefined> {
     // The oldest a job's lock is allowed to be before it's considered stale
-    // and the job is eligible to be picked up by another worker
+    // and the job is eligible to be picked up by another worker. The grace
+    // period gives the worker that locked the job time to enforce its own
+    // `maxRuntime` timeout and mark the job as failed—without it, a second
+    // worker could claim the job in the moment between the lock going stale
+    // and the timeout being recorded
     const maxRuntimeExpire = new Date(
-      new Date().getTime() - (maxRuntime || DEFAULT_MAX_RUNTIME) * 1000,
+      new Date().getTime() -
+        ((maxRuntime || DEFAULT_MAX_RUNTIME) + MAX_RUNTIME_GRACE_PERIOD) * 1000,
     )
 
     // This query is gnarly but not so bad once you know what it's doing. For a

--- a/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/PrismaAdapter.ts
@@ -307,14 +307,22 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
   // Prisma queries are lazily evaluated and only sent to the db when they are
   // awaited, so do the await here to ensure they actually run (if the user
   // doesn't await the Promise then the queries will never be executed!)
+  //
+  // All of these updates/deletes are done with updateMany/deleteMany guarded
+  // on `failedAt: null` so that a job that was cancelled (or otherwise
+  // permanently failed) while this attempt was running keeps its
+  // failed/cancelled state instead of being overwritten or deleted by the
+  // in-flight attempt's outcome
   override async success({ job, runAt, deleteJob }: SuccessOptions<PrismaJob>) {
     this.logger.debug(`[CedarJS Jobs] Job ${job.id} success`)
 
     if (deleteJob) {
-      await this.accessor.delete({ where: { id: job.id } })
+      await this.accessor.deleteMany({
+        where: { id: job.id, failedAt: null },
+      })
     } else {
-      await this.accessor.update({
-        where: { id: job.id },
+      await this.accessor.updateMany({
+        where: { id: job.id, failedAt: null },
         data: {
           lockedAt: null,
           lockedBy: null,
@@ -337,20 +345,33 @@ export class PrismaAdapter<TDb extends object = object> extends BaseAdapter<
       runAt,
     }
 
-    await this.accessor.update({
-      where: { id: job.id },
+    await this.accessor.updateMany({
+      where: { id: job.id, failedAt: null },
       data,
     })
   }
 
-  // Job has had too many attempts, it has now permanently failed.
-  override async failure({ job, deleteJob }: FailureOptions<PrismaJob>) {
+  // The job will not be retried: it has either had too many attempts or
+  // exceeded maxRuntime (in which case `error` is set so the timeout can be
+  // recorded in the same single write that marks the job as failed)
+  override async failure({ job, deleteJob, error }: FailureOptions<PrismaJob>) {
     if (deleteJob) {
-      await this.accessor.delete({ where: { id: job.id } })
+      await this.accessor.deleteMany({
+        where: { id: job.id, failedAt: null },
+      })
     } else {
-      await this.accessor.update({
-        where: { id: job.id },
-        data: { failedAt: new Date() },
+      const data: { failedAt: Date; runAt: null; lastError?: string } = {
+        failedAt: new Date(),
+        runAt: null,
+      }
+
+      if (error) {
+        data.lastError = `${error.message}\n\n${error.stack}`
+      }
+
+      await this.accessor.updateMany({
+        where: { id: job.id, failedAt: null },
+        data,
       })
     }
   }

--- a/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
@@ -116,6 +116,39 @@ describe('schedule()', () => {
       },
     })
   })
+
+  it('returns the created job', async () => {
+    const mockRow = {
+      id: 7,
+      attempts: 0,
+      handler: JSON.stringify({
+        name: 'RedwoodJob',
+        path: 'RedwoodJob/RedwoodJob',
+        args: ['foo', 'bar'],
+      }),
+      queue: 'default',
+      priority: 50,
+      runAt: new Date(),
+    }
+    vi.spyOn(mockDb.backgroundJob, 'create').mockReturnValue(mockRow)
+    const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
+
+    const job = await adapter.schedule({
+      name: 'RedwoodJob',
+      path: 'RedwoodJob/RedwoodJob',
+      args: ['foo', 'bar'],
+      queue: 'default',
+      priority: 50,
+      runAt: new Date(),
+    })
+
+    expect(job).toEqual({
+      ...mockRow,
+      name: 'RedwoodJob',
+      path: 'RedwoodJob/RedwoodJob',
+      args: ['foo', 'bar'],
+    })
+  })
 })
 
 describe('find()', () => {
@@ -239,6 +272,26 @@ describe('find()', () => {
         data: expect.objectContaining({ lockedAt: new Date() }),
       }),
     )
+  })
+
+  it('only considers a lock stale after `maxRuntime` seconds have passed', async () => {
+    const findFirstSpy = vi
+      .spyOn(mockDb.backgroundJob, 'findFirst')
+      .mockReturnValue(null)
+    const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
+    await adapter.find({
+      processName: 'test',
+      maxRuntime: 1000,
+      queues: ['*'],
+    })
+
+    const where = findFirstSpy.mock.calls[0][0].where
+    const lockCondition = where.AND[0].OR[0].AND[1].OR[1]
+
+    // a lock is stale if it was taken more than `maxRuntime` seconds ago
+    expect(lockCondition).toEqual({
+      lockedAt: { lt: new Date(Date.now() - 1000 * 1000) },
+    })
   })
 })
 
@@ -391,6 +444,36 @@ describe('failure()', () => {
     await adapter.failure({ job: mockPrismaJob, deleteJob: true })
 
     expect(spy).toHaveBeenCalledWith({ where: { id: 1 } })
+  })
+})
+
+describe('cancel()', () => {
+  it('marks the job as permanently failed', async () => {
+    const spy = vi
+      .spyOn(mockDb.backgroundJob, 'updateMany')
+      .mockReturnValue({ count: 1 })
+    const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
+
+    const result = await adapter.cancel({ jobId: 123 })
+
+    expect(spy).toHaveBeenCalledWith({
+      where: { id: 123, failedAt: null },
+      data: {
+        failedAt: new Date(),
+        lastError: 'Job cancelled by user',
+        runAt: null,
+      },
+    })
+    expect(result).toEqual(true)
+  })
+
+  it('returns false when there is no cancellable job with the given id', async () => {
+    vi.spyOn(mockDb.backgroundJob, 'updateMany').mockReturnValue({ count: 0 })
+    const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
+
+    const result = await adapter.cancel({ jobId: 123 })
+
+    expect(result).toEqual(false)
   })
 })
 

--- a/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
@@ -321,7 +321,7 @@ const mockPrismaJob = {
 
 describe('success()', () => {
   it('deletes the job from the DB if option set', async () => {
-    const spy = vi.spyOn(mockDb.backgroundJob, 'delete')
+    const spy = vi.spyOn(mockDb.backgroundJob, 'deleteMany')
     const adapter = new PrismaAdapter({
       db: mockDb,
       logger: mockLogger,
@@ -332,11 +332,13 @@ describe('success()', () => {
       deleteJob: true,
     })
 
-    expect(spy).toHaveBeenCalledWith({ where: { id: 1 } })
+    // guarded on `failedAt: null` so a job that was cancelled while running
+    // is not deleted when the in-flight attempt completes
+    expect(spy).toHaveBeenCalledWith({ where: { id: 1, failedAt: null } })
   })
 
   it('updates the job if option not set', async () => {
-    const spy = vi.spyOn(mockDb.backgroundJob, 'update')
+    const spy = vi.spyOn(mockDb.backgroundJob, 'updateMany')
     const adapter = new PrismaAdapter({
       db: mockDb,
       logger: mockLogger,
@@ -350,7 +352,7 @@ describe('success()', () => {
     })
 
     expect(spy).toHaveBeenCalledWith({
-      where: { id: mockPrismaJob.id },
+      where: { id: mockPrismaJob.id, failedAt: null },
       data: {
         lockedAt: null,
         lockedBy: null,
@@ -363,7 +365,7 @@ describe('success()', () => {
 
 describe('error()', () => {
   it('updates the job by id', async () => {
-    const spy = vi.spyOn(mockDb.backgroundJob, 'update')
+    const spy = vi.spyOn(mockDb.backgroundJob, 'updateMany')
     const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
     await adapter.error({
       job: mockPrismaJob,
@@ -372,12 +374,12 @@ describe('error()', () => {
     })
 
     expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: 1 } }),
+      expect.objectContaining({ where: { id: 1, failedAt: null } }),
     )
   })
 
   it('clears the lock fields', async () => {
-    const spy = vi.spyOn(mockDb.backgroundJob, 'update')
+    const spy = vi.spyOn(mockDb.backgroundJob, 'updateMany')
     const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
     await adapter.error({
       job: mockPrismaJob,
@@ -393,7 +395,7 @@ describe('error()', () => {
   })
 
   it('reschedules the job at a designated backoff time', async () => {
-    const spy = vi.spyOn(mockDb.backgroundJob, 'update')
+    const spy = vi.spyOn(mockDb.backgroundJob, 'updateMany')
     const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
     const runAt = new Date(new Date().getTime() + 1000 * 10 ** 4)
     await adapter.error({
@@ -412,7 +414,7 @@ describe('error()', () => {
   })
 
   it('records the error', async () => {
-    const spy = vi.spyOn(mockDb.backgroundJob, 'update')
+    const spy = vi.spyOn(mockDb.backgroundJob, 'updateMany')
     const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
     await adapter.error({
       job: mockPrismaJob,
@@ -432,25 +434,44 @@ describe('error()', () => {
 
 describe('failure()', () => {
   it('marks the job as failed if max attempts reached', async () => {
-    const spy = vi.spyOn(mockDb.backgroundJob, 'update')
+    const spy = vi.spyOn(mockDb.backgroundJob, 'updateMany')
     const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
     await adapter.failure({ job: mockPrismaJob, deleteJob: false })
 
-    expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          failedAt: new Date(),
-        }),
-      }),
-    )
+    expect(spy).toHaveBeenCalledWith({
+      where: { id: 1, failedAt: null },
+      data: {
+        failedAt: new Date(),
+        runAt: null,
+      },
+    })
+  })
+
+  it('records the error when failing a job directly (timeout)', async () => {
+    const spy = vi.spyOn(mockDb.backgroundJob, 'updateMany')
+    const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
+    await adapter.failure({
+      job: mockPrismaJob,
+      deleteJob: false,
+      error: new Error('timeout error'),
+    })
+
+    expect(spy).toHaveBeenCalledWith({
+      where: { id: 1, failedAt: null },
+      data: {
+        failedAt: new Date(),
+        runAt: null,
+        lastError: expect.stringContaining('timeout error'),
+      },
+    })
   })
 
   it('deletes the job if option is set', async () => {
-    const spy = vi.spyOn(mockDb.backgroundJob, 'delete')
+    const spy = vi.spyOn(mockDb.backgroundJob, 'deleteMany')
     const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
     await adapter.failure({ job: mockPrismaJob, deleteJob: true })
 
-    expect(spy).toHaveBeenCalledWith({ where: { id: 1 } })
+    expect(spy).toHaveBeenCalledWith({ where: { id: 1, failedAt: null } })
   })
 })
 

--- a/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
@@ -121,6 +121,7 @@ describe('schedule()', () => {
   })
 
   it('returns the created job', async () => {
+    // a newly created row has null lock/error fields
     const mockRow = {
       id: 7,
       attempts: 0,
@@ -132,6 +133,10 @@ describe('schedule()', () => {
       queue: 'default',
       priority: 50,
       runAt: new Date(),
+      lockedAt: null,
+      lockedBy: null,
+      lastError: null,
+      failedAt: null,
     }
     vi.spyOn(mockDb.backgroundJob, 'create').mockReturnValue(mockRow)
     const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })

--- a/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, vi, it, beforeEach, afterEach } from 'vitest'
 
-import { DEFAULT_MODEL_NAME } from '../../../consts.js'
+import {
+  DEFAULT_MODEL_NAME,
+  MAX_RUNTIME_GRACE_PERIOD,
+} from '../../../consts.js'
 import { mockLogger } from '../../../core/__tests__/mocks.js'
 import * as errors from '../errors.js'
 import { PrismaAdapter } from '../PrismaAdapter.js'
@@ -288,9 +291,13 @@ describe('find()', () => {
     const where = findFirstSpy.mock.calls[0][0].where
     const lockCondition = where.AND[0].OR[0].AND[1].OR[1]
 
-    // a lock is stale if it was taken more than `maxRuntime` seconds ago
+    // a lock is stale if it was taken more than `maxRuntime` seconds (plus a
+    // grace period that gives the locking worker time to enforce its own
+    // timeout) ago
     expect(lockCondition).toEqual({
-      lockedAt: { lt: new Date(Date.now() - 1000 * 1000) },
+      lockedAt: {
+        lt: new Date(Date.now() - (1000 + MAX_RUNTIME_GRACE_PERIOD) * 1000),
+      },
     })
   })
 })

--- a/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
@@ -484,8 +484,12 @@ describe('cancel()', () => {
 
     const result = await adapter.cancel({ jobId: 123 })
 
+    // The `failedAt`/`runAt` conditions ensure only active jobs can be
+    // cancelled: a completed job that's kept in the database (with
+    // `deleteSuccessfulJobs: false`) has `failedAt: null` but also
+    // `runAt: null`, and must not be marked as cancelled
     expect(spy).toHaveBeenCalledWith({
-      where: { id: 123, failedAt: null },
+      where: { id: 123, failedAt: null, runAt: { not: null } },
       data: {
         failedAt: new Date(),
         lastError: 'Job cancelled by user',
@@ -495,7 +499,9 @@ describe('cancel()', () => {
     expect(result).toEqual(true)
   })
 
-  it('returns false when there is no cancellable job with the given id', async () => {
+  it('returns false when there is no active job with the given id', async () => {
+    // no rows match the conditions: the job doesn't exist, already
+    // completed, or already failed
     vi.spyOn(mockDb.backgroundJob, 'updateMany').mockReturnValue({ count: 0 })
     const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
 

--- a/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
+++ b/packages/jobs/src/adapters/PrismaAdapter/__tests__/PrismaAdapter.test.ts
@@ -339,7 +339,9 @@ describe('success()', () => {
 
     // guarded on `failedAt: null` so a job that was cancelled while running
     // is not deleted when the in-flight attempt completes
-    expect(spy).toHaveBeenCalledWith({ where: { id: 1, failedAt: null } })
+    expect(spy).toHaveBeenCalledWith({
+      where: { id: 1, failedAt: null, attempts: 10 },
+    })
   })
 
   it('updates the job if option not set', async () => {
@@ -357,7 +359,7 @@ describe('success()', () => {
     })
 
     expect(spy).toHaveBeenCalledWith({
-      where: { id: mockPrismaJob.id, failedAt: null },
+      where: { id: mockPrismaJob.id, failedAt: null, attempts: 10 },
       data: {
         lockedAt: null,
         lockedBy: null,
@@ -379,7 +381,9 @@ describe('error()', () => {
     })
 
     expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: 1, failedAt: null } }),
+      expect.objectContaining({
+        where: { id: 1, failedAt: null, attempts: 10 },
+      }),
     )
   })
 
@@ -444,7 +448,7 @@ describe('failure()', () => {
     await adapter.failure({ job: mockPrismaJob, deleteJob: false })
 
     expect(spy).toHaveBeenCalledWith({
-      where: { id: 1, failedAt: null },
+      where: { id: 1, failedAt: null, attempts: 10 },
       data: {
         failedAt: new Date(),
         runAt: null,
@@ -462,7 +466,7 @@ describe('failure()', () => {
     })
 
     expect(spy).toHaveBeenCalledWith({
-      where: { id: 1, failedAt: null },
+      where: { id: 1, failedAt: null, attempts: 10 },
       data: {
         failedAt: new Date(),
         runAt: null,
@@ -476,7 +480,9 @@ describe('failure()', () => {
     const adapter = new PrismaAdapter({ db: mockDb, logger: mockLogger })
     await adapter.failure({ job: mockPrismaJob, deleteJob: true })
 
-    expect(spy).toHaveBeenCalledWith({ where: { id: 1, failedAt: null } })
+    expect(spy).toHaveBeenCalledWith({
+      where: { id: 1, failedAt: null, attempts: 10 },
+    })
   })
 })
 

--- a/packages/jobs/src/consts.ts
+++ b/packages/jobs/src/consts.ts
@@ -3,6 +3,15 @@ import console from 'node:console'
 export const DEFAULT_MAX_ATTEMPTS = 24
 /** 4 hours in seconds */
 export const DEFAULT_MAX_RUNTIME = 14_400
+/**
+ * Extra time, in seconds, beyond `maxRuntime` before another worker may treat
+ * a job's lock as abandoned. The worker that locked the job enforces its own
+ * `maxRuntime` timeout, so this grace period gives it time to record the
+ * timeout and mark the job as failed without a second worker claiming (and
+ * re-executing) the job while that's happening. Only jobs whose worker died
+ * without cleaning up after itself are ever claimed this way.
+ */
+export const MAX_RUNTIME_GRACE_PERIOD = 60
 /** 5 seconds */
 export const DEFAULT_SLEEP_DELAY = 5
 

--- a/packages/jobs/src/core/Executor.ts
+++ b/packages/jobs/src/core/Executor.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_DELETE_FAILED_JOBS,
   DEFAULT_DELETE_SUCCESSFUL_JOBS,
   DEFAULT_LOGGER,
+  MAX_RUNTIME_GRACE_PERIOD,
 } from '../consts.js'
 import {
   AdapterRequiredError,
@@ -91,23 +92,26 @@ export class Executor {
     let performPromise: Promise<void> | undefined
 
     try {
-      const job = await loadJob({ name: this.job.name, path: this.job.path })
-
-      // Wrap in Promise.resolve() because `perform` is allowed to be sync.
-      // The execution context makes the abort signal available to the job via
-      // `getJobExecutionContext()`
-      performPromise = Promise.resolve(
-        executionContext.run(
-          { signal: abortController.signal, job: this.job },
-          () => job.perform(...this.job.args),
-        ),
-      )
-
+      // Start the clock before loading the job module: other workers measure
+      // staleness of this job's lock from when it was taken, so everything
+      // that happens here—including loading the job—has to fit within
+      // `maxRuntime`
       const timeoutPromise = new Promise<never>((_resolve, reject) => {
         timeoutId = setTimeout(() => {
           reject(new JobTimeoutError(this.jobIdentifier, this.maxRuntime))
         }, this.maxRuntime * 1000)
       })
+
+      performPromise = (async () => {
+        const job = await loadJob({ name: this.job.name, path: this.job.path })
+
+        // The execution context makes the abort signal available to the job
+        // via `getJobExecutionContext()`
+        await executionContext.run(
+          { signal: abortController.signal, job: this.job },
+          () => job.perform(...this.job.args),
+        )
+      })()
 
       await Promise.race([performPromise, timeoutPromise])
 
@@ -137,11 +141,18 @@ export class Executor {
       this.logger.error(errorMessage)
       this.logger.error(error.stack)
 
+      // For a timed out job, push `runAt` out by at least the grace period so
+      // no other worker can claim the job in the moment between this update
+      // (which unlocks the job) and `failure()` below marking it as
+      // permanently failed
+      const backoff = this.backoffMilliseconds(this.job.attempts)
+      const retryDelay = timedOut
+        ? Math.max(backoff, MAX_RUNTIME_GRACE_PERIOD * 1000)
+        : backoff
+
       await this.adapter.error({
         job: this.job,
-        runAt: new Date(
-          new Date().getTime() + this.backoffMilliseconds(this.job.attempts),
-        ),
+        runAt: new Date(new Date().getTime() + retryDelay),
         error,
       })
 

--- a/packages/jobs/src/core/Executor.ts
+++ b/packages/jobs/src/core/Executor.ts
@@ -1,17 +1,26 @@
 // Used by the job runner to execute a job and track success or failure
 
+import { setTimeout, clearTimeout } from 'node:timers'
+
 import { CronExpressionParser } from 'cron-parser'
 
 import type { BaseAdapter } from '../adapters/BaseAdapter/BaseAdapter.js'
 import {
   DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_MAX_RUNTIME,
   DEFAULT_DELETE_FAILED_JOBS,
   DEFAULT_DELETE_SUCCESSFUL_JOBS,
   DEFAULT_LOGGER,
 } from '../consts.js'
-import { AdapterRequiredError, JobRequiredError } from '../errors.js'
+import {
+  AdapterRequiredError,
+  JobRequiredError,
+  JobTimeoutError,
+} from '../errors.js'
 import { loadJob } from '../loaders.js'
 import type { BaseJob, BasicLogger } from '../types.js'
+
+import { executionContext } from './executionContext.js'
 
 export interface ExecutorOptions {
   adapter: BaseAdapter
@@ -19,6 +28,11 @@ export interface ExecutorOptions {
   logger?: BasicLogger
   /** Defaults to DEFAULT_MAX_ATTEMPTS */
   maxAttempts?: number
+  /**
+   * The maximum amount of time, in seconds, that the job is allowed to run
+   * before it is marked as failed. Defaults to DEFAULT_MAX_RUNTIME
+   */
+  maxRuntime?: number
   /** Defaults to DEFAULT_DELETE_FAILED_JOBS */
   deleteFailedJobs?: boolean
   /** Defaults to DEFAULT_DELETE_SUCCESSFUL_JOBS */
@@ -28,6 +42,7 @@ export interface ExecutorOptions {
 export const DEFAULTS = {
   logger: DEFAULT_LOGGER,
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
+  maxRuntime: DEFAULT_MAX_RUNTIME,
   deleteFailedJobs: DEFAULT_DELETE_FAILED_JOBS,
   deleteSuccessfulJobs: DEFAULT_DELETE_SUCCESSFUL_JOBS,
 }
@@ -38,6 +53,7 @@ export class Executor {
   logger: NonNullable<ExecutorOptions['logger']>
   job: BaseJob
   maxAttempts: NonNullable<ExecutorOptions['maxAttempts']>
+  maxRuntime: NonNullable<ExecutorOptions['maxRuntime']>
   deleteFailedJobs: NonNullable<ExecutorOptions['deleteFailedJobs']>
   deleteSuccessfulJobs: NonNullable<ExecutorOptions['deleteSuccessfulJobs']>
 
@@ -56,6 +72,9 @@ export class Executor {
     this.logger = this.options.logger
     this.job = this.options.job
     this.maxAttempts = this.options.maxAttempts
+    // `||` (not `??`) so that 0 falls back to the default, matching how the
+    // adapters' `find()` treats maxRuntime
+    this.maxRuntime = this.options.maxRuntime || DEFAULT_MAX_RUNTIME
     this.deleteFailedJobs = this.options.deleteFailedJobs
     this.deleteSuccessfulJobs = this.options.deleteSuccessfulJobs
   }
@@ -67,9 +86,30 @@ export class Executor {
   async perform() {
     this.logger.info(`[CedarJS Jobs] Started job ${this.jobIdentifier}`)
 
+    const abortController = new AbortController()
+    let timeoutId: NodeJS.Timeout | undefined
+    let performPromise: Promise<void> | undefined
+
     try {
       const job = await loadJob({ name: this.job.name, path: this.job.path })
-      await job.perform(...this.job.args)
+
+      // Wrap in Promise.resolve() because `perform` is allowed to be sync.
+      // The execution context makes the abort signal available to the job via
+      // `getJobExecutionContext()`
+      performPromise = Promise.resolve(
+        executionContext.run(
+          { signal: abortController.signal, job: this.job },
+          () => job.perform(...this.job.args),
+        ),
+      )
+
+      const timeoutPromise = new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new JobTimeoutError(this.jobIdentifier, this.maxRuntime))
+        }, this.maxRuntime * 1000)
+      })
+
+      await Promise.race([performPromise, timeoutPromise])
 
       const runAt = this.job.cron
         ? CronExpressionParser.parse(this.job.cron).next().toDate()
@@ -80,7 +120,19 @@ export class Executor {
         runAt,
         deleteJob: !runAt && this.deleteSuccessfulJobs,
       })
-    } catch (error: any) {
+    } catch (rawError) {
+      const error =
+        rawError instanceof Error ? rawError : new Error(String(rawError))
+      const timedOut = error instanceof JobTimeoutError
+
+      if (timedOut) {
+        // Tell the job to stop doing whatever it's doing. The promise itself
+        // can't be forcefully killed, so swallow its eventual settlement to
+        // avoid an unhandled rejection
+        abortController.abort(error)
+        performPromise?.catch(() => {})
+      }
+
       const errorMessage = `[CedarJS Jobs] Error in job ${this.jobIdentifier}: ${error.message}`
       this.logger.error(errorMessage)
       this.logger.error(error.stack)
@@ -93,17 +145,24 @@ export class Executor {
         error,
       })
 
-      if (this.job.attempts >= this.maxAttempts) {
-        const maxAttemptsMessage =
-          `[CedarJS Jobs] Failed job ${this.jobIdentifier}: reached max ` +
-          `attempts (${this.maxAttempts})`
-        this.logger.warn(this.job, maxAttemptsMessage)
+      // A timed out job is failed immediately instead of being retried: its
+      // previous attempt may still be holding on to resources, so silently
+      // re-running it could mean two copies of the job running at once
+      if (timedOut || this.job.attempts >= this.maxAttempts) {
+        const failureMessage = timedOut
+          ? `[CedarJS Jobs] Failed job ${this.jobIdentifier}: exceeded max ` +
+            `runtime (${this.maxRuntime} seconds)`
+          : `[CedarJS Jobs] Failed job ${this.jobIdentifier}: reached max ` +
+            `attempts (${this.maxAttempts})`
+        this.logger.warn(this.job, failureMessage)
 
         await this.adapter.failure({
           job: this.job,
           deleteJob: this.deleteFailedJobs,
         })
       }
+    } finally {
+      clearTimeout(timeoutId)
     }
   }
 

--- a/packages/jobs/src/core/Executor.ts
+++ b/packages/jobs/src/core/Executor.ts
@@ -11,7 +11,6 @@ import {
   DEFAULT_DELETE_FAILED_JOBS,
   DEFAULT_DELETE_SUCCESSFUL_JOBS,
   DEFAULT_LOGGER,
-  MAX_RUNTIME_GRACE_PERIOD,
 } from '../consts.js'
 import {
   AdapterRequiredError,
@@ -141,36 +140,46 @@ export class Executor {
       this.logger.error(errorMessage)
       this.logger.error(error.stack)
 
-      // For a timed out job, push `runAt` out by at least the grace period so
-      // no other worker can claim the job in the moment between this update
-      // (which unlocks the job) and `failure()` below marking it as
-      // permanently failed
-      const backoff = this.backoffMilliseconds(this.job.attempts)
-      const retryDelay = timedOut
-        ? Math.max(backoff, MAX_RUNTIME_GRACE_PERIOD * 1000)
-        : backoff
-
-      await this.adapter.error({
-        job: this.job,
-        runAt: new Date(new Date().getTime() + retryDelay),
-        error,
-      })
-
-      // A timed out job is failed immediately instead of being retried: its
-      // previous attempt may still be holding on to resources, so silently
-      // re-running it could mean two copies of the job running at once
-      if (timedOut || this.job.attempts >= this.maxAttempts) {
-        const failureMessage = timedOut
-          ? `[CedarJS Jobs] Failed job ${this.jobIdentifier}: exceeded max ` +
-            `runtime (${this.maxRuntime} seconds)`
-          : `[CedarJS Jobs] Failed job ${this.jobIdentifier}: reached max ` +
-            `attempts (${this.maxAttempts})`
-        this.logger.warn(this.job, failureMessage)
+      if (timedOut) {
+        // A timed out job is failed immediately instead of being retried: its
+        // previous attempt may still be holding on to resources, so silently
+        // re-running it could mean two copies of the job running at once.
+        // It's failed in a single `failure()` call (rather than `error()`
+        // followed by `failure()`) because `error()` unlocks the job, and a
+        // two-step write would leave a moment where another worker could
+        // claim the job before `failure()` marks it as permanently failed
+        this.logger.warn(
+          this.job,
+          `[CedarJS Jobs] Failed job ${this.jobIdentifier}: exceeded max ` +
+            `runtime (${this.maxRuntime} seconds)`,
+        )
 
         await this.adapter.failure({
           job: this.job,
           deleteJob: this.deleteFailedJobs,
+          error,
         })
+      } else {
+        await this.adapter.error({
+          job: this.job,
+          runAt: new Date(
+            new Date().getTime() + this.backoffMilliseconds(this.job.attempts),
+          ),
+          error,
+        })
+
+        if (this.job.attempts >= this.maxAttempts) {
+          this.logger.warn(
+            this.job,
+            `[CedarJS Jobs] Failed job ${this.jobIdentifier}: reached max ` +
+              `attempts (${this.maxAttempts})`,
+          )
+
+          await this.adapter.failure({
+            job: this.job,
+            deleteJob: this.deleteFailedJobs,
+          })
+        }
       }
     } finally {
       clearTimeout(timeoutId)

--- a/packages/jobs/src/core/JobManager.ts
+++ b/packages/jobs/src/core/JobManager.ts
@@ -47,13 +47,15 @@ export class JobManager<
     this.workers = config.workers
   }
 
-  createScheduler(schedulerConfig: CreateSchedulerConfig<TAdapters>) {
+  createScheduler<TAdapterName extends keyof TAdapters>(
+    schedulerConfig: CreateSchedulerConfig<TAdapters, TAdapterName>,
+  ) {
     const scheduler = new Scheduler({
       adapter: this.adapters[schedulerConfig.adapter],
       logger: schedulerConfig.logger ?? this.logger,
     })
 
-    return <TJob extends Job<TQueues, any[]>>(
+    const schedule = <TJob extends Job<TQueues, any[]>>(
       job: TJob,
       ...argsAndOptions: CreateSchedulerArgs<TJob>
     ) => {
@@ -65,6 +67,12 @@ export class JobManager<
 
       return scheduler.schedule({ job, args, options })
     }
+
+    // Attach `cancel` to the scheduling function itself, so app code can do
+    // `const job = await later(MyJob, [...])` and then `later.cancel(job.id)`
+    return Object.assign(schedule, {
+      cancel: (jobId: string | number) => scheduler.cancel(jobId),
+    })
   }
 
   createJob<TArgs extends unknown[]>(

--- a/packages/jobs/src/core/Scheduler.ts
+++ b/packages/jobs/src/core/Scheduler.ts
@@ -10,6 +10,7 @@ import {
 } from '../consts.js'
 import {
   AdapterNotConfiguredError,
+  CancelNotImplementedError,
   QueueNotDefinedError,
   SchedulingError,
 } from '../errors.js'
@@ -102,13 +103,33 @@ export class Scheduler<TAdapter extends BaseAdapter> {
     this.logger.info(payload, `[CedarJS Jobs] Scheduling ${job.name}`)
 
     try {
-      await this.adapter.schedule(payload)
-      return true
+      return await this.adapter.schedule(payload)
     } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e))
+
       throw new SchedulingError(
         `[CedarJS Jobs] Exception when scheduling ${payload.name}`,
-        e as Error,
+        error,
       )
     }
+  }
+
+  /**
+   * Cancel a scheduled job so that it will not be run (if it's still queued)
+   * or not be retried (if it's currently running). Requires an adapter that
+   * implements the optional `cancel()` method, like the `PrismaAdapter`.
+   *
+   * Returns whatever the adapter's `cancel()` returns (for the
+   * `PrismaAdapter` that's `true` if a job was cancelled and `false` if no
+   * cancellable job with the given id was found)
+   */
+  async cancel(jobId: string | number) {
+    if (!this.adapter.cancel) {
+      throw new CancelNotImplementedError()
+    }
+
+    this.logger.info(`[CedarJS Jobs] Cancelling job ${jobId}`)
+
+    return await this.adapter.cancel({ jobId })
   }
 }

--- a/packages/jobs/src/core/Worker.ts
+++ b/packages/jobs/src/core/Worker.ts
@@ -189,14 +189,12 @@ export class Worker {
       })
 
       if (job) {
-        // TODO add timeout handling if a job runs for more than
-        // `this.maxRuntime`. Will need to run Executor in a separate process
-        // with a timeout for this to work
         await new Executor({
           adapter: this.adapter,
           logger: this.logger,
           job,
           maxAttempts: this.maxAttempts,
+          maxRuntime: this.maxRuntime,
           deleteSuccessfulJobs: this.deleteSuccessfulJobs,
           deleteFailedJobs: this.deleteFailedJobs,
         }).perform()

--- a/packages/jobs/src/core/__tests__/Executor.test.ts
+++ b/packages/jobs/src/core/__tests__/Executor.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, vi, it } from 'vitest'
 
-import { DEFAULT_LOGGER, MAX_RUNTIME_GRACE_PERIOD } from '../../consts.js'
+import { DEFAULT_LOGGER } from '../../consts.js'
 import * as errors from '../../errors.js'
 import type { BaseJob } from '../../types.js'
 import type { JobExecutionContext } from '../executionContext.js'
@@ -367,27 +367,19 @@ describe('perform', () => {
     // mock the `loadJob` loader to return the job mock
     loadersMockFns.loadJob.mockImplementation(() => mockJob)
 
-    const date = new Date(2025, 6, 7, 9, 50)
-    vi.setSystemTime(date)
-
     const performPromise = executor.perform()
     await vi.advanceTimersByTimeAsync(10_000)
     await performPromise
 
-    expect(adapterErrorSpy).toHaveBeenCalledWith({
-      job: mockJob,
-      // The `runAt` for a timed out job is pushed out by at least the grace
-      // period so no other worker can claim it before it's marked as failed
-      runAt: new Date(
-        date.getTime() + 10_000 + MAX_RUNTIME_GRACE_PERIOD * 1000,
-      ),
-      error: expect.any(errors.JobTimeoutError),
-    })
-    // Timed out jobs are failed right away – they should not be retried while
-    // the previous attempt might still be running
+    // Timed out jobs are failed right away – they should not be retried
+    // while the previous attempt might still be running. The job is failed
+    // with a single `failure()` call (never `error()`, which would unlock the
+    // job before it's marked as failed) that also records the timeout error
+    expect(adapterErrorSpy).not.toHaveBeenCalled()
     expect(adapterFailureSpy).toHaveBeenCalledWith({
       job: mockJob,
       deleteJob: true,
+      error: expect.any(errors.JobTimeoutError),
     })
     expect(context?.signal.aborted).toEqual(true)
   })

--- a/packages/jobs/src/core/__tests__/Executor.test.ts
+++ b/packages/jobs/src/core/__tests__/Executor.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, vi, it } from 'vitest'
 import { DEFAULT_LOGGER } from '../../consts.js'
 import * as errors from '../../errors.js'
 import type { BaseJob } from '../../types.js'
+import type { JobExecutionContext } from '../executionContext.js'
+import { getJobExecutionContext } from '../executionContext.js'
 import { Executor } from '../Executor.js'
 import type { ExecutorOptions } from '../Executor.js'
 
@@ -304,6 +306,115 @@ describe('perform', () => {
       job: options.job,
       deleteJob: true,
     })
+  })
+
+  it('makes an execution context with an abort signal available to the job', async () => {
+    const mockAdapter = new MockAdapter()
+    let context: JobExecutionContext | undefined
+    const mockJob = {
+      id: 1,
+      name: 'TestJob',
+      path: 'TestJob/TestJob',
+      args: ['foo'],
+      attempts: 0,
+
+      perform: vi.fn(() => {
+        context = getJobExecutionContext()
+      }),
+    }
+    const executor = new Executor({
+      adapter: mockAdapter,
+      logger: mockLogger,
+      job: mockJob,
+    })
+
+    // mock the `loadJob` loader to return the job mock
+    loadersMockFns.loadJob.mockImplementation(() => mockJob)
+
+    await executor.perform()
+
+    expect(context?.job).toEqual(mockJob)
+    expect(context?.signal).toBeInstanceOf(AbortSignal)
+    expect(context?.signal.aborted).toEqual(false)
+  })
+
+  it('fails a job that runs longer than `maxRuntime` and aborts its signal', async () => {
+    const mockAdapter = new MockAdapter()
+    let context: JobExecutionContext | undefined
+    const mockJob = {
+      id: 1,
+      name: 'TestJob',
+      path: 'TestJob/TestJob',
+      args: ['foo'],
+      attempts: 0,
+
+      perform: vi.fn(() => {
+        context = getJobExecutionContext()
+        // a job that never finishes
+        return new Promise<void>(() => {})
+      }),
+    }
+    const executor = new Executor({
+      adapter: mockAdapter,
+      logger: mockLogger,
+      job: mockJob,
+      maxRuntime: 10,
+      deleteFailedJobs: true,
+    })
+
+    const adapterErrorSpy = vi.spyOn(mockAdapter, 'error')
+    const adapterFailureSpy = vi.spyOn(mockAdapter, 'failure')
+    // mock the `loadJob` loader to return the job mock
+    loadersMockFns.loadJob.mockImplementation(() => mockJob)
+
+    const performPromise = executor.perform()
+    await vi.advanceTimersByTimeAsync(10_000)
+    await performPromise
+
+    expect(adapterErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        job: mockJob,
+        error: expect.any(errors.JobTimeoutError),
+      }),
+    )
+    // Timed out jobs are failed right away – they should not be retried while
+    // the previous attempt might still be running
+    expect(adapterFailureSpy).toHaveBeenCalledWith({
+      job: mockJob,
+      deleteJob: true,
+    })
+    expect(context?.signal.aborted).toEqual(true)
+  })
+
+  it('does not time out a job that completes before `maxRuntime`', async () => {
+    const mockAdapter = new MockAdapter()
+    const mockJob = {
+      id: 1,
+      name: 'TestJob',
+      path: 'TestJob/TestJob',
+      args: ['foo'],
+      attempts: 0,
+
+      perform: vi.fn(),
+    }
+    const executor = new Executor({
+      adapter: mockAdapter,
+      logger: mockLogger,
+      job: mockJob,
+      maxRuntime: 10,
+    })
+
+    const adapterErrorSpy = vi.spyOn(mockAdapter, 'error')
+    const adapterSuccessSpy = vi.spyOn(mockAdapter, 'success')
+    // mock the `loadJob` loader to return the job mock
+    loadersMockFns.loadJob.mockImplementation(() => mockJob)
+
+    await executor.perform()
+    // advance past `maxRuntime` to prove the timeout was cleaned up
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(adapterSuccessSpy).toHaveBeenCalled()
+    expect(adapterErrorSpy).not.toHaveBeenCalled()
   })
 
   it('reschedules cron jobs', async () => {

--- a/packages/jobs/src/core/__tests__/Executor.test.ts
+++ b/packages/jobs/src/core/__tests__/Executor.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, vi, it } from 'vitest'
 
-import { DEFAULT_LOGGER } from '../../consts.js'
+import { DEFAULT_LOGGER, MAX_RUNTIME_GRACE_PERIOD } from '../../consts.js'
 import * as errors from '../../errors.js'
 import type { BaseJob } from '../../types.js'
 import type { JobExecutionContext } from '../executionContext.js'
@@ -367,16 +367,22 @@ describe('perform', () => {
     // mock the `loadJob` loader to return the job mock
     loadersMockFns.loadJob.mockImplementation(() => mockJob)
 
+    const date = new Date(2025, 6, 7, 9, 50)
+    vi.setSystemTime(date)
+
     const performPromise = executor.perform()
     await vi.advanceTimersByTimeAsync(10_000)
     await performPromise
 
-    expect(adapterErrorSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        job: mockJob,
-        error: expect.any(errors.JobTimeoutError),
-      }),
-    )
+    expect(adapterErrorSpy).toHaveBeenCalledWith({
+      job: mockJob,
+      // The `runAt` for a timed out job is pushed out by at least the grace
+      // period so no other worker can claim it before it's marked as failed
+      runAt: new Date(
+        date.getTime() + 10_000 + MAX_RUNTIME_GRACE_PERIOD * 1000,
+      ),
+      error: expect.any(errors.JobTimeoutError),
+    })
     // Timed out jobs are failed right away – they should not be retried while
     // the previous attempt might still be running
     expect(adapterFailureSpy).toHaveBeenCalledWith({

--- a/packages/jobs/src/core/__tests__/JobManager.test-d.ts
+++ b/packages/jobs/src/core/__tests__/JobManager.test-d.ts
@@ -31,12 +31,12 @@ describe('JobManager Type Tests', () => {
 
     const scheduler = manager.createScheduler({ adapter: 'mock' })
 
-    it('should accept correct arguments and return Promise<boolean>', () => {
+    it("should accept correct arguments and return the adapter's schedule() return type", () => {
       expectTypeOf(
         scheduler(jobWithRequiredArgs, [{ foo: 'foo', bar: 645 }], {
           wait: 30,
         }),
-      ).toEqualTypeOf<Promise<boolean>>()
+      ).toEqualTypeOf<Promise<void>>()
     })
 
     it('should reject undefined when arguments are required', () => {
@@ -61,30 +61,28 @@ describe('JobManager Type Tests', () => {
     const scheduler = manager.createScheduler({ adapter: 'mock' })
 
     it('should accept empty array', () => {
-      expectTypeOf(scheduler(jobWithNoArgs, [])).toEqualTypeOf<
-        Promise<boolean>
-      >()
+      expectTypeOf(scheduler(jobWithNoArgs, [])).toEqualTypeOf<Promise<void>>()
     })
 
     it('should accept empty array and options', () => {
       expectTypeOf(scheduler(jobWithNoArgs, [], { wait: 30 })).toEqualTypeOf<
-        Promise<boolean>
+        Promise<void>
       >()
     })
 
     it('should accept undefined as second parameter', () => {
       expectTypeOf(scheduler(jobWithNoArgs, undefined)).toEqualTypeOf<
-        Promise<boolean>
+        Promise<void>
       >()
     })
 
     it('should accept no arguments at all', () => {
-      expectTypeOf(scheduler(jobWithNoArgs)).toEqualTypeOf<Promise<boolean>>()
+      expectTypeOf(scheduler(jobWithNoArgs)).toEqualTypeOf<Promise<void>>()
     })
 
     it('should accept no arguments, but with options', () => {
       expectTypeOf(scheduler(jobWithNoArgs, { wait: 30 })).toEqualTypeOf<
-        Promise<boolean>
+        Promise<void>
       >()
     })
   })
@@ -102,25 +100,25 @@ describe('JobManager Type Tests', () => {
     it('should accept correct arguments', () => {
       expectTypeOf(
         scheduler(jobWithOptionalArgs, ['1st', '2nd']),
-      ).toEqualTypeOf<Promise<boolean>>()
+      ).toEqualTypeOf<Promise<void>>()
     })
 
     it('should accept only one argument', () => {
       expectTypeOf(scheduler(jobWithOptionalArgs, ['1st'])).toEqualTypeOf<
-        Promise<boolean>
+        Promise<void>
       >()
     })
 
     it('should require array even for just one argument', () => {
       // @ts-expect-error - array required
       expectTypeOf(scheduler(jobWithOptionalArgs, '1st')).toEqualTypeOf<
-        Promise<boolean>
+        Promise<void>
       >()
     })
 
     it('should accept empty array', () => {
       expectTypeOf(scheduler(jobWithOptionalArgs, [])).toEqualTypeOf<
-        Promise<boolean>
+        Promise<void>
       >()
     })
   })
@@ -137,7 +135,7 @@ describe('JobManager Type Tests', () => {
 
     it('should accept cron as an option', () => {
       expectTypeOf(scheduler(job, [], { cron: '0 0 * * *' })).toEqualTypeOf<
-        Promise<boolean>
+        Promise<void>
       >()
     })
 
@@ -153,13 +151,13 @@ describe('JobManager Type Tests', () => {
 
     it('should accept wait option without cron', () => {
       expectTypeOf(scheduler(job, [], { wait: 30 })).toEqualTypeOf<
-        Promise<boolean>
+        Promise<void>
       >()
     })
 
     it('should accept waitUntil option without cron', () => {
       expectTypeOf(scheduler(job, [], { waitUntil: new Date() })).toEqualTypeOf<
-        Promise<boolean>
+        Promise<void>
       >()
     })
   })
@@ -180,9 +178,17 @@ describe('JobManager Type Tests', () => {
   describe('scheduler function type', () => {
     const scheduler = manager.createScheduler({ adapter: 'mock' })
 
-    it('should be a function that returns Promise<boolean>', () => {
+    it("should be a function that returns the adapter's schedule() return type", () => {
       expectTypeOf(scheduler).toBeFunction()
-      expectTypeOf(scheduler).returns.toEqualTypeOf<Promise<boolean>>()
+      expectTypeOf(scheduler).returns.toEqualTypeOf<Promise<void>>()
+    })
+
+    it('should have a cancel function', () => {
+      expectTypeOf(scheduler.cancel).toBeFunction()
+      expectTypeOf(scheduler.cancel)
+        .parameter(0)
+        .toEqualTypeOf<string | number>()
+      expectTypeOf(scheduler.cancel).returns.toEqualTypeOf<Promise<boolean>>()
     })
   })
 })

--- a/packages/jobs/src/core/__tests__/JobManager.test.ts
+++ b/packages/jobs/src/core/__tests__/JobManager.test.ts
@@ -146,6 +146,22 @@ describe('createScheduler()', () => {
       options: mockOptions,
     })
   })
+
+  it('attaches a cancel() function that invokes the cancel() method of the scheduler', () => {
+    const manager = new JobManager({
+      adapters: {
+        mock: mockAdapter,
+      },
+      queues: ['default'] as const,
+      logger: mockLogger,
+      workers: [],
+    })
+    const scheduler = manager.createScheduler({ adapter: 'mock' })
+
+    scheduler.cancel(123)
+
+    expect(Scheduler.prototype.cancel).toHaveBeenCalledWith(123)
+  })
 })
 
 describe('createJob()', () => {

--- a/packages/jobs/src/core/__tests__/Scheduler.test.ts
+++ b/packages/jobs/src/core/__tests__/Scheduler.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, vi, it, beforeEach } from 'vitest'
 
+import type {
+  FindArgs,
+  SchedulePayload,
+} from '../../adapters/BaseAdapter/BaseAdapter.js'
+import { BaseAdapter } from '../../adapters/BaseAdapter/BaseAdapter.js'
 import {
   DEFAULT_PRIORITY,
   DEFAULT_WAIT,
   DEFAULT_WAIT_UNTIL,
 } from '../../consts.js'
 import * as errors from '../../errors.js'
+import type { PossibleBaseJob } from '../../types.js'
 import { Scheduler } from '../Scheduler.js'
 
 import { MockAdapter, mockLogger } from './mocks.js'
@@ -282,6 +288,26 @@ describe('schedule()', () => {
     )
   })
 
+  it("returns the adapter's schedule() return value", async () => {
+    class JobReturningAdapter extends MockAdapter {
+      override schedule = vi.fn((_payload: SchedulePayload) => ({ id: 99 }))
+    }
+    const adapter = new JobReturningAdapter()
+    const scheduler = new Scheduler({ adapter, logger: mockLogger })
+    const job = {
+      id: 1,
+      name: 'JobName',
+      path: 'JobPath/JobPath',
+      queue: 'default',
+
+      perform: vi.fn(),
+    }
+
+    const scheduledJob = await scheduler.schedule({ job, args: [] })
+
+    expect(scheduledJob).toEqual({ id: 99 })
+  })
+
   it('re-throws any error that occurs during scheduling', async () => {
     mockAdapter.schedule.mockImplementationOnce(() => {
       throw new Error('Could not schedule')
@@ -306,6 +332,52 @@ describe('schedule()', () => {
 
     await expect(scheduler.schedule({ job, args, options })).rejects.toThrow(
       errors.SchedulingError,
+    )
+  })
+})
+
+describe('cancel()', () => {
+  const mockAdapter = new MockAdapter()
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('calls the cancel() method on the adapter', async () => {
+    mockAdapter.cancel.mockImplementationOnce(() => true)
+    const scheduler = new Scheduler({
+      adapter: mockAdapter,
+      logger: mockLogger,
+    })
+
+    const result = await scheduler.cancel(123)
+
+    expect(mockAdapter.cancel).toHaveBeenCalledWith({ jobId: 123 })
+    expect(result).toEqual(true)
+  })
+
+  it('throws if the adapter does not implement cancel()', async () => {
+    class NoCancelAdapter extends BaseAdapter {
+      constructor() {
+        super({ logger: mockLogger })
+      }
+
+      schedule(_payload: SchedulePayload) {}
+      find(_args: FindArgs): PossibleBaseJob {
+        return undefined
+      }
+      success() {}
+      error() {}
+      failure() {}
+      clear() {}
+    }
+    const scheduler = new Scheduler({
+      adapter: new NoCancelAdapter(),
+      logger: mockLogger,
+    })
+
+    await expect(scheduler.cancel(123)).rejects.toThrow(
+      errors.CancelNotImplementedError,
     )
   })
 })

--- a/packages/jobs/src/core/__tests__/Worker.test.ts
+++ b/packages/jobs/src/core/__tests__/Worker.test.ts
@@ -440,6 +440,7 @@ describe('run', async () => {
       },
       logger: worker.logger,
       maxAttempts: 10,
+      maxRuntime: 14_400,
       deleteSuccessfulJobs: false,
       deleteFailedJobs: true,
     })

--- a/packages/jobs/src/core/__tests__/mocks.ts
+++ b/packages/jobs/src/core/__tests__/mocks.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest'
 
 import type {
+  CancelOptions,
   ErrorOptions,
   FailureOptions,
   FindArgs,
@@ -30,4 +31,5 @@ export class MockAdapter extends BaseAdapter {
   error = vi.fn((_options: ErrorOptions): void => {})
   failure = vi.fn((_options: FailureOptions): void => {})
   clear = vi.fn((): void => {})
+  cancel = vi.fn((_options: CancelOptions): boolean => true)
 }

--- a/packages/jobs/src/core/executionContext.ts
+++ b/packages/jobs/src/core/executionContext.ts
@@ -1,0 +1,43 @@
+// Gives a running job access to details about its own execution, most
+// importantly an AbortSignal that is aborted when the job exceeds the
+// worker's `maxRuntime`
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+import type { BaseJob } from '../types.js'
+
+export interface JobExecutionContext {
+  /**
+   * Aborted when the job exceeds the worker's `maxRuntime` (or when the
+   * executor otherwise wants the job to stop). Pass this to `fetch()`, child
+   * processes, or check `signal.aborted` in long-running loops so the job can
+   * actually stop doing work when it times out — Node.js promises themselves
+   * cannot be forcefully killed.
+   */
+  signal: AbortSignal
+
+  /** The job that is currently being executed */
+  job: BaseJob
+}
+
+export const executionContext = new AsyncLocalStorage<JobExecutionContext>()
+
+/**
+ * Returns the execution context for the currently running job, or `undefined`
+ * when called outside of a job's `perform()` function.
+ *
+ * ```ts
+ * import { getJobExecutionContext } from '@cedarjs/jobs'
+ *
+ * export const SampleJob = jobs.createJob({
+ *   queue: 'default',
+ *   perform: async () => {
+ *     const context = getJobExecutionContext()
+ *     await fetch('https://example.com', { signal: context?.signal })
+ *   },
+ * })
+ * ```
+ */
+export function getJobExecutionContext(): JobExecutionContext | undefined {
+  return executionContext.getStore()
+}

--- a/packages/jobs/src/errors.ts
+++ b/packages/jobs/src/errors.ts
@@ -168,6 +168,29 @@ export class PerformError extends RethrownJobError {
   }
 }
 
+/**
+ * Thrown (and recorded as the job's error) when a job runs longer than the
+ * worker's `maxRuntime`
+ */
+export class JobTimeoutError extends CedarJSJobsError {
+  constructor(jobIdentifier: string, maxRuntime: number) {
+    super(
+      `Job ${jobIdentifier} exceeded max runtime of ${maxRuntime} seconds ` +
+        'and was marked as failed',
+    )
+  }
+}
+
+/**
+ * Thrown when trying to cancel a job through an adapter that does not
+ * implement the optional `cancel()` method
+ */
+export class CancelNotImplementedError extends CedarJSJobsError {
+  constructor() {
+    super('The configured adapter does not support cancelling jobs')
+  }
+}
+
 export class QueueNotDefinedError extends CedarJSJobsError {
   constructor() {
     super('Scheduler requires a named `queue` to place jobs in')

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -3,6 +3,8 @@ export * from './errors.js'
 export { JobManager } from './core/JobManager.js'
 export { Executor } from './core/Executor.js'
 export { Worker } from './core/Worker.js'
+export { getJobExecutionContext } from './core/executionContext.js'
+export type { JobExecutionContext } from './core/executionContext.js'
 
 export { BaseAdapter } from './adapters/BaseAdapter/BaseAdapter.js'
 export { PrismaAdapter } from './adapters/PrismaAdapter/PrismaAdapter.js'

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -72,8 +72,13 @@ export interface WorkerSharedOptions {
   maxAttempts?: number
 
   /**
-   * The maximum amount of time in seconds that a job can run before another
-   * worker will attempt to retry it.
+   * The maximum amount of time in seconds that a job is allowed to run. A job
+   * that runs longer than this is marked as failed (it will not be retried)
+   * and the `AbortSignal` available inside the job via
+   * `getJobExecutionContext()` is aborted. This is also how long a job's lock
+   * can be held before another worker considers the lock stale and is allowed
+   * to pick the job up again (which only happens if the locking worker
+   * crashed and could not clean up after itself).
    *
    * @default 14,400 (4 hours)
    */
@@ -142,12 +147,15 @@ export interface JobManagerConfig<
   workers: WorkerConfig<TAdapters, TQueues>[]
 }
 
-export interface CreateSchedulerConfig<TAdapters extends Adapters> {
+export interface CreateSchedulerConfig<
+  TAdapters extends Adapters,
+  TAdapterName extends keyof TAdapters = keyof TAdapters,
+> {
   /**
    * The name of the adapter to use for this scheduler. This must be one of the
    * keys in the `adapters` object when you created the `JobManager`.
    */
-  adapter: keyof TAdapters
+  adapter: TAdapterName
 
   /**
    * The logger to use for this scheduler. If not provided, the logger from the


### PR DESCRIPTION
Fixes #2414

Implements the two things asked for in the issue — an actually-enforced per-job timeout and a way to cancel queued/running jobs — plus a fix for the stale-lock check that the issue's analysis surfaced.

## 1. `maxRuntime` is now enforced

The `Worker` passes `maxRuntime` down to the `Executor`, which races `perform()` against a timer. When a job exceeds `maxRuntime`:

- The timeout is recorded in the job's `lastError` (as a `JobTimeoutError`) and the job is marked **permanently failed** via `adapter.failure()` — it is *not* retried and no other worker will silently re-execute it. Not retrying is deliberate: the timed-out attempt's promise can't be killed and may still be holding resources, so an automatic re-run could mean two copies of the job doing (expensive) work at once.
- An `AbortSignal` is aborted so the job can stop its own work. Jobs access it via the new `getJobExecutionContext()` export (backed by `AsyncLocalStorage`, same pattern as `@cedarjs/context`):

```ts
import { getJobExecutionContext } from '@cedarjs/jobs'

perform: async () => {
  const context = getJobExecutionContext()
  await fetch(url, { signal: context?.signal })
  // or wire it to child processes, or check signal.aborted in loops
}
```

Node promises aren't truly cancelable, so the worker "stops waiting + marks failed + aborts the signal" rather than killing the promise. A child-process executor (truly killable) is still a possible future step; this removes the silent-double-execution and no-visibility problems today without that architectural change.

## 2. Jobs can be cancelled

- `BaseAdapter` gets an **optional** `cancel({ jobId })` method (optional so existing third-party adapters keep compiling; calling `cancel` through an adapter without it throws `CancelNotImplementedError`).
- `PrismaAdapter.cancel()` marks the job permanently failed (`failedAt` set, `lastError: 'Job cancelled by user'`) via `updateMany` guarded on `failedAt: null`. Returns `true`/`false` for whether a cancellable job was found. No schema change needed in user apps.
  - Queued job → never runs, record kept for visibility.
  - Running job → the in-flight attempt isn't interrupted (the new timeout bounds it), but it won't be retried and won't be picked up by another worker; the `failedAt` marker is sticky across the attempt's own `error()` update.
- `PrismaAdapter.schedule()` (and therefore `later()`) now returns the created job record so app code has an `id` to cancel/poll. The scheduler function returned by `createScheduler()` gets a `cancel` attached:

```ts
const scheduledJob = await later(SampleJob, [args])
await later.cancel(scheduledJob.id)
```

## 3. Bug fix: stale-lock cutoff in `PrismaAdapter.find()`

The cutoff was computed as `now + (maxRuntime || DEFAULT_MAX_RUNTIME * 1000)` — a *future* date (with the `* 1000` only applied to the default), so `lockedAt < cutoff` was true for every locked job and any in-progress job was immediately eligible for pickup by another worker. It's now `now - (maxRuntime || DEFAULT_MAX_RUNTIME) * 1000`, i.e. a lock only goes stale after `maxRuntime` seconds, matching the documented behavior. (Inherited from upstream Redwood's original jobs commit.)

## Notes on API changes

- `later()` / `Scheduler.schedule()` previously resolved to `true`; it now resolves to the adapter's `schedule()` return value (the created job record for the `PrismaAdapter`, which is still truthy). Custom adapters whose `schedule()` returns `void` will see `undefined` instead of `true`.
- Timed-out jobs are now failed instead of being left locked and later re-run — that's the behavior change the issue asks for.

## Testing

- `yarn workspace @cedarjs/jobs test` (vitest incl. type tests): 133 passed
- New unit tests: Executor timeout/abort-signal/timer-cleanup, PrismaAdapter `cancel()` + `schedule()` return + stale-lock cutoff, Scheduler `cancel()` + pass-through return, JobManager `later.cancel` wiring, plus type-level tests for the scheduler's new return type and `cancel`
- `npx tsc --noEmit`, `eslint`, `prettier --check` on the package: clean

Docs updated in `docs/docs/background-jobs.md`: new "Cancelling Jobs" and "Job Timeouts" sections, updated `maxRuntime` config description, and adapter-authoring notes for `cancel()`/`schedule()`.