### PR TITLE
fix(cli): Run the major version upgrade script for release candidates

### DIFF
--- a/packages/cli/src/commands/__tests__/upgrade.test.ts
+++ b/packages/cli/src/commands/__tests__/upgrade.test.ts
@@ -276,12 +276,12 @@ describe('runPreUpgradeScripts script selection', () => {
       const href = url.toString()
 
       if (href.endsWith('/manifest.json')) {
-        return { status: 200, json: async () => manifest } as Response
+        return new Response(JSON.stringify(manifest), { status: 200 })
       }
 
       downloaded.push(href.slice(BASE.length))
 
-      return { status: 200, text: async () => '// script' } as Response
+      return new Response('// script', { status: 200 })
     })
 
     // @ts-expect-error - only mocking the shape these tests exercise

--- a/packages/cli/src/commands/__tests__/upgrade.test.ts
+++ b/packages/cli/src/commands/__tests__/upgrade.test.ts
@@ -257,3 +257,85 @@ describe('runPreUpgradeScripts', () => {
     })
   })
 })
+
+describe('runPreUpgradeScripts script selection', () => {
+  const BASE =
+    'https://raw.githubusercontent.com/cedarjs/cedar/main/upgrade-scripts/'
+
+  /**
+   * Runs the pre-upgrade step against a fake manifest and returns the names of
+   * the scripts it chose to download.
+   */
+  async function selectedScripts(version: string, manifest: string[]) {
+    const execa = await import('execa')
+    const downloaded: string[] = []
+
+    vi.mocked(fs.promises.readFile).mockResolvedValue('// no dependencies')
+
+    vi.mocked(fetch).mockImplementation(async (url: string | URL | Request) => {
+      const href = url.toString()
+
+      if (href.endsWith('/manifest.json')) {
+        return { status: 200, json: async () => manifest } as Response
+      }
+
+      downloaded.push(href.slice(BASE.length))
+
+      return { status: 200, text: async () => '// script' } as Response
+    })
+
+    // @ts-expect-error - only mocking the shape these tests exercise
+    vi.mocked(execa.default).mockImplementation(async () => ({
+      stdout: '',
+      stderr: '',
+    }))
+
+    await runPreUpgradeScripts(
+      { versionToUpgradeTo: version },
+      createMockTask(),
+      { verbose: false, force: false },
+    )
+
+    return downloaded
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('runs the major version script for a release candidate', async () => {
+    // An RC of 6.0.0 is v6, so it needs everything 6.x.ts has to say
+    expect(
+      await selectedScripts('6.0.0-rc.312', ['canary.ts', '6.x.ts']),
+    ).toEqual(['6.x.ts'])
+  })
+
+  it('runs only the tag script for a canary', async () => {
+    // A canary's version number is a placeholder, so 6.x.ts must not run
+    expect(
+      await selectedScripts('6.0.0-canary.2956', ['canary.ts', '6.x.ts']),
+    ).toEqual(['canary.ts'])
+  })
+
+  it('runs the major version script for a stable release', async () => {
+    expect(await selectedScripts('6.0.0', ['canary.ts', '6.x.ts'])).toEqual([
+      '6.x.ts',
+    ])
+  })
+
+  it('prefers an exact-version script for a release candidate', async () => {
+    expect(
+      await selectedScripts('6.0.0-rc.312', ['6.0.0-rc.312.ts', '6.x.ts']),
+    ).toEqual(['6.0.0-rc.312.ts', '6.x.ts'])
+  })
+
+  it('falls back to the patch wildcard for a release candidate', async () => {
+    expect(await selectedScripts('6.2.0-rc.5', ['6.2.x.ts', '6.x.ts'])).toEqual(
+      ['6.2.x.ts', '6.x.ts'],
+    )
+  })
+})

--- a/packages/cli/src/commands/upgrade/preUpgradeScripts.ts
+++ b/packages/cli/src/commands/upgrade/preUpgradeScripts.ts
@@ -9,18 +9,21 @@ import type { ListrRendererFactory, ListrTaskWrapper } from 'listr2'
 import semver from 'semver'
 
 /**
- * Prerelease tags whose version number is a placeholder rather than a real
- * planned release.
+ * Prerelease tags published from `main` rather than from a release branch.
  *
- * A canary is "whatever is on main right now", so the major version it carries
- * says nothing about which major the project is upgrading to, and the
- * version-scoped scripts must not run for it — `canary.ts` can, and eventually
- * will, need to say something different from the current `<major>.x.ts`.
+ * Canaries are published by `publish-prerelease.yml`, which runs on `main`.
+ * That's a different line of development from the branch a release is cut
+ * from, so `canary.ts` can legitimately need to say something quite different
+ * from the current `<major>.x.ts`, and the version-scoped scripts must not run
+ * for it.
  *
- * Other prereleases aren't like that. `6.0.0-rc.312` really is v6, so it gets
- * `6.x.ts` like any other v6 release.
+ * Release candidates are the opposite case. `publish-release-candidate.yml`
+ * runs on `release/**`, the same branch the release itself will be cut from, so
+ * `6.0.0-rc.312` needs exactly what 6.0.0 will need and gets `6.x.ts` like any
+ * other v6 release. Same for `next` prereleases, published from the `next`
+ * branch.
  */
-const PLACEHOLDER_PRERELEASE_TAGS = ['canary']
+const MAIN_BRANCH_PRERELEASE_TAGS = ['canary']
 
 function isExecaError(e: unknown): e is ExecaError {
   return (
@@ -69,12 +72,12 @@ export async function runPreUpgradeScripts(
   }
 
   const prereleaseTag = parsed?.prerelease[0]
-  const isPlaceholderPrerelease =
+  const isMainBranchPrerelease =
     typeof prereleaseTag === 'string' &&
-    PLACEHOLDER_PRERELEASE_TAGS.includes(prereleaseTag)
+    MAIN_BRANCH_PRERELEASE_TAGS.includes(prereleaseTag)
 
   const checkLevels: { id: string; candidates: string[] }[] = []
-  if (parsed && isPlaceholderPrerelease) {
+  if (parsed && isMainBranchPrerelease) {
     checkLevels.push({
       id: 'tag',
       candidates: [`${prereleaseTag}.ts`, `${prereleaseTag}/index.ts`],

--- a/packages/cli/src/commands/upgrade/preUpgradeScripts.ts
+++ b/packages/cli/src/commands/upgrade/preUpgradeScripts.ts
@@ -8,6 +8,20 @@ import type { ExecaError } from 'execa'
 import type { ListrRendererFactory, ListrTaskWrapper } from 'listr2'
 import semver from 'semver'
 
+/**
+ * Prerelease tags whose version number is a placeholder rather than a real
+ * planned release.
+ *
+ * A canary is "whatever is on main right now", so the major version it carries
+ * says nothing about which major the project is upgrading to, and the
+ * version-scoped scripts must not run for it — `canary.ts` can, and eventually
+ * will, need to say something different from the current `<major>.x.ts`.
+ *
+ * Other prereleases aren't like that. `6.0.0-rc.312` really is v6, so it gets
+ * `6.x.ts` like any other v6 release.
+ */
+const PLACEHOLDER_PRERELEASE_TAGS = ['canary']
+
 function isExecaError(e: unknown): e is ExecaError {
   return (
     e instanceof Error && ('stdout' in e || 'stderr' in e || 'exitCode' in e)
@@ -54,9 +68,19 @@ export async function runPreUpgradeScripts(
     return
   }
 
+  const prereleaseTag = parsed?.prerelease[0]
+  const isPlaceholderPrerelease =
+    typeof prereleaseTag === 'string' &&
+    PLACEHOLDER_PRERELEASE_TAGS.includes(prereleaseTag)
+
   const checkLevels: { id: string; candidates: string[] }[] = []
-  if (parsed && !parsed.prerelease.length) {
-    // 1. Exact match: 3.4.1
+  if (parsed && isPlaceholderPrerelease) {
+    checkLevels.push({
+      id: 'tag',
+      candidates: [`${prereleaseTag}.ts`, `${prereleaseTag}/index.ts`],
+    })
+  } else if (parsed) {
+    // 1. Exact match: 3.4.1, or 6.0.0-rc.312 for something only that RC needs
     checkLevels.push({
       id: 'exact',
       candidates: [`${version}.ts`, `${version}/index.ts`],
@@ -75,15 +99,6 @@ export async function runPreUpgradeScripts(
     checkLevels.push({
       id: 'minor',
       candidates: [`${parsed.major}.x.ts`, `${parsed.major}.x/index.ts`],
-    })
-  } else if (parsed && parsed.prerelease.length > 0) {
-    // `parsed.prerelease[0]` is the prerelease tag, e.g. 'canary'
-    checkLevels.push({
-      id: 'tag',
-      candidates: [
-        `${parsed.prerelease[0]}.ts`,
-        `${parsed.prerelease[0]}/index.ts`,
-      ],
     })
   }
 


### PR DESCRIPTION
Follow-up to #2476 / #2477, found while testing those.

## The bug

Pre-upgrade script matching only built version-based candidates for stable releases. Anything with a prerelease tag looked solely for `<tag>.ts`:

```js
if (parsed && !parsed.prerelease.length) {
  // exact / patch / minor levels
} else if (parsed && parsed.prerelease.length > 0) {
  checkLevels.push({ id: 'tag', candidates: [`${parsed.prerelease[0]}.ts`, ...] })
}
```

So upgrading to `6.0.0-rc.312` searched for `rc.ts`, which isn't in the manifest, and gave up:

```
$ cedar upgrade -t rc --verbose
No upgrade scripts found for 6.0.0-rc.312
```

Every v6 pre-upgrade check — the nine that existed plus the two ESLint ones from #2471 — was invisible to exactly the people testing the v6 RCs. That's the audience most likely to hit the problems those checks describe; the `cedar lint` report that started this thread came from an RC user.

## The fix

Prereleases now go through the same exact/patch/minor levels as stable versions, **except canaries**.

The distinction is which branch the prerelease is built from:

| | Workflow | Branch | Gets |
| --- | --- | --- | --- |
| canary | `publish-prerelease.yml` | `main` | `canary.ts` only |
| next | `publish-prerelease.yml` | `next` | version levels |
| rc | `publish-release-candidate.yml` | `release/**` | version levels |
| stable | — | `release/**` | version levels |

A release candidate is cut from the same branch the release itself will be cut from — `publish-release-candidate.yml` runs on `release/**` and parses `release/{semver}/v{version}` straight out of the branch name. So `6.0.0-rc.312` needs exactly what 6.0.0 will need, and should get `6.x.ts` like any other v6 release.

A canary is built from `main`, a different line of development. `canary.ts` can legitimately need to say something quite different from the current `<major>.x.ts`, so version-scoped scripts must not run for it. That's held back by an explicit `MAIN_BRANCH_PRERELEASE_TAGS` list.

This also hands RCs a per-version escape hatch for free — a `6.0.0-rc.312.ts` would match at the exact level.

## Testing

Five new unit tests in `upgrade.test.ts` asserting which scripts get selected. Confirmed they fail against the old code — the three RC ones fail, canary and stable pass either way, which is exactly the intended blast radius:

```
WITHOUT fix:  × runs the major version script for a release candidate
              × prefers an exact-version script for a release candidate
              × falls back to the patch wildcard for a release candidate
              Tests  3 failed | 6 passed (9)
WITH fix:     Tests  9 passed (9)
```

End to end against a fixture with a legacy `eslintConfig`, `upgrade -t rc --dry-run --verbose`:

```
Found upgrade check script: 6.x.ts. Downloading...
Installing dependencies for 6.x.ts: yaml, @cedarjs/project-config@6.0.0-rc.312, ...
Running pre-upgrade script: 6.x.ts...
Pre-upgrade check 6.x.ts failed with exit code 1:
Legacy ESLint config detected
```

Previously that printed `No upgrade scripts found for 6.0.0-rc.312`. It also exercises #2476 and #2477 end to end: the RC now selects `6.x.ts`, which aborts on the legacy config, surfaced as a pre-upgrade error.

`npx prettier --check` / `npx eslint` clean; `tsc --noEmit` error count unchanged from `main`.

## Note

`canary.ts` and `6.x.ts` are currently near-duplicates that have drifted in both directions — `canary.ts` has a `RedwoodProvider` notice `6.x.ts` lacked (fixed in #2479), and `6.x.ts` has the two ESLint checks `canary.ts` lacks. Given they're meant to be able to diverge, that's a maintenance cost rather than a bug, but it does mean a fix landing in one doesn't reach the other.

https://claude.ai/code/session_013z3o1edbfQERVJg6krwwbT