### PR TITLE
fix(git-hooks): clear error when node_modules missing (e.g. worktrees)

### DIFF
--- a/tasks/git-hooks/tasks.mts
+++ b/tasks/git-hooks/tasks.mts
@@ -22,8 +22,7 @@ function checkDependenciesInstalled(): boolean {
   console.error(
     `[git-hooks] No node_modules found in this checkout (${monorepoRoot}).\n` +
       '  Dependencies are not shared across git worktrees — if this is a ' +
-      'linked worktree, run `yarn install` here first, then try again.\n' +
-      '  To skip this check for one commit/push, use `--no-verify`.',
+      'linked worktree, run `yarn install` here first, then try again.',
   )
   return false
 }

--- a/tasks/git-hooks/tasks.mts
+++ b/tasks/git-hooks/tasks.mts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { statSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import path, { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -15,8 +15,13 @@ const monorepoRoot = path.join(__dirname, '..', '..')
 // below fail with a confusing, unrelated-looking Yarn/PnP error. Catch that
 // up front and tell the user exactly what to do instead.
 function checkDependenciesInstalled(): boolean {
-  if (existsSync(path.join(monorepoRoot, 'node_modules'))) {
-    return true
+  const nodeModulesPath = path.join(monorepoRoot, 'node_modules')
+  try {
+    if (statSync(nodeModulesPath).isDirectory()) {
+      return true
+    }
+  } catch {
+    // ENOENT, EACCES, or other errors all mean "not installed"
   }
 
   console.error(

--- a/tasks/git-hooks/tasks.mts
+++ b/tasks/git-hooks/tasks.mts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import path, { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -7,6 +8,25 @@ import { execAsync, isOnReleaseBranch } from './utils.mts'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const monorepoRoot = path.join(__dirname, '..', '..')
+
+// Yarn's install state (node_modules, .yarn/install-state.gz) is per
+// checkout — it is NOT shared between linked git worktrees. A worktree that
+// hasn't had `yarn install` run in it yet will make every `yarn <cmd>` call
+// below fail with a confusing, unrelated-looking Yarn/PnP error. Catch that
+// up front and tell the user exactly what to do instead.
+function checkDependenciesInstalled(): boolean {
+  if (existsSync(path.join(monorepoRoot, 'node_modules'))) {
+    return true
+  }
+
+  console.error(
+    `[git-hooks] No node_modules found in this checkout (${monorepoRoot}).\n` +
+      '  Dependencies are not shared across git worktrees — if this is a ' +
+      'linked worktree, run `yarn install` here first, then try again.\n' +
+      '  To skip this check for one commit/push, use `--no-verify`.',
+  )
+  return false
+}
 
 function isExcluded(file: string): boolean {
   // __fixtures__ at any depth (covers __fixtures__/* and **/__fixtures__/**)
@@ -175,6 +195,10 @@ export async function runPreCommitTasks(): Promise<number> {
     return 0
   }
 
+  if (!checkDependenciesInstalled()) {
+    return 1
+  }
+
   const stagedFiles = getStagedFiles()
 
   if (stagedFiles.length === 0) {
@@ -204,6 +228,10 @@ export async function runPrePushTasks(): Promise<number> {
   // Skip on release branches. We have other tooling for releasing
   if (isOnReleaseBranch()) {
     return 0
+  }
+
+  if (!checkDependenciesInstalled()) {
+    return 1
   }
 
   const buildPromise = execAsync('yarn', ['build'], 'git-hooks', {

--- a/tasks/git-hooks/tasks.mts
+++ b/tasks/git-hooks/tasks.mts
@@ -1,4 +1,4 @@
-import { statSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import path, { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -15,13 +15,8 @@ const monorepoRoot = path.join(__dirname, '..', '..')
 // below fail with a confusing, unrelated-looking Yarn/PnP error. Catch that
 // up front and tell the user exactly what to do instead.
 function checkDependenciesInstalled(): boolean {
-  const nodeModulesPath = path.join(monorepoRoot, 'node_modules')
-  try {
-    if (statSync(nodeModulesPath).isDirectory()) {
-      return true
-    }
-  } catch {
-    // ENOENT, EACCES, or other errors all mean "not installed"
+  if (existsSync(path.join(monorepoRoot, 'node_modules'))) {
+    return true
   }
 
   console.error(


### PR DESCRIPTION
## Problem

Confirmed: git hooks don't work in linked `git worktree`s. Repro:

```
git worktree add /tmp/wt <ref>
cd /tmp/wt
# edit + stage a file
git commit -m "..."
```

fails with:

```
Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)
...
[git-hooks] command failed (exit 1): node .../smart-format.mts ...
Error: [smart-format] command exited with status 1
    at execAsync (.../utils.mts:105:19)
Node.js v22.23.1
```

Root cause: `core.hooksPath` is set to `.git-hooks` and correctly resolves per-worktree (each worktree has its own checked-out copy of `tasks/git-hooks/*`), so the hooks *do* run. But Yarn's install state (`node_modules`, `.yarn/install-state.gz`) is **not** shared between linked worktrees — a worktree that hasn't had `yarn install` run in it yet has no `node_modules` at all. The first `yarn <cmd>` call inside the hook then fails with an internal Yarn/PnP error that gives no indication the actual problem is a missing install, and the raw Node stack trace makes it look like a bug in the hook itself rather than something the user needs to do.

## Fix

Add a `checkDependenciesInstalled()` check at the top of both `runPreCommitTasks` and `runPrePushTasks` that looks for `node_modules` in the resolved monorepo root (which — since it's derived from the hook script's own `__dirname` — already correctly points at the current worktree). If it's missing, print a clear, actionable message and exit non-zero (fail closed, same as today) instead of letting the first `yarn` invocation crash:

```
[git-hooks] No node_modules found in this checkout (/tmp/wt).
  Dependencies are not shared across git worktrees — if this is a linked worktree, run `yarn install` here first, then try again.
  To skip this check for one commit/push, use `--no-verify`.
```

This doesn't try to share/symlink `node_modules` across worktrees (fragile — install state is keyed to the lockfile/package.json content, which can legitimately differ between branches). It just turns an opaque crash into an actionable one, consistent with how a fresh clone would need `yarn install` too.

Verified locally: reproduced the crash in a linked worktree, applied the fix, confirmed the commit is now blocked with the new message instead of a stack trace, and confirmed hooks still function normally in the main worktree (has `node_modules` already).