### PR TITLE
chore(vite)!: Build route hooks with Vite

### DIFF
--- a/packages/babel-config/dist.test.ts
+++ b/packages/babel-config/dist.test.ts
@@ -15,7 +15,6 @@ describe('dist', () => {
         "getApiSideBabelPresets": [Function],
         "getApiSideDefaultBabelConfig": [Function],
         "getPathsFromConfig": [Function],
-        "getRouteHookBabelPlugins": [Function],
         "getWebSideBabelConfigPath": [Function],
         "getWebSideBabelPlugins": [Function],
         "getWebSideBabelPresets": [Function],

--- a/packages/babel-config/src/common.ts
+++ b/packages/babel-config/src/common.ts
@@ -8,7 +8,6 @@ import { parseConfigFileTextToJson } from 'typescript'
 
 import { getPaths } from '@cedarjs/project-config'
 
-import { getWebSideBabelPlugins } from './web.js'
 import type { Flags as WebFlags } from './web.js'
 
 // `@babel/register` patches Node's CJS `require()` to compile files on the
@@ -55,12 +54,6 @@ export const registerBabel = (options: RegisterOptions) => {
   // the extensions .es6, .es, .jsx, .mjs, and .js will be transformed by Babel
   // (unless options.extensions override the default exensions).
   require('@babel/register')(options)
-}
-
-// TODO (STREAMING) double check this, think about it more carefully please!
-// It's related to yarn workspaces to be or not to be
-export const getRouteHookBabelPlugins = () => {
-  return [...getWebSideBabelPlugins()]
 }
 
 /**

--- a/packages/babel-config/src/index.ts
+++ b/packages/babel-config/src/index.ts
@@ -63,7 +63,6 @@ export {
    */
   getPathsFromTypeScriptConfig as getPathsFromConfig,
   /** Used by vite */
-  getRouteHookBabelPlugins,
   /**
    * @deprecated This export isn't used by the framework, so it'll be removed
    * in a future version.

--- a/packages/vite/src/__tests__/buildRouteHooks.test.ts
+++ b/packages/vite/src/__tests__/buildRouteHooks.test.ts
@@ -1,0 +1,31 @@
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { getRouteHookDistPath } from '../buildRouteHooks.js'
+
+const webSrc = path.join('/proj', 'web', 'src')
+
+describe('getRouteHookDistPath', () => {
+  it('mirrors the web/src layout for page route hooks', () => {
+    const src = path.join(webSrc, 'pages', 'HomePage', 'HomePage.routeHooks.ts')
+
+    expect(getRouteHookDistPath(src, webSrc)).toBe(
+      'pages/HomePage/HomePage.routeHooks.js',
+    )
+  })
+
+  it('puts the App route hook at the top level', () => {
+    const src = path.join(webSrc, 'App.routeHooks.tsx')
+
+    expect(getRouteHookDistPath(src, webSrc)).toBe('App.routeHooks.js')
+  })
+
+  it('only rewrites the file extension', () => {
+    const src = path.join(webSrc, 'pages', 'ts.js', 'ts.js.routeHooks.jsx')
+
+    expect(getRouteHookDistPath(src, webSrc)).toBe(
+      'pages/ts.js/ts.js.routeHooks.js',
+    )
+  })
+})

--- a/packages/vite/src/buildRouteHooks.ts
+++ b/packages/vite/src/buildRouteHooks.ts
@@ -1,121 +1,149 @@
-import fs from 'node:fs'
 import path from 'node:path'
 
-import type { PluginBuild } from 'esbuild'
-import { build as esbuildBuild } from 'esbuild'
-import { gqlPlugin } from 'vite-plugin-graphql-tag'
+import type { Plugin } from 'vite'
+import { build as viteBuild } from 'vite'
+import { gqlPlugin as gqlTagPlugin } from 'vite-plugin-graphql-tag'
+import tsPathsMod from 'vite-tsconfig-paths'
 
-import {
-  getRouteHookBabelPlugins,
-  transformWithBabel,
-} from '@cedarjs/babel-config'
 import { findRouteHooksSrc } from '@cedarjs/internal/dist/files.js'
 import type { Paths } from '@cedarjs/project-config'
 import { getPaths } from '@cedarjs/project-config'
 
-const GQL_TAG_PLUGIN_NAME = 'rwjs-babel-graphql-tag'
+import { cedarApiImportGuardPlugin } from './plugins/vite-plugin-cedar-api-import-guard.js'
+import { cedarAutoImportsPlugin } from './plugins/vite-plugin-cedar-auto-import.js'
+import { cedarDirectoryNamedImportPlugin } from './plugins/vite-plugin-cedar-directory-named-import.js'
+import { cedarjsResolveCedarStyleImportsPlugin } from './plugins/vite-plugin-cedarjs-resolve-cedar-style-imports.js'
 
-// gqlPlugin() returns Vite's PluginOption union (broad, includes false/
-// Promise/array). Narrow via control-flow elimination
-const gqlPluginResult = gqlPlugin()
-if (
-  !gqlPluginResult ||
-  Array.isArray(gqlPluginResult) ||
-  !('transform' in gqlPluginResult) ||
-  !gqlPluginResult.transform
+// vite-tsconfig-paths is ESM-only. CJS builds double-wrap its default
+// export: tsconfigPaths.default is the module object, and
+// tsconfigPaths.default.default is the actual function. ESM gets the
+// function directly. The `||` chain resolves correctly for both.
+const tsconfigPaths =
+  // @ts-expect-error – .default only exists at runtime in CJS double-wrap
+  // interop
+  tsPathsMod.default?.default || tsPathsMod.default || tsPathsMod
+
+/**
+ * Returns the path, relative to `web/dist/ssr/routeHooks` and with a `.js`
+ * extension, that the built version of the given route hook source file is
+ * written to. The layout mirrors `web/src`, so
+ * `web/src/pages/HomePage/HomePage.routeHooks.ts` ends up at
+ * `pages/HomePage/HomePage.routeHooks.js` and `web/src/App.routeHooks.ts` at
+ * `App.routeHooks.js`.
+ *
+ * Used both by the build (to name the Rollup entries) and by the route
+ * manifest (so the streaming handler can find the file at request time).
+ */
+export function getRouteHookDistPath(
+  routeHookSrcPath: string,
+  webSrc = getPaths().web.src,
 ) {
-  throw new Error('vite-plugin-graphql-tag did not return the expected shape')
+  return getRouteHookEntryName(routeHookSrcPath, webSrc) + '.js'
 }
 
-// gqlPluginResult.transform is ObjectHook<TransformHook> — Vite 7's union of
-// the raw function form and the object form { handler, filter?, order? }.
-// gqlPlugin() always returns the object form, so narrow to it via typeof.
-const transform = gqlPluginResult.transform
-if (typeof transform !== 'object' || !('handler' in transform)) {
-  throw new Error('vite-plugin-graphql-tag did not return the expected shape')
+function getRouteHookEntryName(routeHookSrcPath: string, webSrc: string) {
+  return path
+    .relative(webSrc, routeHookSrcPath)
+    .replace(/\.(js|ts|tsx|jsx)$/, '')
+    .split(path.sep)
+    .join('/')
 }
 
-const gqlTransform = transform.handler
+/**
+ * vite-plugin-graphql-tag only compiles `gql` tags that are bound to an
+ * import from `graphql-tag`. Route hooks get that import from
+ * cedarAutoImportsPlugin(), which runs as a `post` plugin. Running the gql
+ * plugin as a `post` plugin placed after it means the import is in place by
+ * the time it looks for `gql` tags.
+ */
+function postGqlTagPlugin(): Plugin {
+  const plugin = gqlTagPlugin()
 
+  // gqlPlugin() is typed as Vite's broad PluginOption union, but always
+  // returns a single plugin object
+  if (!plugin || Array.isArray(plugin) || plugin instanceof Promise) {
+    throw new Error('vite-plugin-graphql-tag did not return a plugin object')
+  }
+
+  return { ...plugin, enforce: 'post' }
+}
+
+/**
+ * Bundles every `web/src/** /*.routeHooks.{js,ts,tsx,jsx}` file into
+ * `web/dist/ssr/routeHooks` as a node ESM module, one output file per route
+ * hook. The streaming SSR handler `import()`s them at request time.
+ */
 export async function buildRouteHooks(
   verbose: boolean | undefined,
   rwPaths: Paths,
 ) {
   const allRouteHooks = findRouteHooksSrc()
 
-  const runRwBabelTransformsPlugin = {
-    name: 'cedar-esbuild-babel-transform',
-    setup(build: PluginBuild) {
-      build.onLoad({ filter: /\.(js|ts|tsx|jsx)$/ }, async (args) => {
-        const fileContents = await fs.promises.readFile(args.path, 'utf-8')
-
-        // Start with all route-hook plugins but exclude
-        // babel-plugin-graphql-tag — we handle gql compilation via
-        // vite-plugin-graphql-tag's transform below.
-        const babelPlugins = getRouteHookBabelPlugins().filter(
-          (p) => !(Array.isArray(p) && p[2] === GQL_TAG_PLUGIN_NAME),
-        )
-
-        const transformedCode = await transformWithBabel(
-          fileContents,
-          args.path,
-          babelPlugins,
-        )
-
-        if (transformedCode?.code) {
-          // Apply gql template compilation using vite-plugin-graphql-tag's
-          // transform with a minimal Vite context mock. The plugin only uses
-          // warn()/error() from the context. A full TransformPluginContext
-          // mock (30+ Rollup methods) is impractical here.
-          // We do this so we can use a vite plugin from esbuild. That's why the
-          // types are hacky here
-          const mockCtx = {
-            warn(msg: unknown) {
-              console.warn(`[gql-plugin] ${msg}`)
-            },
-            error(err: unknown): never {
-              throw new Error(String(err))
-            },
-          } as any
-
-          const gqlResult = await gqlTransform.call(
-            mockCtx,
-            transformedCode.code,
-            args.path,
-          )
-
-          const gqlCode =
-            gqlResult && typeof gqlResult === 'object' && 'code' in gqlResult
-              ? (gqlResult as { code: string }).code
-              : undefined
-
-          return {
-            contents: gqlCode ?? transformedCode.code,
-            loader: 'js',
-          }
-        }
-
-        throw new Error(`Could not transform file: ${args.path}`)
-      })
-    },
+  if (allRouteHooks.length === 0) {
+    return
   }
 
-  await esbuildBuild({
-    absWorkingDir: getPaths().web.base,
-    entryPoints: allRouteHooks,
-    platform: 'node',
-    target: 'node16',
-    // @MARK Disable splitting and esm, because Redwood web modules don't support esm yet
-    // outExtension: { '.js': '.mjs' },
-    // format: 'esm',
-    // splitting: true,
-    bundle: true,
-    plugins: [runRwBabelTransformsPlugin],
-    packages: 'external',
+  const input: Record<string, string> = {}
+  for (const routeHook of allRouteHooks) {
+    input[getRouteHookEntryName(routeHook, rwPaths.web.src)] = routeHook
+  }
+
+  await viteBuild({
+    // Route hooks run in node, so the project's web/vite.config, which is set
+    // up for browser and SSR builds of React code, doesn't apply. Only the
+    // plugins listed below are used.
+    configFile: false,
+    root: rwPaths.web.base,
+    // Route hooks are node modules, so the static assets in web/public
+    // must not be copied next to them
+    publicDir: false,
+    envFile: false,
     logLevel: verbose ? 'info' : 'error',
-    outdir: rwPaths.web.distRouteHooks,
-    alias: {
-      'api/src': path.join(getPaths().api.base, 'src'),
+    plugins: [
+      // Turns `$api/` imports into an error in the client environment. It's a
+      // no-op in this ssr-only build, but it has to sit in front of
+      // tsconfigPaths() wherever that plugin is used, so it's kept here for
+      // parity with the web build
+      cedarApiImportGuardPlugin(),
+      // Resolves the `paths` mapping in web/tsconfig.json, like `$api/*`
+      tsconfigPaths(),
+      // Resolves `src/` imports to the web side, `$api/` and `api/` imports to
+      // the api side, and directory-named modules for those
+      cedarjsResolveCedarStyleImportsPlugin(),
+      // Resolves relative `./Foo` imports to `./Foo/index` or `./Foo/Foo`
+      cedarDirectoryNamedImportPlugin(),
+      // Auto-imports `gql` and `React`
+      cedarAutoImportsPlugin(),
+      // Compiles `gql` template literals into DocumentNode objects. Placed
+      // after cedarAutoImportsPlugin(), see postGqlTagPlugin()
+      postGqlTagPlugin(),
+    ],
+    build: {
+      ssr: true,
+      target: 'node24',
+      minify: false,
+      outDir: rwPaths.web.distRouteHooks,
+      // The directory only ever holds route hook output, so clearing it keeps
+      // chunks from earlier builds from piling up
+      emptyOutDir: true,
+      rollupOptions: {
+        input,
+        output: {
+          format: 'es',
+          entryFileNames: '[name].js',
+          // Modules shared between route hooks, like the api side's db.js
+          chunkFileNames: 'chunks/[name]-[hash].js',
+          exports: 'named',
+        },
+      },
+    },
+    // Node builtins and everything that resolves into node_modules stay as
+    // imports for node to resolve at runtime. Only project files (the route
+    // hook itself and whatever it imports from the web and api sides) are
+    // bundled. Bare specifiers like `$api/` and `src/` are resolved by the
+    // plugins above before Vite decides whether to externalize them
+    ssr: {
+      external: true,
     },
   })
 }

--- a/packages/vite/src/buildRouteManifest.ts
+++ b/packages/vite/src/buildRouteManifest.ts
@@ -5,8 +5,9 @@ import url from 'node:url'
 import type { Manifest as ViteBuildManifest } from 'vite'
 
 import { getProjectRoutes } from '@cedarjs/internal/dist/routes.js'
-import { getAppRouteHook, getPaths } from '@cedarjs/project-config'
+import { getPaths } from '@cedarjs/project-config'
 
+import { getRouteHookDistPath } from './buildRouteHooks.js'
 import type { RWRouteManifest } from './types.js'
 
 /**
@@ -39,7 +40,9 @@ export async function buildRouteManifest() {
       // E.g. /blog/post/{id:Int}
       pathDefinition: route.pathDefinition,
       hasParams: route.hasParams,
-      routeHooks: FIXME_constructRouteHookPath(route.routeHooks),
+      routeHooks: route.routeHooks
+        ? getRouteHookDistPath(route.routeHooks)
+        : null,
       redirect: route.redirect
         ? {
             to: route.redirect?.to,
@@ -61,26 +64,4 @@ export async function buildRouteManifest() {
   const webRouteManifest = rwPaths.web.routeManifest
   await fs.mkdir(rwPaths.web.distSsr, { recursive: true })
   return fs.writeFile(webRouteManifest, JSON.stringify(routeManifest, null, 2))
-}
-
-// TODO (STREAMING) Hacky work around because when you don't have a App.routeHook, esbuild doesn't create
-// the pages folder in the dist/ssr/routeHooks directory.
-// @MARK need to change to .mjs here if we use esm
-const FIXME_constructRouteHookPath = (
-  routeHookSrcPath: string | null | undefined,
-) => {
-  const rwPaths = getPaths()
-  if (!routeHookSrcPath) {
-    return null
-  }
-
-  if (getAppRouteHook()) {
-    return path
-      .relative(rwPaths.web.src, routeHookSrcPath)
-      .replace('.ts', '.js')
-  } else {
-    return path
-      .relative(path.join(rwPaths.web.src, 'pages'), routeHookSrcPath)
-      .replace('.ts', '.js')
-  }
 }


### PR DESCRIPTION
## Summary

`web/src/**/*.routeHooks.{js,ts,tsx,jsx}` files are built with `vite.build()` (SSR/node target) using Cedar's existing Vite plugins, instead of an esbuild pass that ran every file through `@babel/core` with the web-side Babel plugin list and a hand-mocked `vite-plugin-graphql-tag` transform.

Plugins used, and why each is there:
- `cedarApiImportGuardPlugin()` — placed ahead of `tsconfigPaths()` for parity with the web build (a no-op in an SSR-only build).
- `tsconfigPaths()` — `web/tsconfig.json` `paths` (`$api/*`).
- `cedarjsResolveCedarStyleImportsPlugin()` — `src/`, `$api/`, `api/` imports and directory-named modules (covers what `babel-plugin-module-resolver` and the esbuild `api/src` alias did).
- `cedarDirectoryNamedImportPlugin()` — relative `./Foo` → `./Foo/Foo`.
- `cedarAutoImportsPlugin()` — `gql`/`React` auto-import.
- `gqlTagPlugin()` wrapped with `enforce: 'post'` and ordered after the auto-import plugin: the gql plugin only compiles tags bound to a `graphql-tag` import, and the auto-import plugin is itself a `post` plugin, so with default ordering `gql` stayed a runtime tagged template.

Build config: `configFile: false`, `root: web.base`, `publicDir: false`, `envFile: false`, `build.ssr: true`, `target: 'node24'`, `minify: false`, ESM output, `ssr.external: true` so node_modules stay external (Rollup `external` callbacks are deliberately not used: they receive unresolved ids, which would mark `$api/…`/`src/…` external before the resolver plugins run).

**Output layout (breaking):** files under `web/dist/ssr/routeHooks` always mirror `web/src` (`pages/AboutPage/AboutPage.routeHooks.js`, `App.routeHooks.js`). One exported helper, `getRouteHookDistPath()`, is used by both the build (Rollup entry names) and `buildRouteManifest.ts`, replacing the manifest's `FIXME_constructRouteHookPath` guess at esbuild's common-ancestor layout. Modules shared between hooks (e.g. the api side's `db.ts`) are emitted to `chunks/`. The loader in `createReactStreamingHandler.ts` uses `import()`, so ESM output is what it expects.

`getRouteHookBabelPlugins` is removed from `@cedarjs/babel-config` (this was its only caller). `transformWithBabel` stays: `buildApp.ts`/`apiDevMiddleware.ts` still use it for projects with an `api/babel.config.js`.

## Testing

- `yarn build`, `yarn lint:fw`, `yarn prettier --check` on touched files
- `CI=1 yarn workspace @cedarjs/vite test` (240 passed, incl. new `buildRouteHooks.test.ts` for the path mapping), `CI=1 yarn workspace @cedarjs/babel-config test` (33 passed), `yarn workspace @cedarjs/vite build:types`
- End-to-end in `local-testing-project` with streaming SSR enabled and a temporary `AboutPage.routeHooks.ts` that imports from `api/src/...`, `src/...` (directory-named), `$api/src/lib/db`, a relative directory-named path, uses `gql` without importing it, and exports `routeParameters`/`meta`: `yarn cedar build` succeeds; the emitted `web/dist/ssr/routeHooks/pages/AboutPage/AboutPage.routeHooks.js` contains the resolved imports (db via `../../chunks/db-*.js`, node_modules external) and the gql query compiled to a DocumentNode; the route manifest lists `pages/AboutPage/AboutPage.routeHooks.js`; `yarn cedar serve` + `curl /about` returns 200 with a `<title>` composed from every hook-derived value. Temporary project changes were reverted.
- Not directly exercised: `ssr.external` with symlinked workspace packages (`experimental.packagesWorkspace`); the test project consumed tarballs.

https://claude.ai/code/session_0118KQts9xYkwQ5uGq2XwLkp
