### PR TITLE
docs(release): Tell people to pin vite 7.3.6, not 7.3.5

### DIFF
--- a/.changesets/release_notes_major.md
+++ b/.changesets/release_notes_major.md
@@ -312,7 +312,7 @@ keep them, but you can delete the `dns` import, the comment, and the call.
 
 - **[No more CJS-only packages](#no-more-cjs-only-packages)** — standard apps are unaffected; only breaks projects that compile their own TypeScript straight to CommonJS with `tsc` and statically import `@cedarjs/*` packages directly.
 - **[`cedar serve api --ud` binds to all interfaces by default](#cedar-serve-api---ud-binds-to-all-interfaces-by-default)** — its default host changed from `localhost` to `::`/`0.0.0.0`, matching every other `serve` path.
-- **[Vitest 4 (ESM projects)](#vitest-4-esm-projects)** — needs a `vite@7.3.5` pin, and your own tests may hit a few Vitest 4 API changes.
+- **[Vitest 4 (ESM projects)](#vitest-4-esm-projects)** — needs a `vite@7.3.6` pin, and your own tests may hit a few Vitest 4 API changes.
 - **[MSW 2](#msw-2)** — breaks tests/stories that import `msw`/`whatwg-fetch` directly, override the Jest preset's `testEnvironment`/`transformIgnorePatterns`, or have an old committed `mockServiceWorker.js`; most apps need no changes.
 - **[`web/babel.config.js` is no longer used by Vite](#webbabelconfigjs-is-no-longer-used-by-vite)** — custom Babel plugins/presets there stop running in the web build unless passed via the new `babel` Vite plugin option.
 - **[GraphQL client-agnostic indirection removed](#graphql-client-agnostic-indirection-removed)** — `GraphQLHooksProvider` and a handful of ambient GraphQL types are gone; switch to Apollo directly.
@@ -390,7 +390,7 @@ v4. After upgrading Cedar:
 
    ```json
    "resolutions": {
-     "vite": "7.3.5"
+     "vite": "7.3.6"
    }
    ```
 
@@ -398,7 +398,7 @@ v4. After upgrading Cedar:
 
    ```json
    "overrides": {
-     "vite": "7.3.5"
+     "vite": "7.3.6"
    }
    ```
 
@@ -406,7 +406,7 @@ v4. After upgrading Cedar:
 
    ```yaml
    overrides:
-     vite: '7.3.5'
+     vite: '7.3.6'
    ```
 
 Cedar's generated `vitest.config.ts` files are already Vitest 4 compatible.

--- a/upgrade-scripts/6.x.ts
+++ b/upgrade-scripts/6.x.ts
@@ -373,14 +373,14 @@ async function main() {
       vitePinInstructions =
         'Add this to your pnpm-workspace.yaml:\n' +
         '  overrides:\n' +
-        "    vite: '7.3.5'"
+        "    vite: '7.3.6'"
     } else if (packageManager === 'npm') {
       vitePinValue = packageJson.overrides?.vite
 
       vitePinInstructions =
         'Add this to your root package.json:\n' +
         '  "overrides": {\n' +
-        '    "vite": "7.3.5"\n' +
+        '    "vite": "7.3.6"\n' +
         '  }'
     } else {
       vitePinValue = packageJson.resolutions?.vite
@@ -388,7 +388,7 @@ async function main() {
       vitePinInstructions =
         'Add this to your root package.json:\n' +
         '  "resolutions": {\n' +
-        '    "vite": "7.3.5"\n' +
+        '    "vite": "7.3.6"\n' +
         '  }'
     }
 

--- a/upgrade-scripts/canary.ts
+++ b/upgrade-scripts/canary.ts
@@ -335,14 +335,14 @@ async function main() {
       vitePinInstructions =
         'Add this to your pnpm-workspace.yaml:\n' +
         '  overrides:\n' +
-        "    vite: '7.3.5'"
+        "    vite: '7.3.6'"
     } else if (packageManager === 'npm') {
       vitePinValue = packageJson.overrides?.vite
 
       vitePinInstructions =
         'Add this to your root package.json:\n' +
         '  "overrides": {\n' +
-        '    "vite": "7.3.5"\n' +
+        '    "vite": "7.3.6"\n' +
         '  }'
     } else {
       vitePinValue = packageJson.resolutions?.vite
@@ -350,7 +350,7 @@ async function main() {
       vitePinInstructions =
         'Add this to your root package.json:\n' +
         '  "resolutions": {\n' +
-        '    "vite": "7.3.5"\n' +
+        '    "vite": "7.3.6"\n' +
         '  }'
     }
 


### PR DESCRIPTION
The v6 Vite pin instructions are one patch version behind what Cedar actually ships.

### What Cedar ships

- `packages/vite/package.json` → `"vite": "7.3.6"`
- `templates/esm-ts/package.json` and all three ESM overlays → `7.3.6`
- `docs/docs/upgrade-guides/cedar-v6.md` → already says `7.3.6`

### What we tell people to pin

- `.changesets/release_notes_major.md` → `7.3.5` (breaking-changes summary + all three package-manager snippets)
- `upgrade-scripts/6.x.ts` → `7.3.5` (the instructions printed when a project has no pin)
- `upgrade-scripts/canary.ts` → same instructions, same stale version

### How it drifted

The instructions were written on 2026-07-23 in #2174 (`chore(release): Start prepping tooling for v6 release`). #2186 bumped Vite to 7.3.6 two days later and didn't update them. The upgrade guide was written afterwards, against the current version, which is why it's the one that's right.

### Impact

Low but not zero. Both upgrade scripts validate the pin with `/^[\^~]?7\./`, so any Vite 7.x satisfies them and nobody following the guide gets a spurious warning. But a user following the notes or the scripts' printed instructions pins 7.3.5, which then overrides `@cedarjs/vite`'s own exact `7.3.6` dependency through resolutions/overrides — contradicting the instructions' own rationale, "pin vite to the version Cedar uses".

### Scope

Mechanical: `7.3.5` → `7.3.6` in the three files, 10 lines total. The `7.3.5` mentions under `docs/implementation-plans/` are deliberately left alone — they're point-in-time notes about what Vite version was current when those plans were written, not instructions.

Worth considering as a follow-up, not done here: these version literals live in four places and drifted precisely because nothing ties them together. A shared constant, or a test asserting the instructions match `packages/vite`'s dependency, would stop it recurring.

`prettier --check` passes on all three files, and `upgrade-scripts`' `node --test manifest.test.ts` passes.

https://claude.ai/code/session_01KwDfwzAdre84V7AtLauMHz