### PR TITLE
fix(deps): Declare react as a peer dependency in vite, auth, router, and ogimage-gen

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -49,9 +49,6 @@
     "test": "vitest run",
     "test:watch": "vitest watch"
   },
-  "dependencies": {
-    "react": "19.2.3"
-  },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.5",
     "@cedarjs/framework-tools": "workspace:*",
@@ -61,9 +58,13 @@
     "concurrently": "9.2.4",
     "msw": "2.15.0",
     "publint": "0.3.23",
+    "react": "19.2.3",
     "type-fest": "5.8.0",
     "typescript": "5.9.3",
     "vitest": "4.1.10"
+  },
+  "peerDependencies": {
+    "react": "19.2.3"
   },
   "engines": {
     "node": ">=24"

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -39,22 +39,24 @@
     "@cedarjs/internal": "workspace:*",
     "@cedarjs/project-config": "workspace:*",
     "fast-glob": "3.3.3",
-    "lodash": "4.18.1",
-    "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "lodash": "4.18.1"
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",
     "@cedarjs/router": "workspace:*",
     "@cedarjs/web": "workspace:*",
     "@playwright/test": "1.62.1",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
     "ts-toolbelt": "9.6.0",
     "typescript": "5.9.3",
     "vite": "7.3.6",
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "@cedarjs/router": "workspace:*"
+    "@cedarjs/router": "workspace:*",
+    "react": "19.2.3",
+    "react-dom": "19.2.3"
   },
   "engines": {
     "node": ">=24"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -54,8 +54,6 @@
   "dependencies": {
     "@cedarjs/project-config": "workspace:*",
     "@cedarjs/server-store": "workspace:*",
-    "react": "19.2.3",
-    "react-dom": "19.2.3",
     "react-server-dom-webpack": "19.2.7",
     "ts-toolbelt": "9.6.0"
   },
@@ -68,6 +66,8 @@
     "@types/react-dom": "^19.2.0",
     "concurrently": "9.2.4",
     "publint": "0.3.23",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
     "tstyche": "5.0.2",
     "typescript": "5.9.3",
     "vite": "7.3.6",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -110,6 +110,7 @@
     "memfs": "4.68.1",
     "publint": "0.3.23",
     "react": "19.2.3",
+    "react-dom": "19.2.3",
     "rollup": "4.60.4",
     "ts-dedent": "2.3.0",
     "typescript": "5.9.3",
@@ -119,7 +120,8 @@
     "@cedarjs/auth": "workspace:*",
     "@cedarjs/router": "workspace:*",
     "@cedarjs/web": "workspace:*",
-    "react": "19.2.3"
+    "react": "19.2.3",
+    "react-dom": "19.2.3"
   },
   "engines": {
     "node": ">=24"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -81,7 +81,6 @@
     "isbot": "5.2.1",
     "magic-string": "0.30.21",
     "oxc-parser": "0.144.0",
-    "react": "19.2.3",
     "react-server-dom-webpack": "19.2.7",
     "unimport": "5.7.0",
     "unplugin-auto-import": "19.3.0",
@@ -110,6 +109,7 @@
     "concurrently": "9.2.4",
     "memfs": "4.68.1",
     "publint": "0.3.23",
+    "react": "19.2.3",
     "rollup": "4.60.4",
     "ts-dedent": "2.3.0",
     "typescript": "5.9.3",
@@ -118,7 +118,8 @@
   "peerDependencies": {
     "@cedarjs/auth": "workspace:*",
     "@cedarjs/router": "workspace:*",
-    "@cedarjs/web": "workspace:*"
+    "@cedarjs/web": "workspace:*",
+    "react": "19.2.3"
   },
   "engines": {
     "node": ">=24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3672,6 +3672,7 @@ __metadata:
     oxc-parser: "npm:0.144.0"
     publint: "npm:0.3.23"
     react: "npm:19.2.3"
+    react-dom: "npm:19.2.3"
     react-server-dom-webpack: "npm:19.2.7"
     rollup: "npm:4.60.4"
     ts-dedent: "npm:2.3.0"
@@ -3690,6 +3691,7 @@ __metadata:
     "@cedarjs/router": "workspace:*"
     "@cedarjs/web": "workspace:*"
     react: 19.2.3
+    react-dom: 19.2.3
   bin:
     cedar-dev-fe: ./dist/devFeServer.js
     cedar-serve-fe: ./dist/runFeServer.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -2630,6 +2630,8 @@ __metadata:
     type-fest: "npm:5.8.0"
     typescript: "npm:5.9.3"
     vitest: "npm:4.1.10"
+  peerDependencies:
+    react: 19.2.3
   languageName: unknown
   linkType: soft
 
@@ -3309,6 +3311,8 @@ __metadata:
     vitest: "npm:4.1.10"
   peerDependencies:
     "@cedarjs/router": "workspace:*"
+    react: 19.2.3
+    react-dom: 19.2.3
   languageName: unknown
   linkType: soft
 
@@ -3685,6 +3689,7 @@ __metadata:
     "@cedarjs/auth": "workspace:*"
     "@cedarjs/router": "workspace:*"
     "@cedarjs/web": "workspace:*"
+    react: 19.2.3
   bin:
     cedar-dev-fe: ./dist/devFeServer.js
     cedar-serve-fe: ./dist/runFeServer.js


### PR DESCRIPTION
**Problem.** `@cedarjs/vite`, `@cedarjs/auth`, `@cedarjs/router`, and `@cedarjs/ogimage-gen` list `react` (and, for some, `react-dom`) under `dependencies`, pinned to an exact version (`19.2.3`). Whenever an app's own React version differs from that pin, Yarn installs a second copy nested under `node_modules/@cedarjs/<pkg>/node_modules/react`. Two React instances in one tree is the classic cause of "Invalid hook call" errors and broken hooks/context, especially in dev where nothing bundles and dedupes.

**Fix.** Move `react` / `react-dom` from `dependencies` to `peerDependencies` (same pinned version string `@cedarjs/web` uses) and add them to `devDependencies` so framework builds and tests still resolve React. This matches how `@cedarjs/web`, `@cedarjs/forms`, and `@cedarjs/prerender` already model React.

| Package | Change |
|---|---|
| `@cedarjs/vite` | `react`: dependencies -> peerDependencies + devDependencies |
| `@cedarjs/auth` | `react`: dependencies -> peerDependencies + devDependencies (empty `dependencies` block removed) |
| `@cedarjs/router` | `react`, `react-dom`: removed from dependencies (peers already declared), added to devDependencies |
| `@cedarjs/ogimage-gen` | `react`, `react-dom`: dependencies -> peerDependencies + devDependencies |

**Why a peer is right for each package**

- `@cedarjs/auth` and `@cedarjs/router` export React components/providers (`AuthProvider`, `Router`, `Link`, ...) that render inside the app's React tree; they must share the app's React instance.
- `@cedarjs/ogimage-gen` calls `createElement` / `renderToString` on the app's own page components, so it must use the same React the components were compiled against.
- `@cedarjs/vite` imports `react` / `react-dom/server` only in server-side streaming/SSR and RSC code (`src/streaming/*`, `src/rsc/*`) to render the app's components. The comments in `streamHelpers.ts` already describe the intent of using one React shared with the app's client components. No code in `packages/vite/src` resolves `react` relative to the package's own location (`createRequire`, `require.resolve`, `import.meta.resolve` searched); the `src/bundled/*` esbuild step resolves React at framework build time, which the devDependency covers. All builds use esbuild `packages: 'external'`, so React is never inlined into `dist`.

`packages/prerender/package.json`'s `"externals": { "react": "react", ... }` is a build-time externals map, not this problem, and is untouched.

Yarn emits `YN0060` peer-range warnings when an app uses a React version other than `19.2.3`; this is the same behaviour as the existing `@cedarjs/web` / `@cedarjs/forms` peers.
