### PR TITLE
fix(mailer): Allow async renderers and upgrade @react-email/render to 2.1.0

### DIFF
--- a/.changesets/2447.md
+++ b/.changesets/2447.md
@@ -1,0 +1,49 @@
+- fix(mailer): Allow async renderers and upgrade @react-email/render to 2.1.0
+  (#2447) by @ladderschool
+
+`@cedarjs/mailer-renderer-react-email` was pinned to
+`@react-email/render@0.0.17`, which renders synchronously. React Email made
+`render()` async in v3 because several of its components cannot be rendered
+synchronously — `<Tailwind>` is the main one, since it suspends while computing
+the styles it inlines. Those components simply did not work with the Cedar
+mailer.
+
+Mail renderers may now be asynchronous:
+
+```ts
+abstract render(
+  template: unknown,
+  options: MailRendererOptions<unknown>,
+  utilities?: MailUtilities,
+): MailRenderedContent | Promise<MailRenderedContent>
+```
+
+`Mailer.send()` awaits the result. It was already `async`, so **app code that
+calls `mailer.send()` needs no changes**, and `<Tailwind>` and other suspending
+React Email components now work:
+
+```tsx
+import { Tailwind, Html, Body, Text } from '@react-email/components'
+
+const Welcome = () => (
+  <Tailwind>
+    <Html>
+      <Body className="bg-white">
+        <Text className="text-lg font-bold">Welcome!</Text>
+      </Body>
+    </Html>
+  </Tailwind>
+)
+
+await mailer.send(<Welcome />, { to: 'someone@example.com', subject: 'Hi' })
+```
+
+Two things to know:
+
+- Custom renderers do **not** need updating — a synchronous `render()` still
+  satisfies the widened signature, and `@cedarjs/mailer-renderer-mjml-react` is
+  unchanged. Only code that calls `renderer.render()` directly (rather than
+  going through the mailer) now has to `await` it.
+- The React Email renderer sets `plainText` itself, after your options rather
+  than before. It is what distinguishes the HTML pass from the text pass, so
+  passing your own `plainText` only ever broke one of the two outputs.

--- a/packages/mailer/core/src/mailer.ts
+++ b/packages/mailer/core/src/mailer.ts
@@ -213,7 +213,7 @@ export class Mailer<
       ...this.config.rendering.options?.[rendererKey],
       ...rendererOptions,
     }
-    const renderedContent = renderer.render(
+    const renderedContent = await renderer.render(
       template,
       defaultedRendererOptions,
       {

--- a/packages/mailer/core/src/renderer.ts
+++ b/packages/mailer/core/src/renderer.ts
@@ -6,11 +6,15 @@ import type {
 
 export abstract class AbstractMailRenderer {
   // Render a template
+  //
+  // May be async. React Email's `render` has been asynchronous since v3 —
+  // components like `<Tailwind>` suspend while they compute their styles, so
+  // they cannot be rendered synchronously at all.
   abstract render(
     template: unknown,
     options: MailRendererOptions<unknown>,
     utilities?: MailUtilities,
-  ): MailRenderedContent
+  ): MailRenderedContent | Promise<MailRenderedContent>
 
   // Provide access to handler specific properties
   abstract internal(): Record<string, unknown>

--- a/packages/mailer/core/src/renderer.ts
+++ b/packages/mailer/core/src/renderer.ts
@@ -5,11 +5,12 @@ import type {
 } from './types.js'
 
 export abstract class AbstractMailRenderer {
-  // Render a template
-  //
-  // May be async. React Email's `render` has been asynchronous since v3 —
-  // components like `<Tailwind>` suspend while they compute their styles, so
-  // they cannot be rendered synchronously at all.
+  /**
+   * Render a template.
+   *
+   * May be async. The `<Tailwind>` component for example suspend while it
+   * computes it styles, so it cannot be rendered synchronously at all.
+   */
   abstract render(
     template: unknown,
     options: MailRendererOptions<unknown>,

--- a/packages/mailer/renderers/react-email/package.json
+++ b/packages/mailer/renderers/react-email/package.json
@@ -22,11 +22,17 @@
   },
   "dependencies": {
     "@cedarjs/mailer-core": "workspace:*",
-    "@react-email/render": "0.0.17"
+    "@react-email/render": "2.1.0"
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
     "typescript": "5.9.3"
+  },
+  "peerDependencies": {
+    "react": "19.2.3",
+    "react-dom": "19.2.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mailer/renderers/react-email/src/index.ts
+++ b/packages/mailer/renderers/react-email/src/index.ts
@@ -12,27 +12,31 @@ export type RendererOptions = MailRendererOptions<SupportedOutputFormats> &
   Parameters<typeof reactEmailRender>[1]
 
 export class ReactEmailRenderer extends AbstractMailRenderer {
-  render(
+  async render(
     template: Parameters<typeof reactEmailRender>[0],
     options: RendererOptions,
     _utilities?: MailUtilities,
-  ): MailRenderedContent {
+  ): Promise<MailRenderedContent> {
+    // `plainText` is set after spreading `options` because it is what
+    // distinguishes the two passes below — the html/text split is driven by
+    // `outputFormat`, so letting a caller override it would just break one of
+    // the two outputs.
     const outputFormat = options.outputFormat ?? 'both'
     const renderHTML = outputFormat === 'both' || outputFormat === 'html'
     const renderText = outputFormat === 'both' || outputFormat === 'text'
     return {
       html: renderHTML
-        ? reactEmailRender(template, {
+        ? await reactEmailRender(template, {
             pretty: true,
-            plainText: false,
             ...options,
+            plainText: false,
           })
         : '',
       text: renderText
-        ? reactEmailRender(template, {
+        ? await reactEmailRender(template, {
             pretty: true,
-            plainText: true,
             ...options,
+            plainText: true,
           })
         : '',
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3279,8 +3279,13 @@ __metadata:
   dependencies:
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/mailer-core": "workspace:*"
-    "@react-email/render": "npm:0.0.17"
+    "@react-email/render": "npm:2.1.0"
+    react: "npm:19.2.3"
+    react-dom: "npm:19.2.3"
     typescript: "npm:5.9.3"
+  peerDependencies:
+    react: 19.2.3
+    react-dom: 19.2.3
   languageName: unknown
   linkType: soft
 
@@ -9440,20 +9445,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-email/render@npm:0.0.17":
-  version: 0.0.17
-  resolution: "@react-email/render@npm:0.0.17"
-  dependencies:
-    html-to-text: "npm:9.0.5"
-    js-beautify: "npm:^1.14.11"
-    react-promise-suspense: "npm:0.3.4"
-  peerDependencies:
-    react: ^18.2.0
-    react-dom: ^18.2.0
-  checksum: 10c0/34a1c5a55586d7cd723638d8cd5328fddf30015e5065a2e9d5204772e0532e84d63af1b2b1b8ec02cef52a8f57d34871200c0075a9ed7b2861362d8138d3db5e
-  languageName: node
-  linkType: hard
-
 "@react-email/render@npm:1.1.2":
   version: 1.1.2
   resolution: "@react-email/render@npm:1.1.2"
@@ -9465,6 +9456,21 @@ __metadata:
     react: ^18.0 || ^19.0 || ^19.0.0-rc
     react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
   checksum: 10c0/def0039a24b797d962d7dcb3a3401c093aa0115545284e00863de4066a826a3e4977b8f2c65b1f3bf77352bee5595e0dedf166ea52467dcb7080e14785e1c3ac
+  languageName: node
+  linkType: hard
+
+"@react-email/render@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@react-email/render@npm:2.1.0"
+  dependencies:
+    entities: "npm:^4.5.0"
+    html-to-text: "npm:^9.0.5"
+    html5parser: "npm:^3.0.0"
+    prettier: "npm:^3.5.3"
+  peerDependencies:
+    react: ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+  checksum: 10c0/d117fb48711fb491f8f958806278c23f5d816e5baf999faef9d93922581d5c9128c7b320418317c486f9a68760deb32a1aa97efde946f4027a7aadda18aab7fc
   languageName: node
   linkType: hard
 
@@ -18663,7 +18669,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-to-text@npm:9.0.5, html-to-text@npm:^9.0.5":
+"html-to-text@npm:^9.0.5":
   version: 9.0.5
   resolution: "html-to-text@npm:9.0.5"
   dependencies:
@@ -18673,6 +18679,13 @@ __metadata:
     htmlparser2: "npm:^8.0.2"
     selderee: "npm:^0.11.0"
   checksum: 10c0/5d2c77b798cf88a81b1da2fc1ea1a3b3e2ff49fe5a3d812392f802fff18ec315cf0969bd7846ef2eb7df8c37f463bc63e8cbdcf84e42696c6f3e15dfa61cdf4f
+  languageName: node
+  linkType: hard
+
+"html5parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "html5parser@npm:3.0.0"
+  checksum: 10c0/1f64db31ce882504ec73c36bc87e5225ad02e472f4953215cbda7a602ad5f5f85ea12d1b490bcf5713ae9ecbdc1b2b0dc8643075fd4cc3816624746762b5c0b3
   languageName: node
   linkType: hard
 
@@ -20373,7 +20386,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-beautify@npm:^1.14.11, js-beautify@npm:^1.6.14":
+"js-beautify@npm:^1.6.14":
   version: 1.15.1
   resolution: "js-beautify@npm:1.15.1"
   dependencies:
@@ -25340,7 +25353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-promise-suspense@npm:0.3.4, react-promise-suspense@npm:^0.3.4":
+"react-promise-suspense@npm:^0.3.4":
   version: 0.3.4
   resolution: "react-promise-suspense@npm:0.3.4"
   dependencies:


### PR DESCRIPTION
## Problem

`@cedarjs/mailer-renderer-react-email` pins `@react-email/render@0.0.17`, which renders synchronously via `renderToStaticMarkup`.

React Email made `render()` async in 3.0 precisely because several of its own components can't be rendered synchronously — `<Tailwind>` is the headline one: it inlines the computed CSS during render and needs Suspense, so it simply does not work under `renderToStaticMarkup`. Anything else that suspends is in the same boat.

The result today is that a Cedar app using the mailer can't use a large part of React Email's component library. The only workaround is to render the template yourself with a modern `render()` and hand the HTML to `mailer.sendWithoutRendering()` — which works, but gives up the renderer configuration the mailer exists to provide.

`@react-email/render` is also three years and two majors behind (0.0.17 → 2.1.0).

## Change

1. `AbstractMailRenderer.render()` may now return `MailRenderedContent | Promise<MailRenderedContent>`, and `Mailer.send()` awaits it. `send()` was already `async`, so this is a one-word change at the call site.
2. `@cedarjs/mailer-renderer-react-email` moves to `@react-email/render@2.1.0` and its `render()` becomes `async`, awaiting the HTML and text passes.

`@cedarjs/mailer-renderer-mjml-react` stays synchronous and is unaffected — the widened return type accepts it unchanged, as does any third-party renderer.

## Compatibility

- **Renderer authors:** no change required. A sync `render()` still satisfies the widened signature.
- **App code calling `mailer.send()`:** no change. It was already awaited.
- **App code calling `renderer.render()` directly** (uncommon — the mailer normally owns this) now gets a possible promise back and has to `await`. That's the only visible break, and it seems worth it to unblock `<Tailwind>`.
- **React Email templates:** `@react-email/render` 2.x expects `react`/`react-dom` 18 or 19; Cedar is on React 19.

Happy to split this into "widen the interface" and "bump the renderer" if you'd rather land them separately.
