### PR TITLE
feat(ci): Nightly cleanup of orphaned staging dist-tags

### DIFF
--- a/.github/scripts/cleanup-staging-tags.mts
+++ b/.github/scripts/cleanup-staging-tags.mts
@@ -44,6 +44,14 @@ const MIN_AGE_MS = 6 * 60 * 60 * 1000
 const READ_CONCURRENCY = 12
 const REMOVE_CONCURRENCY = 6
 
+/**
+ * Deadlines, so a stalled request or child process can't hold the whole run
+ * open until the job-level timeout kills it hours later. A timeout is counted
+ * as a failure like any other.
+ */
+const REGISTRY_TIMEOUT_MS = 30_000
+const COMMAND_TIMEOUT_MS = 60_000
+
 interface Packument {
   'dist-tags'?: Record<string, string>
   time?: Record<string, string>
@@ -52,6 +60,13 @@ interface Packument {
 interface StaleTag {
   packageName: string
   tag: string
+}
+
+interface ScanResult {
+  tags: StaleTag[]
+  /** False when the registry couldn't be read, as opposed to read fine with
+   * nothing stale on it */
+  ok: boolean
 }
 
 function log(message: string) {
@@ -85,6 +100,7 @@ async function runWithConcurrency<T, R>(
 async function getPublishablePackageNames(): Promise<string[]> {
   const { stdout } = await execFile('yarn', ['workspaces', 'list', '--json'], {
     cwd: REPO_ROOT,
+    timeout: COMMAND_TIMEOUT_MS,
   })
 
   const locations: string[] = stdout
@@ -125,20 +141,31 @@ async function getPublishablePackageNames(): Promise<string[]> {
  * A packument gives both the dist-tags and the publish time of every version,
  * so the age of a staging tag is the age of the version it points at.
  */
-async function getStaleTags(packageName: string): Promise<StaleTag[]> {
-  const response = await fetch(
-    `${REGISTRY}/${packageName.replace('/', '%2F')}`,
-    { headers: { accept: 'application/json' } },
-  )
+async function getStaleTags(packageName: string): Promise<ScanResult> {
+  let response: Response
 
+  try {
+    response = await fetch(`${REGISTRY}/${packageName.replace('/', '%2F')}`, {
+      headers: { accept: 'application/json' },
+      signal: AbortSignal.timeout(REGISTRY_TIMEOUT_MS),
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log(`⚠️  Couldn't read ${packageName} (${message})`)
+
+    return { tags: [], ok: false }
+  }
+
+  // A package that has never been published has nothing to clean up. That's a
+  // successful read, not a failure
   if (response.status === 404) {
-    return []
+    return { tags: [], ok: true }
   }
 
   if (!response.ok) {
-    log(`⚠️  Couldn't read ${packageName} (HTTP ${response.status}), skipping`)
+    log(`⚠️  Couldn't read ${packageName} (HTTP ${response.status})`)
 
-    return []
+    return { tags: [], ok: false }
   }
 
   const packument = (await response.json()) as Packument
@@ -146,7 +173,7 @@ async function getStaleTags(packageName: string): Promise<StaleTag[]> {
   const times = packument.time ?? {}
   const now = Date.now()
 
-  return Object.keys(distTags)
+  const tags = Object.keys(distTags)
     .filter((tag) => tag.startsWith(STAGING_TAG_PREFIX))
     .filter((tag) => {
       const publishedAt = times[distTags[tag]]
@@ -160,6 +187,8 @@ async function getStaleTags(packageName: string): Promise<StaleTag[]> {
       return now - new Date(publishedAt).getTime() > MIN_AGE_MS
     })
     .map((tag) => ({ packageName, tag }))
+
+  return { tags, ok: true }
 }
 
 async function main() {
@@ -182,12 +211,40 @@ async function main() {
   )
   process.env['npm_config_userconfig'] = npmrcPath
 
+  try {
+    await cleanUpStagingTags()
+  } finally {
+    // The token lives in here. On a runner the whole machine is thrown away,
+    // but this also gets run locally
+    fs.rmSync(npmrcDir, { recursive: true, force: true })
+  }
+}
+
+async function cleanUpStagingTags() {
   const packageNames = await getPublishablePackageNames()
   log(`Checking ${packageNames.length} published packages`)
 
-  const staleTags = (
-    await runWithConcurrency(packageNames, READ_CONCURRENCY, getStaleTags)
-  ).flat()
+  const scans = await runWithConcurrency(
+    packageNames,
+    READ_CONCURRENCY,
+    getStaleTags,
+  )
+
+  const unreadable = scans.filter((scan) => !scan.ok).length
+  const staleTags = scans.flatMap((scan) => scan.tags)
+
+  // Without this, a registry-wide outage or rate limit reads as "nothing to
+  // clean up" and the job goes green having looked at nothing
+  if (unreadable === packageNames.length) {
+    throw new Error(
+      `Couldn't read any of the ${packageNames.length} packages from the ` +
+        'registry',
+    )
+  }
+
+  if (unreadable > 0) {
+    log(`⚠️  ${unreadable} package(s) couldn't be read and were skipped`)
+  }
 
   // `npm dist-tag rm` removes whatever it's given, so make sure nothing that
   // isn't a staging tag can reach it -- getting this wrong would drop `latest`
@@ -223,6 +280,7 @@ async function main() {
       try {
         await execFile('npm', ['dist-tag', 'rm', packageName, tag], {
           cwd: REPO_ROOT,
+          timeout: COMMAND_TIMEOUT_MS,
         })
         removed += 1
       } catch (error) {

--- a/.github/scripts/cleanup-staging-tags.mts
+++ b/.github/scripts/cleanup-staging-tags.mts
@@ -1,0 +1,243 @@
+/**
+ * Removes orphaned `staging-*` dist-tags from the published packages.
+ *
+ * Publishing tags every package with `staging-<version>`, waits for the
+ * registry to catch up, flips the real dist-tag over, then removes the staging
+ * tag. A run that doesn't reach that last step leaves its staging tag behind on
+ * every package it had already published.
+ *
+ * That happens routinely rather than exceptionally: the prerelease workflow
+ * sets `cancel-in-progress`, so a second push to main kills the first publish
+ * mid-flight, and a cancelled job can't run cleanup on its way out. They
+ * accumulate until something removes them, and they bury the real tags in
+ * `npm view` output.
+ *
+ * Removing a dist-tag does not unpublish anything. Every version stays exactly
+ * where it is and remains installable by exact version -- only the alias goes.
+ *
+ * Environment variables required: NPM_AUTH_TOKEN
+ */
+import { exec as execCb } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import util from 'node:util'
+
+const exec = util.promisify(execCb)
+
+const REPO_ROOT = process.cwd()
+const REGISTRY = 'https://registry.npmjs.org'
+
+const STAGING_TAG_PREFIX = 'staging-'
+
+/**
+ * Staging tags whose version was published more recently than this are left
+ * alone, so a publish that's currently in flight never has the tag pulled out
+ * from under it before it can flip. Publishes take minutes, so hours of slack
+ * is plenty.
+ */
+const MIN_AGE_MS = 6 * 60 * 60 * 1000
+
+/** Registry reads are cheap. Writes are rate limited, so they go narrower. */
+const READ_CONCURRENCY = 12
+const REMOVE_CONCURRENCY = 6
+
+interface Packument {
+  'dist-tags'?: Record<string, string>
+  time?: Record<string, string>
+}
+
+interface StaleTag {
+  packageName: string
+  tag: string
+}
+
+function log(message: string) {
+  console.log(message)
+}
+
+async function runWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let nextIndex = 0
+
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(concurrency, items.length)) },
+    async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex++
+        results[index] = await fn(items[index])
+      }
+    },
+  )
+
+  await Promise.all(workers)
+
+  return results
+}
+
+/** Every non-private workspace, i.e. everything that gets published */
+async function getPublishablePackageNames(): Promise<string[]> {
+  const { stdout } = await exec('yarn workspaces list --json', {
+    cwd: REPO_ROOT,
+  })
+
+  const locations: string[] = stdout
+    .trim()
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line) as { location: string })
+    .map((workspace) => workspace.location)
+    .filter((location) => location !== '.')
+
+  const names: string[] = []
+
+  for (const location of locations) {
+    const pkgJsonPath = path.join(REPO_ROOT, location, 'package.json')
+
+    if (!fs.existsSync(pkgJsonPath)) {
+      continue
+    }
+
+    // Only optional-chained lookups are done on the parsed structure
+    const pkgJson = JSON.parse(
+      fs.readFileSync(pkgJsonPath, 'utf8'),
+    ) as Partial<{ name: string; private: boolean }>
+
+    if (pkgJson.private || !pkgJson.name) {
+      continue
+    }
+
+    names.push(pkgJson.name)
+  }
+
+  return names
+}
+
+/**
+ * Returns the staging tags on a package that are old enough to remove.
+ *
+ * A packument gives both the dist-tags and the publish time of every version,
+ * so the age of a staging tag is the age of the version it points at.
+ */
+async function getStaleTags(packageName: string): Promise<StaleTag[]> {
+  const response = await fetch(
+    `${REGISTRY}/${packageName.replace('/', '%2F')}`,
+    { headers: { accept: 'application/json' } },
+  )
+
+  if (response.status === 404) {
+    return []
+  }
+
+  if (!response.ok) {
+    log(`⚠️  Couldn't read ${packageName} (HTTP ${response.status}), skipping`)
+
+    return []
+  }
+
+  const packument = (await response.json()) as Packument
+  const distTags = packument['dist-tags'] ?? {}
+  const times = packument.time ?? {}
+  const now = Date.now()
+
+  return Object.keys(distTags)
+    .filter((tag) => tag.startsWith(STAGING_TAG_PREFIX))
+    .filter((tag) => {
+      const publishedAt = times[distTags[tag]]
+
+      // No timestamp means we can't tell how old it is. Leave it rather than
+      // risk removing a tag from a publish that's still running
+      if (!publishedAt) {
+        return false
+      }
+
+      return now - new Date(publishedAt).getTime() > MIN_AGE_MS
+    })
+    .map((tag) => ({ packageName, tag }))
+}
+
+async function main() {
+  const npmAuthToken = process.env.NPM_AUTH_TOKEN
+
+  if (!npmAuthToken) {
+    throw new Error('NPM_AUTH_TOKEN is not set or is empty')
+  }
+
+  // Into a temp dir rather than the repo root. `.npmrc` is neither tracked nor
+  // gitignored, so a token written there is one `git add .` away from being
+  // committed by anyone who runs this locally. Child npm processes pick this up
+  // through the inherited environment.
+  const npmrcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cedar-npmrc-'))
+  const npmrcPath = path.join(npmrcDir, '.npmrc')
+
+  fs.writeFileSync(
+    npmrcPath,
+    `//registry.npmjs.org/:_authToken=${npmAuthToken}\n`,
+  )
+  process.env['npm_config_userconfig'] = npmrcPath
+
+  const packageNames = await getPublishablePackageNames()
+  log(`Checking ${packageNames.length} published packages`)
+
+  const staleTags = (
+    await runWithConcurrency(packageNames, READ_CONCURRENCY, getStaleTags)
+  ).flat()
+
+  // `npm dist-tag rm` removes whatever it's given, so make sure nothing that
+  // isn't a staging tag can reach it -- getting this wrong would drop `latest`
+  // off every package
+  for (const { packageName, tag } of staleTags) {
+    if (!tag.startsWith(STAGING_TAG_PREFIX)) {
+      throw new Error(
+        `Refusing to continue: '${tag}' on ${packageName} is not a staging ` +
+          'tag but ended up on the removal list',
+      )
+    }
+  }
+
+  if (staleTags.length === 0) {
+    log('✨ No staging dist-tags to remove')
+
+    return
+  }
+
+  const distinctTags = new Set(staleTags.map(({ tag }) => tag))
+  log(
+    `Removing ${staleTags.length} staging dist-tag(s) across ` +
+      `${distinctTags.size} version(s)`,
+  )
+
+  let removed = 0
+  let failed = 0
+
+  await runWithConcurrency(
+    staleTags,
+    REMOVE_CONCURRENCY,
+    async ({ packageName, tag }) => {
+      try {
+        await exec(`npm dist-tag rm ${packageName} ${tag}`, { cwd: REPO_ROOT })
+        removed += 1
+      } catch (error) {
+        failed += 1
+
+        const message = error instanceof Error ? error.message : String(error)
+        log(`⚠️  Couldn't remove '${tag}' from ${packageName}: ${message}`)
+      }
+    },
+  )
+
+  log(`✨ Removed ${removed} staging dist-tag(s), ${failed} failed`)
+
+  // Leftovers are harmless and the next run will try again, so a few failures
+  // aren't worth failing the job over. A total wipeout usually means the token
+  // expired, which is worth being loud about
+  if (removed === 0 && failed > 0) {
+    throw new Error('Every removal failed. Is NPM_AUTH_TOKEN still valid?')
+  }
+}
+
+main()

--- a/.github/scripts/cleanup-staging-tags.mts
+++ b/.github/scripts/cleanup-staging-tags.mts
@@ -17,13 +17,15 @@
  *
  * Environment variables required: NPM_AUTH_TOKEN
  */
-import { exec as execCb } from 'node:child_process'
+import { execFile as execFileCb } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import util from 'node:util'
 
-const exec = util.promisify(execCb)
+// execFile rather than exec: package and tag names come from the registry, so
+// they must never be interpolated into a shell command line
+const execFile = util.promisify(execFileCb)
 
 const REPO_ROOT = process.cwd()
 const REGISTRY = 'https://registry.npmjs.org'
@@ -81,7 +83,7 @@ async function runWithConcurrency<T, R>(
 
 /** Every non-private workspace, i.e. everything that gets published */
 async function getPublishablePackageNames(): Promise<string[]> {
-  const { stdout } = await exec('yarn workspaces list --json', {
+  const { stdout } = await execFile('yarn', ['workspaces', 'list', '--json'], {
     cwd: REPO_ROOT,
   })
 
@@ -219,7 +221,9 @@ async function main() {
     REMOVE_CONCURRENCY,
     async ({ packageName, tag }) => {
       try {
-        await exec(`npm dist-tag rm ${packageName} ${tag}`, { cwd: REPO_ROOT })
+        await execFile('npm', ['dist-tag', 'rm', packageName, tag], {
+          cwd: REPO_ROOT,
+        })
         removed += 1
       } catch (error) {
         failed += 1

--- a/.github/workflows/cleanup-staging-tags.yml
+++ b/.github/workflows/cleanup-staging-tags.yml
@@ -5,6 +5,17 @@ on:
     - cron: '30 3 * * *' # daily at 03:30 UTC
   workflow_dispatch:
 
+# Queue rather than cancel: a manual sweep and the nightly run would otherwise
+# race on the same tags and log spurious "not found" failures
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+# Nothing here needs the GitHub token -- the only credential in play is the npm
+# one
+permissions:
+  contents: read
+
 jobs:
   cleanup:
     if: github.repository == 'cedarjs/cedar'
@@ -12,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: ⬢ Enable Corepack
         run: corepack enable

--- a/.github/workflows/cleanup-staging-tags.yml
+++ b/.github/workflows/cleanup-staging-tags.yml
@@ -1,0 +1,29 @@
+name: 🧹 Cleanup staging dist-tags
+
+on:
+  schedule:
+    - cron: '30 3 * * *' # daily at 03:30 UTC
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    if: github.repository == 'cedarjs/cedar'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: ⬢ Enable Corepack
+        run: corepack enable
+
+      - name: ⬢ Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      # No install or build. The script only needs `yarn workspaces list` to
+      # find the published packages, then talks to the registry directly.
+      - name: 🧹 Remove orphaned staging dist-tags
+        run: node .github/scripts/cleanup-staging-tags.mts
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Why

Publishing tags every package with `staging-<version>`, waits for the registry, flips the real dist-tag over, then removes the staging tag. A run that doesn't reach that last step leaves its staging tag on every package it had already published.

That's routine rather than exceptional. `publish-prerelease.yml` sets:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

So a second push to `main` kills the first publish mid-flight. No amount of error handling in the publish script covers that — a cancellation is a kill, not a catchable failure — which is why these need sweeping up out-of-band rather than fixed at the source.

They've built up to **8.7k tags** across the published packages. `npm view @cedarjs/core dist-tags` is over a hundred lines of `staging-*` with `latest` somewhere in the middle.

## What

A nightly job at 03:30 UTC, alongside the existing Netlify and Vercel cleanups, plus `workflow_dispatch` for a manual sweep.

## Safety

- **Only `staging-` tags are ever considered**, and that's asserted again immediately before removal. `npm dist-tag rm` removes whatever it's handed, and getting this wrong would drop `latest` off every package, so the check is worth having twice.
- **Nothing younger than six hours is touched**, so a publish in flight never has its staging tag pulled out from under it before it can flip. Same idea as the Netlify cleanup's two-hour cutoff. The age comes from the packument's `time` map — the publish time of the version each tag points at.
- **A version with no recorded publish time is skipped** rather than guessed at.
- **Removing a dist-tag doesn't unpublish anything.** Every version stays exactly where it is and remains installable by exact version; only the alias goes.
- The token is written to an `.npmrc` in a temp dir rather than the repo root. `.npmrc` is neither tracked nor gitignored, so a token written there would be one `git add .` away from being committed by anyone running this locally.
- A handful of failed removals doesn't fail the job — leftovers are harmless and the next run retries. *Every* removal failing does fail it, since that usually means the token expired.

## Notes

No install or build in the workflow. The script only needs `yarn workspaces list` to find the published packages, then talks to the registry directly, so it's a checkout plus corepack plus node.
