### PR TITLE
feat(vite): run background jobs in-process under Unified Dev (--ud)

### DIFF
--- a/.changesets/2444.md
+++ b/.changesets/2444.md
@@ -1,0 +1,6 @@
+- feat(vite): run background jobs in-process under Unified Dev (#2444) by @lisa-assistant
+
+Follow-up to #2442. Under Unified Dev (`--ud`), background job workers now
+run in-process through the same Vite server that serves `api/src`, instead
+of requiring a separate `cedar-jobs work` process against a manually-built
+`api/dist`.

--- a/.changesets/2444.md
+++ b/.changesets/2444.md
@@ -1,6 +1,7 @@
-- feat(vite): run background jobs in-process under Unified Dev (#2444) by @lisa-assistant
+- feat(vite): run background jobs in-process under Unified Dev (#2444) by
+  @lisa-assistant
 
-Follow-up to #2442. Under Unified Dev (`--ud`), background job workers now
-run in-process through the same Vite server that serves `api/src`, instead
-of requiring a separate `cedar-jobs work` process against a manually-built
+Follow-up to #2442. Under Unified Dev (`--ud`), background job workers now run
+in-process through the same Vite server that serves `api/src`, instead of
+requiring a separate `cedar-jobs work` process against a manually-built
 `api/dist`.

--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -129,10 +129,13 @@ cedar dev:
                   │    ├─ API requests handled inline via `configureServer`
                   │    │    middleware (Vite SSR + fetch-native dispatch,
                   │    │    no separate Fastify listener)
-                  │    └─ Web assets served by Vite client dev server (SPA, HMR)
-                  ├─ cedar-gen-watch
-                  └─ jobs: same as above (still conditional, still opt-out via
-                     --no-jobs)
+                  │    ├─ Web assets served by Vite client dev server (SPA, HMR)
+                  │    └─ jobs: run in-process, in the same Vite server
+                  │         (still conditional, still opt-out via --no-jobs).
+                  │         Loads config/job files from api/src via Vite's
+                  │         SSR module runner instead of api/dist, since
+                  │         Unified Dev never writes compiled output.
+                  └─ cedar-gen-watch
 
 *SSR/RSC: cedar-vite-dev adds Express + Vite SSR servers. See [SSR-RSC-DOC].
 

--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -130,7 +130,7 @@ cedar dev:
                   │    │    middleware (Vite SSR + fetch-native dispatch,
                   │    │    no separate Fastify listener)
                   │    ├─ Web assets served by Vite client dev server (SPA, HMR)
-                  │    └─ jobs: run in-process, in the same Vite server
+                  │    └─ jobs: run in-process, in the API Vite SSR server
                   │         (still conditional, still opt-out via --no-jobs).
                   │         Loads config/job files from api/src via Vite's
                   │         SSR module runner instead of api/dist, since

--- a/packages/cli/src/commands/dev/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/dev.test.ts
@@ -603,6 +603,73 @@ describe('yarn cedar dev', () => {
     expect(findJobsCommand()).toBeUndefined()
   })
 
+  it('Should forward --no-jobs to cedar-unified-dev under --ud', async () => {
+    // `cedar-unified-dev` starts its own in-process jobs worker pool rather
+    // than the nodemon-wrapped worker pushed as a separate job, so `--jobs
+    // false` has to reach it via a CLI flag instead - it isn't otherwise
+    // forwarded (unlike args the user passes after `--`).
+    vi.mocked(getPaths).mockReturnValue({
+      base: '/mocked/project',
+      // @ts-expect-error - only declaring what the test needs
+      api: {
+        base: '/mocked/project/api',
+        src: '/mocked/project/api/src',
+        functions: '/mocked/project/api/src/functions',
+        dist: '/mocked/project/api/dist',
+        jobs: '/mocked/project/api/src/jobs',
+        jobsConfig: '/mocked/project/api/src/lib/jobs.ts',
+      },
+      // @ts-expect-error - only declaring what the test needs
+      web: {
+        base: '/mocked/project/web',
+        src: '/mocked/project/web/src',
+        dist: '/mocked/project/web/dist',
+      },
+      packages: '/mocked/project/packages',
+      generated: {
+        base: '/mocked/project/.cedar',
+      },
+    })
+    mockJobsDirEntries = ['WelcomeNoticeJob']
+
+    await handler({ workspace: ['api', 'web'], ud: true, jobs: false })
+
+    const devCommand = findUnifiedDevCommand()
+    expect(devCommand.command).toContain('--no-jobs')
+    expect(findJobsCommand()).toBeUndefined()
+  })
+
+  it('Should not forward --no-jobs to cedar-unified-dev when jobs are not opted out', async () => {
+    vi.mocked(getPaths).mockReturnValue({
+      base: '/mocked/project',
+      // @ts-expect-error - only declaring what the test needs
+      api: {
+        base: '/mocked/project/api',
+        src: '/mocked/project/api/src',
+        functions: '/mocked/project/api/src/functions',
+        dist: '/mocked/project/api/dist',
+        jobs: '/mocked/project/api/src/jobs',
+        jobsConfig: '/mocked/project/api/src/lib/jobs.ts',
+      },
+      // @ts-expect-error - only declaring what the test needs
+      web: {
+        base: '/mocked/project/web',
+        src: '/mocked/project/web/src',
+        dist: '/mocked/project/web/dist',
+      },
+      packages: '/mocked/project/packages',
+      generated: {
+        base: '/mocked/project/.cedar',
+      },
+    })
+    mockJobsDirEntries = ['WelcomeNoticeJob']
+
+    await handler({ workspace: ['api', 'web'], ud: true })
+
+    const devCommand = findUnifiedDevCommand()
+    expect(devCommand.command).not.toContain('--no-jobs')
+  })
+
   it('Should push the classic nodemon jobs worker when --ud falls back to classic dev', async () => {
     // `--ud` was requested, but `buildUnifiedDevCommand()` still returns
     // `null` here (streaming SSR has its own dev server setup), so `cedar

--- a/packages/cli/src/commands/dev/__tests__/dev.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/dev.test.ts
@@ -571,7 +571,7 @@ describe('yarn cedar dev', () => {
     expect(findJobsCommand()).toBeUndefined()
   })
 
-  it('Should not start the jobs worker under --ud, and should warn instead', async () => {
+  it('Should not push a separate jobs worker job under --ud (cedar-unified-dev runs jobs in-process)', async () => {
     vi.mocked(getPaths).mockReturnValue({
       base: '/mocked/project',
       // @ts-expect-error - only declaring what the test needs
@@ -596,28 +596,20 @@ describe('yarn cedar dev', () => {
     })
     mockJobsDirEntries = ['WelcomeNoticeJob']
 
-    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-
     await handler({ workspace: ['api', 'web'], ud: true })
 
+    // `cedar-unified-dev` (started as the single unified dev job) loads and
+    // runs jobs workers itself - see `jobsDevMiddleware.ts` in `@cedarjs/vite`.
     expect(findJobsCommand()).toBeUndefined()
-    expect(
-      consoleLogSpy.mock.calls.some(([message]) =>
-        String(message).includes(
-          'Background jobs are not yet supported with Unified Dev (--ud)',
-        ),
-      ),
-    ).toBe(true)
-
-    consoleLogSpy.mockRestore()
   })
 
-  it('Should start the jobs worker (not warn) when --ud falls back to classic dev', async () => {
+  it('Should push the classic nodemon jobs worker when --ud falls back to classic dev', async () => {
     // `--ud` was requested, but `buildUnifiedDevCommand()` still returns
     // `null` here (streaming SSR has its own dev server setup), so `cedar
     // dev` falls back to classic separate api+web servers, which do produce
-    // `api/dist`. The jobs worker should follow that fallback rather than
-    // treating `--ud` as if unified dev were actually running.
+    // `api/dist`. The jobs worker should follow that fallback (classic
+    // nodemon+dist job) rather than treating `--ud` as if unified dev (and
+    // its in-process job loading) were actually running.
     const config = await defaultConfig()
 
     vi.mocked(getConfig).mockReturnValue({
@@ -654,22 +646,11 @@ describe('yarn cedar dev', () => {
     })
     mockJobsDirEntries = ['WelcomeNoticeJob']
 
-    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-
     await handler({ workspace: ['api', 'web'], ud: true })
 
     const jobsCommand = findJobsCommand()
     expect(jobsCommand?.command).toContain('cedar-jobs work')
     expect(jobsCommand?.command).toContain('nodemon')
-    expect(
-      consoleLogSpy.mock.calls.some(([message]) =>
-        String(message).includes(
-          'Background jobs are not yet supported with Unified Dev (--ud)',
-        ),
-      ),
-    ).toBe(false)
-
-    consoleLogSpy.mockRestore()
   })
 
   it('Should not start the jobs worker when only a .keep placeholder exists', async () => {

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -465,27 +465,16 @@ export const handler = async ({
     fs.readdirSync(cedarPaths.api.jobs).some((entry) => !entry.startsWith('.'))
 
   if (jobsConfigured && unifiedDevCommand) {
-    // `cedar-jobs work` loads its config and job files from `api/dist`
-    // (compiled output). Unified dev never writes that output — API
-    // functions are served in-process straight from `api/src` via Vite's
-    // module runner — so there's no dist directory for the worker to ever
-    // find, not just a startup race like in classic dev below. Rather than
-    // let the worker crash with a confusing "file not found" error, skip it
-    // and say so up front. Note this checks `unifiedDevCommand`, not the
-    // `ud` flag directly: `buildUnifiedDevCommand()` can still fall back to
-    // `null` even when `--ud` was passed (streaming SSR, API-only/web-only
-    // workspace, a custom server file), in which case classic dev runs
-    // instead and does produce `api/dist` — see the `else` branch below.
-    // Tracked for a proper fix (loading jobs through Vite's Environment API
-    // instead of compiled output) in
-    // https://github.com/cedarjs/cedar/issues/2421.
-    console.log(
-      c.warning(
-        'Background jobs are not yet supported with Unified Dev (--ud). ' +
-          'Run `cedar jobs work` in a separate terminal once you have a ' +
-          'production-like `api/dist` build, or omit --ud for now.',
-      ),
-    )
+    // Under Unified Dev, `cedar-unified-dev` starts and runs the jobs
+    // workers itself, in-process, loading jobs through the same Vite server
+    // that already serves `api/src` (see `jobsDevMiddleware.ts`) instead of
+    // `cedar-jobs work`'s `api/dist`-only loading. No separate job to push
+    // here — it all happens inside the single `unifiedDevCommand` process
+    // started below. Note this checks `unifiedDevCommand`, not the `ud` flag
+    // directly: `buildUnifiedDevCommand()` can still fall back to `null` even
+    // when `--ud` was passed (streaming SSR, API-only/web-only workspace, a
+    // custom server file), in which case classic dev runs instead and the
+    // nodemon+dist worker below is the correct path.
   } else if (jobsConfigured) {
     jobs.push({
       name: 'jobs',

--- a/packages/cli/src/commands/dev/devHandler.ts
+++ b/packages/cli/src/commands/dev/devHandler.ts
@@ -336,6 +336,11 @@ export const handler = async ({
       `  --apiPort ${apiAvailablePort}`,
       getApiDebugFlag(apiDebugPort, apiAvailablePort),
       debugBrk ? '--debug-brk' : '',
+      // `cedar-unified-dev` starts its own in-process jobs worker pool (see
+      // `jobsDevMiddleware.ts`) rather than relying on the nodemon-wrapped
+      // worker pushed below, so `--no-jobs` has to be forwarded explicitly -
+      // it isn't part of `forward` unless the user passed it after `--`.
+      jobsOption === false ? '--no-jobs' : '',
       forward,
     ]
       .join(' ')

--- a/packages/jobs/src/__tests__/loaders.test.ts
+++ b/packages/jobs/src/__tests__/loaders.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { JobManager } from '../core/JobManager.js'
 import { JobsLibNotFoundError } from '../errors.js'
 import { loadJob, loadJobsManager, setJobLoaderOverrides } from '../loaders.js'
+import type { Adapters, BasicLogger, Job, QueueNames } from '../types.js'
 
 vi.mock('@cedarjs/project-config', () => ({
   getPaths: () => ({
@@ -19,7 +21,12 @@ describe('setJobLoaderOverrides', () => {
   })
 
   it('loadJobsManager uses the override when one is set', async () => {
-    const fakeManager = { workers: [] } as any
+    // Only `workers` is read by the code under test; the rest of the real
+    // `JobManager` class (adapters, queues, createScheduler, ...) is
+    // irrelevant here, hence the cast rather than constructing a full one.
+    const fakeManager = {
+      workers: [],
+    } as unknown as JobManager<Adapters, QueueNames, BasicLogger>
     const loadJobsManagerOverride = vi.fn().mockResolvedValue(fakeManager)
 
     setJobLoaderOverrides({
@@ -34,7 +41,9 @@ describe('setJobLoaderOverrides', () => {
   })
 
   it('loadJob uses the override when one is set, forwarding the computed properties', async () => {
-    const fakeJob = { perform: vi.fn() } as any
+    const fakeJob = {
+      perform: vi.fn(),
+    } as unknown as Job<QueueNames, unknown[]>
     const loadJobOverride = vi.fn().mockResolvedValue(fakeJob)
 
     setJobLoaderOverrides({

--- a/packages/jobs/src/__tests__/loaders.test.ts
+++ b/packages/jobs/src/__tests__/loaders.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { JobsLibNotFoundError } from '../errors.js'
+import { loadJob, loadJobsManager, setJobLoaderOverrides } from '../loaders.js'
+
+vi.mock('@cedarjs/project-config', () => ({
+  getPaths: () => ({
+    api: {
+      distJobsConfig: null,
+      distJobs: '/mocked/project/api/dist/jobs',
+    },
+  }),
+}))
+
+describe('setJobLoaderOverrides', () => {
+  afterEach(() => {
+    // Don't let overrides set by one test leak into the next
+    setJobLoaderOverrides(undefined)
+  })
+
+  it('loadJobsManager uses the override when one is set', async () => {
+    const fakeManager = { workers: [] } as any
+    const loadJobsManagerOverride = vi.fn().mockResolvedValue(fakeManager)
+
+    setJobLoaderOverrides({
+      loadJobsManager: loadJobsManagerOverride,
+      loadJob: vi.fn(),
+    })
+
+    const result = await loadJobsManager()
+
+    expect(result).toBe(fakeManager)
+    expect(loadJobsManagerOverride).toHaveBeenCalledTimes(1)
+  })
+
+  it('loadJob uses the override when one is set, forwarding the computed properties', async () => {
+    const fakeJob = { perform: vi.fn() } as any
+    const loadJobOverride = vi.fn().mockResolvedValue(fakeJob)
+
+    setJobLoaderOverrides({
+      loadJobsManager: vi.fn(),
+      loadJob: loadJobOverride,
+    })
+
+    const computedProperties = { name: 'MyJob', path: 'MyJob/MyJob' }
+    const result = await loadJob(computedProperties)
+
+    expect(result).toBe(fakeJob)
+    expect(loadJobOverride).toHaveBeenCalledWith(computedProperties)
+  })
+
+  it('falls back to the default dist-file behaviour once overrides are cleared', async () => {
+    setJobLoaderOverrides({
+      loadJobsManager: vi.fn().mockResolvedValue({ workers: [] }),
+      loadJob: vi.fn(),
+    })
+    setJobLoaderOverrides(undefined)
+
+    // With no override and a `null` distJobsConfig (per the mocked
+    // getPaths()), the default implementation must throw rather than call
+    // the (now-cleared) override.
+    await expect(loadJobsManager()).rejects.toThrow(JobsLibNotFoundError)
+  })
+})

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -9,4 +9,7 @@ export type { JobExecutionContext } from './core/executionContext.js'
 export { BaseAdapter } from './adapters/BaseAdapter/BaseAdapter.js'
 export { PrismaAdapter } from './adapters/PrismaAdapter/PrismaAdapter.js'
 
+export { loadJobsManager, setJobLoaderOverrides } from './loaders.js'
+export type { JobLoaderOverrides } from './loaders.js'
+
 export type * from './types.js'

--- a/packages/jobs/src/loaders.ts
+++ b/packages/jobs/src/loaders.ts
@@ -14,6 +14,26 @@ import type {
 } from './types.js'
 import { makeFilePath } from './util.js'
 
+export interface JobLoaderOverrides {
+  loadJobsManager: () => Promise<JobManager<Adapters, QueueNames, BasicLogger>>
+  loadJob: (
+    computedProperties: JobComputedProperties,
+  ) => Promise<Job<QueueNames, unknown[]>>
+}
+
+// Allows an alternative loading strategy (e.g. Vite's SSR module runner
+// under Unified Dev, where compiled `api/dist` output never exists on disk)
+// to be swapped in without changing `Executor`, `JobManager`, or any of the
+// `cedar-jobs*` bins, all of which only ever call the `loadJobsManager`/
+// `loadJob` functions exported below.
+let overrides: JobLoaderOverrides | undefined
+
+export const setJobLoaderOverrides = (
+  newOverrides: JobLoaderOverrides | undefined,
+) => {
+  overrides = newOverrides
+}
+
 /**
  * Loads the job manager from the users project
  *
@@ -22,6 +42,10 @@ import { makeFilePath } from './util.js'
 export const loadJobsManager = async (): Promise<
   JobManager<Adapters, QueueNames, BasicLogger>
 > => {
+  if (overrides) {
+    return overrides.loadJobsManager()
+  }
+
   // Confirm the specific lib/jobs.ts file exists
   const jobsConfigPath = getPaths().api.distJobsConfig
   if (!jobsConfigPath) {
@@ -41,10 +65,15 @@ export const loadJobsManager = async (): Promise<
 /**
  * Load a specific job implementation from the users project
  */
-export const loadJob = async ({
-  name: jobName,
-  path: jobPath,
-}: JobComputedProperties): Promise<Job<QueueNames, unknown[]>> => {
+export const loadJob = async (
+  computedProperties: JobComputedProperties,
+): Promise<Job<QueueNames, unknown[]>> => {
+  if (overrides) {
+    return overrides.loadJob(computedProperties)
+  }
+
+  const { name: jobName, path: jobPath } = computedProperties
+
   // Confirm the specific job file exists
   const completeJobPath = path.join(getPaths().api.distJobs, jobPath) + '.js'
 

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -58,6 +58,7 @@
     "@cedarjs/context": "workspace:*",
     "@cedarjs/graphql-server": "workspace:*",
     "@cedarjs/internal": "workspace:*",
+    "@cedarjs/jobs": "workspace:*",
     "@cedarjs/project-config": "workspace:*",
     "@cedarjs/server-store": "workspace:*",
     "@cedarjs/structure": "workspace:*",

--- a/packages/vite/src/__tests__/jobsDevMiddleware.test.ts
+++ b/packages/vite/src/__tests__/jobsDevMiddleware.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { JobNotFoundError } from '@cedarjs/jobs'
+import * as jobsModule from '@cedarjs/jobs'
+
+import { startJobsDevWorkers } from '../jobsDevMiddleware.js'
+
+vi.mock('@cedarjs/project-config', () => ({
+  getPaths: () => ({
+    api: {
+      jobsConfig: '/mocked/project/api/src/lib/jobs.ts',
+      jobs: '/mocked/project/api/src/jobs',
+    },
+  }),
+}))
+
+function makeFakeWorker(processName: string) {
+  const worker: any = {
+    processName,
+    forever: true,
+    run: vi.fn(async () => {
+      while (worker.forever) {
+        await new Promise((resolve) => setTimeout(resolve, 1))
+      }
+    }),
+  }
+  return worker
+}
+
+function makeLogger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}
+
+function makeViteServer(mod: Record<string, unknown>) {
+  return {
+    ssrLoadModule: vi.fn().mockResolvedValue(mod),
+  } as any
+}
+
+describe('startJobsDevWorkers', () => {
+  afterEach(() => {
+    jobsModule.setJobLoaderOverrides(undefined)
+    vi.restoreAllMocks()
+  })
+
+  it('returns null and clears overrides when the project has no jobs config', async () => {
+    const setOverridesSpy = vi.spyOn(jobsModule, 'setJobLoaderOverrides')
+    // No `jobs` export on the loaded module -> JobsLibNotFoundError
+    const viteServer = makeViteServer({})
+
+    const pool = await startJobsDevWorkers(viteServer)
+
+    expect(pool).toBeNull()
+    // Last call clears the override that was set at the start of the function
+    expect(setOverridesSpy).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('returns null when jobs are configured but no workers are defined', async () => {
+    const jobsManager = {
+      workers: [],
+      logger: makeLogger(),
+      createWorker: vi.fn(),
+    }
+    const viteServer = makeViteServer({ jobs: jobsManager })
+
+    const pool = await startJobsDevWorkers(viteServer)
+
+    expect(pool).toBeNull()
+    expect(jobsManager.createWorker).not.toHaveBeenCalled()
+  })
+
+  it('starts one worker per configured count and stops them gracefully', async () => {
+    const createdWorkers: ReturnType<typeof makeFakeWorker>[] = []
+    const jobsManager = {
+      workers: [
+        { adapter: 'prisma', queue: 'default', count: 2 },
+        { adapter: 'prisma', queue: ['critical'] },
+      ],
+      logger: makeLogger(),
+      createWorker: vi.fn(({ processName }: { processName: string }) => {
+        const worker = makeFakeWorker(processName)
+        createdWorkers.push(worker)
+        return worker
+      }),
+    }
+    const viteServer = makeViteServer({ jobs: jobsManager })
+
+    const pool = await startJobsDevWorkers(viteServer)
+
+    expect(pool).not.toBeNull()
+    expect(jobsManager.createWorker).toHaveBeenCalledTimes(3)
+    expect(createdWorkers.map((w) => w.processName)).toEqual([
+      'ud-jobs.default.0',
+      'ud-jobs.default.1',
+      'ud-jobs.critical.0',
+    ])
+    createdWorkers.forEach((w) => expect(w.run).toHaveBeenCalledTimes(1))
+
+    await pool!.stop()
+
+    expect(createdWorkers.every((w) => w.forever === false)).toBe(true)
+  })
+
+  it('wires loadJobsManager/loadJob overrides through the vite server', async () => {
+    const fakeJob = { perform: vi.fn() }
+    const jobsManager = {
+      workers: [{ adapter: 'prisma', queue: 'default', count: 1 }],
+      logger: makeLogger(),
+      createWorker: vi.fn(({ processName }: { processName: string }) =>
+        makeFakeWorker(processName),
+      ),
+    }
+    const viteServer = {
+      ssrLoadModule: vi.fn((url: string) => {
+        if (url.includes('lib/jobs.ts')) {
+          return Promise.resolve({ jobs: jobsManager })
+        }
+        if (url.includes('MyJob/MyJob')) {
+          return Promise.resolve({ MyJob: fakeJob })
+        }
+        return Promise.resolve({})
+      }),
+    } as any
+    const setOverridesSpy = vi.spyOn(jobsModule, 'setJobLoaderOverrides')
+
+    const pool = await startJobsDevWorkers(viteServer)
+    expect(pool).not.toBeNull()
+
+    const overrides = setOverridesSpy.mock.calls[0][0]!
+
+    const loaded = await overrides.loadJob({
+      name: 'MyJob',
+      path: 'MyJob/MyJob',
+    })
+    expect(loaded).toBe(fakeJob)
+    expect(viteServer.ssrLoadModule).toHaveBeenCalledWith(
+      expect.stringContaining('api/src/jobs/MyJob/MyJob'),
+    )
+
+    await expect(
+      overrides.loadJob({ name: 'MissingJob', path: 'MissingJob/MissingJob' }),
+    ).rejects.toThrow(JobNotFoundError)
+
+    await pool!.stop()
+  })
+})

--- a/packages/vite/src/__tests__/jobsDevMiddleware.test.ts
+++ b/packages/vite/src/__tests__/jobsDevMiddleware.test.ts
@@ -15,7 +15,7 @@ vi.mock('@cedarjs/project-config', () => ({
 }))
 
 function makeFakeWorker(processName: string) {
-  const worker: any = {
+  const worker = {
     processName,
     forever: true,
     run: vi.fn(async () => {
@@ -34,7 +34,7 @@ function makeLogger() {
 function makeViteServer(mod: Record<string, unknown>) {
   return {
     ssrLoadModule: vi.fn().mockResolvedValue(mod),
-  } as any
+  }
 }
 
 describe('startJobsDevWorkers', () => {
@@ -120,7 +120,7 @@ describe('startJobsDevWorkers', () => {
         }
         return Promise.resolve({})
       }),
-    } as any
+    }
     const setOverridesSpy = vi.spyOn(jobsModule, 'setJobLoaderOverrides')
 
     const pool = await startJobsDevWorkers(viteServer)

--- a/packages/vite/src/cedar-unified-dev.ts
+++ b/packages/vite/src/cedar-unified-dev.ts
@@ -104,6 +104,7 @@ export function parseCliArgs(argv = process.argv) {
     apiPort: _apiPortArg,
     'debug-port': debugPort,
     'debug-brk': debugBrk,
+    jobs: jobsArg,
     _: _positional,
     ...serverArgs
   } = yargsParser(argv.slice(2), {
@@ -115,11 +116,20 @@ export function parseCliArgs(argv = process.argv) {
       'cors',
       'debug',
       'debug-brk',
+      'jobs',
     ],
     number: ['port', 'apiPort', 'debug-port'],
   })
 
-  return { forceOptimize, debug, portArg, debugPort, debugBrk, serverArgs }
+  return {
+    forceOptimize,
+    debug,
+    portArg,
+    debugPort,
+    debugBrk,
+    jobsArg,
+    serverArgs,
+  }
 }
 
 /**
@@ -337,8 +347,15 @@ export async function startUnifiedDevServer() {
     throw new Error('Could not locate your web/vite.config.{js,ts} file')
   }
 
-  const { forceOptimize, debug, portArg, debugPort, debugBrk, serverArgs } =
-    parseCliArgs()
+  const {
+    forceOptimize,
+    debug,
+    portArg,
+    debugPort,
+    debugBrk,
+    jobsArg,
+    serverArgs,
+  } = parseCliArgs()
 
   // Default to not auto-opening a browser when there's no interactive
   // terminal attached (CI, AI coding agents, etc.), unless the user
@@ -367,8 +384,9 @@ export async function startUnifiedDevServer() {
   // Background jobs, loaded and run in-process via the api Vite server
   // instead of `cedar-jobs work`'s `api/dist`-only loading (see
   // `jobsDevMiddleware.ts`). Returns `null` when the project has no jobs
-  // configured.
-  const jobsWorkerPool = await startJobsDevWorkers(apiViteServer)
+  // configured, or when the user passed `--no-jobs`.
+  const jobsWorkerPool =
+    jobsArg === false ? null : await startJobsDevWorkers(apiViteServer)
 
   const devServer = await createServer({
     configFile,
@@ -464,8 +482,14 @@ export async function startUnifiedDevServer() {
   const shutdown = createShutdownHandler({
     close: async () => {
       await devServer.close()
-      await jobsWorkerPool?.stop()
-      await closeApi()
+      try {
+        await jobsWorkerPool?.stop()
+      } finally {
+        // Always close the api Vite server, even if a worker rejected while
+        // finishing its current job - the alternative is leaking that server
+        // (and the port it holds) on every unclean job worker shutdown.
+        await closeApi()
+      }
     },
   })
 

--- a/packages/vite/src/cedar-unified-dev.ts
+++ b/packages/vite/src/cedar-unified-dev.ts
@@ -7,6 +7,7 @@ import yargsParser from 'yargs-parser'
 import { getPaths, getConfig } from '@cedarjs/project-config'
 
 import { startApiDevMiddleware } from './apiDevMiddleware.js'
+import { startJobsDevWorkers } from './jobsDevMiddleware.js'
 
 /**
  * How long to wait for the dev servers to close gracefully after a SIGINT or
@@ -356,8 +357,18 @@ export async function startUnifiedDevServer() {
   // Start the API dev middleware (Vite SSR, no separate HTTP listener).
   // API requests will be handled inline via the web Vite dev server's
   // middleware pipeline.
-  const { close: closeApi, handler: apiHandler } = await startApiDevMiddleware()
+  const {
+    viteServer: apiViteServer,
+    close: closeApi,
+    handler: apiHandler,
+  } = await startApiDevMiddleware()
   const apiAdapter = createServerAdapter(apiHandler)
+
+  // Background jobs, loaded and run in-process via the api Vite server
+  // instead of `cedar-jobs work`'s `api/dist`-only loading (see
+  // `jobsDevMiddleware.ts`). Returns `null` when the project has no jobs
+  // configured.
+  const jobsWorkerPool = await startJobsDevWorkers(apiViteServer)
 
   const devServer = await createServer({
     configFile,
@@ -453,6 +464,7 @@ export async function startUnifiedDevServer() {
   const shutdown = createShutdownHandler({
     close: async () => {
       await devServer.close()
+      await jobsWorkerPool?.stop()
       await closeApi()
     },
   })

--- a/packages/vite/src/jobsDevMiddleware.ts
+++ b/packages/vite/src/jobsDevMiddleware.ts
@@ -1,0 +1,184 @@
+// Runs CedarJS background jobs in-process under Unified Dev (`--ud`).
+//
+// `cedar-jobs work` (used by classic `cedar dev`) forks one OS process per
+// worker and loads both the jobs config and job implementations from
+// compiled `api/dist` output. Unified Dev never writes that output — API
+// code is served straight from `api/src` via Vite's SSR module runner — so
+// that loading strategy can never work here (see
+// https://github.com/cedarjs/cedar/issues/2421).
+//
+// Instead, this module swaps in a Vite-SSR-backed loading strategy (via
+// `setJobLoaderOverrides`) and runs the resulting `Worker` instances
+// in-process, inside the Unified Dev server itself. `Worker.run()` has no OS
+// process affinity — it's a plain async loop — so multiple workers can run
+// concurrently in one process via `Promise.all()`.
+//
+// A nice side effect of loading jobs through the same Vite server that
+// already serves `api/src`: job implementation files are re-fetched (and
+// therefore hot-reloaded) automatically, since `Executor` calls `loadJob()`
+// fresh for every single job execution and `setupHmrHandlers()` in
+// `apiDevMiddleware.ts` already invalidates that server's module graph on
+// every `api/src` change — no extra watching code needed here. Changes to
+// the jobs *topology* (worker counts/queues in `api/src/lib/jobs.ts`) are
+// not picked up without a dev server restart; that's a documented
+// limitation for now.
+
+import { pathToFileURL } from 'node:url'
+
+import ansis from 'ansis'
+import type { ViteDevServer } from 'vite'
+
+import {
+  JobNotFoundError,
+  JobsLibNotFoundError,
+  setJobLoaderOverrides,
+} from '@cedarjs/jobs'
+import type {
+  Adapters,
+  BasicLogger,
+  JobComputedProperties,
+  JobManager,
+  QueueNames,
+  Worker,
+} from '@cedarjs/jobs'
+import { getPaths } from '@cedarjs/project-config'
+
+// Mirrors `buildNumWorkers` in `@cedarjs/jobs`'s `cedar-jobs.ts` bin: turns
+// a `[{ count: 2, ... }, { count: 1, ... }]` workers config into
+// `[[0, 0], [0, 1], [1, 0]]` (worker-config index, worker count id) pairs.
+// Not imported directly from that bin file since importing it would also
+// run its top-level `main()` call.
+function buildNumWorkers(workers: { count?: number }[]): [number, number][] {
+  const numWorkers: [number, number][] = []
+
+  workers.forEach((worker, index) => {
+    const count = worker.count ?? 1
+
+    for (let id = 0; id < count; id++) {
+      numWorkers.push([index, id])
+    }
+  })
+
+  return numWorkers
+}
+
+async function loadJobsManagerViaVite(
+  viteServer: ViteDevServer,
+): Promise<JobManager<Adapters, QueueNames, BasicLogger>> {
+  const jobsConfigPath = getPaths().api.jobsConfig
+  if (!jobsConfigPath) {
+    throw new JobsLibNotFoundError()
+  }
+
+  const mod = await viteServer.ssrLoadModule(pathToFileURL(jobsConfigPath).href)
+
+  if (!mod.jobs) {
+    throw new JobsLibNotFoundError()
+  }
+
+  return mod.jobs
+}
+
+async function loadJobViaVite(
+  viteServer: ViteDevServer,
+  { name: jobName, path: jobPath }: JobComputedProperties,
+) {
+  const completeJobPath = `${getPaths().api.jobs}/${jobPath}`
+
+  let mod
+  try {
+    mod = await viteServer.ssrLoadModule(pathToFileURL(completeJobPath).href)
+  } catch {
+    throw new JobNotFoundError(jobName)
+  }
+
+  if (!mod[jobName]) {
+    throw new JobNotFoundError(jobName)
+  }
+
+  return mod[jobName]
+}
+
+export interface JobsWorkerPool {
+  stop: () => Promise<void>
+}
+
+/**
+ * Starts the configured background jobs workers in-process, loading both the
+ * jobs config and job implementations through the given (already-running)
+ * api Vite dev server instead of from compiled `api/dist` output.
+ *
+ * Returns `null` (and logs nothing) when no jobs are configured, mirroring
+ * the "just works, opt-in already happened at `cedar setup jobs` time"
+ * behaviour of classic dev's nodemon-wrapped worker.
+ */
+export async function startJobsDevWorkers(
+  viteServer: ViteDevServer,
+): Promise<JobsWorkerPool | null> {
+  setJobLoaderOverrides({
+    loadJobsManager: () => loadJobsManagerViaVite(viteServer),
+    loadJob: (computedProperties: JobComputedProperties) =>
+      loadJobViaVite(viteServer, computedProperties),
+  })
+
+  let jobsManager: JobManager<Adapters, QueueNames, BasicLogger>
+  try {
+    jobsManager = await loadJobsManagerViaVite(viteServer)
+  } catch (e) {
+    if (e instanceof JobsLibNotFoundError) {
+      // Jobs aren't configured for this project - nothing to do.
+      setJobLoaderOverrides(undefined)
+      return null
+    }
+    throw e
+  }
+
+  const numWorkers = buildNumWorkers(jobsManager.workers)
+  const logger = jobsManager.logger ?? console
+
+  if (numWorkers.length === 0) {
+    setJobLoaderOverrides(undefined)
+    return null
+  }
+
+  logger.warn(
+    `[CedarJS Jobs] Starting ${numWorkers.length} worker(s) in-process ` +
+      '(Unified Dev)...',
+  )
+
+  const workers: Worker[] = numWorkers.map(([index, id]) => {
+    const workerConfig = jobsManager.workers[index]
+    const processName = `ud-jobs.${[workerConfig.queue].flat().join('-')}.${id}`
+
+    return jobsManager.createWorker({
+      index,
+      clear: false,
+      workoff: false,
+      processName,
+    })
+  })
+
+  const runPromise = Promise.all(workers.map((worker) => worker.run()))
+
+  console.log(
+    ansis.dim.italic(
+      `[CedarJS Jobs] ${workers.length} worker(s) running: ` +
+        workers.map((w) => w.processName).join(', '),
+    ),
+  )
+
+  const stop = async () => {
+    // Same graceful-shutdown shape as `cedar-jobs-worker.ts`'s SIGINT
+    // handler: let each worker finish its current job (if any), then stop
+    // picking up new ones.
+    workers.forEach((worker) => {
+      worker.forever = false
+    })
+
+    await runPromise
+
+    setJobLoaderOverrides(undefined)
+  }
+
+  return { stop }
+}

--- a/packages/vite/src/jobsDevMiddleware.ts
+++ b/packages/vite/src/jobsDevMiddleware.ts
@@ -186,6 +186,12 @@ export async function startJobsDevWorkers(
   )
 
   const stop = async () => {
+    console.log(
+      ansis.dim.italic(
+        '[CedarJS Jobs] Waiting for in-progress jobs to finish...',
+      ),
+    )
+
     // Same graceful-shutdown shape as `cedar-jobs-worker.ts`'s SIGINT
     // handler: let each worker finish its current job (if any), then stop
     // picking up new ones.

--- a/packages/vite/src/jobsDevMiddleware.ts
+++ b/packages/vite/src/jobsDevMiddleware.ts
@@ -163,16 +163,20 @@ export async function startJobsDevWorkers(
     })
   })
 
-  const runPromise = Promise.all(workers.map((worker) => worker.run()))
-
   // A worker's adapter can reject (e.g. the DB connection drops) at any
-  // point while it's running, well before anyone calls `stop()` to await
-  // `runPromise`. Attach a handler synchronously so Node doesn't treat that
-  // as an unhandled rejection and crash the whole Unified Dev process -
-  // `stop()` below still awaits the same promise and observes the failure.
-  runPromise.catch((e) => {
-    logger.error('[CedarJS Jobs] A worker stopped unexpectedly', e)
-  })
+  // point while it's running, well before anyone calls `stop()`. Catch per
+  // worker (rather than wrapping everything in a single `Promise.all()`) so:
+  //   1. Node never sees an unhandled rejection, no matter when `stop()` is
+  //      called - each promise gets a handler synchronously here.
+  //   2. One worker crashing doesn't short-circuit the others. `stop()`
+  //      below awaits every worker's promise to let surviving workers finish
+  //      their current job before the caller closes the API Vite SSR server
+  //      they depend on to load job modules.
+  const workerRunPromises = workers.map((worker) =>
+    worker.run().catch((e) => {
+      logger.error('[CedarJS Jobs] A worker stopped unexpectedly', e)
+    }),
+  )
 
   console.log(
     ansis.dim.italic(
@@ -190,7 +194,10 @@ export async function startJobsDevWorkers(
     })
 
     try {
-      await runPromise
+      // Each promise here already swallows its own rejection above, so this
+      // simply waits for every worker to actually finish (or fail) instead
+      // of returning as soon as the first one does.
+      await Promise.all(workerRunPromises)
     } finally {
       // Always clear the loader override, even if a worker rejected -
       // otherwise a failed shutdown would leak Vite-SSR-backed loading into

--- a/packages/vite/src/jobsDevMiddleware.ts
+++ b/packages/vite/src/jobsDevMiddleware.ts
@@ -63,7 +63,7 @@ function buildNumWorkers(workers: { count?: number }[]): [number, number][] {
 }
 
 async function loadJobsManagerViaVite(
-  viteServer: ViteDevServer,
+  viteServer: SsrModuleLoader,
 ): Promise<JobManager<Adapters, QueueNames, BasicLogger>> {
   const jobsConfigPath = getPaths().api.jobsConfig
   if (!jobsConfigPath) {
@@ -80,7 +80,7 @@ async function loadJobsManagerViaVite(
 }
 
 async function loadJobViaVite(
-  viteServer: ViteDevServer,
+  viteServer: SsrModuleLoader,
   { name: jobName, path: jobPath }: JobComputedProperties,
 ) {
   const completeJobPath = `${getPaths().api.jobs}/${jobPath}`
@@ -103,6 +103,11 @@ export interface JobsWorkerPool {
   stop: () => Promise<void>
 }
 
+// Only `ssrLoadModule` is needed from `ViteDevServer` here. Narrowing to it
+// keeps this module's tests from having to fake out (or cast around) the
+// rest of Vite's dev server interface.
+type SsrModuleLoader = Pick<ViteDevServer, 'ssrLoadModule'>
+
 /**
  * Starts the configured background jobs workers in-process, loading both the
  * jobs config and job implementations through the given (already-running)
@@ -113,7 +118,7 @@ export interface JobsWorkerPool {
  * behaviour of classic dev's nodemon-wrapped worker.
  */
 export async function startJobsDevWorkers(
-  viteServer: ViteDevServer,
+  viteServer: SsrModuleLoader,
 ): Promise<JobsWorkerPool | null> {
   setJobLoaderOverrides({
     loadJobsManager: () => loadJobsManagerViaVite(viteServer),
@@ -160,6 +165,15 @@ export async function startJobsDevWorkers(
 
   const runPromise = Promise.all(workers.map((worker) => worker.run()))
 
+  // A worker's adapter can reject (e.g. the DB connection drops) at any
+  // point while it's running, well before anyone calls `stop()` to await
+  // `runPromise`. Attach a handler synchronously so Node doesn't treat that
+  // as an unhandled rejection and crash the whole Unified Dev process -
+  // `stop()` below still awaits the same promise and observes the failure.
+  runPromise.catch((e) => {
+    logger.error('[CedarJS Jobs] A worker stopped unexpectedly', e)
+  })
+
   console.log(
     ansis.dim.italic(
       `[CedarJS Jobs] ${workers.length} worker(s) running: ` +
@@ -175,9 +189,14 @@ export async function startJobsDevWorkers(
       worker.forever = false
     })
 
-    await runPromise
-
-    setJobLoaderOverrides(undefined)
+    try {
+      await runPromise
+    } finally {
+      // Always clear the loader override, even if a worker rejected -
+      // otherwise a failed shutdown would leak Vite-SSR-backed loading into
+      // whatever runs next in this process.
+      setJobLoaderOverrides(undefined)
+    }
   }
 
   return { stop }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3624,6 +3624,7 @@ __metadata:
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/graphql-server": "workspace:*"
     "@cedarjs/internal": "workspace:*"
+    "@cedarjs/jobs": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
     "@cedarjs/router": "workspace:*"
     "@cedarjs/server-store": "workspace:*"


### PR DESCRIPTION
Follow-up to #2442.

`cedar-jobs work` loads its config and job files from `api/dist` (compiled output), which Unified Dev never writes — API functions are served in-process straight from `api/src` via Vite's module runner. Rather than requiring a separate `cedar-jobs work` process against a manually-built `api/dist`, this loads and runs job workers in-process through the same Vite server, resolving job/config modules straight from `api/src`.

- `packages/vite/src/jobsDevMiddleware.ts` (new): starts/stops in-process job workers against the dev Vite server, loading `api/src/lib/jobs.ts` and job files through the Vite module runner instead of `api/dist`.
- `packages/jobs/src/loaders.ts`: extended to support loading from an arbitrary module loader (needed to plug in Vite's `ssrLoadModule` instead of native `require`/`import`).
- `packages/vite/src/cedar-unified-dev.ts`: wires up `jobsDevMiddleware` alongside the existing Vite dev server when jobs are configured.
- `packages/cli/src/commands/dev/devHandler.ts`: when `unifiedDevCommand` is set (i.e. `--ud` didn't fall back to classic dev) and jobs are configured, no separate `cedar-jobs work` job is pushed to the process list — `cedar-unified-dev` handles it in-process. Classic dev (including `--ud` falling back) is unaffected and still uses the nodemon+`api/dist` worker.

This also carries forward the two CodeRabbit-driven fixes already applied on #2442 (checking `unifiedDevCommand` rather than the raw `ud` flag, and an explicit `fs.existsSync` check on `cedarPaths.api.jobsConfig` to guard against a stale in-process paths cache), since this branch is based on top of that work.