### PR TITLE
fix(upgrade-scripts): Don't drop the generator-templates headline

### DIFF
--- a/upgrade-scripts/6.x.ts
+++ b/upgrade-scripts/6.x.ts
@@ -564,21 +564,13 @@ async function main() {
     if (fs.existsSync(generatorTemplatesPath)) {
       shouldAbort = true
 
-      console.error(
-        'Unsupported generator templates path detected at ' +
-          generatorTemplatesPath,
-      )
-      console.log()
-      console.log(
-        'Run `yarn dlx @cedarjs/codemods move-generator-templates` to move ' +
-          'them to the new supported path',
-      )
-      console.log()
-      console.log(
-        'Please see https://github.com/cedarjs/cedar/pull/813 for more ' +
+      fail('Unsupported generator templates path detected', [
+        'Found: ' + path.relative(projectRoot, generatorTemplatesPath),
+        'Run `yarn dlx @cedarjs/codemods move-generator-templates` to move\n' +
+          'them to the new supported path.',
+        'Please see https://github.com/cedarjs/cedar/pull/813 for more\n' +
           'information.',
-      )
-      console.log()
+      ])
     }
   }
 


### PR DESCRIPTION
## The bug

The generator-templates check wrote its headline with `console.error` and the rest of its message with `console.log`:

```js
console.error('Unsupported generator templates path detected at ' + generatorTemplatesPath)
console.log()
console.log('Run `yarn dlx @cedarjs/codemods move-generator-templates` ...')
```

The CLI reads a failed script's **stdout** into the error it shows the user, and only surfaces stderr under `--verbose`:

```js
// preUpgradeScripts.ts
errorOutput = e.stdout || e.message
```

So the single line saying what was wrong never reached anyone. This is what a user actually saw — an instruction with no problem statement, and no mention of which directory triggered it:

```

Run `yarn dlx @cedarjs/codemods move-generator-templates` to move them to the new supported path

Please see https://github.com/cedarjs/cedar/pull/813 for more information.

```

## The fix

Uses the `fail()` helper added in #2476, which puts the title on stdout for precisely this reason. After:

```
Unsupported generator templates path detected

Found: api/generators

Run `yarn dlx @cedarjs/codemods move-generator-templates` to move
them to the new supported path.

Please see https://github.com/cedarjs/cedar/pull/813 for more
information.
```

Also switches the path to project-relative. That follows the convention the comment above `webBabelConfigFiles` asks for — *"Convert before printing so all warnings are consistent — remember this for future upgrade scripts"* — and this was the last check still printing an absolute path.

Exit code is unchanged (1), and `shouldAbort` handling is untouched. `console.error` no longer appears anywhere in the script.

## Same bug in canary.ts

`canary.ts` has the identical block with the identical defect. Not fixed here, because it has no `fail()` helper — that was added to `6.x.ts` in #2476 — so fixing it means copying the helper across too. Given the two scripts are deliberately maintained independently, that felt like a separate call. Happy to do it if you want them consistent.
