### PR TITLE
feat(upgrade-scripts): Fail the upgrade on a broken ESLint setup

### DIFF
--- a/upgrade-scripts/6.x.ts
+++ b/upgrade-scripts/6.x.ts
@@ -95,6 +95,24 @@ function warn(title: string, lines: string[]) {
 }
 
 /**
+ * Like `warn`, but for problems that block the upgrade. Callers must also set
+ * `shouldAbort`, which makes the script exit non-zero.
+ *
+ * Writes to stdout like the other two helpers, even though this is an error.
+ * The CLI reads a failed script's stdout into the message it shows the user
+ * (`preUpgradeScripts.ts`: `errorOutput = e.stdout || e.message`) and only
+ * surfaces stderr under `--verbose`, so anything written to stderr here would
+ * be invisible in the default output.
+ */
+function fail(title: string, lines: string[]) {
+  console.log(util.styleText('red', title) + '\n')
+
+  for (const line of lines) {
+    console.log(line + '\n')
+  }
+}
+
+/**
  * Like `warn`, but for things that don't break anything and that the user can
  * safely ignore. Deliberately not colored, so it doesn't compete with the
  * warnings about actual breaking changes.
@@ -108,6 +126,11 @@ function info(title: string, lines: string[]) {
 }
 
 async function main() {
+  // Set by any check that has found something the user must fix before
+  // upgrading. Checked once at the end so every problem gets reported in one
+  // pass, rather than the user fixing one and rerunning to find the next
+  let shouldAbort = false
+
   const filesWithGetCommonPlugins: string[] = []
   const filesWithNodePolyfills: string[] = []
   const filesWithGraphQLHooksProvider: string[] = []
@@ -397,7 +420,9 @@ async function main() {
     }
 
     if (!flatEslintConfigPath && legacyEslintConfigSources.length > 0) {
-      warn('Legacy ESLint config detected', [
+      shouldAbort = true
+
+      fail('Legacy ESLint config detected', [
         'Found: ' + legacyEslintConfigSources.join(', '),
         'Support for .eslintrc.* and the eslintConfig field in package.json\n' +
           'was removed in v6. Create an eslint.config.mjs in your project\n' +
@@ -442,7 +467,9 @@ async function main() {
     }
 
     if (usesCedarEslintConfig && !hasEslintConfigPackage) {
-      warn('Missing dependency: @cedarjs/eslint-config', [
+      shouldAbort = true
+
+      fail('Missing dependency: @cedarjs/eslint-config', [
         'Your ESLint config uses @cedarjs/eslint-config, but the package is\n' +
           'not in your root package.json.',
         'Up until v6 @cedarjs/core depended on @cedarjs/eslint-config, so\n' +
@@ -520,8 +547,6 @@ async function main() {
       ])
     }
   }
-
-  let shouldAbort = false
 
   const apiGeneratorTemplatesPath = path.join(
     projectPaths.api.base,


### PR DESCRIPTION
Follow-up to #2471, which added the two ESLint checks as warnings. This makes them fatal.

## Summary

A legacy ESLint config, or a missing `@cedarjs/eslint-config`, means `yarn cedar lint` won't run after the upgrade. That's worth stopping for rather than burying in post-upgrade output, so both checks now abort.

- New `fail()` helper alongside `warn()` and `info()`, red title.
- `shouldAbort` hoisted to the top of `main()` so the ESLint checks can set it. It's still only acted on at the very end, so a project with several problems is told about all of them in one run instead of discovering the next on each retry.
- Every other check keeps its existing severity: unsupported generator template paths still abort, everything else still warns.

`fail()` writes to stdout, like the other two helpers, even though it reports an error. That's deliberate — the CLI reads a failed script's stdout into the message it shows the user:

```js
// preUpgradeScripts.ts
errorOutput = e.stdout || e.message
```

and only surfaces `stderr` under `--verbose`. An error written to stderr would be invisible in default output.

## Testing

Fixtures for each path, checking exit code and output:

```
legacy       -> exit 1 | Legacy ESLint config detected
missing-pkg  -> exit 1 | Missing dependency: @cedarjs/eslint-config
both         -> exit 1 | Legacy ESLint config detected; Missing dependency: @cedarjs/eslint-config
happy        -> exit 0 |
warn-only    -> exit 0 | whatwg-fetch usage detected
```

`both` confirms multiple problems are reported in a single pass; `warn-only` confirms the non-ESLint advisories are untouched and still exit 0.

`npx prettier --check` / `npx eslint` clean, `upgrade-scripts/manifest.test.ts` passes (no new script file, so no manifest change).

## Please read before merging: `--force` is not a working escape hatch

`upgrade --force` is documented as "Force upgrade even if pre-upgrade checks fail", but it doesn't currently do that. `ctx.preUpgradeError` is set *before* the force check in `preUpgradeScripts.ts`, and every subsequent task in `upgradeHandler.ts` is guarded by:

```js
enabled: (ctx) => !ctx.preUpgradeError
```

So with `--force` the upgrade prints the error, skips every remaining task, and exits 0. It doesn't upgrade — it just fails quietly instead of loudly.

This is pre-existing and already applies to the generator-templates check, so this PR doesn't create the trap. It does widen how many projects hit it: anyone with a legacy `.eslintrc.js` will be unable to upgrade until they migrate, with no override available.

Worth fixing `--force` separately — probably by not setting `preUpgradeError` when `force` is true, or by having the `enabled` guards take `force` into account. Happy to pick that up; say the word if you'd rather it land before this.

Separately, the generator-templates check writes its headline line via `console.error`, which by the same stdout/stderr logic means that line is dropped from the default output. Not touched here.

https://claude.ai/code/session_013z3o1edbfQERVJg6krwwbT
