### PR TITLE
fix(codegen): Surface client preset (Trusted Documents) generation errors

### DIFF
--- a/.changesets/2459.md
+++ b/.changesets/2459.md
@@ -1,0 +1,22 @@
+- fix(codegen): Surface client preset (Trusted Documents) errors (#2459) by
+  @ladderschool
+
+When GraphQL Trusted Documents codegen failed, nothing said so. `generate()`
+pushed the client preset's files into its result but never read
+`preset.errors`, so `yarn cedar g types` printed `... done.` and exited `0`, and
+`yarn cedar setup graphql trusted-documents` ticked
+"Generating Trusted Documents store ..." green — while writing none of
+`web/src/graphql/gql.ts`, `web/src/graphql/persisted-documents.json` or
+`api/src/lib/trustedDocumentsStore.ts`. The first real symptom was the app
+rejecting every operation at runtime with `Use Trusted Only!`.
+
+Those errors are now reported and set a non-zero exit code. The generated
+`trustedDocumentsStore.ts` is also listed among the output files — it was always
+being written, just never shown.
+
+One way to trigger the underlying failure is worth knowing about: the `client`
+preset excludes its own output directory from document discovery, and Cedar
+points it at `./web/src/graphql/`. If your GraphQL documents live in that
+directory, codegen finds zero documents and fails with
+`Unable to find any GraphQL type definitions`. Keep documents anywhere else
+(`web/src/queries/`, colocated with components, ...) and it generates normally.

--- a/packages/internal/src/__tests__/generate.test.ts
+++ b/packages/internal/src/__tests__/generate.test.ts
@@ -35,7 +35,10 @@ vi.mock('../generate/clientPreset.js', () => ({
 }))
 
 afterEach(() => {
-  vi.clearAllMocks()
+  vi.resetAllMocks()
+  mockedGetConfig.mockReturnValue({
+    graphql: { trustedDocuments: true },
+  })
 })
 
 describe('generate', () => {

--- a/packages/internal/src/__tests__/generate.test.ts
+++ b/packages/internal/src/__tests__/generate.test.ts
@@ -1,0 +1,88 @@
+import { vi, afterEach, describe, expect, test } from 'vitest'
+
+import type ProjectConfig from '@cedarjs/project-config'
+
+import { generate } from '../generate/generate.js'
+
+const { mockedGetConfig, mockedGenerateClientPreset } = vi.hoisted(() => {
+  return {
+    mockedGetConfig: vi.fn().mockReturnValue({
+      graphql: { trustedDocuments: true },
+    }),
+    mockedGenerateClientPreset: vi.fn(),
+  }
+})
+
+vi.mock('@cedarjs/project-config', async (importOriginal) => {
+  const projectConfig = await importOriginal<typeof ProjectConfig>()
+  return { ...projectConfig, getConfig: mockedGetConfig }
+})
+
+vi.mock('../generate/graphqlSchema.js', () => ({
+  generateGraphQLSchema: async () => ({ schemaPath: '', errors: [] }),
+}))
+vi.mock('../generate/typeDefinitions.js', () => ({
+  generateTypeDefs: async () => ({ typeDefFiles: [], errors: [] }),
+}))
+vi.mock('../generate/possibleTypes.js', () => ({
+  generatePossibleTypes: async () => ({ possibleTypesFiles: [], errors: [] }),
+}))
+vi.mock('../generate/gqlormSchema.js', () => ({
+  generateGqlormArtifacts: async () => ({ files: [], errors: [] }),
+}))
+vi.mock('../generate/clientPreset.js', () => ({
+  generateClientPreset: mockedGenerateClientPreset,
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('generate', () => {
+  test('surfaces client preset errors instead of swallowing them', async () => {
+    mockedGenerateClientPreset.mockResolvedValue({
+      clientPresetFiles: [],
+      trustedDocumentsStoreFile: '',
+      errors: [
+        {
+          message: 'Error: Could not generate GraphQL client preset',
+          error: new Error('Unable to find any GraphQL type definitions'),
+        },
+      ],
+    })
+
+    const { files, errors } = await generate()
+
+    expect(files).toEqual([])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toBe(
+      'Error: Could not generate GraphQL client preset',
+    )
+  })
+
+  test('lists the generated trusted documents store', async () => {
+    mockedGenerateClientPreset.mockResolvedValue({
+      clientPresetFiles: ['/app/web/src/graphql/gql.ts'],
+      trustedDocumentsStoreFile: '/app/api/src/lib/trustedDocumentsStore.ts',
+      errors: [],
+    })
+
+    const { files, errors } = await generate()
+
+    expect(errors).toHaveLength(0)
+    expect(files).toEqual([
+      '/app/web/src/graphql/gql.ts',
+      '/app/api/src/lib/trustedDocumentsStore.ts',
+    ])
+  })
+
+  test('does not run the client preset when trusted documents are off', async () => {
+    mockedGetConfig.mockReturnValue({ graphql: { trustedDocuments: false } })
+
+    const { files, errors } = await generate()
+
+    expect(mockedGenerateClientPreset).not.toHaveBeenCalled()
+    expect(files).toEqual([])
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/packages/internal/src/generate/clientPreset.ts
+++ b/packages/internal/src/generate/clientPreset.ts
@@ -24,7 +24,7 @@ export const generateClientPreset = async () => {
   const errors: { message: string; error: unknown }[] = []
 
   if (!shouldGenerateTrustedDocuments()) {
-    return { clientPresetFiles, trustedDocumentsStoreFile: [], errors }
+    return { clientPresetFiles, trustedDocumentsStoreFile: '', errors }
   }
 
   // The documents glob and the generates path have to be relative (resolved
@@ -82,7 +82,7 @@ export const generateClientPreset = async () => {
 
     return {
       clientPresetFiles,
-      trustedDocumentsStoreFile: [],
+      trustedDocumentsStoreFile: '',
       errors,
     }
   }

--- a/packages/internal/src/generate/generate.ts
+++ b/packages/internal/src/generate/generate.ts
@@ -17,6 +17,7 @@ export const generate = async () => {
     await generateTypeDefs()
 
   const clientPresetFiles = []
+  const clientPresetErrors = []
 
   const { possibleTypesFiles, errors: generatePossibleTypesErrors } =
     await generatePossibleTypes()
@@ -27,6 +28,12 @@ export const generate = async () => {
   if (config.graphql.trustedDocuments) {
     const preset = await generateClientPreset()
     clientPresetFiles.push(...preset.clientPresetFiles)
+
+    if (preset.trustedDocumentsStoreFile) {
+      clientPresetFiles.push(preset.trustedDocumentsStoreFile)
+    }
+
+    clientPresetErrors.push(...preset.errors)
   }
 
   let files = []
@@ -49,6 +56,7 @@ export const generate = async () => {
       ...generateGraphQLSchemaErrors,
       ...generateTypeDefsErrors,
       ...generatePossibleTypesErrors,
+      ...clientPresetErrors,
       ...gqlormErrors,
     ],
   }


### PR DESCRIPTION
## Problem

`generate()` in `@cedarjs/internal` pushes the client preset's *files* into its
result but silently drops its *errors*:

```ts
if (config.graphql.trustedDocuments) {
  const preset = await generateClientPreset()
  clientPresetFiles.push(...preset.clientPresetFiles)
  // preset.errors is never read
}
```

`generateClientPreset()` catches everything and reports it through that array,
so when Trusted Documents codegen fails there is no signal at all:

- `yarn cedar g types` prints `... done.` and exits `0`
- `yarn cedar setup graphql trusted-documents` ticks
  **"Generating Trusted Documents store ..."** green
- and none of `web/src/graphql/gql.ts`,
  `web/src/graphql/persisted-documents.json`, or
  `api/src/lib/trustedDocumentsStore.ts` is written

The next thing that happens is the app boots against a missing (or stale) store
and rejects every operation with `Use Trusted Only!`, which is a long way from
the actual cause.

### How I hit it

The `client` preset excludes its own output directory from document discovery —
`prepareDocuments` appends `` `!${outputFilePath}` `` — and Cedar's output
directory is `./web/src/graphql/`. My app keeps all of its GraphQL documents in
`web/src/graphql/*.ts`, so codegen discovered **zero** documents and threw:

```
Unable to find any GraphQL type definitions for the following pointers:
  - ./web/src/**/!(*.d).{ts,tsx,js,jsx}
```

With the errors dropped, the only symptom was that setup reported success and
generated nothing. It took a debugger to find the message that was already being
produced.

(Moving my documents to `web/src/queries/` fixes it on my side — this PR is just
about making the failure visible. Whether the preset output should live
somewhere that can't collide with user documents is a separate question.)

## Change

- propagate `preset.errors` into `generate()`'s returned `errors`, so `run()`
  prints them and sets a non-zero exit code
- list the generated `trustedDocumentsStore.ts` among the output files — it was
  already being written, just never reported
- return `''` instead of `[]` for `trustedDocumentsStoreFile` on the no-op and
  error paths, so the type matches the success path

## Tests

New `packages/internal/src/__tests__/generate.test.ts` — three cases: errors are
surfaced, the store file is listed, and the preset is skipped when
`trustedDocuments` is off. Two of the three fail on `main`.