### PR TITLE
chore(cli): Tidy up upgrade command implementation

### DIFF
--- a/packages/cli/src/commands/upgrade/__tests__/mergeTemplateDependencies.test.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/mergeTemplateDependencies.test.ts
@@ -2,113 +2,16 @@ import { describe, expect, it } from 'vitest'
 
 import { mergeTemplateDependencies } from '../upgradeHandler.js'
 
-const CEDAR_VERSION = '6.0.0-rc.312'
-
 describe('mergeTemplateDependencies', () => {
-  describe('CedarJS packages', () => {
-    it('adds one the project is missing, at the version being upgraded to', () => {
-      const local = { devDependencies: { '@cedarjs/core': CEDAR_VERSION } }
-      const messages: string[] = []
-
-      mergeTemplateDependencies(
-        'devDependencies',
-        // The template pins a literal version. It's whatever is on `main`, so
-        // it must not end up in the project
-        { devDependencies: { '@cedarjs/eslint-config': '6.0.0' } },
-        local,
-        CEDAR_VERSION,
-        messages,
-      )
-
-      expect(local.devDependencies['@cedarjs/eslint-config']).toBe(
-        CEDAR_VERSION,
-      )
-      expect(messages).toEqual([
-        ' - @cedarjs/eslint-config: (added) => 6.0.0-rc.312',
-      ])
-    })
-
-    it('reports an added package even when not verbose', () => {
-      const local = { devDependencies: {} }
-      const messages: string[] = []
-
-      mergeTemplateDependencies(
-        'devDependencies',
-        { devDependencies: { '@cedarjs/eslint-config': '6.0.0' } },
-        local,
-        CEDAR_VERSION,
-        messages,
-        { verbose: false, dryRun: false },
-      )
-
-      expect(messages).toHaveLength(1)
-    })
-
-    it('leaves one the project already has alone', () => {
-      // The earlier "Updating your CedarJS version" task owns this one
-      const local = { devDependencies: { '@cedarjs/eslint-config': '5.0.6' } }
-      const messages: string[] = []
-
-      mergeTemplateDependencies(
-        'devDependencies',
-        { devDependencies: { '@cedarjs/eslint-config': '6.0.0' } },
-        local,
-        CEDAR_VERSION,
-        messages,
-      )
-
-      expect(local.devDependencies['@cedarjs/eslint-config']).toBe('5.0.6')
-      expect(messages).toEqual([])
-    })
-
-    it('does not duplicate one the project keeps in the other section', () => {
-      const local = {
-        dependencies: { '@cedarjs/api-server': '5.0.6' },
-        devDependencies: {},
-      }
-      const messages: string[] = []
-
-      mergeTemplateDependencies(
-        'devDependencies',
-        { devDependencies: { '@cedarjs/api-server': '6.0.0' } },
-        local,
-        CEDAR_VERSION,
-        messages,
-      )
-
-      expect(local.devDependencies).toEqual({})
-      expect(local.dependencies['@cedarjs/api-server']).toBe('5.0.6')
-      expect(messages).toEqual([])
-    })
-
-    it('never adds @cedarjs/studio', () => {
-      const local = { devDependencies: {} }
-      const messages: string[] = []
-
-      mergeTemplateDependencies(
-        'devDependencies',
-        { devDependencies: { '@cedarjs/studio': '6.0.0' } },
-        local,
-        CEDAR_VERSION,
-        messages,
-      )
-
-      expect(local.devDependencies).toEqual({})
-      expect(messages).toEqual([])
-    })
-  })
-
   describe('non-CedarJS packages', () => {
     it('pins to the template version, adding missing ones', () => {
       const local = { devDependencies: { prettier: '3.0.0' } }
-      const messages: string[] = []
 
       mergeTemplateDependencies(
         'devDependencies',
         { devDependencies: { prettier: '3.8.4', typescript: '5.9.3' } },
         local,
-        CEDAR_VERSION,
-        messages,
+        [],
       )
 
       expect(local.devDependencies).toEqual({
@@ -126,14 +29,12 @@ describe('mergeTemplateDependencies', () => {
         'devDependencies',
         template,
         { devDependencies: { prettier: '3.0.0' } },
-        CEDAR_VERSION,
         quiet,
       )
       mergeTemplateDependencies(
         'devDependencies',
         template,
         { devDependencies: { prettier: '3.0.0' } },
-        CEDAR_VERSION,
         loud,
         { verbose: true },
       )
@@ -143,33 +44,83 @@ describe('mergeTemplateDependencies', () => {
     })
   })
 
+  describe('CedarJS packages', () => {
+    it('leaves an existing one alone', () => {
+      // The earlier "Updating your CedarJS version" task owns this one
+      const local = { devDependencies: { '@cedarjs/eslint-config': '5.0.6' } }
+      const messages: string[] = []
+
+      mergeTemplateDependencies(
+        'devDependencies',
+        { devDependencies: { '@cedarjs/eslint-config': '6.0.0' } },
+        local,
+        messages,
+        { verbose: true },
+      )
+
+      expect(local.devDependencies['@cedarjs/eslint-config']).toBe('5.0.6')
+      expect(messages).toEqual([])
+    })
+
+    it('does not add a missing one', () => {
+      // Indistinguishable from one the user deliberately removed
+      const local: { devDependencies?: Record<string, string> } = {
+        devDependencies: {},
+      }
+      const messages: string[] = []
+
+      mergeTemplateDependencies(
+        'devDependencies',
+        { devDependencies: { '@cedarjs/forms': '6.0.0' } },
+        local,
+        messages,
+        { verbose: true },
+      )
+
+      expect(local.devDependencies).toEqual({})
+      expect(messages).toEqual([])
+    })
+  })
+
   describe('missing sections', () => {
     it('creates the section when the project has none', () => {
+      const local: { dependencies?: Record<string, string> } = {}
+
+      mergeTemplateDependencies(
+        'dependencies',
+        { dependencies: { react: '19.2.3' } },
+        local,
+        [],
+      )
+
+      expect(local.dependencies).toEqual({ react: '19.2.3' })
+    })
+
+    it('does not report against a section the project does not have', () => {
       const local: { dependencies?: Record<string, string> } = {}
       const messages: string[] = []
 
       mergeTemplateDependencies(
         'dependencies',
-        { dependencies: { '@cedarjs/api-server': '6.0.0' } },
+        { dependencies: { react: '19.2.3' } },
         local,
-        CEDAR_VERSION,
         messages,
+        { verbose: true },
       )
 
-      expect(local.dependencies).toEqual({
-        '@cedarjs/api-server': CEDAR_VERSION,
-      })
+      expect(messages).toEqual([' - react: undefined => 19.2.3'])
     })
 
-    it('does not create an empty section the template does not have', () => {
+    it('does not create a section it would leave empty', () => {
       const local: { dependencies?: Record<string, string> } = {}
 
-      mergeTemplateDependencies('dependencies', {}, local, CEDAR_VERSION, [])
+      mergeTemplateDependencies('dependencies', {}, local, [])
+      mergeTemplateDependencies('dependencies', { dependencies: {} }, local, [])
+      // Only CedarJS packages, all of which are skipped
       mergeTemplateDependencies(
         'dependencies',
-        { dependencies: {} },
+        { dependencies: { '@cedarjs/api-server': '6.0.0' } },
         local,
-        CEDAR_VERSION,
         [],
       )
 

--- a/packages/cli/src/commands/upgrade/__tests__/mergeTemplateDependencies.test.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/mergeTemplateDependencies.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeTemplateDependencies } from '../upgradeHandler.js'
+
+const CEDAR_VERSION = '6.0.0-rc.312'
+
+describe('mergeTemplateDependencies', () => {
+  describe('CedarJS packages', () => {
+    it('adds one the project is missing, at the version being upgraded to', () => {
+      const local = { devDependencies: { '@cedarjs/core': CEDAR_VERSION } }
+      const messages: string[] = []
+
+      mergeTemplateDependencies(
+        'devDependencies',
+        // The template pins a literal version. It's whatever is on `main`, so
+        // it must not end up in the project
+        { devDependencies: { '@cedarjs/eslint-config': '6.0.0' } },
+        local,
+        CEDAR_VERSION,
+        messages,
+      )
+
+      expect(local.devDependencies['@cedarjs/eslint-config']).toBe(
+        CEDAR_VERSION,
+      )
+      expect(messages).toEqual([
+        ' - @cedarjs/eslint-config: (added) => 6.0.0-rc.312',
+      ])
+    })
+
+    it('reports an added package even when not verbose', () => {
+      const local = { devDependencies: {} }
+      const messages: string[] = []
+
+      mergeTemplateDependencies(
+        'devDependencies',
+        { devDependencies: { '@cedarjs/eslint-config': '6.0.0' } },
+        local,
+        CEDAR_VERSION,
+        messages,
+        { verbose: false, dryRun: false },
+      )
+
+      expect(messages).toHaveLength(1)
+    })
+
+    it('leaves one the project already has alone', () => {
+      // The earlier "Updating your CedarJS version" task owns this one
+      const local = { devDependencies: { '@cedarjs/eslint-config': '5.0.6' } }
+      const messages: string[] = []
+
+      mergeTemplateDependencies(
+        'devDependencies',
+        { devDependencies: { '@cedarjs/eslint-config': '6.0.0' } },
+        local,
+        CEDAR_VERSION,
+        messages,
+      )
+
+      expect(local.devDependencies['@cedarjs/eslint-config']).toBe('5.0.6')
+      expect(messages).toEqual([])
+    })
+
+    it('does not duplicate one the project keeps in the other section', () => {
+      const local = {
+        dependencies: { '@cedarjs/api-server': '5.0.6' },
+        devDependencies: {},
+      }
+      const messages: string[] = []
+
+      mergeTemplateDependencies(
+        'devDependencies',
+        { devDependencies: { '@cedarjs/api-server': '6.0.0' } },
+        local,
+        CEDAR_VERSION,
+        messages,
+      )
+
+      expect(local.devDependencies).toEqual({})
+      expect(local.dependencies['@cedarjs/api-server']).toBe('5.0.6')
+      expect(messages).toEqual([])
+    })
+
+    it('never adds @cedarjs/studio', () => {
+      const local = { devDependencies: {} }
+      const messages: string[] = []
+
+      mergeTemplateDependencies(
+        'devDependencies',
+        { devDependencies: { '@cedarjs/studio': '6.0.0' } },
+        local,
+        CEDAR_VERSION,
+        messages,
+      )
+
+      expect(local.devDependencies).toEqual({})
+      expect(messages).toEqual([])
+    })
+  })
+
+  describe('non-CedarJS packages', () => {
+    it('pins to the template version, adding missing ones', () => {
+      const local = { devDependencies: { prettier: '3.0.0' } }
+      const messages: string[] = []
+
+      mergeTemplateDependencies(
+        'devDependencies',
+        { devDependencies: { prettier: '3.8.4', typescript: '5.9.3' } },
+        local,
+        CEDAR_VERSION,
+        messages,
+      )
+
+      expect(local.devDependencies).toEqual({
+        prettier: '3.8.4',
+        typescript: '5.9.3',
+      })
+    })
+
+    it('only reports changes when verbose or dry run', () => {
+      const template = { devDependencies: { prettier: '3.8.4' } }
+      const quiet: string[] = []
+      const loud: string[] = []
+
+      mergeTemplateDependencies(
+        'devDependencies',
+        template,
+        { devDependencies: { prettier: '3.0.0' } },
+        CEDAR_VERSION,
+        quiet,
+      )
+      mergeTemplateDependencies(
+        'devDependencies',
+        template,
+        { devDependencies: { prettier: '3.0.0' } },
+        CEDAR_VERSION,
+        loud,
+        { verbose: true },
+      )
+
+      expect(quiet).toEqual([])
+      expect(loud).toEqual([' - prettier: 3.0.0 => 3.8.4'])
+    })
+  })
+
+  describe('missing sections', () => {
+    it('creates the section when the project has none', () => {
+      const local: { dependencies?: Record<string, string> } = {}
+      const messages: string[] = []
+
+      mergeTemplateDependencies(
+        'dependencies',
+        { dependencies: { '@cedarjs/api-server': '6.0.0' } },
+        local,
+        CEDAR_VERSION,
+        messages,
+      )
+
+      expect(local.dependencies).toEqual({
+        '@cedarjs/api-server': CEDAR_VERSION,
+      })
+    })
+
+    it('does not create an empty section the template does not have', () => {
+      const local: { dependencies?: Record<string, string> } = {}
+
+      mergeTemplateDependencies('dependencies', {}, local, CEDAR_VERSION, [])
+      mergeTemplateDependencies(
+        'dependencies',
+        { dependencies: {} },
+        local,
+        CEDAR_VERSION,
+        [],
+      )
+
+      expect(local).toEqual({})
+    })
+  })
+})

--- a/packages/cli/src/commands/upgrade/upgradeHandler.ts
+++ b/packages/cli/src/commands/upgrade/upgradeHandler.ts
@@ -404,6 +404,78 @@ function updateCedarJSDepsForAllSides(
   )
 }
 
+interface TemplatePackageJson {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+function hasDependency(packageJson: TemplatePackageJson, depName: string) {
+  return (
+    depName in (packageJson.dependencies ?? {}) ||
+    depName in (packageJson.devDependencies ?? {})
+  )
+}
+
+/**
+ * Copies one section (`dependencies` or `devDependencies`) of the app
+ * template's package.json into the project's own, collecting a line into
+ * `messages` for every change worth telling the user about.
+ *
+ * Non-CedarJS packages are always pinned to the template's version. CedarJS
+ * packages are only added when the project doesn't already have them
+ * somewhere, because:
+ *
+ * - Ones the project already has were bumped to the version being upgraded to
+ *   by the earlier "Updating your CedarJS version" task.
+ * - The template's literal version is whatever is on `main`, which is not
+ *   necessarily the version being upgraded to, so it can't be used as-is.
+ */
+export function mergeTemplateDependencies(
+  field: 'dependencies' | 'devDependencies',
+  templatePackageJson: TemplatePackageJson,
+  localPackageJson: TemplatePackageJson,
+  cedarVersion: string,
+  messages: string[],
+  { dryRun, verbose }: { dryRun?: boolean; verbose?: boolean } = {},
+) {
+  const templateDeps = templatePackageJson[field]
+
+  if (!templateDeps || Object.keys(templateDeps).length === 0) {
+    return
+  }
+
+  const localDeps = (localPackageJson[field] ??= {})
+
+  for (const [depName, depVersion] of Object.entries(templateDeps)) {
+    if (depName.startsWith('@cedarjs/')) {
+      // @cedarjs/studio is never managed by the upgrade command, matching
+      // `updatePackageJsonVersion`
+      if (depName === '@cedarjs/studio') {
+        continue
+      }
+
+      if (hasDependency(localPackageJson, depName)) {
+        continue
+      }
+
+      localDeps[depName] = cedarVersion
+
+      // Deliberately not gated behind `verbose`. Bumping a version the project
+      // already has is routine, but a package the project has never had before
+      // is worth surfacing every time
+      messages.push(` - ${depName}: (added) => ${cedarVersion}`)
+
+      continue
+    }
+
+    if (verbose || dryRun) {
+      messages.push(` - ${depName}: ${localDeps[depName]} => ${depVersion}`)
+    }
+
+    localDeps[depName] = depVersion
+  }
+}
+
 async function updatePackageVersionsFromTemplate(
   ctx: Record<string, unknown>,
   { dryRun, verbose }: { dryRun?: boolean; verbose?: boolean },
@@ -449,35 +521,16 @@ async function updatePackageVersionsFromTemplate(
 
           const messages: string[] = []
 
-          Object.entries(templatePackageJson.dependencies || {}).forEach(
-            ([depName, depVersion]: [string, unknown]) => {
-              // CedarJS packages are handled in another task
-              if (!depName.startsWith('@cedarjs/')) {
-                if (verbose || dryRun) {
-                  messages.push(
-                    ` - ${depName}: ${localPackageJson.dependencies[depName]} => ${depVersion}`,
-                  )
-                }
-
-                localPackageJson.dependencies[depName] = depVersion
-              }
-            },
-          )
-
-          Object.entries(templatePackageJson.devDependencies || {}).forEach(
-            ([depName, depVersion]: [string, unknown]) => {
-              // CedarJS packages are handled in another task
-              if (!depName.startsWith('@cedarjs/')) {
-                if (verbose || dryRun) {
-                  messages.push(
-                    ` - ${depName}: ${localPackageJson.devDependencies[depName]} => ${depVersion}`,
-                  )
-                }
-
-                localPackageJson.devDependencies[depName] = depVersion
-              }
-            },
-          )
+          for (const field of ['dependencies', 'devDependencies'] as const) {
+            mergeTemplateDependencies(
+              field,
+              templatePackageJson,
+              localPackageJson,
+              String(ctx.versionToUpgradeTo),
+              messages,
+              { dryRun, verbose },
+            )
+          }
 
           if (messages.length > 0) {
             task.title = task.title + '\n' + messages.join('\n')

--- a/packages/cli/src/commands/upgrade/upgradeHandler.ts
+++ b/packages/cli/src/commands/upgrade/upgradeHandler.ts
@@ -124,6 +124,13 @@ export const handler = async (upgradeOptions: UpgradeOptions) => {
         title: 'Updating other packages in your package.json(s)',
         task: (ctx) =>
           updatePackageVersionsFromTemplate(ctx, { dryRun, verbose }),
+        // Canary only. This forces the template's dependency versions onto the
+        // project and adds back any the project is missing, which resurrects
+        // packages people have deliberately removed — a project that moved off
+        // SQLite gets better-sqlite3 back, for example. That's too blunt for
+        // regular upgrades, but people running canary are already signed up
+        // for rougher edges.
+        // https://github.com/redwoodjs/redwood/pull/8855
         enabled: (ctx) =>
           String(ctx.versionToUpgradeTo).includes('canary') &&
           !ctx.preUpgradeError,
@@ -417,9 +424,7 @@ interface TemplatePackageJson {
  * CedarJS packages are skipped. The earlier "Updating your CedarJS version"
  * task owns the ones the project already has, and ones it doesn't have can't
  * be handled from this comparison at all: a package missing from the project
- * looks exactly like one the user deliberately removed. Telling those apart
- * needs a diff between the template at the version being upgraded from and the
- * one being upgraded to, which this task doesn't have.
+ * looks exactly like one the user deliberately removed.
  */
 export function mergeTemplateDependencies(
   field: 'dependencies' | 'devDependencies',

--- a/packages/cli/src/commands/upgrade/upgradeHandler.ts
+++ b/packages/cli/src/commands/upgrade/upgradeHandler.ts
@@ -409,64 +409,37 @@ interface TemplatePackageJson {
   devDependencies?: Record<string, string>
 }
 
-function hasDependency(packageJson: TemplatePackageJson, depName: string) {
-  return (
-    depName in (packageJson.dependencies ?? {}) ||
-    depName in (packageJson.devDependencies ?? {})
-  )
-}
-
 /**
  * Copies one section (`dependencies` or `devDependencies`) of the app
- * template's package.json into the project's own, collecting a line into
- * `messages` for every change worth telling the user about.
+ * template's package.json into the project's own, pinning each package to the
+ * template's version and collecting a line into `messages` for every change.
  *
- * Non-CedarJS packages are always pinned to the template's version. CedarJS
- * packages are only added when the project doesn't already have them
- * somewhere, because:
- *
- * - Ones the project already has were bumped to the version being upgraded to
- *   by the earlier "Updating your CedarJS version" task.
- * - The template's literal version is whatever is on `main`, which is not
- *   necessarily the version being upgraded to, so it can't be used as-is.
+ * CedarJS packages are skipped. The earlier "Updating your CedarJS version"
+ * task owns the ones the project already has, and ones it doesn't have can't
+ * be handled from this comparison at all: a package missing from the project
+ * looks exactly like one the user deliberately removed. Telling those apart
+ * needs a diff between the template at the version being upgraded from and the
+ * one being upgraded to, which this task doesn't have.
  */
 export function mergeTemplateDependencies(
   field: 'dependencies' | 'devDependencies',
   templatePackageJson: TemplatePackageJson,
   localPackageJson: TemplatePackageJson,
-  cedarVersion: string,
   messages: string[],
   { dryRun, verbose }: { dryRun?: boolean; verbose?: boolean } = {},
 ) {
   const templateDeps = templatePackageJson[field]
 
-  if (!templateDeps || Object.keys(templateDeps).length === 0) {
+  if (!templateDeps) {
     return
   }
 
-  const localDeps = (localPackageJson[field] ??= {})
-
   for (const [depName, depVersion] of Object.entries(templateDeps)) {
     if (depName.startsWith('@cedarjs/')) {
-      // @cedarjs/studio is never managed by the upgrade command, matching
-      // `updatePackageJsonVersion`
-      if (depName === '@cedarjs/studio') {
-        continue
-      }
-
-      if (hasDependency(localPackageJson, depName)) {
-        continue
-      }
-
-      localDeps[depName] = cedarVersion
-
-      // Deliberately not gated behind `verbose`. Bumping a version the project
-      // already has is routine, but a package the project has never had before
-      // is worth surfacing every time
-      messages.push(` - ${depName}: (added) => ${cedarVersion}`)
-
       continue
     }
+
+    const localDeps = (localPackageJson[field] ??= {})
 
     if (verbose || dryRun) {
       messages.push(` - ${depName}: ${localDeps[depName]} => ${depVersion}`)
@@ -526,7 +499,6 @@ async function updatePackageVersionsFromTemplate(
               field,
               templatePackageJson,
               localPackageJson,
-              String(ctx.versionToUpgradeTo),
               messages,
               { dryRun, verbose },
             )


### PR DESCRIPTION
## Summary

Tidy-up of `updatePackageVersionsFromTemplate`, plus a latent crash fix. No behaviour change beyond the crash.

The two near-identical `dependencies` / `devDependencies` loops are merged into a single `mergeTemplateDependencies` helper. In doing so it stops indexing into a package.json section without checking it exists — the old code read `localPackageJson.dependencies[depName]` when building its verbose message, so a package.json with no `dependencies` (or no `devDependencies`) field would throw. The helper now creates the section lazily, and only when it actually has something to write into it, so a section the template fills exclusively with CedarJS packages isn't added to the project as an empty object.

## What this PR deliberately does *not* do

An earlier version of this branch also made the sync **add** `@cedarjs/*` packages the project was missing, to fix the v6 fallout from #2249 (`@cedarjs/core` stopped depending on `@cedarjs/eslint-config`, `@cedarjs/project-config` and `@cedarjs/testing`, so older projects silently lost ESLint).

That was the wrong layer, for two reasons.

**It can't infer intent.** This task compares the project against the current template. Under that comparison, "this package became required after your project was generated" and "the user deliberately removed this" are the same state: in the template, absent from the project. Auto-adding resolves the ambiguity by overruling the user, on every upgrade, with no opt-out. The set it would have forced back:

```
root: @cedarjs/api-server, @cedarjs/core, @cedarjs/eslint-config,
      @cedarjs/project-config, @cedarjs/testing
web:  @cedarjs/forms, @cedarjs/router, @cedarjs/web, @cedarjs/vite
```

`@cedarjs/forms` makes the problem obvious — plenty of apps don't use Cedar forms. Remove it, upgrade, it's back.

Distinguishing the two cases needs a diff between the template at the version being upgraded *from* and the one being upgraded *to*, which this task doesn't have. (Templates are fetchable at version tags, so that's viable as a follow-up, but it's a different change.)

**It wouldn't have helped anyway.** This task is gated to canary upgrades:

```js
enabled: (ctx) => String(ctx.versionToUpgradeTo).includes('canary') && ...
```

So it never runs for a `latest` or `rc` upgrade, which is where the v6 ESLint problem was reported. Worth noting for reviewers that everything in this PR is likewise canary-only.

The v6 ESLint fallout is handled where it belongs, in a separate PR against `upgrade-scripts/6.x.ts`: version-scoped, advisory rather than destructive, and written by someone who knows *why* the dependency set changed.

## Testing

- New `mergeTemplateDependencies.test.ts` — 7 tests: non-Cedar version pinning, verbose vs quiet reporting, Cedar packages left alone whether present or missing, and section creation / non-creation.
- Existing `upgrade.test.ts` — 4 tests, still pass.
- `npx prettier --check` / `npx eslint` clean on both files; `tsc --noEmit` error count unchanged from `main` (207, all pre-existing, none in these files).

https://claude.ai/code/session_013z3o1edbfQERVJg6krwwbT
