### PR TITLE
docs(release): v6 upgrade guide

### DIFF
--- a/docs/docs/upgrade-guides/v6.md
+++ b/docs/docs/upgrade-guides/v6.md
@@ -1,7 +1,6 @@
 ---
 title: CedarJS v6.0.0
-description:
-  Fragment Cells, a Vite-native build pipeline, and container-native deploys
+description: Fragment Cells, a Vite-native build pipeline, and container-native deploys
 ---
 
 # Highlights
@@ -33,6 +32,8 @@ export const Success = ({ author }) => <span>{author.fullName}</span>
 
 ```tsx
 // BlogPostCell.tsx
+import { AuthorCell } from 'src/components/AuthorCell'
+
 export const QUERY = gql`
   query FindBlogPostQuery($id: Int!) {
     post(id: $id) {
@@ -149,8 +150,9 @@ find the ones that apply to your app, then follow the steps in
   statically import `@cedarjs/*` packages directly.
 - **`cedar serve api --ud` binds to all interfaces by default** — its default
   host changed from `localhost` to `::`/`0.0.0.0`, matching every other `serve`
-  path.
-- **Vitest 4 (ESM projects)** — needs a `vite@7.3.5` pin, and your own tests may
+  path. This makes a locally-run api reachable from other hosts on the network;
+  pass `--host localhost` if you need local-only access.
+- **Vitest 4 (ESM projects)** — needs a `vite@7.3.6` pin, and your own tests may
   hit a few Vitest 4 API changes.
 - **MSW 2** — breaks tests/stories that import `msw`/`whatwg-fetch` directly,
   override the Jest preset's `testEnvironment`/`transformIgnorePatterns`, or
@@ -175,6 +177,11 @@ find the ones that apply to your app, then follow the steps in
   it's returned an empty array for a long time.
 - **Web dev server `Buffer` polyfill removed** — web code relying on the global
   `Buffer` in dev now fails immediately instead of only in production.
+- **Context-wrapping plugin renamed** — only affects advanced setups that
+  reference the AsyncLocalStorage-wrapping plugin by name.
+- **`yarn cedar setup neon` now requires `--migrations`/`--no-migrations` in
+  non-interactive shells** — run bare in a non-TTY environment (CI/CD), it now
+  exits 1 instead of running migrations automatically like before.
 
 If you want to see every single change in this release, including all the PRs
 that went into it, check the
@@ -185,11 +192,11 @@ that went into it, check the
 ### Begin with the latest v5
 
 It's always best to start from the latest previous version. Make sure you're on
-the latest v5 release and everything is working as expected before upgrading to
-v6:
+v5.0.6 (the latest v5 release) and everything is working as expected before
+upgrading to v6:
 
 ```bash
-yarn rw upgrade -t latest
+yarn cedar upgrade -t 5.0.6
 ```
 
 ### Running the upgrade command
@@ -282,7 +289,7 @@ v3 to v4:
 
    ```json
    "resolutions": {
-     "vite": "7.3.5"
+     "vite": "7.3.6"
    }
    ```
 
@@ -290,7 +297,7 @@ v3 to v4:
 
    ```json
    "overrides": {
-     "vite": "7.3.5"
+     "vite": "7.3.6"
    }
    ```
 
@@ -298,7 +305,7 @@ v3 to v4:
 
    ```yaml
    overrides:
-     vite: '7.3.5'
+     vite: '7.3.6'
    ```
 
 Cedar's generated `vitest.config.ts` files are already Vitest 4 compatible, but
@@ -365,6 +372,20 @@ import `QueryResult`, `MutationTuple`, `QueryHookOptions`,
   `Uint8Array`/`TextEncoder`/`TextDecoder`/`atob`/`btoa`, or add
   `vite-plugin-node-polyfills` to your own `web/vite.config.ts` if you genuinely
   need `Buffer` in the browser.
+- **Context-wrapping plugin renamed** — the internal plugin that wraps api
+  request handlers in `AsyncLocalStorage` (so context never leaks between
+  requests on serverless providers) has been renamed to say what it does. No
+  behavior change, but if you reference it by name:
+  `cedarContextWrappingPlugin` → `handlerAlsWrappingPlugin` (`@cedarjs/vite`),
+  `applyContextWrapping` → `applyHandlerAlsWrapping`, and the Vite plugin name
+  `'cedar-context-wrapping'` → `'handler-als-wrapping'`.
+- **`yarn cedar setup neon` requires an explicit migrations flag in CI** — it
+  now supports `--migrations`/`--no-migrations` to control whether Prisma
+  migrations run after provisioning. Run interactively, it prompts when the
+  flag is omitted; run in a non-interactive shell (CI/CD) with the flag
+  omitted, it now exits 1 instead of running migrations automatically like
+  before. Pass `--migrations` explicitly in scripted/CI usage of
+  `yarn cedar setup neon`.
 
 ## Things to watch out for
 

--- a/docs/docs/upgrade-guides/v6.md
+++ b/docs/docs/upgrade-guides/v6.md
@@ -5,9 +5,10 @@ description: Fragment Cells, a Vite-native build pipeline, and container-native 
 
 # Highlights
 
-CedarJS v6 focuses on three things: less boilerplate in your components, a build
-pipeline that's fully Vite instead of half Babel, and deploying to a plain
-container host with as close to zero config as we can get you.
+CedarJS v6 focuses on three things: a new Fragment Cell for cutting query
+waterfalls between components, a build pipeline that's fully Vite instead of
+half Babel, and deploying to a plain container host with as close to zero
+config as we can get you.
 
 ## Fragment Cells
 

--- a/docs/docs/upgrade-guides/v6.md
+++ b/docs/docs/upgrade-guides/v6.md
@@ -1,0 +1,385 @@
+---
+title: CedarJS v6.0.0
+description:
+  Fragment Cells, a Vite-native build pipeline, and container-native deploys
+---
+
+# Highlights
+
+CedarJS v6 focuses on three things: less boilerplate in your components, a build
+pipeline that's fully Vite instead of half Babel, and deploying to a plain
+container host with as close to zero config as we can get you.
+
+## Fragment Cells
+
+Cells can now declare their data requirements with a `FRAGMENT` export instead
+of firing a query of their own. A parent Cell spreads the fragment in its
+`QUERY` and passes the matching slice of the result down as a prop named after
+the fragment, so nested Cells no longer create request waterfalls — one single
+GraphQL request fetches everything.
+
+```tsx
+// AuthorCell.tsx
+export const FRAGMENT = gql`
+  fragment AuthorCell_author on User {
+    id
+    email
+    fullName
+  }
+`
+
+export const Success = ({ author }) => <span>{author.fullName}</span>
+```
+
+```tsx
+// BlogPostCell.tsx
+export const QUERY = gql`
+  query FindBlogPostQuery($id: Int!) {
+    post(id: $id) {
+      id
+      title
+      author {
+        ...AuthorCell_author
+      }
+    }
+  }
+`
+
+export const Success = ({ post }) => (
+  <article>
+    <h2>{post.title}</h2>
+    <AuthorCell author={post.author} />
+  </article>
+)
+```
+
+Fragment Cells automatically register their fragment with the GraphQL client, so
+spreading it by name is enough — no imports or interpolation needed. When the
+fragment selects the type's `id`, the Cell reads its data live from the Apollo
+cache and re-renders when mutations update the entity. See "Fragment Cells:
+Aggregating Queries" in the [Cells docs](/docs/cells).
+
+## A Vite-native build pipeline
+
+Cedar's custom Babel plugins have been ported to native Vite plugins:
+directory-named imports, GraphQL options extraction, gql tag handling, mock Cell
+data, OpenTelemetry wrapping, job path injection, and the
+`src/`/`$api/`/tsconfig-paths aliases. Transforms that Vite already handles
+natively are no longer duplicated through Babel. Unless you enable the React
+Compiler, Babel is now entirely out of the web build — faster transforms,
+correct sourcemaps, and fewer configuration edge cases.
+
+## Deploy: standard container-host conventions
+
+A generated Cedar app now deploys to a container host — Railway, Render, Fly.io,
+Google Cloud Run, Coolify, Dokku, Dokploy, Koyeb, Northflank, and similar — with
+little to no platform-specific configuration:
+
+- Generated apps ship `build`/`dev`/`start`/`start:api`/`start:web` scripts in
+  their root `package.json`, so zero-config builders that detect a `start`
+  script (Railpack, Nixpacks, Paketo, Google Cloud buildpacks) can boot a Cedar
+  app with no Dockerfile.
+- `cedar serve` and `cedar serve api` read the `PORT`/`HOST` environment
+  variables every container PaaS sets, instead of requiring an explicit
+  `--port`/`--host`.
+- `yarn cedar setup database postgres` converts a project from SQLite to
+  Postgres — schema, Prisma adapter, config — without also provisioning a Neon
+  database, so the conversion isn't locked to one provider anymore.
+
+## Background jobs: enforced timeouts and cancellation
+
+A job that runs past `maxRuntime` is now permanently failed by the worker
+running it, instead of silently staying eligible for another worker to pick up
+and re-run concurrently. Jobs can opt into cooperative cancellation via
+`getJobExecutionContext()`, and queued or running jobs can be cancelled
+directly:
+
+```ts
+import { getJobExecutionContext } from '@cedarjs/jobs'
+
+perform: async () => {
+  const context = getJobExecutionContext()
+  await fetch(url, { signal: context?.signal })
+}
+```
+
+```ts
+const scheduledJob = await later(SampleJob, [args])
+await later.cancel(scheduledJob.id)
+```
+
+## `configureGraphQLServer` and `configureServer` for the API server
+
+`createServer()` gains two configuration hooks alongside the existing
+`configureApiServer`: `configureGraphQLServer`, scoped to the GraphQL route, and
+`configureServer`, which runs on the root Fastify instance before either the api
+functions or the GraphQL plugin register their routes — the right place for
+plugins with a "global" registration mode, like `@fastify/compress`, that only
+affect routes registered after them. This also fixes a bug where registering
+compression through `configureApiServer` alone only ever compressed api-function
+responses, never GraphQL responses.
+
+## Better DX for AI coding agents
+
+A batch of fixes came out of watching an AI coding agent build a Cedar app
+end-to-end and tracking down every place it got stuck or produced insecure code
+— `cedar generate scaffold` now wraps generated routes in `<PrivateSet>`
+automatically when auth is set up, `cedar check` warns when a route isn't
+protected but its page calls an `@requireAuth` mutation,
+`cedar generate sdl`/`scaffold` generate read-only stubs for related models
+instead of leaving the project broken, and dbAuth's sensitive fields
+(`hashedPassword`, `salt`, `resetToken`, ...) are now excluded by name from
+generated SDL, inputs, and scaffolds.
+
+There's plenty more in this release — more Redwood → Cedar renaming, CLI
+improvements, and smaller fixes. The
+[v6.0.0 release on GitHub](https://github.com/cedarjs/cedar/releases/tag/v6.0.0)
+has the full, PR-by-PR list.
+
+# Upgrade Guide
+
+## What you need to know before you upgrade
+
+This is a big release with a number of breaking changes. Skim the list below,
+find the ones that apply to your app, then follow the steps in
+[Let's get started](#lets-get-started).
+
+- **No more CJS-only packages** — standard apps are unaffected; only breaks
+  projects that compile their own TypeScript straight to CommonJS with `tsc` and
+  statically import `@cedarjs/*` packages directly.
+- **`cedar serve api --ud` binds to all interfaces by default** — its default
+  host changed from `localhost` to `::`/`0.0.0.0`, matching every other `serve`
+  path.
+- **Vitest 4 (ESM projects)** — needs a `vite@7.3.5` pin, and your own tests may
+  hit a few Vitest 4 API changes.
+- **MSW 2** — breaks tests/stories that import `msw`/`whatwg-fetch` directly,
+  override the Jest preset's `testEnvironment`/`transformIgnorePatterns`, or
+  have an old committed `mockServiceWorker.js`; most apps need no changes.
+- **Legacy ESLint config format removed** — `.eslintrc.js` and `package.json`'s
+  `eslintConfig` field are no longer supported; migrate to flat config
+  (`eslint.config.mjs`).
+- **`@cedarjs/core` no longer pulls in `@cedarjs/eslint-config`** — projects
+  that never listed it explicitly (typically ones upgraded from RedwoodJS) must
+  add it to their root `devDependencies`, or `yarn cedar lint` stops working.
+- **`web/babel.config.js` is no longer used by Vite** — custom Babel
+  plugins/presets there stop running in the web build unless passed via the new
+  `babel` Vite plugin option.
+- **GraphQL client-agnostic indirection removed** — `GraphQLHooksProvider` and a
+  handful of ambient GraphQL types are gone; switch to Apollo directly.
+- **`yarn cedar console` removed** — moved to a standalone package, run with
+  `yarn dlx @cedarjs/console` instead.
+- **Custom generator templates path removed** — move
+  `api/generators/`/`web/generators/` templates to `generatorTemplates/` (a
+  codemod does this for you).
+- **`getCommonPlugins()` removed** — delete any `...getCommonPlugins()` usage;
+  it's returned an empty array for a long time.
+- **Web dev server `Buffer` polyfill removed** — web code relying on the global
+  `Buffer` in dev now fails immediately instead of only in production.
+
+If you want to see every single change in this release, including all the PRs
+that went into it, check the
+[release notes on GitHub](https://github.com/cedarjs/cedar/releases/tag/v6.0.0).
+
+## Let's get started!
+
+### Begin with the latest v5
+
+It's always best to start from the latest previous version. Make sure you're on
+the latest v5 release and everything is working as expected before upgrading to
+v6:
+
+```bash
+yarn rw upgrade -t latest
+```
+
+### Running the upgrade command
+
+Now you're ready to upgrade to v6:
+
+```bash
+yarn cedar upgrade -t latest
+```
+
+If you want to try a pre-release/RC build instead, target `rc`:
+
+```bash
+yarn cedar upgrade -t rc
+```
+
+### Node and Yarn versions
+
+CedarJS v6 requires **Node 24.x**. Update the `engines` field in your root
+`package.json`:
+
+```diff
+ "engines": {
+-  "node": "20.x"
++  "node": "24.x"
+ }
+```
+
+The default Yarn version for new Cedar apps is now `4.14.1`. Update the
+`packageManager` field in your root `package.json` to match, then run
+`yarn install`:
+
+```diff
+-  "packageManager": "yarn@4.4.0",
++  "packageManager": "yarn@4.14.1",
+```
+
+### Migrate to flat ESLint config
+
+If your project still uses `.eslintrc.js` or the `eslintConfig` field in
+`package.json`, you need to migrate to flat config — there's no codemod for this
+one, it has to be done by hand. Create an `eslint.config.mjs` in your project
+root (`eslint.config.js` if your project is ESM):
+
+```javascript
+import cedarConfig from '@cedarjs/eslint-config'
+
+export default await cedarConfig()
+```
+
+If you had custom rules in the old config, add them in an extra config object
+after Cedar's:
+
+```javascript
+import cedarConfig from '@cedarjs/eslint-config'
+
+export default [
+  ...(await cedarConfig()),
+  {
+    rules: {
+      // Your custom rules here
+    },
+  },
+]
+```
+
+Then delete `.eslintrc.js` and remove the `eslintConfig` field from
+`package.json`. See
+[`packages/eslint-config/README.md`](https://github.com/cedarjs/cedar/blob/main/packages/eslint-config/README.md)
+for the full guide.
+
+**If your project predates the standard app template** — including apps upgraded
+from RedwoodJS — you may have relied on `@cedarjs/core` transitively pulling in
+`@cedarjs/eslint-config`. That no longer happens, so add it explicitly:
+
+```shell
+yarn add -D @cedarjs/eslint-config@6.0.0
+```
+
+### Vitest 4 (ESM projects only)
+
+If your project is ESM, it runs tests with Vitest, which Cedar has upgraded from
+v3 to v4:
+
+1. Bump `vitest` to `4.1.10` in your root `package.json`.
+2. Pin Vite to the version Cedar uses — without a pin, Vitest 4 pulls in its own
+   copy of Vite 8 and web tests fail to parse JSX.
+
+   yarn — in your root `package.json`:
+
+   ```json
+   "resolutions": {
+     "vite": "7.3.5"
+   }
+   ```
+
+   npm — in your root `package.json`:
+
+   ```json
+   "overrides": {
+     "vite": "7.3.5"
+   }
+   ```
+
+   pnpm — in your `pnpm-workspace.yaml`:
+
+   ```yaml
+   overrides:
+     vite: '7.3.5'
+   ```
+
+Cedar's generated `vitest.config.ts` files are already Vitest 4 compatible, but
+your own tests and config customizations may hit some of Vitest 4's breaking
+changes — most commonly the removal of
+`poolOptions`/`minWorkers`/`maxThreads`/`minThreads`, `workspace` being renamed
+to `projects`, and `vi.restoreAllMocks()` only restoring `vi.spyOn` spies rather
+than `vi.fn()` mocks. See the
+[Vitest migration guide](https://vitest.dev/guide/migration) for the full list.
+
+### MSW 2
+
+`@cedarjs/testing` now uses MSW 2 internally. Cedar's own mocking API
+(`mockGraphQLQuery`, `mockGraphQLMutation`, `mockCurrentUser`, Cell `*.mock.ts`
+files) is unchanged, and most apps need no action. You do need to act if you:
+
+- **Import from `msw` directly** in tests or stories — MSW 2 renamed `rest` to
+  `http`, resolvers return an `HttpResponse`, and `setupWorker` moved to
+  `msw/browser`. See the
+  [MSW migration guide](https://mswjs.io/docs/migrations/1.x-to-2.x).
+- **Import `whatwg-fetch`** in your own test/setup files — it's no longer a
+  dependency of `@cedarjs/testing`; you can usually just delete the import.
+- **Customized `web/jest.config.js`** beyond the default preset — don't override
+  `testEnvironment` or `transformIgnorePatterns`, both are now load-bearing for
+  MSW under Jest.
+- **Have a committed `web/public/mockServiceWorker.js`** — delete it, it's
+  regenerated the next time you run `yarn cedar storybook`.
+
+### `web/babel.config.js` changes
+
+The `cedar()` Vite plugin no longer feeds a default Babel config to
+`@vitejs/plugin-react`, so custom Babel plugins/presets in `web/babel.config.js`
+silently stop running in the browser bundle (the file is still used for Jest
+tests and linting). If you rely on custom Babel plugins in your web build, pass
+them via the new `babel` option instead:
+
+```ts
+// web/vite.config.ts
+export default defineConfig({
+  plugins: [cedar({ babel: { plugins: ['my-babel-plugin'] } })],
+})
+```
+
+### GraphQL client-agnostic indirection removed
+
+`GraphQLHooksProvider` is no longer exported from `@cedarjs/web`. If you used it
+to plug in a non-Apollo GraphQL client, switch to `CedarApolloProvider` or your
+own `ApolloProvider` setup. The ambient global types `QueryOperationResult`,
+`MutationOperationResult`, `GraphQLQueryHookOptions`,
+`GraphQLMutationHookOptions`, and `GraphQLOperationVariables` no longer exist —
+import `QueryResult`, `MutationTuple`, `QueryHookOptions`,
+`MutationHookOptions`, and `OperationVariables` from `@apollo/client` instead.
+`useQuery`, `useMutation`, `useSubscription`, and Cells are unaffected.
+
+### Other changes
+
+- **`yarn cedar console` removed** — run `yarn dlx @cedarjs/console` instead.
+- **Custom generator templates path removed** — move
+  `api/generators/`/`web/generators/` templates to `generatorTemplates/`.
+  There's a codemod: `yarn dlx @cedarjs/codemods move-generator-templates`.
+- **`getCommonPlugins()` removed** from `@cedarjs/babel-config` — delete any
+  `...getCommonPlugins()` usage.
+- **Web dev server `Buffer` polyfill removed** — use
+  `Uint8Array`/`TextEncoder`/`TextDecoder`/`atob`/`btoa`, or add
+  `vite-plugin-node-polyfills` to your own `web/vite.config.ts` if you genuinely
+  need `Buffer` in the browser.
+
+## Things to watch out for
+
+### Prisma Client
+
+Make sure you've generated a new Prisma client once you've upgraded. Even though
+the upgrade regenerates the client, you may need to run
+`yarn cedar prisma generate` again to avoid errors.
+
+### More Redwood → Cedar renaming
+
+Several more public APIs now have Cedar-named counterparts —
+`RedwoodApolloProvider` → `CedarApolloProvider`, `RedwoodProvider` →
+`CedarProvider`, the GraphQL Yoga plugins (`useRedwoodDirective` →
+`useCedarDirective`, and similar), and `RedwoodError`/`RedwoodLoggerOptions` →
+`CedarError`/`CedarLoggerOptions`. The Redwood-named originals keep working as
+deprecated aliases — nothing breaks — but update to the new names when
+convenient, since the old ones will be removed in a future release.

--- a/docs/docs/upgrade-guides/v6.md
+++ b/docs/docs/upgrade-guides/v6.md
@@ -32,7 +32,7 @@ export const Success = ({ author }) => <span>{author.fullName}</span>
 
 ```tsx
 // BlogPostCell.tsx
-import { AuthorCell } from 'src/components/AuthorCell'
+import AuthorCell from 'src/components/AuthorCell'
 
 export const QUERY = gql`
   query FindBlogPostQuery($id: Int!) {


### PR DESCRIPTION
The v6 release notes were too long for a regular GitHub release. Like, they had too much detail. And they wanted to use syntax and features not supported to GitHub on the release page. So they're promoted to a separate docs page the GH release notes can link to