### PR TITLE
fix(deps): Accept React 19 as a peer dependency

### DIFF
--- a/__fixtures__/test-project-esm/web/src/lib/formatters.tsx
+++ b/__fixtures__/test-project-esm/web/src/lib/formatters.tsx
@@ -40,7 +40,7 @@ export const jsonTruncate = (obj: unknown) => {
 }
 
 export const timeTag = (dateTime?: string) => {
-  let output: string | JSX.Element = ''
+  let output: string | React.JSX.Element = ''
 
   if (dateTime) {
     output = (

--- a/__fixtures__/test-project-live/web/src/lib/formatters.tsx
+++ b/__fixtures__/test-project-live/web/src/lib/formatters.tsx
@@ -40,7 +40,7 @@ export const jsonTruncate = (obj: unknown) => {
 }
 
 export const timeTag = (dateTime?: string) => {
-  let output: string | JSX.Element = ''
+  let output: string | React.JSX.Element = ''
 
   if (dateTime) {
     output = (

--- a/__fixtures__/test-project-pnpm/web/src/lib/formatters.tsx
+++ b/__fixtures__/test-project-pnpm/web/src/lib/formatters.tsx
@@ -40,7 +40,7 @@ export const jsonTruncate = (obj: unknown) => {
 }
 
 export const timeTag = (dateTime?: string) => {
-  let output: string | JSX.Element = ''
+  let output: string | React.JSX.Element = ''
 
   if (dateTime) {
     output = (

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/lib/formatters.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/lib/formatters.tsx
@@ -40,7 +40,7 @@ export const jsonTruncate = (obj: unknown) => {
 }
 
 export const timeTag = (dateTime?: string) => {
-  let output: string | JSX.Element = ''
+  let output: string | React.JSX.Element = ''
 
   if (dateTime) {
     output = (

--- a/__fixtures__/test-project/web/src/lib/formatters.tsx
+++ b/__fixtures__/test-project/web/src/lib/formatters.tsx
@@ -40,7 +40,7 @@ export const jsonTruncate = (obj: unknown) => {
 }
 
 export const timeTag = (dateTime?: string) => {
-  let output: string | JSX.Element = ''
+  let output: string | React.JSX.Element = ''
 
   if (dateTime) {
     output = (

--- a/local-testing-project-live/web/src/lib/formatters.tsx
+++ b/local-testing-project-live/web/src/lib/formatters.tsx
@@ -40,7 +40,7 @@ export const jsonTruncate = (obj: unknown) => {
 }
 
 export const timeTag = (dateTime?: string) => {
-  let output: string | JSX.Element = ''
+  let output: string | React.JSX.Element = ''
 
   if (dateTime) {
     output = (

--- a/local-testing-project/web/src/lib/formatters.tsx
+++ b/local-testing-project/web/src/lib/formatters.tsx
@@ -40,7 +40,7 @@ export const jsonTruncate = (obj: unknown) => {
 }
 
 export const timeTag = (dateTime?: string) => {
-  let output: string | JSX.Element = ''
+  let output: string | React.JSX.Element = ''
 
   if (dateTime) {
     output = (

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.ts.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.ts.snap
@@ -2314,7 +2314,7 @@ export const jsonTruncate = (obj: unknown) => {
 }
 
 export const timeTag = (dateTime?: string) => {
-  let output: string | JSX.Element = ''
+  let output: string | React.JSX.Element = ''
 
   if (dateTime) {
     output = (

--- a/packages/cli/src/commands/generate/scaffold/templates/lib/formatters.tsx.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/lib/formatters.tsx.template
@@ -40,7 +40,7 @@ export const jsonTruncate = (obj: unknown) => {
 }
 
 export const timeTag = (dateTime?: string) => {
-  let output: string | JSX.Element = ''
+  let output: string | React.JSX.Element = ''
 
   if (dateTime) {
     output = (

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -53,7 +53,7 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "react": "18.3.1"
+    "react": "18.3.1 || ^19.0.0"
   },
   "engines": {
     "node": ">=24"

--- a/packages/gqlorm/package.json
+++ b/packages/gqlorm/package.json
@@ -113,8 +113,8 @@
   },
   "peerDependencies": {
     "@cedarjs/web": "6.0.0",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react": "18.3.1 || ^19.0.0",
+    "react-dom": "18.3.1 || ^19.0.0"
   },
   "engines": {
     "node": ">=24"

--- a/packages/mailer/renderers/react-email/package.json
+++ b/packages/mailer/renderers/react-email/package.json
@@ -31,8 +31,8 @@
     "typescript": "5.9.3"
   },
   "peerDependencies": {
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react": "18.3.1 || ^19.0.0",
+    "react-dom": "18.3.1 || ^19.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -105,8 +105,8 @@
   "peerDependencies": {
     "@cedarjs/router": "6.0.0",
     "@cedarjs/web": "6.0.0",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react": "18.3.1 || ^19.0.0",
+    "react-dom": "18.3.1 || ^19.0.0"
   },
   "engines": {
     "node": ">=24"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -74,8 +74,8 @@
   },
   "peerDependencies": {
     "@cedarjs/auth": "6.0.0",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react": "18.3.1 || ^19.0.0",
+    "react-dom": "18.3.1 || ^19.0.0"
   },
   "engines": {
     "node": ">=24"

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -70,8 +70,8 @@
   "peerDependencies": {
     "@cedarjs/project-config": "6.0.0",
     "@cedarjs/router": "6.0.0",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
+    "react": "18.3.1 || ^19.0.0",
+    "react-dom": "18.3.1 || ^19.0.0",
     "storybook": "8.6.18"
   },
   "engines": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -121,8 +121,8 @@
   },
   "peerDependencies": {
     "@cedarjs/auth": "6.0.0",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react": "18.3.1 || ^19.0.0",
+    "react-dom": "18.3.1 || ^19.0.0"
   },
   "engines": {
     "node": ">=24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3029,7 +3029,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:4.1.10"
   peerDependencies:
-    react: 18.3.1
+    react: 18.3.1 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -3077,8 +3077,8 @@ __metadata:
     vitest: "npm:4.1.10"
   peerDependencies:
     "@cedarjs/web": 6.0.0
-    react: 18.3.1
-    react-dom: 18.3.1
+    react: 18.3.1 || ^19.0.0
+    react-dom: 18.3.1 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -3289,8 +3289,8 @@ __metadata:
     react-dom: "npm:18.3.1"
     typescript: "npm:5.9.3"
   peerDependencies:
-    react: 18.3.1
-    react-dom: 18.3.1
+    react: 18.3.1 || ^19.0.0
+    react-dom: 18.3.1 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -3356,8 +3356,8 @@ __metadata:
   peerDependencies:
     "@cedarjs/router": 6.0.0
     "@cedarjs/web": 6.0.0
-    react: 18.3.1
-    react-dom: 18.3.1
+    react: 18.3.1 || ^19.0.0
+    react-dom: 18.3.1 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -3451,8 +3451,8 @@ __metadata:
     vitest: "npm:4.1.10"
   peerDependencies:
     "@cedarjs/auth": 6.0.0
-    react: 18.3.1
-    react-dom: 18.3.1
+    react: 18.3.1 || ^19.0.0
+    react-dom: 18.3.1 || ^19.0.0
   languageName: unknown
   linkType: soft
 
@@ -3759,8 +3759,8 @@ __metadata:
     vitest: "npm:4.1.10"
   peerDependencies:
     "@cedarjs/auth": 6.0.0
-    react: 18.3.1
-    react-dom: 18.3.1
+    react: 18.3.1 || ^19.0.0
+    react-dom: 18.3.1 || ^19.0.0
   bin:
     cedar: ./dist/bins/cedar.js
     cedarjs: ./dist/bins/cedar.js
@@ -26701,8 +26701,8 @@ __metadata:
   peerDependencies:
     "@cedarjs/project-config": 6.0.0
     "@cedarjs/router": 6.0.0
-    react: 18.3.1
-    react-dom: 18.3.1
+    react: 18.3.1 || ^19.0.0
+    react-dom: 18.3.1 || ^19.0.0
     storybook: 8.6.18
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

Targets `next` (the v6 release line) as a 6.0.x patch.

Cedar v7 (#2498) drops React 18 support. The v7 upgrade guide tells users to upgrade React to 19 **while still on v6**, then move to v7 as a separate step. This patch makes that a clean experience on v6:

- **Peer dependency ranges** for `react` and `react-dom` now accept `18.3.1 || ^19.0.0` in `@cedarjs/web`, `@cedarjs/router`, `@cedarjs/forms`, `@cedarjs/prerender`, `@cedarjs/gqlorm`, `@cedarjs/mailer-renderer-react-email`, and `storybook-framework-cedarjs`. With the exact `18.3.1` pin, upgrading React prints `YN0060` peer warnings for all of them. `dependencies` / `devDependencies` pins are unchanged, so nothing changes for projects staying on React 18.
- **Scaffold `formatters.tsx` template** (and its fixture / local-testing copies + snapshot) types `output` as `React.JSX.Element` instead of the global `JSX.Element`. `React.JSX` exists in both `@types/react` 18 and 19; the global `JSX` namespace is gone in 19, and it was the one Cedar-generated line that made `yarn cedar type-check` fail after a React 19 upgrade.

Not changed here, but worth a follow-up: `@cedarjs/vite`, `@cedarjs/auth`, `@cedarjs/router`, and `@cedarjs/ogimage-gen` list `react@18.3.1` as a hard `dependencies` entry, so a project on React 19 gets nested React 18 copies under those packages in `node_modules`. The production bundle dedupes to a single React and nothing broke in testing, but it is a latent duplicate-React risk. `main` has the same design at 19.2.3.

## Testing

- A fresh `yarn create cedar-app@6.0.0 --typescript` app, baseline green on React 18, then only `react`/`react-dom`/`@types/react`/`@types/react-dom` bumped to 19.x: `yarn cedar type-check`, `test` (26 tests), `build`, `dev`, and `serve` all pass; a scaffolded CRUD flow (react-hook-form → GraphQL mutation → toast → redirect) works end-to-end in dev and prod with zero console errors. The only app-side change needed was the `formatters.tsx` line this PR fixes in the template.
- On this branch: `yarn build` (74/74 projects), `CI=1 yarn workspace @cedarjs/cli test scaffold` (585 tests), `lint:fw` and `lint:templates` clean.

https://claude.ai/code/session_0118KQts9xYkwQ5uGq2XwLkp
