### PR TITLE
fix(prerender): Only emit the Apollo state script when there is state

### DIFF
--- a/.changesets/2446.md
+++ b/.changesets/2446.md
@@ -1,0 +1,20 @@
+- fix(prerender): Only emit the Apollo state script when there is state (#2446)
+  by @ladderschool
+
+Prerendered pages used to always get an inline
+
+```html
+<script>
+  globalThis.__CEDAR__APOLLO_STATE = {}
+</script>
+```
+
+in their `<head>`, even when the page prerendered no Cells and so had nothing to
+restore. The Apollo providers already default to `{}`, so it did nothing at
+runtime — but it is an inline script, so apps running a strict
+Content-Security-Policy had to allow-list it with a `sha256-` hash that goes
+stale whenever the payload changes.
+
+That script is now only emitted when there is actually state to restore. If your
+prerendered pages contain Cells, nothing changes. If they don't, you can drop
+the corresponding hash from your CSP.

--- a/packages/prerender/src/__tests__/apolloState.test.ts
+++ b/packages/prerender/src/__tests__/apolloState.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasApolloState } from '../apolloState.js'
+
+describe('hasApolloState', () => {
+  it('is false for an empty extracted state', () => {
+    expect(hasApolloState({})).toBe(false)
+  })
+
+  it('is true for a populated extracted state', () => {
+    expect(hasApolloState({ 'Query:root': { __typename: 'Query' } })).toBe(true)
+  })
+})

--- a/packages/prerender/src/apolloState.ts
+++ b/packages/prerender/src/apolloState.ts
@@ -1,0 +1,18 @@
+/**
+ * Whether an extracted Apollo cache state is non-empty and worth inlining
+ * into the prerendered HTML as a bootstrap `<script>`.
+ *
+ * Only emit the Apollo state bootstrap when there is state to restore. Both
+ * consumers (`CedarApolloProvider` and the suspense provider) already do
+ * `.restore(globalThis?.__CEDAR__APOLLO_STATE ?? {})`, so an empty payload is
+ * a no-op. It is still an inline `<script>` though, which every strict-CSP app
+ * has to allow-list with a hash that goes stale whenever the payload changes.
+ * A page that prerenders no Cells emits nothing.
+ */
+export function hasApolloState(
+  state: unknown,
+): state is Record<string, unknown> {
+  return (
+    typeof state === 'object' && state !== null && Object.keys(state).length > 0
+  )
+}

--- a/packages/prerender/src/runPrerender.tsx
+++ b/packages/prerender/src/runPrerender.tsx
@@ -36,6 +36,12 @@ const prerenderApolloClient = new ApolloClient({
   link: ApolloLink.empty(),
 })
 
+function hasApolloState(state: unknown): state is Record<string, unknown> {
+  return (
+    typeof state === 'object' && state !== null && Object.keys(state).length > 0
+  )
+}
+
 async function recursivelyRender(
   App: ElementType,
   Routes: ElementType,
@@ -371,11 +377,21 @@ export const runPrerender = async ({
     }
   }
 
-  indexHtmlTree('head').append(
-    `<script> globalThis.__CEDAR__APOLLO_STATE = ${JSON.stringify(
-      prerenderApolloClient.extract(),
-    )}</script>`,
-  )
+  // Only emit the Apollo state bootstrap when there is state to restore. Both
+  // consumers (`CedarApolloProvider` and the suspense provider) already do
+  // `.restore(globalThis?.__CEDAR__APOLLO_STATE ?? {})`, so an empty payload is
+  // a no-op — but it is still an inline <script>, which every strict-CSP app
+  // has to allow-list with a hash that goes stale whenever the payload changes.
+  // A page that prerenders no Cells emits nothing now.
+  const apolloState = prerenderApolloClient.extract()
+
+  if (hasApolloState(apolloState)) {
+    indexHtmlTree('head').append(
+      `<script> globalThis.__CEDAR__APOLLO_STATE = ${JSON.stringify(
+        apolloState,
+      )}</script>`,
+    )
+  }
 
   // Reset the cache after the apollo state is appended into the head
   // If we don't call this all the data will be cached but you can run into issues with the cache being too large

--- a/packages/prerender/src/runPrerender.tsx
+++ b/packages/prerender/src/runPrerender.tsx
@@ -16,6 +16,7 @@ import {
 import { getPaths, ensurePosixPath } from '@cedarjs/project-config'
 import type { QueryInfo } from '@cedarjs/web'
 
+import { hasApolloState } from './apolloState.js'
 import { babelPluginRedwoodCell } from './babelPlugins/babel-plugin-redwood-cell.js'
 import { babelPluginRedwoodPrerenderMediaImports } from './babelPlugins/babel-plugin-redwood-prerender-media-imports.js'
 import { detectPrerenderRoutes } from './detection/detection.js'
@@ -35,12 +36,6 @@ const prerenderApolloClient = new ApolloClient({
   cache: new InMemoryCache(),
   link: ApolloLink.empty(),
 })
-
-function hasApolloState(state: unknown): state is Record<string, unknown> {
-  return (
-    typeof state === 'object' && state !== null && Object.keys(state).length > 0
-  )
-}
 
 async function recursivelyRender(
   App: ElementType,
@@ -377,12 +372,6 @@ export const runPrerender = async ({
     }
   }
 
-  // Only emit the Apollo state bootstrap when there is state to restore. Both
-  // consumers (`CedarApolloProvider` and the suspense provider) already do
-  // `.restore(globalThis?.__CEDAR__APOLLO_STATE ?? {})`, so an empty payload is
-  // a no-op — but it is still an inline <script>, which every strict-CSP app
-  // has to allow-list with a hash that goes stale whenever the payload changes.
-  // A page that prerenders no Cells emits nothing now.
   const apolloState = prerenderApolloClient.extract()
 
   if (hasApolloState(apolloState)) {

--- a/packages/prerender/src/runPrerenderEsm.tsx
+++ b/packages/prerender/src/runPrerenderEsm.tsx
@@ -17,6 +17,7 @@ import {
 import { matchPath } from '@cedarjs/router/dist/util'
 import type { QueryInfo } from '@cedarjs/web'
 
+import { hasApolloState } from './apolloState.js'
 import { buildAndImport } from './build-and-import/buildAndImport.js'
 import { detectPrerenderRoutes } from './detection/detection.js'
 import {
@@ -36,12 +37,6 @@ const prerenderApolloClient = new ApolloClient({
   cache: new InMemoryCache(),
   link: ApolloLink.empty(),
 })
-
-function hasApolloState(state: unknown): state is Record<string, unknown> {
-  return (
-    typeof state === 'object' && state !== null && Object.keys(state).length > 0
-  )
-}
 
 async function recursivelyRender(
   App: ElementType,
@@ -393,12 +388,6 @@ export const runPrerender = async ({
     }
   }
 
-  // Only emit the Apollo state bootstrap when there is state to restore. Both
-  // consumers (`CedarApolloProvider` and the suspense provider) already do
-  // `.restore(globalThis?.__CEDAR__APOLLO_STATE ?? {})`, so an empty payload is
-  // a no-op — but it is still an inline <script>, which every strict-CSP app
-  // has to allow-list with a hash that goes stale whenever the payload changes.
-  // A page that prerenders no Cells emits nothing now.
   const apolloState = prerenderApolloClient.extract()
 
   if (hasApolloState(apolloState)) {

--- a/packages/prerender/src/runPrerenderEsm.tsx
+++ b/packages/prerender/src/runPrerenderEsm.tsx
@@ -37,6 +37,12 @@ const prerenderApolloClient = new ApolloClient({
   link: ApolloLink.empty(),
 })
 
+function hasApolloState(state: unknown): state is Record<string, unknown> {
+  return (
+    typeof state === 'object' && state !== null && Object.keys(state).length > 0
+  )
+}
+
 async function recursivelyRender(
   App: ElementType,
   Routes: ElementType,
@@ -387,11 +393,21 @@ export const runPrerender = async ({
     }
   }
 
-  indexHtmlTree('head').append(
-    `<script> globalThis.__CEDAR__APOLLO_STATE = ${JSON.stringify(
-      prerenderApolloClient.extract(),
-    )}</script>`,
-  )
+  // Only emit the Apollo state bootstrap when there is state to restore. Both
+  // consumers (`CedarApolloProvider` and the suspense provider) already do
+  // `.restore(globalThis?.__CEDAR__APOLLO_STATE ?? {})`, so an empty payload is
+  // a no-op — but it is still an inline <script>, which every strict-CSP app
+  // has to allow-list with a hash that goes stale whenever the payload changes.
+  // A page that prerenders no Cells emits nothing now.
+  const apolloState = prerenderApolloClient.extract()
+
+  if (hasApolloState(apolloState)) {
+    indexHtmlTree('head').append(
+      `<script> globalThis.__CEDAR__APOLLO_STATE = ${JSON.stringify(
+        apolloState,
+      )}</script>`,
+    )
+  }
 
   // Reset the cache after the apollo state is appended into the head
   // If we don't call this all the data will be cached but you can run into issues with the cache being too large

--- a/tasks/smoke-tests/prerender/tests/prerender.spec.ts
+++ b/tasks/smoke-tests/prerender/tests/prerender.spec.ts
@@ -25,6 +25,12 @@ test('Check that homepage is prerendered', async () => {
 
   await checkHomePageCellRender(pageWithoutJs)
 
+  // The home page prerenders a Cell (BlogPostsCell), so its extracted Apollo
+  // state is non-empty and the bootstrap script must be inlined for
+  // hydration to pick up the prerendered data.
+  const html = await pageWithoutJs.content()
+  expect(html).toContain('globalThis.__CEDAR__APOLLO_STATE')
+
   pageWithoutJs.close()
 })
 
@@ -254,6 +260,13 @@ test('Check that about is prerendered', async () => {
   expect(aboutPageContent).toBe(
     'This site was created to demonstrate my mastery of Cedar: Look on my works, ye mighty, and despair!',
   )
+
+  // The about page prerenders no Cells, so its extracted Apollo state is
+  // empty and the bootstrap script must be omitted (see
+  // packages/prerender/src/apolloState.ts).
+  const html = await pageWithoutJs.content()
+  expect(html).not.toContain('__CEDAR__APOLLO_STATE')
+
   pageWithoutJs.close()
 })
 


### PR DESCRIPTION
## What

Prerendering unconditionally appends

```html
<script> globalThis.__CEDAR__APOLLO_STATE = {}</script>
```

to `<head>`, even on a page that prerenders no Cells and therefore extracts an empty cache.

## Why it's worth skipping

Both consumers already default correctly — `packages/web/src/apollo/CedarApolloProvider.tsx` and `packages/web/src/apollo/suspense.tsx` both do `.restore(globalThis?.__CEDAR__APOLLO_STATE ?? {})` — so an empty payload is a no-op at runtime.

It isn't free at build time, though. It's an *inline* script, so any app serving a strict `Content-Security-Policy` (no `'unsafe-inline'`) has to allow-list it with a `sha256-` hash, and that hash goes stale whenever the payload changes. On a fully-prerendered marketing site where every route extracts `{}`, this is the only inline script in the entire build — skipping it lets the CSP carry no script hashes at all.

More generally: emitting a bootstrap that restores nothing is just bytes in every prerendered document.

## The change

Extract once, and append only when the state is non-empty. Applied to both `runPrerender.tsx` and `runPrerenderEsm.tsx`.

Pages that *do* prerender Cells are unaffected — the script is emitted exactly as before and hydration is unchanged.
