### PR TITLE
fix(windows): Quote spawn arguments so paths with spaces work

### DIFF
--- a/packages/cli/src/lib/__tests__/background.test.ts
+++ b/packages/cli/src/lib/__tests__/background.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { quoteForWindowsShell } from '../background.js'
+
+describe('quoteForWindowsShell', () => {
+  it('quotes a path containing a space', () => {
+    // Unquoted, the shell splits at the space, node tries to load
+    // `C:\Users\Ada` and the background process dies with MODULE_NOT_FOUND --
+    // silently, because its output is redirected to a log file
+    expect(quoteForWindowsShell('C:\\Users\\Ada Lovelace\\app\\send.js')).toBe(
+      '"C:\\Users\\Ada Lovelace\\app\\send.js"',
+    )
+  })
+
+  it('quotes a bare command name', () => {
+    expect(quoteForWindowsShell('yarn')).toBe('"yarn"')
+  })
+
+  it('escapes embedded double quotes', () => {
+    expect(quoteForWindowsShell('{"a":1}')).toBe('"{\\"a\\":1}"')
+  })
+
+  it('doubles a trailing backslash so it cannot escape the closing quote', () => {
+    expect(quoteForWindowsShell('C:\\Program Files\\')).toBe(
+      '"C:\\Program Files\\\\"',
+    )
+  })
+})

--- a/packages/cli/src/lib/background.ts
+++ b/packages/cli/src/lib/background.ts
@@ -19,9 +19,28 @@ import { getPaths } from '@cedarjs/project-config'
  * backslashes are doubled so they can't escape the closing quote.
  */
 export function quoteForWindowsShell(arg: string) {
-  const escaped = arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, '$1$1')
+  let quoted = '"'
+  let backslashes = 0
 
-  return `"${escaped}"`
+  for (const char of arg) {
+    if (char === '\\') {
+      backslashes += 1
+      continue
+    }
+
+    if (char === '"') {
+      // Double the run of backslashes before the quote so they aren't read as
+      // escapes themselves, then escape the quote
+      quoted += '\\'.repeat(backslashes * 2 + 1) + '"'
+    } else {
+      quoted += '\\'.repeat(backslashes) + char
+    }
+
+    backslashes = 0
+  }
+
+  // Trailing backslashes would escape the closing quote, so double them
+  return quoted + '\\'.repeat(backslashes * 2) + '"'
 }
 
 /**

--- a/packages/cli/src/lib/background.ts
+++ b/packages/cli/src/lib/background.ts
@@ -6,6 +6,25 @@ import path from 'path'
 import { getPaths } from '@cedarjs/project-config'
 
 /**
+ * Quotes a single argument for a Windows shell command string.
+ *
+ * The Windows branch below spawns with `shell: true` and a command string, so
+ * every argument is re-parsed by the shell. Without quoting, anything with a
+ * space in it is split: a project at `C:\Users\Ada Lovelace\app` makes node
+ * try to load `C:\Users\Ada` and the background process dies immediately with
+ * MODULE_NOT_FOUND, silently, because its output goes to a log file.
+ *
+ * Follows the usual Windows argument-encoding rules: backslashes immediately
+ * before a double quote are doubled, the quote itself is escaped, and trailing
+ * backslashes are doubled so they can't escape the closing quote.
+ */
+export function quoteForWindowsShell(arg: string) {
+  const escaped = arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, '$1$1')
+
+  return `"${escaped}"`
+}
+
+/**
  * Spawn a background process with the stdout/stderr redirected to log files
  * within the `.cedar` directory. Stdin will not be available to the process as
  * it will be set to the 'ignore' value.
@@ -66,10 +85,13 @@ export function spawnBackgroundProcess(
     // argument, but when the spawn options include `shell: true`, like they do
     // here, that causes Node.js to print a DEP0190 warning. To get around this
     // we instead concatenate the command and arguments into a single string.
-    // It's safe to do that here since the arguments aren't user-provided.
+    // Each argument has to be quoted on the way in -- they're not
+    // user-provided, but they are filesystem paths, and those routinely
+    // contain spaces.
     //
     // https://nodejs.org/api/deprecations.html#DEP0190
-    const child = spawn(cmd + ' ' + args.join(' '), spawnOptions)
+    const command = [cmd, ...args].map(quoteForWindowsShell).join(' ')
+    const child = spawn(command, spawnOptions)
     child.unref()
   } else {
     const spawnOptions = {

--- a/packages/telemetry/src/__tests__/quoteForWindowsShell.test.ts
+++ b/packages/telemetry/src/__tests__/quoteForWindowsShell.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { quoteForWindowsShell } from '../telemetry.js'
+
+describe('quoteForWindowsShell', () => {
+  it('quotes a path containing a space', () => {
+    // The bug this exists for: unquoted, the shell splits at the space and
+    // node tries to load `D:\a\cedar\test`
+    expect(quoteForWindowsShell('D:\\a\\cedar\\test project\\invoke.js')).toBe(
+      '"D:\\a\\cedar\\test project\\invoke.js"',
+    )
+  })
+
+  it('quotes a path without a space', () => {
+    expect(quoteForWindowsShell('D:\\a\\cedar\\cedar\\invoke.js')).toBe(
+      '"D:\\a\\cedar\\cedar\\invoke.js"',
+    )
+  })
+
+  it('escapes the double quotes in a JSON payload', () => {
+    // `--argv` is passed as JSON.stringify(...), so it always contains quotes
+    expect(quoteForWindowsShell('["node","cedar","build"]')).toBe(
+      '"[\\"node\\",\\"cedar\\",\\"build\\"]"',
+    )
+  })
+
+  it('handles a JSON payload that also contains a space', () => {
+    expect(quoteForWindowsShell('["cedar","g","page","My Page"]')).toBe(
+      '"[\\"cedar\\",\\"g\\",\\"page\\",\\"My Page\\"]"',
+    )
+  })
+
+  it('doubles a trailing backslash so it cannot escape the closing quote', () => {
+    expect(quoteForWindowsShell('C:\\Users\\Ada Lovelace\\')).toBe(
+      '"C:\\Users\\Ada Lovelace\\\\"',
+    )
+  })
+
+  it('doubles backslashes that precede a double quote', () => {
+    expect(quoteForWindowsShell('a\\"b')).toBe('"a\\\\\\"b"')
+  })
+
+  it('leaves an argument with nothing to escape intact inside the quotes', () => {
+    expect(quoteForWindowsShell('--argv')).toBe('"--argv"')
+  })
+})

--- a/packages/telemetry/src/telemetry.ts
+++ b/packages/telemetry/src/telemetry.ts
@@ -17,9 +17,28 @@ import path from 'path'
  * backslashes are doubled so they can't escape the closing quote.
  */
 export function quoteForWindowsShell(arg: string) {
-  const escaped = arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, '$1$1')
+  let quoted = '"'
+  let backslashes = 0
 
-  return `"${escaped}"`
+  for (const char of arg) {
+    if (char === '\\') {
+      backslashes += 1
+      continue
+    }
+
+    if (char === '"') {
+      // Double the run of backslashes before the quote so they aren't read as
+      // escapes themselves, then escape the quote
+      quoted += '\\'.repeat(backslashes * 2 + 1) + '"'
+    } else {
+      quoted += '\\'.repeat(backslashes) + char
+    }
+
+    backslashes = 0
+  }
+
+  // Trailing backslashes would escape the closing quote, so double them
+  return quoted + '\\'.repeat(backslashes * 2) + '"'
 }
 
 const spawnProcess = (...args: string[]) => {

--- a/packages/telemetry/src/telemetry.ts
+++ b/packages/telemetry/src/telemetry.ts
@@ -3,11 +3,29 @@ import type { SpawnOptions } from 'child_process'
 import os from 'os'
 import path from 'path'
 
+/**
+ * Quotes a single argument for a Windows shell command string.
+ *
+ * On Windows we spawn with `shell: true` and a command string, so every
+ * argument is re-parsed by the shell. Without quoting, anything containing a
+ * space is split: a project at `C:\Users\Ada Lovelace\app` makes node try to
+ * load `C:\Users\Ada`, and the process dies with MODULE_NOT_FOUND. The JSON
+ * payloads passed below need it too, since they contain double quotes.
+ *
+ * Follows the usual Windows argument-encoding rules: backslashes immediately
+ * before a double quote are doubled, the quote itself is escaped, and trailing
+ * backslashes are doubled so they can't escape the closing quote.
+ */
+export function quoteForWindowsShell(arg: string) {
+  const escaped = arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, '$1$1')
+
+  return `"${escaped}"`
+}
+
 const spawnProcess = (...args: string[]) => {
   // "os.type()" returns 'Windows_NT' on Windows.
   // See https://nodejs.org/docs/latest-v12.x/api/os.html#os_os_type.
   const isWindows = os.type() === 'Windows_NT'
-  const execPath = isWindows ? `"${process.execPath}"` : process.execPath
 
   const spawnOptions: Partial<SpawnOptions> = isWindows
     ? {
@@ -44,7 +62,11 @@ const spawnProcess = (...args: string[]) => {
   if (isWindows) {
     // Use command string with empty args array to avoid DEP0190 warning when
     // `shell: true`
-    spawn([execPath, ...scriptArgs].join(' '), [], spawnOptions).unref()
+    const command = [process.execPath, ...scriptArgs]
+      .map(quoteForWindowsShell)
+      .join(' ')
+
+    spawn(command, [], spawnOptions).unref()
   } else {
     // Use proper args array when no shell needed
     spawn(process.execPath, scriptArgs, spawnOptions).unref()


### PR DESCRIPTION
Found while investigating the recurring `Cannot find module 'D:\a\cedar\test'` noise in Windows CI (the test project lives at `D:\a\cedar\test project`).

## The bug

Two background processes are spawned on Windows with `shell: true` and a command string, so the shell re-parses every argument. Neither quoted them.

`packages/telemetry/src/telemetry.ts`:

```js
const execPath = isWindows ? `"${process.execPath}"` : process.execPath
...
spawn([execPath, ...scriptArgs].join(' '), [], spawnOptions).unref()
```

`execPath` is quoted — presumably after someone hit `C:\Program Files\nodejs\node.exe` — but the script path after it isn't, and that path lives inside the *project's* `node_modules`.

`packages/cli/src/lib/background.ts`:

```js
// It's safe to do that here since the arguments aren't user-provided.
const child = spawn(cmd + ' ' + args.join(' '), spawnOptions)
```

That comment conflates *untrusted input* with *input that needs quoting*. The arguments are filesystem paths, and those routinely contain spaces.

## What it does to users

On Windows, for any project whose path contains a space — `C:\Users\Ada Lovelace\app` is enough:

- **Telemetry never sends.** Visible as a raw Node stack trace on every CLI command when `CEDAR_VERBOSE_TELEMETRY` is set (which is why CI shows it), silent otherwise.
- **The update check never runs**, so "a new version is available" never appears. Completely silent — that child's output goes to a log file under `.cedar/logs/`.

Both children die instantly with `MODULE_NOT_FOUND` on a truncated path.

## The fix

A `quoteForWindowsShell` helper applied uniformly to the command and every argument, in both spawn sites. It follows the usual Windows argument-encoding rules: backslashes before a double quote are doubled, the quote is escaped, and trailing backslashes are doubled so they can't escape the closing quote.

Command string for the CI scenario, before and after:

```
BEFORE
  "C:\Program Files\nodejs\node.exe" D:\a\cedar\test project\node_modules\...\invoke.js --argv ["cedar","build"]
                                     ^ splits here

AFTER
  "C:\Program Files\nodejs\node.exe" "D:\a\cedar\test project\node_modules\...\invoke.js" "--argv" "[\"cedar\",\"build\"]"
```

Note the fix also repairs the `--argv` payload. It's `JSON.stringify` output, so it was previously going through the shell with bare double quotes.

The helper is defined locally in each package rather than shared — `@cedarjs/telemetry` doesn't depend on `@cedarjs/cli-helpers`, and a new cross-package dependency for three lines isn't worth it. Both copies have their own tests so they can't drift silently.

## Testing

New tests in both packages, 11 in total, covering paths with and without spaces, JSON payloads containing quotes, a JSON payload containing both, trailing backslashes, backslash-before-quote, and a bare command name.

Existing suites pass: `packages/cli` lib tests 149/149 (including `updateCheck`, the other caller), `packages/telemetry` 12/12. Prettier and eslint clean. `tsc --noEmit` error count unchanged from `main` (207, all pre-existing, none in these files).

**Not verified on Windows** — I have no Windows machine. The change is verified at the level it can be: the generated command string, asserted by unit tests. Whether the CI noise disappears will show up on this PR's own Windows runs.

## Related, not fixed here

This is *not* what's failing Windows CI. The `Cannot find module` lines are non-fatal — `cedar build` and `cedar prerender` both complete straight after them. The actual intermittent failure is `Smoke tests React 18 / windows / Run serve smoke tests`, where Playwright exits 1 after ~3s with no output and no `test-results` artifacts. Still undiagnosed; its stderr isn't in the logs the API returns.

Seven workflow files also use an unquoted `$GITHUB_WORKSPACE` (`.github/scripts/run-nx.sh` gets it right). Latent rather than live, since that path has no space today.
