### PR TITLE
docs(release): Correct cell-type-annotations notes

### DIFF
--- a/.changesets/release_notes_major.md
+++ b/.changesets/release_notes_major.md
@@ -61,8 +61,11 @@ flagged but never autofixed — Cedar can't safely guess your props shape — bu
 it's worth annotating by hand, since it drives Cedar's prop-type inference for
 the rest of the Cell.
 
-Like `service-type-annotations`, it's off by default. Enable it in your
-project's `eslint.config.mjs`:
+New TypeScript projects get the rule enabled out of the box. JavaScript
+projects don't — there are no type annotations for it to check. For projects
+generated before v6 it's off by default, like `service-type-annotations`;
+enable it in your project's `eslint.config.mjs` (`eslint.config.js` in ESM
+projects):
 
 ```js
 import cedarConfig from '@cedarjs/eslint-config'
@@ -70,7 +73,7 @@ import cedarConfig from '@cedarjs/eslint-config'
 export default [
   ...(await cedarConfig()),
   {
-    files: ['web/src/components/**/*Cell.tsx'],
+    files: ['web/src/**/*Cell.tsx'],
     rules: {
       '@cedarjs/cell-type-annotations': 'error',
     },
@@ -273,7 +276,8 @@ code:
 - **The new `cell-type-annotations` ESLint rule catches untyped Cells.**
   Cells generated (or hand-edited) without their `beforeQuery`/`afterQuery`/
   `isEmpty` and `Loading`/`Failure`/`Success` type annotations now get flagged
-  and mostly autofixed. See the Highlights section above for how to enable it.
+  and mostly autofixed. New TypeScript projects get the rule out of the box;
+  see the Highlights section above for enabling it in an existing project.
 
 ### `postcss-loader` is no longer installed
 


### PR DESCRIPTION
The release notes for the next major release describe the `cell-type-annotations` rule as it worked before #2396 landed on 2026-08-13. #2463 was written six days later and kept the older description, so four details are out of date.

### What's wrong

- **"Off by default" isn't true for new TypeScript projects.** Both `templates/ts/eslint.config.mjs` and `templates/esm-ts/eslint.config.js` ship the rule set to `error`. It's off by default only for projects generated before v6. JavaScript projects (`js`, `esm-js`) never enable it — there are no type annotations to check.
- **The example glob is narrower than what ships.** The notes used `web/src/components/**/*Cell.tsx`; the templates use `web/src/**/*Cell.tsx`. The narrow one covers generated and scaffolded Cells, but silently skips any Cell kept elsewhere under `web/src/`.
- **`eslint.config.mjs` only fits half the templates.** ESM projects have `eslint.config.js`.
- **The "Better DX for AI coding agents" bullet repeats the wrong premise**, pointing readers at the Highlights section "for how to enable it".
