### PR TITLE
fix(cli): auto-start jobs worker in `cedar dev` when jobs are configured

### DIFF
--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -116,8 +116,13 @@ cedar dev:
                   │      (aliases of the same ESM watch.js; chokidar + esbuild,
                   │      kept for SSR/RSC)
                   ├─ web: cedar-vite-dev (SPA) or cedar-dev-fe (Streaming SSR)
-                  └─ cedar-gen-watch (regenerate types on SDL or Prisma schema
-                     change)
+                  ├─ gen: cedar-gen-watch (regenerate types on SDL or Prisma
+                  │      schema change)
+                  └─ jobs: nodemon-wrapped `cedar-jobs work` (only when jobs
+                     are set up via `cedar setup jobs` and at least one job
+                     exists; opt out with `--no-jobs`). Wrapped in nodemon,
+                     watching api/dist, since the worker loads its config
+                     from compiled api/dist output, not api/src.
 
   With --ud (opt-in unified dev):
     concurrently ─┬─ cedar-unified-dev (single Vite dev server on one port)
@@ -125,7 +130,9 @@ cedar dev:
                   │    │    middleware (Vite SSR + fetch-native dispatch,
                   │    │    no separate Fastify listener)
                   │    └─ Web assets served by Vite client dev server (SPA, HMR)
-                  └─ cedar-gen-watch
+                  ├─ cedar-gen-watch
+                  └─ jobs: same as above (still conditional, still opt-out via
+                     --no-jobs)
 
 *SSR/RSC: cedar-vite-dev adds Express + Vite SSR servers. See [SSR-RSC-DOC].
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -60,6 +60,14 @@ export const builder = (yargs: Argv) => {
         'CLI args to pass to the node process running the web dev server, for ' +
         'example: `--node-args="--inspect --max-old-space-size=8192"`.',
     })
+    .option('jobs', {
+      type: 'boolean',
+      description:
+        'Start the background jobs worker alongside the other dev servers ' +
+        'when jobs are configured (`cedar setup jobs` + at least one ' +
+        '`cedar g job`). Pass `--no-jobs` to opt out and run `cedar jobs ' +
+        'work` yourself instead.',
+    })
     .middleware(() => {
       const check = checkNodeVersion()
 

--- a/packages/cli/src/commands/dev/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/dev.test.ts
@@ -18,6 +18,11 @@ import { handler } from '../devHandler.js'
 
 let mockCedarToml = ''
 let mockJobsDirEntries: string[] = []
+// `getPaths()` resolves `jobsConfig` once and caches it, so it can point at
+// a path that used to exist but has since been deleted. Lets tests exercise
+// that "configured path, missing file" case independently of `readdirSync`
+// (see the `existsSync` mock below).
+let mockJobsConfigExists = true
 
 vi.mock('concurrently', () => ({
   __esModule: true, // this property makes it work
@@ -54,7 +59,13 @@ vi.mock('node:fs', async (importOriginal) => {
 
         return 'File content'
       },
-      existsSync: () => true,
+      existsSync: (filePath: string) => {
+        if (filePath === '/mocked/project/api/src/lib/jobs.ts') {
+          return mockJobsConfigExists
+        }
+
+        return true
+      },
       readdirSync: () => mockJobsDirEntries,
     },
   }
@@ -220,6 +231,7 @@ describe('yarn cedar dev', () => {
     // api port" test below) would otherwise leak `serverFile: true` into
     // every test that runs after it.
     vi.mocked(serverFileExists).mockReturnValue(false)
+    mockJobsConfigExists = true
     mockCedarToml = ''
     mockJobsDirEntries = []
   })
@@ -522,6 +534,41 @@ describe('yarn cedar dev', () => {
     // finishes writing asynchronously after `cedar dev` starts.
     expect(jobsCommand?.command).toContain('nodemon')
     expect(jobsCommand?.command).toContain('/mocked/project/api/dist')
+  })
+
+  it('Should not start the jobs worker when jobsConfig path is set but the file no longer exists', async () => {
+    // `getPaths()` resolves and caches `jobsConfig` once; if `api/src/lib/jobs.ts`
+    // is deleted after that (e.g. mid dev session, or a stale cache), the
+    // cached path would still look "configured" even though there's no
+    // config file left for the worker to load.
+    vi.mocked(getPaths).mockReturnValue({
+      base: '/mocked/project',
+      // @ts-expect-error - only declaring what the test needs
+      api: {
+        base: '/mocked/project/api',
+        src: '/mocked/project/api/src',
+        functions: '/mocked/project/api/src/functions',
+        dist: '/mocked/project/api/dist',
+        jobs: '/mocked/project/api/src/jobs',
+        jobsConfig: '/mocked/project/api/src/lib/jobs.ts',
+      },
+      // @ts-expect-error - only declaring what the test needs
+      web: {
+        base: '/mocked/project/web',
+        src: '/mocked/project/web/src',
+        dist: '/mocked/project/web/dist',
+      },
+      packages: '/mocked/project/packages',
+      generated: {
+        base: '/mocked/project/.cedar',
+      },
+    })
+    mockJobsDirEntries = ['.keep', 'WelcomeNoticeJob']
+    mockJobsConfigExists = false
+
+    await handler({ workspace: ['api', 'web'] })
+
+    expect(findJobsCommand()).toBeUndefined()
   })
 
   it('Should not start the jobs worker under --ud, and should warn instead', async () => {

--- a/packages/cli/src/commands/dev/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/dev.test.ts
@@ -17,6 +17,7 @@ import { serverFileExists } from '../../../lib/project.js'
 import { handler } from '../devHandler.js'
 
 let mockCedarToml = ''
+let mockJobsDirEntries: string[] = []
 
 vi.mock('concurrently', () => ({
   __esModule: true, // this property makes it work
@@ -54,6 +55,7 @@ vi.mock('node:fs', async (importOriginal) => {
         return 'File content'
       },
       existsSync: () => true,
+      readdirSync: () => mockJobsDirEntries,
     },
   }
 })
@@ -107,6 +109,8 @@ vi.mock('../../../lib/index.js', () => ({
         src: '/mocked/project/api/src',
         functions: '/mocked/project/api/src/functions',
         dist: '/mocked/project/api/dist',
+        jobs: '/mocked/project/api/src/jobs',
+        jobsConfig: null,
       },
       web: {
         base: '/mocked/project/web',
@@ -183,6 +187,12 @@ function findSeparateCommands() {
   }
 }
 
+function findJobsCommand() {
+  const concurrentlyArgs = vi.mocked(concurrently).mock.lastCall![0]
+
+  return asCommandInfo(find(concurrentlyArgs, { name: 'jobs' }))
+}
+
 function findApiCommands() {
   const concurrentlyArgs = vi.mocked(concurrently).mock.lastCall![0]
 
@@ -206,6 +216,7 @@ describe('yarn cedar dev', () => {
     vi.mocked(getPaths).mockReset()
     vi.mocked(getConfig).mockReset()
     mockCedarToml = ''
+    mockJobsDirEntries = []
   })
 
   it('Should run unified dev server when --ud is passed', async () => {
@@ -465,6 +476,133 @@ describe('yarn cedar dev', () => {
     const { apiCommand } = findSeparateCommands()
     expect(apiCommand?.command).toContain('--port 8911')
   })
+
+  it('Should not start the jobs worker when jobs are not configured', async () => {
+    await handler({ workspace: ['api', 'web'] })
+
+    expect(findJobsCommand()).toBeUndefined()
+  })
+
+  it('Should start the jobs worker when jobs are configured and at least one job exists', async () => {
+    vi.mocked(getPaths).mockReturnValue({
+      base: '/mocked/project',
+      // @ts-expect-error - only declaring what the test needs
+      api: {
+        base: '/mocked/project/api',
+        src: '/mocked/project/api/src',
+        functions: '/mocked/project/api/src/functions',
+        dist: '/mocked/project/api/dist',
+        jobs: '/mocked/project/api/src/jobs',
+        jobsConfig: '/mocked/project/api/src/lib/jobs.ts',
+      },
+      // @ts-expect-error - only declaring what the test needs
+      web: {
+        base: '/mocked/project/web',
+        src: '/mocked/project/web/src',
+        dist: '/mocked/project/web/dist',
+      },
+      packages: '/mocked/project/packages',
+      generated: {
+        base: '/mocked/project/.cedar',
+      },
+    })
+    mockJobsDirEntries = ['.keep', 'WelcomeNoticeJob']
+
+    await handler({ workspace: ['api', 'web'] })
+
+    const jobsCommand = findJobsCommand()
+    expect(jobsCommand?.command).toContain('cedar-jobs work')
+  })
+
+  it('Should not start the jobs worker when only a .keep placeholder exists', async () => {
+    vi.mocked(getPaths).mockReturnValue({
+      base: '/mocked/project',
+      // @ts-expect-error - only declaring what the test needs
+      api: {
+        base: '/mocked/project/api',
+        src: '/mocked/project/api/src',
+        functions: '/mocked/project/api/src/functions',
+        dist: '/mocked/project/api/dist',
+        jobs: '/mocked/project/api/src/jobs',
+        jobsConfig: '/mocked/project/api/src/lib/jobs.ts',
+      },
+      // @ts-expect-error - only declaring what the test needs
+      web: {
+        base: '/mocked/project/web',
+        src: '/mocked/project/web/src',
+        dist: '/mocked/project/web/dist',
+      },
+      packages: '/mocked/project/packages',
+      generated: {
+        base: '/mocked/project/.cedar',
+      },
+    })
+    mockJobsDirEntries = ['.keep']
+
+    await handler({ workspace: ['api', 'web'] })
+
+    expect(findJobsCommand()).toBeUndefined()
+  })
+
+  it('Should not start the jobs worker when --no-jobs is passed, even if configured', async () => {
+    vi.mocked(getPaths).mockReturnValue({
+      base: '/mocked/project',
+      // @ts-expect-error - only declaring what the test needs
+      api: {
+        base: '/mocked/project/api',
+        src: '/mocked/project/api/src',
+        functions: '/mocked/project/api/src/functions',
+        dist: '/mocked/project/api/dist',
+        jobs: '/mocked/project/api/src/jobs',
+        jobsConfig: '/mocked/project/api/src/lib/jobs.ts',
+      },
+      // @ts-expect-error - only declaring what the test needs
+      web: {
+        base: '/mocked/project/web',
+        src: '/mocked/project/web/src',
+        dist: '/mocked/project/web/dist',
+      },
+      packages: '/mocked/project/packages',
+      generated: {
+        base: '/mocked/project/.cedar',
+      },
+    })
+    mockJobsDirEntries = ['WelcomeNoticeJob']
+
+    await handler({ workspace: ['api', 'web'], jobs: false })
+
+    expect(findJobsCommand()).toBeUndefined()
+  })
+
+  it('Should not start the jobs worker when the api workspace is not selected', async () => {
+    vi.mocked(getPaths).mockReturnValue({
+      base: '/mocked/project',
+      // @ts-expect-error - only declaring what the test needs
+      api: {
+        base: '/mocked/project/api',
+        src: '/mocked/project/api/src',
+        functions: '/mocked/project/api/src/functions',
+        dist: '/mocked/project/api/dist',
+        jobs: '/mocked/project/api/src/jobs',
+        jobsConfig: '/mocked/project/api/src/lib/jobs.ts',
+      },
+      // @ts-expect-error - only declaring what the test needs
+      web: {
+        base: '/mocked/project/web',
+        src: '/mocked/project/web/src',
+        dist: '/mocked/project/web/dist',
+      },
+      packages: '/mocked/project/packages',
+      generated: {
+        base: '/mocked/project/.cedar',
+      },
+    })
+    mockJobsDirEntries = ['WelcomeNoticeJob']
+
+    await handler({ workspace: ['web'] })
+
+    expect(findJobsCommand()).toBeUndefined()
+  })
 })
 
 describe('npm and pnpm', () => {
@@ -474,6 +612,7 @@ describe('npm and pnpm', () => {
     vi.mocked(getPaths).mockReset()
     vi.mocked(getConfig).mockReset()
     mockCedarToml = ''
+    mockJobsDirEntries = []
     vi.mocked(getPackageManager).mockReset()
     vi.mocked(getPackageManager).mockReturnValue('yarn')
   })

--- a/packages/cli/src/commands/dev/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/dev.test.ts
@@ -512,6 +512,11 @@ describe('yarn cedar dev', () => {
 
     const jobsCommand = findJobsCommand()
     expect(jobsCommand?.command).toContain('cedar-jobs work')
+    // Wrapped in nodemon watching api/dist, since `cedar-jobs work` loads
+    // its config from compiled dist output, which the api watcher only
+    // finishes writing asynchronously after `cedar dev` starts.
+    expect(jobsCommand?.command).toContain('nodemon')
+    expect(jobsCommand?.command).toContain('/mocked/project/api/dist')
   })
 
   it('Should not start the jobs worker when only a .keep placeholder exists', async () => {
@@ -538,6 +543,36 @@ describe('yarn cedar dev', () => {
       },
     })
     mockJobsDirEntries = ['.keep']
+
+    await handler({ workspace: ['api', 'web'] })
+
+    expect(findJobsCommand()).toBeUndefined()
+  })
+
+  it('Should not start the jobs worker when only stray dotfiles exist (e.g. .DS_Store)', async () => {
+    vi.mocked(getPaths).mockReturnValue({
+      base: '/mocked/project',
+      // @ts-expect-error - only declaring what the test needs
+      api: {
+        base: '/mocked/project/api',
+        src: '/mocked/project/api/src',
+        functions: '/mocked/project/api/src/functions',
+        dist: '/mocked/project/api/dist',
+        jobs: '/mocked/project/api/src/jobs',
+        jobsConfig: '/mocked/project/api/src/lib/jobs.ts',
+      },
+      // @ts-expect-error - only declaring what the test needs
+      web: {
+        base: '/mocked/project/web',
+        src: '/mocked/project/web/src',
+        dist: '/mocked/project/web/dist',
+      },
+      packages: '/mocked/project/packages',
+      generated: {
+        base: '/mocked/project/.cedar',
+      },
+    })
+    mockJobsDirEntries = ['.keep', '.DS_Store']
 
     await handler({ workspace: ['api', 'web'] })
 

--- a/packages/cli/src/commands/dev/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/dev.test.ts
@@ -215,6 +215,11 @@ describe('yarn cedar dev', () => {
     vi.clearAllMocks()
     vi.mocked(getPaths).mockReset()
     vi.mocked(getConfig).mockReset()
+    // `mockReturnValue` (unlike `mockReset`) survives `vi.clearAllMocks()`,
+    // so a test that opts into the custom-server lane (like the "reserved
+    // api port" test below) would otherwise leak `serverFile: true` into
+    // every test that runs after it.
+    vi.mocked(serverFileExists).mockReturnValue(false)
     mockCedarToml = ''
     mockJobsDirEntries = []
   })
@@ -556,6 +561,66 @@ describe('yarn cedar dev', () => {
         ),
       ),
     ).toBe(true)
+
+    consoleLogSpy.mockRestore()
+  })
+
+  it('Should start the jobs worker (not warn) when --ud falls back to classic dev', async () => {
+    // `--ud` was requested, but `buildUnifiedDevCommand()` still returns
+    // `null` here (streaming SSR has its own dev server setup), so `cedar
+    // dev` falls back to classic separate api+web servers, which do produce
+    // `api/dist`. The jobs worker should follow that fallback rather than
+    // treating `--ud` as if unified dev were actually running.
+    const config = await defaultConfig()
+
+    vi.mocked(getConfig).mockReturnValue({
+      ...config,
+      experimental: {
+        ...config.experimental,
+        streamingSsr: {
+          enabled: true,
+        },
+      },
+    })
+
+    vi.mocked(getPaths).mockReturnValue({
+      base: '/mocked/project',
+      // @ts-expect-error - only declaring what the test needs
+      api: {
+        base: '/mocked/project/api',
+        src: '/mocked/project/api/src',
+        functions: '/mocked/project/api/src/functions',
+        dist: '/mocked/project/api/dist',
+        jobs: '/mocked/project/api/src/jobs',
+        jobsConfig: '/mocked/project/api/src/lib/jobs.ts',
+      },
+      // @ts-expect-error - only declaring what the test needs
+      web: {
+        base: '/mocked/project/web',
+        src: '/mocked/project/web/src',
+        dist: '/mocked/project/web/dist',
+      },
+      packages: '/mocked/project/packages',
+      generated: {
+        base: '/mocked/project/.cedar',
+      },
+    })
+    mockJobsDirEntries = ['WelcomeNoticeJob']
+
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await handler({ workspace: ['api', 'web'], ud: true })
+
+    const jobsCommand = findJobsCommand()
+    expect(jobsCommand?.command).toContain('cedar-jobs work')
+    expect(jobsCommand?.command).toContain('nodemon')
+    expect(
+      consoleLogSpy.mock.calls.some(([message]) =>
+        String(message).includes(
+          'Background jobs are not yet supported with Unified Dev (--ud)',
+        ),
+      ),
+    ).toBe(false)
 
     consoleLogSpy.mockRestore()
   })

--- a/packages/cli/src/commands/dev/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/dev.test.ts
@@ -519,6 +519,47 @@ describe('yarn cedar dev', () => {
     expect(jobsCommand?.command).toContain('/mocked/project/api/dist')
   })
 
+  it('Should not start the jobs worker under --ud, and should warn instead', async () => {
+    vi.mocked(getPaths).mockReturnValue({
+      base: '/mocked/project',
+      // @ts-expect-error - only declaring what the test needs
+      api: {
+        base: '/mocked/project/api',
+        src: '/mocked/project/api/src',
+        functions: '/mocked/project/api/src/functions',
+        dist: '/mocked/project/api/dist',
+        jobs: '/mocked/project/api/src/jobs',
+        jobsConfig: '/mocked/project/api/src/lib/jobs.ts',
+      },
+      // @ts-expect-error - only declaring what the test needs
+      web: {
+        base: '/mocked/project/web',
+        src: '/mocked/project/web/src',
+        dist: '/mocked/project/web/dist',
+      },
+      packages: '/mocked/project/packages',
+      generated: {
+        base: '/mocked/project/.cedar',
+      },
+    })
+    mockJobsDirEntries = ['WelcomeNoticeJob']
+
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await handler({ workspace: ['api', 'web'], ud: true })
+
+    expect(findJobsCommand()).toBeUndefined()
+    expect(
+      consoleLogSpy.mock.calls.some(([message]) =>
+        String(message).includes(
+          'Background jobs are not yet supported with Unified Dev (--ud)',
+        ),
+      ),
+    ).toBe(true)
+
+    consoleLogSpy.mockRestore()
+  })
+
   it('Should not start the jobs worker when only a .keep placeholder exists', async () => {
     vi.mocked(getPaths).mockReturnValue({
       base: '/mocked/project',

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -448,7 +448,35 @@ export const handler = async ({
   // same "just works" pattern as the api/web/gen watchers above. `--no-jobs`
   // is the escape hatch for folks who want to run `cedar jobs work`
   // themselves (custom queue selection, `--workoff`, etc).
-  if (jobsOption !== false && workspace.includes('api')) {
+  const jobsConfigured =
+    jobsOption !== false &&
+    workspace.includes('api') &&
+    !!cedarPaths.api.jobsConfig &&
+    fs.existsSync(cedarPaths.api.jobs) &&
+    // Job files always live in `api/src/jobs/<ComponentName>Job/`
+    // subdirectories (see `generate/job/jobHandler.ts`), so entries here are
+    // directories, not files — only the `.keep` placeholder (and any stray
+    // dotfiles, e.g. `.DS_Store`) should be excluded.
+    fs.readdirSync(cedarPaths.api.jobs).some((entry) => !entry.startsWith('.'))
+
+  if (jobsConfigured && ud) {
+    // `cedar-jobs work` loads its config and job files from `api/dist`
+    // (compiled output). Unified dev never writes that output — API
+    // functions are served in-process straight from `api/src` via Vite's
+    // module runner — so there's no dist directory for the worker to ever
+    // find, not just a startup race like in classic dev below. Rather than
+    // let the worker crash with a confusing "file not found" error, skip it
+    // and say so up front. Tracked for a proper fix (loading jobs through
+    // Vite's Environment API instead of compiled output) in
+    // https://github.com/cedarjs/cedar/issues/2421.
+    console.log(
+      c.warning(
+        'Background jobs are not yet supported with Unified Dev (--ud). ' +
+          'Run `cedar jobs work` in a separate terminal once you have a ' +
+          'production-like `api/dist` build, or omit --ud for now.',
+      ),
+    )
+  } else if (jobsConfigured) {
     jobs.push({
       name: 'jobs',
       // `cedar-jobs work` loads its config and job files from `api/dist`
@@ -467,19 +495,6 @@ export const handler = async ({
         `--exec "${formatRunBinCommand('cedar-jobs', ['work'])}"`,
       ]),
       prefixColor: 'magenta',
-      runWhen: () => {
-        if (!cedarPaths.api.jobsConfig || !fs.existsSync(cedarPaths.api.jobs)) {
-          return false
-        }
-
-        // Job files always live in `api/src/jobs/<ComponentName>Job/`
-        // subdirectories (see `generate/job/jobHandler.ts`), so entries here
-        // are directories, not files — only the `.keep` placeholder (and any
-        // stray dotfiles, e.g. `.DS_Store`) should be excluded.
-        return fs
-          .readdirSync(cedarPaths.api.jobs)
-          .some((entry) => !entry.startsWith('.'))
-      },
     })
   }
 

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -451,16 +451,34 @@ export const handler = async ({
   if (jobsOption !== false && workspace.includes('api')) {
     jobs.push({
       name: 'jobs',
-      command: formatRunBinCommand('cedar-jobs', ['work']),
+      // `cedar-jobs work` loads its config and job files from `api/dist`
+      // (compiled output), not `api/src`. That dist output is only written
+      // once the `api` watcher's initial build finishes, which happens
+      // asynchronously — so on a clean `cedar dev` start there's a window
+      // where `api/dist` doesn't exist yet and the worker would exit
+      // immediately. Wrapping it in nodemon (same tool the `api` job above
+      // uses) means it retries as soon as `api/dist` changes, instead of
+      // staying dead for the rest of the session. This also means the
+      // worker restarts automatically whenever job code is rebuilt, since
+      // Node's ESM cache would otherwise keep serving stale job code.
+      command: formatRunBinCommand('nodemon', [
+        '--quiet',
+        `--watch "${cedarPaths.api.dist}"`,
+        `--exec "${formatRunBinCommand('cedar-jobs', ['work'])}"`,
+      ]),
       prefixColor: 'magenta',
       runWhen: () => {
         if (!cedarPaths.api.jobsConfig || !fs.existsSync(cedarPaths.api.jobs)) {
           return false
         }
 
+        // Job files always live in `api/src/jobs/<ComponentName>Job/`
+        // subdirectories (see `generate/job/jobHandler.ts`), so entries here
+        // are directories, not files — only the `.keep` placeholder (and any
+        // stray dotfiles, e.g. `.DS_Store`) should be excluded.
         return fs
           .readdirSync(cedarPaths.api.jobs)
-          .some((entry) => entry !== '.keep')
+          .some((entry) => !entry.startsWith('.'))
       },
     })
   }

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -459,15 +459,20 @@ export const handler = async ({
     // dotfiles, e.g. `.DS_Store`) should be excluded.
     fs.readdirSync(cedarPaths.api.jobs).some((entry) => !entry.startsWith('.'))
 
-  if (jobsConfigured && ud) {
+  if (jobsConfigured && unifiedDevCommand) {
     // `cedar-jobs work` loads its config and job files from `api/dist`
     // (compiled output). Unified dev never writes that output — API
     // functions are served in-process straight from `api/src` via Vite's
     // module runner — so there's no dist directory for the worker to ever
     // find, not just a startup race like in classic dev below. Rather than
     // let the worker crash with a confusing "file not found" error, skip it
-    // and say so up front. Tracked for a proper fix (loading jobs through
-    // Vite's Environment API instead of compiled output) in
+    // and say so up front. Note this checks `unifiedDevCommand`, not the
+    // `ud` flag directly: `buildUnifiedDevCommand()` can still fall back to
+    // `null` even when `--ud` was passed (streaming SSR, API-only/web-only
+    // workspace, a custom server file), in which case classic dev runs
+    // instead and does produce `api/dist` — see the `else` branch below.
+    // Tracked for a proper fix (loading jobs through Vite's Environment API
+    // instead of compiled output) in
     // https://github.com/cedarjs/cedar/issues/2421.
     console.log(
       c.warning(

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -452,6 +452,11 @@ export const handler = async ({
     jobsOption !== false &&
     workspace.includes('api') &&
     !!cedarPaths.api.jobsConfig &&
+    // `getPaths()` resolves `jobsConfig` once and caches it in-process, so
+    // if `api/src/lib/jobs.ts` is deleted mid-session the cached path would
+    // otherwise still look "configured". Guard against starting a worker
+    // that can't load a jobs config that no longer exists.
+    fs.existsSync(cedarPaths.api.jobsConfig) &&
     fs.existsSync(cedarPaths.api.jobs) &&
     // Job files always live in `api/src/jobs/<ComponentName>Job/`
     // subdirectories (see `generate/job/jobHandler.ts`), so entries here are

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -33,6 +33,7 @@ interface DevHandlerOptions {
   debugBrk?: boolean
   ud?: boolean
   nodeArgs?: string
+  jobs?: boolean
 }
 
 interface VitePackageJson {
@@ -112,6 +113,7 @@ export const handler = async ({
   debugBrk,
   ud = false,
   nodeArgs = '',
+  jobs: jobsOption,
 }: DevHandlerOptions) => {
   recordTelemetryAttributes({
     command: 'dev',
@@ -437,6 +439,29 @@ export const handler = async ({
       name: 'gen',
       command: formatRunBinCommand('cedar-gen-watch'),
       prefixColor: 'green',
+    })
+  }
+
+  // Start the background jobs worker automatically once jobs are configured
+  // (`cedar setup jobs`) and at least one job exists (`cedar g job`) — the
+  // deliberate opt-in already happened at setup time, so this follows the
+  // same "just works" pattern as the api/web/gen watchers above. `--no-jobs`
+  // is the escape hatch for folks who want to run `cedar jobs work`
+  // themselves (custom queue selection, `--workoff`, etc).
+  if (jobsOption !== false && workspace.includes('api')) {
+    jobs.push({
+      name: 'jobs',
+      command: formatRunBinCommand('cedar-jobs', ['work']),
+      prefixColor: 'magenta',
+      runWhen: () => {
+        if (!cedarPaths.api.jobsConfig || !fs.existsSync(cedarPaths.api.jobs)) {
+          return false
+        }
+
+        return fs
+          .readdirSync(cedarPaths.api.jobs)
+          .some((entry) => entry !== '.keep')
+      },
     })
   }
 


### PR DESCRIPTION
`cedar dev` now automatically starts the background jobs worker (`cedar-jobs work`) alongside the existing api/web/gen watchers, once background jobs have been set up in the project. This closes #2421.

- Added a `--jobs` boolean flag to `cedar dev` (no static default — `--no-jobs` is the explicit opt-out).
- In `devHandler.ts`, the jobs worker job is pushed whenever `workspace` includes `api` and `--no-jobs` wasn't passed. Whether it actually runs is gated (like the existing api/web watchers) via `runWhen`:
  - `getPaths().api.jobsConfig` must resolve (i.e. `cedar setup jobs` has been run, `api/src/lib/jobs.ts` exists)
  - `api/src/jobs` must contain at least one entry other than the `.keep` placeholder (i.e. `cedar g job` has been run at least once)
- Uses the existing `formatRunBinCommand('cedar-jobs', ['work'])` helper (same pattern already used by the `cedar jobs work` CLI command) so npm/pnpm/yarn all resolve correctly.

Per Tobbe's own comment directly on #2421, this PR intentionally implements only the auto-start flag (part 1 of the original issue) and skips the proposed dev-startup log line (part 2), since he wasn't sold on that as the right UX.