### PR TITLE
chore(ci): recognize refactor(scope) as a conventional commit prefix

### DIFF
--- a/.github/actions/check_changesets/check_changesets.mjs
+++ b/.github/actions/check_changesets/check_changesets.mjs
@@ -38,6 +38,7 @@ async function main() {
   // skip label requirement
   const conventionalCommitPrefixes = [
     /^chore\([^)]+\)!?:/,
+    /^refactor\([^)]+\)!?:/,
     /^feat\([^)]+\)!?:/,
     /^fix\([^)]+\)!?:/,
     /^docs\([^)]+\)!?:/,

--- a/.github/actions/milestoneLib.mjs
+++ b/.github/actions/milestoneLib.mjs
@@ -43,7 +43,7 @@ export function getMilestoneEnv() {
  */
 export function getMilestoneFromConventionalCommit(title) {
   // Breaking changes (indicated by !)
-  if (/^(feat|fix|docs|chore)(\([^)]+\))!:/.test(title)) {
+  if (/^(feat|fix|docs|chore|refactor)(\([^)]+\))!:/.test(title)) {
     return 'next-release-major'
   }
 
@@ -57,8 +57,9 @@ export function getMilestoneFromConventionalCommit(title) {
     return 'next-release-patch'
   }
 
-  // Chore (framework-side maintenance)
-  if (/^chore\([^)]+\):/.test(title)) {
+  // Chore (framework-side maintenance). `refactor` is treated the same as
+  // `chore` — no user-facing behavior change, just internal code movement.
+  if (/^(chore|refactor)\([^)]+\):/.test(title)) {
     return 'chore'
   }
 

--- a/.github/actions/require-milestone/requireMilestone.mjs
+++ b/.github/actions/require-milestone/requireMilestone.mjs
@@ -106,6 +106,7 @@ async function main() {
       '- fix(scope): for bug fixes → automatically sets "next-release-patch"',
       '- docs(scope): for documentation changes → automatically sets "next-release-patch"',
       '- chore(scope): for maintenance tasks → automatically sets "chore"',
+      '- refactor(scope): for internal-only code changes → automatically sets "chore"',
       '- feat(scope)!: or fix(scope)!: for breaking changes → automatically sets "next-release-major"',
       '',
       'Where "scope" should describe the area of the codebase being changed.',

--- a/.github/actions/require-release-label-or-cc-message/requireReleaseLabelOrCcMessage.mts
+++ b/.github/actions/require-release-label-or-cc-message/requireReleaseLabelOrCcMessage.mts
@@ -76,6 +76,7 @@ async function main() {
   // skip label requirement
   const conventionalCommitPrefixes = [
     /^chore\([^)]+\)!?:/,
+    /^refactor\([^)]+\)!?:/,
     /^feat\([^)]+\)!?:/,
     /^fix\([^)]+\)!?:/,
     /^docs\([^)]+\)!?:/,
@@ -129,6 +130,7 @@ async function main() {
         'Alternatively, you can update the PR title to start with one of ' +
           'these conventional commit prefixes:',
         '- chore(scope): for maintenance tasks',
+        '- refactor(scope): for internal-only code changes',
         '- feat(scope): for new features',
         '- fix(scope): for bug fixes',
         '- docs(scope): for documentation changes',


### PR DESCRIPTION
AI coding agents frequently title PRs like `refactor(cli): deduplicate template dependency sync, fix latent crash`, which isn't currently recognized by any of the PR-title tooling — it fails the milestone/changeset/release-label checks and has to be manually renamed to `chore(...)` before it can merge.

This treats `refactor(scope):` identically to `chore(scope):` everywhere a conventional-commit prefix is checked:

- `.github/actions/milestoneLib.mjs` — `refactor(scope):` now auto-assigns the `chore` milestone; `refactor(scope)!:` counts as a breaking change like the other types.
- `.github/actions/require-milestone/requireMilestone.mjs` — help text mentions the new prefix.
- `.github/actions/require-release-label-or-cc-message/requireReleaseLabelOrCcMessage.mts` — `refactor(scope):` now skips the release-label requirement, same as `chore(scope):`.
- `.github/actions/check_changesets/check_changesets.mjs` — `refactor(scope):` now skips the "must add a changeset" requirement, same as `chore(scope):`. No change needed to `skipOnMilestone`, since refactor PRs get the `chore` milestone auto-assigned by the (now updated) `milestoneLib.mjs`.

Note: I searched for an in-repo emoji-categorized changelog generator (the `🚀 Features` / `🛠️ Fixes` / `📚 Docs` / `📦 Dependencies` / `🧹 Chore` sections seen in release notes) to also update, but couldn't find one — no `.github/release.yml` and no matching script anywhere in the repo. That categorization must live outside this checkout (repo settings or an external tool) — flagging in case it also needs a `refactor` → chore mapping.