### PR TITLE
chore(eslint-config): Drop project Babel config from the JS parser options

### DIFF
--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -26,11 +26,6 @@ export interface Flags {
   /** changes what babel-plugin-redwood-routes-auto-loader does */
   forPrerender?: boolean
   /**
-   * will enable presets to supporting linting in the absence of typescript
-   * related presets/plugins/parsers
-   */
-  forJavaScriptLinting?: boolean
-  /**
    * skip src/ alias and directory-named-import handling. The Vite
    * `cedarjs-resolve-cedar-style-imports` plugin covers these
    */
@@ -182,7 +177,7 @@ export const getWebSideOverrides = (
 export const getWebSideBabelPresets = (options: Flags) => {
   // When we perform prerendering we don't use vite, so we need to add the
   // appropriate presets for react, env, and typescript, etc.
-  if (options.forPrerender || options.forJavaScriptLinting) {
+  if (options.forPrerender) {
     let reactPresetConfig: babel.PluginItem = { runtime: 'automatic' }
 
     // This is a special case, where @babel/preset-react needs config

--- a/packages/eslint-config/index.mjs
+++ b/packages/eslint-config/index.mjs
@@ -5,12 +5,8 @@
 import jsxA11yPlugin from 'eslint-plugin-jsx-a11y'
 import globals from 'globals'
 
-import {
-  getApiSideDefaultBabelConfig,
-  getWebSideDefaultBabelConfig,
-} from '@cedarjs/babel-config'
 import cedarjsPlugin from '@cedarjs/eslint-plugin'
-import { getConfig, isTypeScriptProject } from '@cedarjs/project-config'
+import { getConfig } from '@cedarjs/project-config'
 
 import sharedConfigs from './shared.mjs'
 
@@ -18,35 +14,6 @@ import sharedConfigs from './shared.mjs'
 /** @returns {Promise<import('eslint').Linter.FlatConfig[]>} */
 export default async function createConfig() {
   const config = await getConfig()
-
-  /** @returns {import('@babel/core').TransformOptions} */
-  const getProjectBabelOptions = () => {
-    // We can't nest the web overrides inside the overrides block
-    // So we just take it out and put it as a separate item
-    // Ignoring overrides, as I don't think it has any impact on linting
-    const { overrides: _webOverrides, ...otherWebConfig } =
-      getWebSideDefaultBabelConfig({
-        // We have to enable certain presets like `@babel/preset-react` for JavaScript projects
-        forJavaScriptLinting: !isTypeScriptProject(),
-      })
-
-    const { overrides: _apiOverrides, ...otherApiConfig } =
-      getApiSideDefaultBabelConfig()
-
-    return {
-      plugins: [],
-      overrides: [
-        {
-          test: ['./api/', './scripts/'],
-          ...otherApiConfig,
-        },
-        {
-          test: ['./web/'],
-          ...otherWebConfig,
-        },
-      ],
-    }
-  }
 
   const plugins = {}
   const rules = {}
@@ -66,12 +33,21 @@ export default async function createConfig() {
     {
       ignores: ['!.storybook/'],
     },
+    // `@babel/eslint-parser` only parses, so it needs no presets, transform
+    // plugins or project Babel config. It ignores `ecmaFeatures.jsx` and takes
+    // its syntax plugins from `babelOptions.parserOpts` instead, so JSX is
+    // enabled there. The `React`, `gql` and `context` globals are declared
+    // further down in this file.
     {
       files: ['**/*.js', '**/*.jsx'],
       languageOptions: {
         parserOptions: {
           requireConfigFile: false,
-          babelOptions: getProjectBabelOptions(),
+          babelOptions: {
+            parserOpts: {
+              plugins: ['jsx'],
+            },
+          },
         },
       },
       plugins,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,7 +32,6 @@
     "@babel/core": "^7.26.10",
     "@babel/eslint-parser": "7.29.7",
     "@babel/eslint-plugin": "7.29.7",
-    "@cedarjs/babel-config": "workspace:*",
     "@cedarjs/eslint-plugin": "workspace:*",
     "@cedarjs/project-config": "workspace:*",
     "@eslint/js": "8.57.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,7 +2854,6 @@ __metadata:
     "@babel/core": "npm:^7.26.10"
     "@babel/eslint-parser": "npm:7.29.7"
     "@babel/eslint-plugin": "npm:7.29.7"
-    "@cedarjs/babel-config": "workspace:*"
     "@cedarjs/eslint-plugin": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
     "@eslint/js": "npm:8.57.1"


### PR DESCRIPTION
## Summary

`@cedarjs/eslint-config` no longer feeds a project Babel config into `@babel/eslint-parser` for `.js`/`.jsx` files, and no longer depends on `@cedarjs/babel-config`.

`@babel/eslint-parser` only parses; it needs no presets or transform plugins. The Cedar plugins that were being passed in (`module-resolver`, `directory-named-import`, `auto-import`, `graphql-tag`, ...) are pure transforms with no syntax hooks, so they contributed nothing to parsing. The `React`, `gql` and `context` globals that `babel-plugin-auto-import` would provide at build time are declared explicitly in `index.mjs`, so `no-undef` never depended on the plugin either.

The parser does need JSX enabled, and it ignores `ecmaFeatures.jsx` (it takes syntax plugins only from its Babel options). The config therefore passes a minimal, dependency-free `babelOptions: { parserOpts: { plugins: ['jsx'] } }`.

`forJavaScriptLinting` in `@cedarjs/babel-config`'s `getWebSideBabelPresets` had this config as its only caller and is removed; `forPrerender` behaviour is unchanged.

Effect for projects: building the lint config no longer calls `getConfig()`/`parseTypeScriptConfigFiles()` on every lint run, and `@cedarjs/eslint-config` no longer pulls `@babel/preset-env`, `@babel/preset-react`, `babel-plugin-auto-import`, `babel-plugin-graphql-tag`, `babel-plugin-module-resolver` etc. into the project through `@cedarjs/babel-config`. Lint output is unchanged.

## Testing

- `yarn install`, `yarn dedupe --check`, `yarn constraints`, `yarn check`, `yarn build`
- `yarn lint:fw`, `yarn prettier --check` on touched files
- `yarn lint:templates` — both the TS and the JS template (which has `.jsx` files) pass. Removing `babelOptions` entirely made the JS template's `.jsx` files fail with "This experimental syntax requires enabling ... jsx", which is what the `parserOpts` entry addresses.
- `CI=1 yarn workspace @cedarjs/babel-config test` (33 passed)

https://claude.ai/code/session_0118KQts9xYkwQ5uGq2XwLkp
