### PR TITLE
fix(cli): Make `upgrade --force` actually force the upgrade

### DIFF
--- a/packages/cli/src/commands/upgrade/upgradeHandler.ts
+++ b/packages/cli/src/commands/upgrade/upgradeHandler.ts
@@ -50,6 +50,17 @@ export const handler = async (upgradeOptions: UpgradeOptions) => {
   let preUpgradeMessage = ''
   let preUpgradeError = ''
 
+  /**
+   * Whether the tasks that do the actual upgrading are allowed to run.
+   *
+   * A failed pre-upgrade check normally stops everything after it. `--force`
+   * is documented as "Force upgrade even if pre-upgrade checks fail", so it
+   * has to get past that — the error is still recorded and printed, it just
+   * doesn't hold the upgrade back.
+   */
+  const notBlockedByPreUpgradeChecks = (ctx: { preUpgradeError?: unknown }) =>
+    force || !ctx.preUpgradeError
+
   // structuring as nested tasks to avoid bug with task.title causing duplicates
   const tasks = new Listr(
     [
@@ -118,7 +129,8 @@ export const handler = async (upgradeOptions: UpgradeOptions) => {
       {
         title: 'Updating your CedarJS version',
         task: (ctx) => updateCedarJSDepsForAllSides(ctx, { dryRun, verbose }),
-        enabled: (ctx) => !!ctx.versionToUpgradeTo && !ctx.preUpgradeError,
+        enabled: (ctx) =>
+          !!ctx.versionToUpgradeTo && notBlockedByPreUpgradeChecks(ctx),
       },
       {
         title: 'Updating other packages in your package.json(s)',
@@ -133,36 +145,37 @@ export const handler = async (upgradeOptions: UpgradeOptions) => {
         // https://github.com/redwoodjs/redwood/pull/8855
         enabled: (ctx) =>
           String(ctx.versionToUpgradeTo).includes('canary') &&
-          !ctx.preUpgradeError,
+          notBlockedByPreUpgradeChecks(ctx),
       },
       {
         title: 'Downloading yarn patches',
         task: (ctx) => downloadYarnPatches(ctx, { dryRun, verbose }),
         enabled: (ctx) =>
           String(ctx.versionToUpgradeTo).includes('canary') &&
-          !ctx.preUpgradeError,
+          notBlockedByPreUpgradeChecks(ctx),
       },
       {
         title: 'Removing CLI cache',
         task: () => removeCliCache({ dryRun, verbose }),
-        enabled: (ctx) => !ctx.preUpgradeError,
+        enabled: (ctx) => notBlockedByPreUpgradeChecks(ctx),
       },
       {
         title: `Running ${getPackageManager()} ${install()}`,
         task: () => packageManagerInstall({ verbose }),
-        enabled: (ctx) => !ctx.preUpgradeError,
+        enabled: (ctx) => notBlockedByPreUpgradeChecks(ctx),
         skip: () => !!dryRun,
       },
       {
         title: 'Refreshing the Prisma client',
         task: (_ctx, task) => refreshPrismaClient(task, { verbose }),
-        enabled: (ctx) => !ctx.preUpgradeError,
+        enabled: (ctx) => notBlockedByPreUpgradeChecks(ctx),
         skip: () => !!dryRun,
       },
       {
         title: 'De-duplicating dependencies',
         skip: () => !!dryRun || !dedupe,
-        enabled: (ctx) => dedupeIsSupported() && !ctx.preUpgradeError,
+        enabled: (ctx) =>
+          dedupeIsSupported() && notBlockedByPreUpgradeChecks(ctx),
         task: (_ctx, task) => dedupeDeps(task, { verbose }),
       },
       {


### PR DESCRIPTION
Independent of #2476 — different files, either can merge first. #2476 makes a broken ESLint setup abort the upgrade, and this is the escape hatch for it.

## The bug

`--force` is documented as "Force upgrade even if pre-upgrade checks fail". It doesn't do that.

`ctx.preUpgradeError` is set *before* the force check in `preUpgradeScripts.ts`, and every task after the pre-upgrade step was guarded by:

```js
enabled: (ctx) => !ctx.preUpgradeError
```

So with `--force` the upgrade skipped every remaining task and exited 0. It converted a loud failure into a silent one instead of forcing anything.

Worse, the final "One more thing.." task has no guard at all, so it still printed **"Your project has been upgraded to CedarJS x.y.z"** having done precisely nothing.

## The fix

The seven guards now go through one helper that accounts for `--force`:

```js
const notBlockedByPreUpgradeChecks = (ctx: { preUpgradeError?: unknown }) =>
  force || !ctx.preUpgradeError
```

One place to get it right, rather than seven copies of a condition that has to remember a flag declared 100 lines away. Behaviour without `--force` is unchanged: the error prints and the process exits 1 before anything touches the project.

## Testing

End to end against a fixture project containing an `api/generators/` directory, which makes the `canary` pre-upgrade script exit non-zero. `--dry-run` throughout, and the fixture's `package.json` was confirmed unmodified after each run.

| | tasks run | error shown | exit |
|---|---|---|---|
| before, `--force` | ✗ (but claimed success) | ✓ | 0 |
| after, `--force` | ✓ | ✓ | 0 |
| after, no flag | ✗ | ✓ | 1 |

`npx prettier --check` / `npx eslint` clean; existing `upgrade.test.ts` (4 tests) passes; `tsc --noEmit` error count unchanged from `main` (207, all pre-existing, none in this file).

## Unrelated finding, worth a separate look

While testing I found that **`upgrade-scripts/6.x.ts` never runs for anyone upgrading to `6.0.0-rc.*`**.

For a prerelease target, `preUpgradeScripts.ts` only builds one candidate level, from the prerelease tag:

```js
} else if (parsed && parsed.prerelease.length > 0) {
  // `parsed.prerelease[0]` is the prerelease tag, e.g. 'canary'
  checkLevels.push({ id: 'tag', candidates: [`${parsed.prerelease[0]}.ts`, ...] })
}
```

For `6.0.0-rc.312` that looks for `rc.ts`, which isn't in the manifest — the version levels (`6.x.ts`, `6.0.x.ts`) are only added when `!parsed.prerelease.length`. Confirmed live: `upgrade -t rc --verbose` prints `No upgrade scripts found for 6.0.0-rc.312`.

So every v6 pre-upgrade warning — the nine already there plus the two ESLint ones from #2471 — is invisible to RC testers, and only starts working when 6.0.0 stable ships. That's exactly the audience that hit the original `cedar lint` report. Not touched here; happy to pick it up separately.

https://claude.ai/code/session_013z3o1edbfQERVJg6krwwbT
