### PR TITLE
fix(ci): Make create-cedar-app RC publish idempotent to duplicate versions

### DIFF
--- a/.github/scripts/publish-release-candidate.mts
+++ b/.github/scripts/publish-release-candidate.mts
@@ -620,9 +620,21 @@ async function main() {
         fs.readFileSync(ccaPkgJsonPath, 'utf-8'),
       )
       const ccaPackageName = ccaPkgJson.name || 'create-cedar-app'
-      log(`Publishing ${ccaPackageName}@${versionToPublish}...`)
-      execCommand(`npm publish --tag rc --access public`, CREATE_CEDAR_APP_DIR)
-      log('✅ Published create-cedar-app')
+
+      const alreadyPublished = await isPublished(
+        ccaPackageName,
+        versionToPublish,
+      )
+      if (alreadyPublished) {
+        log(`Already published: ${ccaPackageName}@${versionToPublish}`)
+      } else {
+        log(`Publishing ${ccaPackageName}@${versionToPublish}...`)
+        execCommand(
+          `npm publish --tag rc --access public`,
+          CREATE_CEDAR_APP_DIR,
+        )
+        log('✅ Published create-cedar-app')
+      }
     }
 
     log('🎉 Release candidate publishing completed successfully!')


### PR DESCRIPTION
## Summary
- The RC version published for `create-cedar-app` and all `@cedarjs/*` packages is derived from `git rev-list --count <latestTag>..HEAD`, not the commit SHA, so two separate pushes to a release branch can land close together and compute the exact same RC version.
- Every scoped `@cedarjs/*` package already handles this correctly: `publishPackage()` checks `isPublished()` first and skips republishing if the version is already on npm.
- `create-cedar-app`'s own publish step didn't have that guard — it called `npm publish` unconditionally, so a second run with a colliding version failed the entire job with `npm error 403 ... You cannot publish over the previously published versions`, even though every package (including `create-cedar-app` from the earlier run) was already correctly published.
- This fixes it by adding the same `isPublished` check before publishing `create-cedar-app`, matching the existing pattern.

Confirmed against CI history: two runs on `release/major/v6.0.0` (different commit SHAs, ~2 hours apart) both computed `6.0.0-rc.340`. In the second, every `@cedarjs/*` package logged `Already published: ...` and was skipped, while `create-cedar-app` hit the 403 and failed the job.

## Test plan
- [ ] `yarn tsx .github/scripts/publish-release-candidate.mts --dry-run` on a release branch to confirm the script still runs end-to-end
- [ ] Watch the next real RC publish run to confirm no regression in the normal (non-colliding) path

https://claude.ai/code/session_01BW8KviCnAvhH6GoMg25NwK