### PR TITLE
fix(cli): Include packages/* workspaces when running tests

### DIFF
--- a/.changesets/2439.md
+++ b/.changesets/2439.md
@@ -10,9 +10,10 @@ In ESM projects, which run their tests with Vitest, newly generated packages now
 come with a `vitest.config` of their own, and `cedar test` runs every project
 when no side is named. Jest projects are unaffected: they keep their existing
 Jest configuration, and packages generated there get no Vitest config. The
-generated test now asserts correctly too — `expect(myPackage()).not.toThrow()`
-fails whatever `myPackage()` returns, because `.toThrow()` needs to be given a
-function.
+generated test now asserts correctly too: `expect(myPackage()).not.toThrow()`
+handed the matcher what `myPackage()` returned instead of something to call, so
+it failed with "expected 0 to be a function". It's now
+`expect(() => myPackage()).not.toThrow()`.
 
 Existing ESM projects need two changes to pick up their `packages/*` tests.
 First, update the `projects` line in the root `vitest.config.ts`:

--- a/.changesets/2439.md
+++ b/.changesets/2439.md
@@ -6,8 +6,10 @@ top-level workspaces, the generator didn't give the new package a Vitest config
 of its own, and `cedar test` narrowed every unfiltered run to
 `--project web --project api`.
 
-Newly generated packages now come with a `vitest.config` and a `test` script,
-and `cedar test` runs every project when no side is named.
+Newly generated packages now come with a `vitest.config` of their own, and
+`cedar test` runs every project when no side is named. The generated test now
+asserts correctly too — `expect(myPackage()).not.toThrow()` fails whatever
+`myPackage()` returns, because `.toThrow()` needs to be given a function.
 
 Existing apps need two changes to pick up their `packages/*` tests. First,
 update the `projects` line in the root `vitest.config.ts`:

--- a/.changesets/2439.md
+++ b/.changesets/2439.md
@@ -6,19 +6,23 @@ top-level workspaces, the generator didn't give the new package a Vitest config
 of its own, and `cedar test` narrowed every unfiltered run to
 `--project web --project api`.
 
-Newly generated packages now come with a `vitest.config` of their own, and
-`cedar test` runs every project when no side is named. The generated test now
-asserts correctly too — `expect(myPackage()).not.toThrow()` fails whatever
-`myPackage()` returns, because `.toThrow()` needs to be given a function.
+In ESM projects, which run their tests with Vitest, newly generated packages now
+come with a `vitest.config` of their own, and `cedar test` runs every project
+when no side is named. Jest projects are unaffected: they keep their existing
+Jest configuration, and packages generated there get no Vitest config. The
+generated test now asserts correctly too — `expect(myPackage()).not.toThrow()`
+fails whatever `myPackage()` returns, because `.toThrow()` needs to be given a
+function.
 
-Existing apps need two changes to pick up their `packages/*` tests. First,
-update the `projects` line in the root `vitest.config.ts`:
+Existing ESM projects need two changes to pick up their `packages/*` tests.
+First, update the `projects` line in the root `vitest.config.ts`:
 
 ```js
 projects: ['<rootDir>/{*,packages/*}/vite?(st).config.{js,ts}'],
 ```
 
-Then add a `vitest.config.ts` to each package that has tests:
+Then add a `vitest.config.ts` to each package that has tests (Jest projects
+don't need this — their packages stay on Jest):
 
 ```js
 import { defineConfig } from 'vitest/config'

--- a/.changesets/2439.md
+++ b/.changesets/2439.md
@@ -1,0 +1,31 @@
+- fix(cli): Include packages/\* workspaces when running tests (#2439) by @Tobbe
+
+Packages created with `cedar g package` came with a test file that nothing ever
+ran. The `projects` glob in an app's root `vitest.config.ts` only matched
+top-level workspaces, the generator didn't give the new package a Vitest config
+of its own, and `cedar test` narrowed every unfiltered run to
+`--project web --project api`.
+
+Newly generated packages now come with a `vitest.config` and a `test` script,
+and `cedar test` runs every project when no side is named.
+
+Existing apps need two changes to pick up their `packages/*` tests. First,
+update the `projects` line in the root `vitest.config.ts`:
+
+```js
+projects: ['<rootDir>/{*,packages/*}/vite?(st).config.{js,ts}'],
+```
+
+Then add a `vitest.config.ts` to each package that has tests:
+
+```js
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'my-package',
+    // Enables global test APIs like describe, it, expect
+    globals: true,
+  },
+})
+```

--- a/__fixtures__/test-project-esm/packages/validators/src/validators.test.ts
+++ b/__fixtures__/test-project-esm/packages/validators/src/validators.test.ts
@@ -1,7 +1,7 @@
 import { validateEmail } from './index.js'
 
 describe('validators', () => {
-  it('should not throw any errors', async () => {
-    expect(validateEmail('valid@email.com')).not.toThrow()
+  it('returns true for a valid email', () => {
+    expect(validateEmail('valid@email.com')).toBe(true)
   })
 })

--- a/__fixtures__/test-project-esm/packages/validators/vitest.config.ts
+++ b/__fixtures__/test-project-esm/packages/validators/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'validators',
+    // Enables global test APIs like describe, it, expect
+    globals: true,
+  },
+})

--- a/__fixtures__/test-project-esm/vitest.config.ts
+++ b/__fixtures__/test-project-esm/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    projects: ['<rootDir>/{*,!(node_modules)/**/}/vite?(st).config.{js,ts}'],
+    projects: ['<rootDir>/{*,packages/*}/vite?(st).config.{js,ts}'],
   },
 })

--- a/__fixtures__/test-project-live/packages/validators/src/validators.test.ts
+++ b/__fixtures__/test-project-live/packages/validators/src/validators.test.ts
@@ -1,7 +1,7 @@
 import { validateEmail } from './index.js'
 
 describe('validators', () => {
-  it('should not throw any errors', async () => {
-    expect(validateEmail('valid@email.com')).not.toThrow()
+  it('returns true for a valid email', () => {
+    expect(validateEmail('valid@email.com')).toBe(true)
   })
 })

--- a/__fixtures__/test-project-live/vitest.config.ts
+++ b/__fixtures__/test-project-live/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    projects: ['<rootDir>/{*,!(node_modules)/**/}/vite?(st).config.{js,ts}'],
+    projects: ['<rootDir>/{*,packages/*}/vite?(st).config.{js,ts}'],
   },
 })

--- a/__fixtures__/test-project-pnpm/packages/validators/src/validators.test.ts
+++ b/__fixtures__/test-project-pnpm/packages/validators/src/validators.test.ts
@@ -1,7 +1,7 @@
 import { validateEmail } from './index.js'
 
 describe('validators', () => {
-  it('should not throw any errors', async () => {
-    expect(validateEmail('valid@email.com')).not.toThrow()
+  it('returns true for a valid email', () => {
+    expect(validateEmail('valid@email.com')).toBe(true)
   })
 })

--- a/__fixtures__/test-project/packages/validators/src/validators.test.ts
+++ b/__fixtures__/test-project/packages/validators/src/validators.test.ts
@@ -1,7 +1,7 @@
 import { validateEmail } from './index.js'
 
 describe('validators', () => {
-  it('should not throw any errors', async () => {
-    expect(validateEmail('valid@email.com')).not.toThrow()
+  it('returns true for a valid email', () => {
+    expect(validateEmail('valid@email.com')).toBe(true)
   })
 })

--- a/packages/cli/src/commands/generate/package/__tests__/__snapshots__/package.test.ts.snap
+++ b/packages/cli/src/commands/generate/package/__tests__/__snapshots__/package.test.ts.snap
@@ -30,8 +30,8 @@ exports[`packageHandler > files > multi-word package names > creates a multi-wor
 "import { formValidators } from './index.js'
 
 describe('formValidators', () => {
-  it('should not throw any errors', async () => {
-    expect(formValidators()).not.toThrow()
+  it('should not throw any errors', () => {
+    expect(() => formValidators()).not.toThrow()
   })
 })
 "
@@ -67,8 +67,8 @@ exports[`packageHandler > files > multi-word package names > creates a multiWord
 "import { formValidators } from './index.js'
 
 describe('formValidators', () => {
-  it('should not throw any errors', async () => {
-    expect(formValidators()).not.toThrow()
+  it('should not throw any errors', () => {
+    expect(() => formValidators()).not.toThrow()
   })
 })
 "
@@ -97,8 +97,7 @@ exports[`packageHandler > files > multi-word package names > uses the provided s
   },
   "scripts": {
     "build": "tsc",
-    "watch": "tsc --watch",
-    "test": "vitest run"
+    "watch": "tsc --watch"
   },
   "devDependencies": {
     "@cedarjs/testing": "2.2.1",
@@ -131,8 +130,8 @@ exports[`packageHandler > files > multi-word package names > uses the provided s
 "import { formValidatorsPkg } from './index.js'
 
 describe('formValidatorsPkg', () => {
-  it('should not throw any errors', async () => {
-    expect(formValidatorsPkg()).not.toThrow()
+  it('should not throw any errors', () => {
+    expect(() => formValidatorsPkg()).not.toThrow()
   })
 })
 "
@@ -174,8 +173,8 @@ exports[`packageHandler > files > single word package name > infers package scop
 "import { foo } from './index.js'
 
 describe('foo', () => {
-  it('should not throw any errors', async () => {
-    expect(foo()).not.toThrow()
+  it('should not throw any errors', () => {
+    expect(() => foo()).not.toThrow()
   })
 })
 "
@@ -204,8 +203,7 @@ exports[`packageHandler > files > single word package name > infers package scop
   },
   "scripts": {
     "build": "tsc",
-    "watch": "tsc --watch",
-    "test": "vitest run"
+    "watch": "tsc --watch"
   },
   "devDependencies": {
     "@cedarjs/testing": "2.2.1",

--- a/packages/cli/src/commands/generate/package/__tests__/__snapshots__/package.test.ts.snap
+++ b/packages/cli/src/commands/generate/package/__tests__/__snapshots__/package.test.ts.snap
@@ -97,7 +97,8 @@ exports[`packageHandler > files > multi-word package names > uses the provided s
   },
   "scripts": {
     "build": "tsc",
-    "watch": "tsc --watch"
+    "watch": "tsc --watch",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@cedarjs/testing": "2.2.1",
@@ -133,6 +134,19 @@ describe('formValidatorsPkg', () => {
   it('should not throw any errors', async () => {
     expect(formValidatorsPkg()).not.toThrow()
   })
+})
+"
+`;
+
+exports[`packageHandler > files > multi-word package names > uses the provided scope for multiWord-package name > vitestConfig 1`] = `
+"import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'form-validators-pkg',
+    // Enables global test APIs like describe, it, expect
+    globals: true,
+  },
 })
 "
 `;
@@ -190,7 +204,8 @@ exports[`packageHandler > files > single word package name > infers package scop
   },
   "scripts": {
     "build": "tsc",
-    "watch": "tsc --watch"
+    "watch": "tsc --watch",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@cedarjs/testing": "2.2.1",

--- a/packages/cli/src/commands/generate/package/__tests__/package.test.ts
+++ b/packages/cli/src/commands/generate/package/__tests__/package.test.ts
@@ -348,11 +348,11 @@ describe('packageHandler', () => {
         ]),
       )
 
-      const vitestConfigPath = fileNames.find((fileName) =>
-        fileName.endsWith('vitest.config.js'),
+      const vitestConfigPath = path.normalize(
+        mockBase.path + '/packages/sample/vitest.config.js',
       )
 
-      expect(jsFiles[vitestConfigPath as string]).toMatch("name: 'sample'")
+      expect(jsFiles[vitestConfigPath]).toMatch("name: 'sample'")
     })
 
     it('does not generate a Vitest config for a Jest project', async () => {

--- a/packages/cli/src/commands/generate/package/__tests__/package.test.ts
+++ b/packages/cli/src/commands/generate/package/__tests__/package.test.ts
@@ -148,13 +148,14 @@ describe('packageHandler', () => {
         })
 
         const fileNames = Object.keys(files)
-        expect(fileNames.length).toEqual(5)
+        expect(fileNames.length).toEqual(6)
 
         expect(fileNames).toEqual(
           expect.arrayContaining([
             expect.stringContaining('README.md'),
             expect.stringContaining('package.json'),
             expect.stringContaining('tsconfig.json'),
+            expect.stringContaining('vitest.config.ts'),
             expect.stringContaining('index.ts'),
             expect.stringContaining('foo.test.ts'),
           ]),
@@ -300,6 +301,9 @@ describe('packageHandler', () => {
           mockBase.path +
             '/packages/form-validators-pkg/src/formValidatorsPkg.test.ts',
         )
+        const vitestConfigPath = path.normalize(
+          mockBase.path + '/packages/form-validators-pkg/vitest.config.ts',
+        )
 
         // Both making sure the file is valid json (parsing would fail otherwise)
         // and that the package name is correct
@@ -310,10 +314,15 @@ describe('packageHandler', () => {
           'export function formValidatorsPkg() {',
         )
 
+        // The Vitest project is named after the folder, so it can be run
+        // with `vitest --project form-validators-pkg`
+        expect(files[vitestConfigPath]).toMatch("name: 'form-validators-pkg'")
+
         expect(files[readmePath]).toMatchSnapshot('readme')
         expect(files[packageJsonPath]).toMatchSnapshot('packageJson')
         expect(files[indexPath]).toMatchSnapshot('index')
         expect(files[testPath]).toMatchSnapshot('test')
+        expect(files[vitestConfigPath]).toMatchSnapshot('vitestConfig')
       })
     })
 
@@ -322,7 +331,7 @@ describe('packageHandler', () => {
         ...packageHandler.nameVariants('Sample'),
       })
       const fileNames = Object.keys(jsFiles)
-      expect(fileNames.length).toEqual(5)
+      expect(fileNames.length).toEqual(6)
 
       expect(fileNames).toEqual(
         expect.arrayContaining([
@@ -330,10 +339,17 @@ describe('packageHandler', () => {
           expect.stringContaining('package.json'),
           // TODO: Make the script output jsconfig.json
           expect.stringContaining('tsconfig.json'),
+          expect.stringContaining('vitest.config.js'),
           expect.stringContaining('index.js'),
           expect.stringContaining('sample.test.js'),
         ]),
       )
+
+      const vitestConfigPath = fileNames.find((fileName) =>
+        fileName.endsWith('vitest.config.js'),
+      )
+
+      expect(jsFiles[vitestConfigPath as string]).toMatch("name: 'sample'")
     })
   })
 

--- a/packages/cli/src/commands/generate/package/__tests__/package.test.ts
+++ b/packages/cli/src/commands/generate/package/__tests__/package.test.ts
@@ -145,6 +145,7 @@ describe('packageHandler', () => {
         const files = await filesTask.files({
           ...packageHandler.nameVariants('foo'),
           typescript: true,
+          esm: true,
         })
 
         const fileNames = Object.keys(files)
@@ -286,6 +287,7 @@ describe('packageHandler', () => {
         const files = await filesTask.files({
           ...packageHandler.nameVariants('@myOrg/formValidators-pkg'),
           typescript: true,
+          esm: true,
         })
 
         const readmePath = path.normalize(
@@ -329,6 +331,7 @@ describe('packageHandler', () => {
     it('returns the corrent files for JS', async () => {
       const jsFiles = await filesTask.files({
         ...packageHandler.nameVariants('Sample'),
+        esm: true,
       })
       const fileNames = Object.keys(jsFiles)
       expect(fileNames.length).toEqual(6)
@@ -350,6 +353,23 @@ describe('packageHandler', () => {
       )
 
       expect(jsFiles[vitestConfigPath as string]).toMatch("name: 'sample'")
+    })
+
+    it('does not generate a Vitest config for a Jest project', async () => {
+      const files = await filesTask.files({
+        ...packageHandler.nameVariants('Sample'),
+        typescript: true,
+        esm: false,
+      })
+      const fileNames = Object.keys(files)
+
+      expect(fileNames.length).toEqual(5)
+      expect(fileNames).toEqual(
+        expect.arrayContaining([expect.stringContaining('sample.test.ts')]),
+      )
+      expect(fileNames).not.toEqual(
+        expect.arrayContaining([expect.stringContaining('vitest.config')]),
+      )
     })
   })
 

--- a/packages/cli/src/commands/generate/package/filesTask.ts
+++ b/packages/cli/src/commands/generate/package/filesTask.ts
@@ -102,7 +102,20 @@ export const files = async ({
       outputPath: path.join(folderName, 'src', `${fileName}.test${extension}`),
     })
 
+    // Without a config of its own the package isn't a Vitest project, so
+    // nothing — not `cedar test`, not a plain `vitest` run — picks up the
+    // test file above
+    const vitestConfigFile = await templateForFile({
+      name,
+      side: 'packages',
+      generator: 'package',
+      templatePath: 'vitest.config.ts.template',
+      templateVars: { folderName, ...rest },
+      outputPath: path.join(folderName, `vitest.config${extension}`),
+    })
+
     outputFiles.push(testFile)
+    outputFiles.push(vitestConfigFile)
   }
 
   return outputFiles.reduce(async (accP, [outputPath, content]) => {

--- a/packages/cli/src/commands/generate/package/filesTask.ts
+++ b/packages/cli/src/commands/generate/package/filesTask.ts
@@ -16,6 +16,7 @@ import { templateForFile } from '../yargsHandlerHelpers.js'
  * @param {string} options.fileName - The camelCase file name
  * @param {boolean} [options.typescript] - Whether to generate TypeScript files (defaults to JS if not provided)
  * @param {boolean} [options.tests=true] - Whether to generate test files
+ * @param {boolean} [options.esm] - Whether the project runs its tests with Vitest, in which case the package gets a Vitest config of its own
  *
  * @returns {Promise<Object>} A promise that resolves to an object mapping file paths to their content
  *
@@ -27,7 +28,8 @@ import { templateForFile } from '../yargsHandlerHelpers.js'
  *   packageName: '@myorg/my-package',
  *   fileName: 'myPackage',
  *   typescript: true,
- *   tests: true
+ *   tests: true,
+ *   esm: true
  * })
  */
 export const files = async ({
@@ -37,6 +39,7 @@ export const files = async ({
   fileName,
   typescript,
   tests: generateTests = true,
+  esm = false,
   ...rest
 }: {
   name: string
@@ -45,6 +48,7 @@ export const files = async ({
   fileName: string
   typescript?: boolean
   tests?: boolean
+  esm?: boolean
   [key: string]: unknown
 }) => {
   const extension = typescript ? '.ts' : '.js'
@@ -102,20 +106,24 @@ export const files = async ({
       outputPath: path.join(folderName, 'src', `${fileName}.test${extension}`),
     })
 
+    outputFiles.push(testFile)
+
     // Without a config of its own the package isn't a Vitest project, so
     // nothing — not `cedar test`, not a plain `vitest` run — picks up the
-    // test file above
-    const vitestConfigFile = await templateForFile({
-      name,
-      side: 'packages',
-      generator: 'package',
-      templatePath: 'vitest.config.ts.template',
-      templateVars: { folderName, ...rest },
-      outputPath: path.join(folderName, `vitest.config${extension}`),
-    })
+    // test file above. Jest projects don't get one: they have no Vitest to
+    // import, and their own root config doesn't look for packages either.
+    if (esm) {
+      const vitestConfigFile = await templateForFile({
+        name,
+        side: 'packages',
+        generator: 'package',
+        templatePath: 'vitest.config.ts.template',
+        templateVars: { folderName, ...rest },
+        outputPath: path.join(folderName, `vitest.config${extension}`),
+      })
 
-    outputFiles.push(testFile)
-    outputFiles.push(vitestConfigFile)
+      outputFiles.push(vitestConfigFile)
+    }
   }
 
   return outputFiles.reduce(async (accP, [outputPath, content]) => {

--- a/packages/cli/src/commands/generate/package/packageHandler.ts
+++ b/packages/cli/src/commands/generate/package/packageHandler.ts
@@ -13,7 +13,7 @@ import { workspacePackageSpecifier } from '@cedarjs/cli-helpers/packageManager'
 import { runScript, runBinSync } from '@cedarjs/cli-helpers/packageManager/exec'
 import { installPackages } from '@cedarjs/cli-helpers/packageManager/packages'
 import { addWorkspaceDir } from '@cedarjs/cli-helpers/packageManager/workspaces'
-import { getConfig } from '@cedarjs/project-config'
+import { getConfig, projectIsEsm } from '@cedarjs/project-config'
 import { getPackageManager } from '@cedarjs/project-config/packageManager'
 import { errorTelemetry } from '@cedarjs/telemetry'
 
@@ -510,7 +510,12 @@ export const handler = async ({
       {
         title: 'Generating package files...',
         task: async (ctx) => {
-          packageFiles = await files({ ...ctx.nameVariants, ...rest })
+          packageFiles = await files({
+            ...ctx.nameVariants,
+            // Only Vitest projects get a config generated for them
+            esm: projectIsEsm(),
+            ...rest,
+          })
           return writeFilesTask(packageFiles, { overwriteExisting: force })
         },
       },

--- a/packages/cli/src/commands/generate/package/templates/package.json.template
+++ b/packages/cli/src/commands/generate/package/templates/package.json.template
@@ -13,8 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "watch": "tsc --watch",
-    "test": "vitest run"
+    "watch": "tsc --watch"
   },
   "devDependencies": {
     "@cedarjs/testing": "2.2.1",

--- a/packages/cli/src/commands/generate/package/templates/package.json.template
+++ b/packages/cli/src/commands/generate/package/templates/package.json.template
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "watch": "tsc --watch"
+    "watch": "tsc --watch",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@cedarjs/testing": "2.2.1",

--- a/packages/cli/src/commands/generate/package/templates/test.ts.template
+++ b/packages/cli/src/commands/generate/package/templates/test.ts.template
@@ -1,7 +1,7 @@
 import { ${camelName} } from './index.js'
 
 describe('${camelName}', () => {
-  it('should not throw any errors', async () => {
-    expect(${camelName}()).not.toThrow()
+  it('should not throw any errors', () => {
+    expect(() => ${camelName}()).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/package/templates/vitest.config.ts.template
+++ b/packages/cli/src/commands/generate/package/templates/vitest.config.ts.template
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: '${folderName}',
+    // Enables global test APIs like describe, it, expect
+    globals: true,
+  },
+})

--- a/packages/cli/src/commands/test/__tests__/testEsm.test.ts
+++ b/packages/cli/src/commands/test/__tests__/testEsm.test.ts
@@ -29,13 +29,14 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-test('Runs tests for all available sides if no filter passed', async () => {
+test('Runs every project if no filter passed', async () => {
   await handler({})
 
   expect(execa.mock.results[0].value.cmd).toBe('yarn')
   expect(execa.mock.results[0].value.params).toContain('vitest')
-  expect(execa.mock.results[0].value.params).toContain('web')
-  expect(execa.mock.results[0].value.params).toContain('api')
+  // No --project filter, so Vitest runs every project in the root config —
+  // both sides, plus any packages/* workspaces
+  expect(execa.mock.results[0].value.params).not.toContain('--project')
 })
 
 test('Syncs or creates test database when the flag --db-push is set to true', async () => {
@@ -62,16 +63,17 @@ test('Skips test database sync/creation when the flag --db-push is set to false'
   expect(execa.mock.results[0].value.params).toContain('vitest')
 })
 
-test('Runs tests for all available sides if no side filter passed', async () => {
+test('Runs every project if no side filter passed', async () => {
   await handler({
     filter: ['bazinga'],
   })
 
   expect(execa.mock.results[0].value.cmd).toBe('yarn')
   expect(execa.mock.results[0].value.params).toContain('vitest')
+  // Passed on to Vitest as a test name filter, and it doesn't narrow the
+  // run to any particular project
   expect(execa.mock.results[0].value.params).toContain('bazinga')
-  expect(execa.mock.results[0].value.params).toContain('web')
-  expect(execa.mock.results[0].value.params).toContain('api')
+  expect(execa.mock.results[0].value.params).not.toContain('--project')
 })
 
 test('Runs tests specified side even with additional filters', async () => {

--- a/packages/cli/src/commands/test/testHandlerEsm.ts
+++ b/packages/cli/src/commands/test/testHandlerEsm.ts
@@ -102,12 +102,17 @@ export const handler = async ({
   // When a custom --config is provided the config manages its own project
   // setup, so adding --project flags would fail with "No projects matched".
   if (!others['config']) {
-    // if no sides declared with yargs, default to all sides
+    // Sides named on the command line filter the run. With none named we
+    // pass no --project flag at all, so every project in the root config
+    // runs — including `packages/*` workspaces, which aren't sides and so
+    // could never be named here.
+    sides.forEach((side) => vitestArgs.push('--project', side))
+
     if (!sides.length) {
+      // The database handling below keys off `sides`, and an unfiltered run
+      // covers every side
       project.workspaces().forEach((side: string) => sides.push(side))
     }
-
-    sides.forEach((side) => vitestArgs.push('--project', side))
   }
 
   try {

--- a/packages/create-cedar-app/templates/esm-js/vitest.config.mjs
+++ b/packages/create-cedar-app/templates/esm-js/vitest.config.mjs
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    projects: ['<rootDir>/{*,!(node_modules)/**/}/vite?(st).config.{js,ts}'],
+    projects: ['<rootDir>/{*,packages/*}/vite?(st).config.{js,ts}'],
   },
 })

--- a/packages/create-cedar-app/templates/esm-ts/vitest.config.ts
+++ b/packages/create-cedar-app/templates/esm-ts/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    projects: ['<rootDir>/{*,!(node_modules)/**/}/vite?(st).config.{js,ts}'],
+    projects: ['<rootDir>/{*,packages/*}/vite?(st).config.{js,ts}'],
   },
 })

--- a/tasks/test-project/rebuild-test-project-fixture.mts
+++ b/tasks/test-project/rebuild-test-project-fixture.mts
@@ -598,8 +598,8 @@ async function rebuildTestProject() {
         "import { validateEmail } from './index.js'\n" +
           '\n' +
           "describe('validators', () => {\n" +
-          "  it('should not throw any errors', async () => {\n" +
-          "    expect(validateEmail('valid@email.com')).not.toThrow()\n" +
+          "  it('returns true for a valid email', () => {\n" +
+          "    expect(validateEmail('valid@email.com')).toBe(true)\n" +
           '  })\n' +
           '})\n',
       )


### PR DESCRIPTION
`cedar g package` generates a test file that nothing ever runs. Several things have to be true for that, and this PR fixes all of them.

### 1. The root `projects` glob never matched below the top level

create-cedar-app's ESM templates ship:

```js
projects: ['<rootDir>/{*,!(node_modules)/**/}/vite?(st).config.{js,ts}']
```

The `!(node_modules)/**/` branch matches nothing at any depth, so the pattern is effectively `*/vite?(st).config.{js,ts}` — `api` and `web` only. Against a fixture with configs at `api/`, `packages/foo/` and `packages/deep/nested/`, it returns just `api/`.

It's now `{*,packages/*}`, which matches both levels.

Why not `**/`: it works for discovery, and the `!(node_modules)` guard turns out to be unnecessary since Vitest skips `node_modules` on its own — but `**/` also matches the root config itself, which registers the root as a project as well and makes every test file run twice (I measured 6 test runs for 3 test files).

### 2. `cedar g package` didn't give the package a Vitest config

The generator writes `src/<name>.test.ts` but nothing that makes the package a Vitest project, and the `describe`/`it`/`expect` that generated test uses aren't enabled anywhere either.

It now also writes a `vitest.config.{ts,js}` with `globals: true` and `name: '<folder-name>'` — the name so the project can be targeted as `vitest --project my-package` instead of by its scoped npm name.

Only for ESM projects: `cedar g package` works in Jest projects too, and there a `vitest.config` would import a Vitest that isn't installed, in a project whose root config wouldn't look for it anyway. `projectIsEsm()` is passed down from the handler, so `filesTask` stays a pure function and both branches are covered by tests.

### 3. `cedar test` enumerated sides, which excludes packages by construction

With no side named it pushed `--project web --project api`. It now passes no `--project` filter in that case, so every project in the root config runs. `sides` is still populated afterwards for the database handling, so `--db-push` behaviour is unchanged.

`cedar dev` and `cedar build` already account for `packages/*` via `workspaces({ includePackages: true })`, so `test` looks like it was just missed.

### 4. The generated test never passed

```js
expect(myPackage()).not.toThrow()
```

`.toThrow()` needs a function; given a value it fails with "expected 0 to be a function" — so every generated package shipped with a failing test. Nothing ever ran it, which is how it survived. It's now `expect(() => myPackage()).not.toThrow()`.

The test-project fixtures carry their own copy of that assertion (written by `rebuild-test-project-fixture`, not by the generator), so the task and the four fixtures are updated too. Since those tests now really run, the fixture's version asserts on the return value rather than on not-throwing.

### Notes

- Fixture updates are what the `check-test-project-fixture-esm` workflow asked for after the template and generator changes; `test-project`, `test-project-live` and `test-project-pnpm` get the assertion fix for the same reason. `local-testing-project*` left alone.
- Not addressed here: naming a package as a side (`cedar test my-package`) still falls through to Vitest as a test-name filter, because sides are classified with `workspaces()` without `includePackages`. Also untouched: Jest projects have the same gap, mirrored in their own root `jest.config.js` glob. Happy to follow up on either.

### Verification

- `packages/cli`: 1496 tests pass (99 files); `packages/create-cedar-app`: 4 tests pass
- Glob behaviour checked against real Vitest 4.1.10 with fixture projects at `api/`, `web/`, `packages/foo/` and `node_modules/pkg/`: 3 projects discovered, `node_modules` skipped, no duplicate runs
