### PR TITLE
fix(ci): pass --migrations to setup neon in E2E workflows

### DIFF
--- a/.github/workflows/e2e-netlify.yml
+++ b/.github/workflows/e2e-netlify.yml
@@ -34,7 +34,7 @@ jobs:
           # can't run on Postgres, so remove them before setup neon creates the
           # fresh Postgres baseline migration.
           rm -rf api/db/migrations
-          yarn cedar setup neon
+          yarn cedar setup neon --no-migrations
 
       - name: 🆕 Create Netlify site
         id: create-site

--- a/.github/workflows/e2e-netlify.yml
+++ b/.github/workflows/e2e-netlify.yml
@@ -34,7 +34,7 @@ jobs:
           # can't run on Postgres, so remove them before setup neon creates the
           # fresh Postgres baseline migration.
           rm -rf api/db/migrations
-          yarn cedar setup neon --no-migrations
+          yarn cedar setup neon --migrations
 
       - name: 🆕 Create Netlify site
         id: create-site

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ../cedar-test-app
         run: |
           rm -rf api/db/migrations
-          yarn cedar setup neon
+          yarn cedar setup neon --no-migrations
 
       - name: 🔧 Set up Universal Deploy
         working-directory: ../cedar-test-app

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ../cedar-test-app
         run: |
           rm -rf api/db/migrations
-          yarn cedar setup neon --no-migrations
+          yarn cedar setup neon --migrations
 
       - name: 🔧 Set up Universal Deploy
         working-directory: ../cedar-test-app


### PR DESCRIPTION
## Summary

Fixes the CI regression introduced by #1830 on the `▲ E2E - Vercel Deploy` and `🔷 E2E - Netlify Deploy` workflows (e.g. run https://github.com/cedarjs/cedar/actions/runs/32005075569/job/95321695664).

#1830 made `cedar setup neon` require an explicit `--migrations`/`--no-migrations` flag when running in a non-interactive terminal, exiting with code 1 instead of prompting:

```
Cannot prompt for confirmation in a non-interactive terminal. Please pass --migrations or --no-migrations explicitly.
```

Both E2E workflows call `yarn cedar setup neon` with no flag, so every run since #1830 merged has failed at the "🗄️ Set up Neon database" step.

**Edit:** the first version of this PR used `--no-migrations`, which turned out to be wrong ([caught by Greptile](https://github.com/cedarjs/cedar/pull/2452#discussion_r1)) — that flag skips the `cedar prisma migrate dev --name init-neon` step, which is where the Postgres baseline migration actually gets generated (both workflows delete the fixture's sqlite migrations first). Skipping it would leave the later `prisma migrate deploy` step with no migration files to apply, so the deployed app would have no tables. Now using `--migrations` instead, which restores the original (pre-#1830) always-run behavior while still satisfying #1830's non-interactive flag requirement.
