### PR TITLE
chore(cli): Convert TypeScript templates to JavaScript with sucrase

### DIFF
--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -72,7 +72,6 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@babel/core": "^7.26.10",
     "@cedarjs/project-config": "workspace:*",
     "@cedarjs/telemetry": "workspace:*",
     "@listr2/prompt-adapter-enquirer": "4.3.0",

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -88,6 +88,7 @@
     "prompts": "2.4.2",
     "semver": "7.8.5",
     "smol-toml": "1.8.0",
+    "sucrase": "3.35.1",
     "termi-link": "1.1.0",
     "yargs-parser": "21.1.1"
   },

--- a/packages/cli-helpers/src/index.ts
+++ b/packages/cli-helpers/src/index.ts
@@ -11,6 +11,7 @@ export {
 } from './lib/loadEnvFiles.js'
 export * from './lib/paths.js'
 export * from './lib/project.js'
+export * from './lib/transpileTSToJS.js'
 export * from './lib/version.js'
 export * from './auth/setupHelpers.js'
 export type { AuthHandlerArgs, AuthGeneratorCtx } from './auth/setupHelpers.js'

--- a/packages/cli-helpers/src/lib/index.ts
+++ b/packages/cli-helpers/src/lib/index.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs'
 import { pathToFileURL } from 'node:url'
 import path from 'path'
 
-import * as babel from '@babel/core'
 import type {
   ListrTaskWrapper,
   ListrRenderer,
@@ -13,6 +12,7 @@ import { format } from 'prettier'
 
 import { colors } from './colors.js'
 import { getPaths } from './paths.js'
+import { transpileTSToJS } from './transpileTSToJS.js'
 
 // TODO: Move this into `generateTemplate` when all templates have TS support
 /*
@@ -23,31 +23,17 @@ export const transformTSToJS = (filename: string, content: string) => {
     return content
   }
 
-  const babelFileResult = babel.transform(content, {
-    filename,
-    // If you ran `yarn cedar generate` in `./web` transformSync would import the `.babelrc.js` file,
-    // in `./web`? despite us setting `configFile: false`.
-    cwd: process.env.NODE_ENV === 'test' ? undefined : getPaths().base,
-    configFile: false,
-    plugins: [
-      [
-        '@babel/plugin-transform-typescript',
-        {
-          isTSX: true,
-          allExtensions: true,
-        },
-      ],
-    ],
-    retainLines: true,
-  })
+  let code: string
 
-  if (!babelFileResult?.code) {
-    console.error(colors.error(`Could not transform ${filename} to JS`))
+  try {
+    code = transpileTSToJS(filename, content)
+  } catch (e) {
+    console.error(colors.error(e instanceof Error ? e.message : String(e)))
 
     process.exit(1)
   }
 
-  return prettify(filename.replace(/\.ts(x)?$/, '.js$1'), babelFileResult.code)
+  return prettify(filename.replace(/\.ts(x)?$/, '.js$1'), code)
 }
 
 /**

--- a/packages/cli-helpers/src/lib/transpileTSToJS.ts
+++ b/packages/cli-helpers/src/lib/transpileTSToJS.ts
@@ -1,0 +1,222 @@
+import path from 'node:path'
+
+import ts from 'typescript'
+
+const BLANK_LINE_MARKER = '//__CEDAR_TS_TO_JS_BLANK_LINE__'
+const BLANK_LINE_REGEX = /^[ \t]*$/gm
+const BLANK_LINE_MARKER_REGEX =
+  /^[ \t]*\/\/__CEDAR_TS_TO_JS_BLANK_LINE__[ \t]*$/gm
+
+const JSX_COMMENT_PLACEHOLDER = '__CEDAR_TS_TO_JS_JSX_COMMENT_'
+const JSX_COMMENT_PLACEHOLDER_REGEX =
+  /\{\s*'__CEDAR_TS_TO_JS_JSX_COMMENT_(\d+)__'\s*\}/g
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ESNext,
+  module: ts.ModuleKind.ESNext,
+  // Keep JSX untouched. Generated .js/.jsx files contain JSX that the
+  // project's own build compiles.
+  jsx: ts.JsxEmit.Preserve,
+  // Drop imports that are only used as types, including regular imports
+  // whose bindings are never used as values.
+  verbatimModuleSyntax: false,
+  removeComments: false,
+}
+
+/**
+ * Whether the emitter drops this statement entirely because it only carries
+ * type information.
+ */
+function isTypeOnlyStatement(statement: ts.Statement) {
+  if (
+    ts.isInterfaceDeclaration(statement) ||
+    ts.isTypeAliasDeclaration(statement)
+  ) {
+    return true
+  }
+
+  if (ts.isImportDeclaration(statement)) {
+    const clause = statement.importClause
+
+    if (!clause) {
+      return false
+    }
+
+    if (clause.isTypeOnly) {
+      return true
+    }
+
+    const bindings = clause.namedBindings
+
+    return (
+      !clause.name &&
+      !!bindings &&
+      ts.isNamedImports(bindings) &&
+      bindings.elements.length > 0 &&
+      bindings.elements.every((element) => element.isTypeOnly)
+    )
+  }
+
+  if (ts.isExportDeclaration(statement)) {
+    return statement.isTypeOnly
+  }
+
+  const modifiers = ts.canHaveModifiers(statement)
+    ? (ts.getModifiers(statement) ?? [])
+    : []
+
+  return modifiers.some(
+    (modifier) => modifier.kind === ts.SyntaxKind.DeclareKeyword,
+  )
+}
+
+/**
+ * The emitter discards comments that sit above a type-only statement together
+ * with the statement itself. This transformer moves such comments to the next
+ * emitted statement so that, for example, a file-level comment above an
+ * `interface` still ends up in the JavaScript output.
+ */
+const keepCommentsOfTypeOnlyStatements: ts.TransformerFactory<
+  ts.SourceFile
+> = () => {
+  return (sourceFile) => {
+    const text = sourceFile.getFullText()
+    let pending: ts.CommentRange[] = []
+
+    for (const statement of sourceFile.statements) {
+      const ranges =
+        ts.getLeadingCommentRanges(text, statement.getFullStart()) ?? []
+
+      if (isTypeOnlyStatement(statement)) {
+        pending = [...pending, ...ranges]
+        continue
+      }
+
+      if (pending.length === 0) {
+        continue
+      }
+
+      ts.setEmitFlags(statement, ts.EmitFlags.NoLeadingComments)
+
+      for (const range of [...pending, ...ranges]) {
+        const raw = text.slice(range.pos, range.end)
+        const body =
+          range.kind === ts.SyntaxKind.SingleLineCommentTrivia
+            ? raw.slice(2)
+            : raw.slice(2, -2)
+
+        ts.addSyntheticLeadingComment(statement, range.kind, body, true)
+      }
+
+      pending = []
+    }
+
+    return sourceFile
+  }
+}
+
+/**
+ * The emitter re-indents the lines of multi-line comments inside JSX
+ * expressions (`{/* ... *\/}`). Such comments are swapped for a string
+ * placeholder before transpiling and put back verbatim afterwards.
+ */
+function extractJsxComments(fileName: string, content: string) {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    content,
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TSX,
+  )
+
+  const comments: string[] = []
+  const replacements: { start: number; end: number; text: string }[] = []
+
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxExpression(node) && !node.expression) {
+      const index = comments.push(node.getText(sourceFile)) - 1
+
+      replacements.push({
+        start: node.getStart(sourceFile),
+        end: node.getEnd(),
+        text: `{'${JSX_COMMENT_PLACEHOLDER}${index}__'}`,
+      })
+
+      return
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+
+  let result = content
+
+  for (const replacement of replacements.reverse()) {
+    result =
+      result.slice(0, replacement.start) +
+      replacement.text +
+      result.slice(replacement.end)
+  }
+
+  return { content: result, comments }
+}
+
+function restoreJsxComments(content: string, comments: string[]) {
+  return content.replace(
+    JSX_COMMENT_PLACEHOLDER_REGEX,
+    (_match, index: string) => comments[Number(index)],
+  )
+}
+
+/**
+ * Strips the TypeScript syntax from `content` and returns the resulting
+ * JavaScript source. JSX is left untouched. Comments and blank lines are kept
+ * where they are so the output only needs formatting.
+ *
+ * `filename` is used for error messages. The content is always parsed as TSX
+ * because templates can contain JSX regardless of their extension.
+ *
+ * Throws when the TypeScript compiler reports a syntax error.
+ */
+export function transpileTSToJS(filename: string, content: string) {
+  const fileName = path.basename(filename).replace(/\.tsx?$/, '') + '.tsx'
+
+  // The TypeScript emitter does not keep blank lines, so every blank line is
+  // swapped for a marker comment before transpiling and restored afterwards.
+  // Comments survive the emitter (`removeComments: false`) and end up in the
+  // same spot the blank line had.
+  const withMarkers = content.replace(BLANK_LINE_REGEX, BLANK_LINE_MARKER)
+  const { content: source, comments } = extractJsxComments(
+    fileName,
+    withMarkers,
+  )
+
+  const result = ts.transpileModule(source, {
+    fileName,
+    compilerOptions: COMPILER_OPTIONS,
+    reportDiagnostics: true,
+    transformers: { before: [keepCommentsOfTypeOnlyStatements] },
+  })
+
+  const errors = (result.diagnostics ?? []).filter(
+    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+  )
+
+  if (errors.length > 0) {
+    const details = errors
+      .map((diagnostic) =>
+        ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+      )
+      .join('\n')
+
+    throw new Error(
+      `Could not transform ${filename} from TypeScript to JavaScript:\n${details}`,
+    )
+  }
+
+  return restoreJsxComments(
+    result.outputText.replace(BLANK_LINE_MARKER_REGEX, ''),
+    comments,
+  )
+}

--- a/packages/cli-helpers/src/lib/transpileTSToJS.ts
+++ b/packages/cli-helpers/src/lib/transpileTSToJS.ts
@@ -1,222 +1,69 @@
-import path from 'node:path'
+import { transform } from 'sucrase'
 
-import ts from 'typescript'
-
-const BLANK_LINE_MARKER = '//__CEDAR_TS_TO_JS_BLANK_LINE__'
-const BLANK_LINE_REGEX = /^[ \t]*$/gm
-const BLANK_LINE_MARKER_REGEX =
-  /^[ \t]*\/\/__CEDAR_TS_TO_JS_BLANK_LINE__[ \t]*$/gm
-
-const JSX_COMMENT_PLACEHOLDER = '__CEDAR_TS_TO_JS_JSX_COMMENT_'
-const JSX_COMMENT_PLACEHOLDER_REGEX =
-  /\{\s*'__CEDAR_TS_TO_JS_JSX_COMMENT_(\d+)__'\s*\}/g
-
-const COMPILER_OPTIONS: ts.CompilerOptions = {
-  target: ts.ScriptTarget.ESNext,
-  module: ts.ModuleKind.ESNext,
-  // Keep JSX untouched. Generated .js/.jsx files contain JSX that the
-  // project's own build compiles.
-  jsx: ts.JsxEmit.Preserve,
-  // Drop imports that are only used as types, including regular imports
-  // whose bindings are never used as values.
-  verbatimModuleSyntax: false,
-  removeComments: false,
-}
-
-/**
- * Whether the emitter drops this statement entirely because it only carries
- * type information.
- */
-function isTypeOnlyStatement(statement: ts.Statement) {
-  if (
-    ts.isInterfaceDeclaration(statement) ||
-    ts.isTypeAliasDeclaration(statement)
-  ) {
-    return true
-  }
-
-  if (ts.isImportDeclaration(statement)) {
-    const clause = statement.importClause
-
-    if (!clause) {
-      return false
-    }
-
-    if (clause.isTypeOnly) {
-      return true
-    }
-
-    const bindings = clause.namedBindings
-
-    return (
-      !clause.name &&
-      !!bindings &&
-      ts.isNamedImports(bindings) &&
-      bindings.elements.length > 0 &&
-      bindings.elements.every((element) => element.isTypeOnly)
-    )
-  }
-
-  if (ts.isExportDeclaration(statement)) {
-    return statement.isTypeOnly
-  }
-
-  const modifiers = ts.canHaveModifiers(statement)
-    ? (ts.getModifiers(statement) ?? [])
-    : []
-
-  return modifiers.some(
-    (modifier) => modifier.kind === ts.SyntaxKind.DeclareKeyword,
-  )
-}
-
-/**
- * The emitter discards comments that sit above a type-only statement together
- * with the statement itself. This transformer moves such comments to the next
- * emitted statement so that, for example, a file-level comment above an
- * `interface` still ends up in the JavaScript output.
- */
-const keepCommentsOfTypeOnlyStatements: ts.TransformerFactory<
-  ts.SourceFile
-> = () => {
-  return (sourceFile) => {
-    const text = sourceFile.getFullText()
-    let pending: ts.CommentRange[] = []
-
-    for (const statement of sourceFile.statements) {
-      const ranges =
-        ts.getLeadingCommentRanges(text, statement.getFullStart()) ?? []
-
-      if (isTypeOnlyStatement(statement)) {
-        pending = [...pending, ...ranges]
-        continue
-      }
-
-      if (pending.length === 0) {
-        continue
-      }
-
-      ts.setEmitFlags(statement, ts.EmitFlags.NoLeadingComments)
-
-      for (const range of [...pending, ...ranges]) {
-        const raw = text.slice(range.pos, range.end)
-        const body =
-          range.kind === ts.SyntaxKind.SingleLineCommentTrivia
-            ? raw.slice(2)
-            : raw.slice(2, -2)
-
-        ts.addSyntheticLeadingComment(statement, range.kind, body, true)
-      }
-
-      pending = []
-    }
-
-    return sourceFile
-  }
-}
-
-/**
- * The emitter re-indents the lines of multi-line comments inside JSX
- * expressions (`{/* ... *\/}`). Such comments are swapped for a string
- * placeholder before transpiling and put back verbatim afterwards.
- */
-function extractJsxComments(fileName: string, content: string) {
-  const sourceFile = ts.createSourceFile(
-    fileName,
-    content,
-    ts.ScriptTarget.ESNext,
-    true,
-    ts.ScriptKind.TSX,
-  )
-
-  const comments: string[] = []
-  const replacements: { start: number; end: number; text: string }[] = []
-
-  const visit = (node: ts.Node) => {
-    if (ts.isJsxExpression(node) && !node.expression) {
-      const index = comments.push(node.getText(sourceFile)) - 1
-
-      replacements.push({
-        start: node.getStart(sourceFile),
-        end: node.getEnd(),
-        text: `{'${JSX_COMMENT_PLACEHOLDER}${index}__'}`,
-      })
-
-      return
-    }
-
-    ts.forEachChild(node, visit)
-  }
-
-  visit(sourceFile)
-
-  let result = content
-
-  for (const replacement of replacements.reverse()) {
-    result =
-      result.slice(0, replacement.start) +
-      replacement.text +
-      result.slice(replacement.end)
-  }
-
-  return { content: result, comments }
-}
-
-function restoreJsxComments(content: string, comments: string[]) {
-  return content.replace(
-    JSX_COMMENT_PLACEHOLDER_REGEX,
-    (_match, index: string) => comments[Number(index)],
-  )
-}
+const BLANK_LINE_REGEX = /^[ \t]*$/
 
 /**
  * Strips the TypeScript syntax from `content` and returns the resulting
- * JavaScript source. JSX is left untouched. Comments and blank lines are kept
- * where they are so the output only needs formatting.
+ * JavaScript source. Everything that is not TypeScript syntax, including JSX,
+ * comments, blank lines and indentation, is kept byte-for-byte, so the output
+ * only needs formatting.
+ *
+ * `import type` statements, `type` specifiers and imports whose bindings are
+ * only used as types are removed. Lines that only held removed syntax (for
+ * example an `import type` line or an `interface` body) are dropped so they
+ * do not turn into stray blank lines.
  *
  * `filename` is used for error messages. The content is always parsed as TSX
  * because templates can contain JSX regardless of their extension.
  *
- * Throws when the TypeScript compiler reports a syntax error.
+ * Throws when sucrase reports a syntax error.
  */
 export function transpileTSToJS(filename: string, content: string) {
-  const fileName = path.basename(filename).replace(/\.tsx?$/, '') + '.tsx'
+  let code: string
 
-  // The TypeScript emitter does not keep blank lines, so every blank line is
-  // swapped for a marker comment before transpiling and restored afterwards.
-  // Comments survive the emitter (`removeComments: false`) and end up in the
-  // same spot the blank line had.
-  const withMarkers = content.replace(BLANK_LINE_REGEX, BLANK_LINE_MARKER)
-  const { content: source, comments } = extractJsxComments(
-    fileName,
-    withMarkers,
-  )
-
-  const result = ts.transpileModule(source, {
-    fileName,
-    compilerOptions: COMPILER_OPTIONS,
-    reportDiagnostics: true,
-    transformers: { before: [keepCommentsOfTypeOnlyStatements] },
-  })
-
-  const errors = (result.diagnostics ?? []).filter(
-    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
-  )
-
-  if (errors.length > 0) {
-    const details = errors
-      .map((diagnostic) =>
-        ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
-      )
-      .join('\n')
+  try {
+    code = transform(content, {
+      // `jsx` is required to parse JSX at all. `jsxRuntime: 'preserve'` keeps
+      // the JSX untouched so the project's own build compiles it.
+      transforms: ['typescript', 'jsx'],
+      jsxRuntime: 'preserve',
+      // Keep modern ECMAScript syntax (optional chaining, class fields, ...)
+      // as written.
+      disableESTransforms: true,
+      keepUnusedImports: false,
+      filePath: filename,
+    }).code
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
 
     throw new Error(
-      `Could not transform ${filename} from TypeScript to JavaScript:\n${details}`,
+      `Could not transform ${filename} from TypeScript to JavaScript:\n${message}`,
     )
   }
 
-  return restoreJsxComments(
-    result.outputText.replace(BLANK_LINE_MARKER_REGEX, ''),
-    comments,
-  )
+  return dropEmptiedLines(content, code)
+}
+
+/**
+ * sucrase keeps every line break, so line `n` of the output corresponds to
+ * line `n` of the input. A line that is blank in the output but was not blank
+ * in the input only contained TypeScript syntax and is removed.
+ */
+function dropEmptiedLines(input: string, output: string) {
+  const inputLines = input.split('\n')
+  const outputLines = output.split('\n')
+
+  if (inputLines.length !== outputLines.length) {
+    return output
+  }
+
+  return outputLines
+    .filter(
+      (line, index) =>
+        !(
+          BLANK_LINE_REGEX.test(line) &&
+          !BLANK_LINE_REGEX.test(inputLines[index])
+        ),
+    )
+    .join('\n')
 }

--- a/packages/cli-helpers/src/lib/transpileTSToJS.ts
+++ b/packages/cli-helpers/src/lib/transpileTSToJS.ts
@@ -45,8 +45,8 @@ export function transpileTSToJS(filename: string, content: string) {
 }
 
 /**
- * sucrase keeps every line break, so line `n` of the output corresponds to
- * line `n` of the input. A line that is blank in the output but was not blank
+ * sucrase keeps every line break, so line number X of the output corresponds to
+ * line X of the input. A line that is blank in the output but was not blank
  * in the input only contained TypeScript syntax and is removed.
  */
 function dropEmptiedLines(input: string, output: string) {
@@ -60,10 +60,8 @@ function dropEmptiedLines(input: string, output: string) {
   return outputLines
     .filter(
       (line, index) =>
-        !(
-          BLANK_LINE_REGEX.test(line) &&
-          !BLANK_LINE_REGEX.test(inputLines[index])
-        ),
+        !BLANK_LINE_REGEX.test(line) ||
+        BLANK_LINE_REGEX.test(inputLines[index]),
     )
     .join('\n')
 }

--- a/packages/cli/src/commands/generate/dbAuth/__tests__/__snapshots__/dbAuth.test.ts.snap
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/__snapshots__/dbAuth.test.ts.snap
@@ -438,7 +438,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="username" className="rw-field-error" />
 
                   <Label
@@ -460,7 +459,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="secret" className="rw-field-error" />
 
                   <div className="rw-button-group">
@@ -918,7 +916,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="username" className="rw-field-error" />
 
                   <Label
@@ -940,7 +937,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="secret" className="rw-field-error" />
 
                   <div className="rw-button-group">
@@ -1398,7 +1394,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="email" className="rw-field-error" />
 
                   <Label
@@ -1420,7 +1415,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="secret" className="rw-field-error" />
 
                   <div className="rw-button-group">
@@ -1878,7 +1872,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="email" className="rw-field-error" />
 
                   <Label
@@ -1900,7 +1893,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="secret" className="rw-field-error" />
 
                   <div className="rw-button-group">
@@ -2490,7 +2482,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="email" className="rw-field-error" />
 
                   <Label
@@ -2512,7 +2503,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="secret" className="rw-field-error" />
 
                   <div className="rw-button-group">
@@ -3102,7 +3092,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="email" className="rw-field-error" />
 
                   <Label
@@ -3124,7 +3113,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="secret" className="rw-field-error" />
 
                   <div className="rw-button-group">
@@ -3588,7 +3576,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="email" className="rw-field-error" />
 
                   <Label
@@ -3610,7 +3597,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="password" className="rw-field-error" />
 
                   <div className="rw-button-group">
@@ -4074,7 +4060,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="email" className="rw-field-error" />
 
                   <Label
@@ -4096,7 +4081,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="password" className="rw-field-error" />
 
                   <div className="rw-button-group">
@@ -4560,7 +4544,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="username" className="rw-field-error" />
 
                   <Label
@@ -4582,7 +4565,6 @@ const SignupPage = () => {
                       },
                     }}
                   />
-
                   <FieldError name="password" className="rw-field-error" />
 
                   <div className="rw-button-group">

--- a/packages/cli/src/commands/generate/function/__tests__/function.test.ts
+++ b/packages/cli/src/commands/generate/function/__tests__/function.test.ts
@@ -87,9 +87,9 @@ test('creates a .js file if --javascript=true', async () => {
       )
     ],
   ).toMatchSnapshot()
-  // ^ JS-function-args should be stripped of their types and consequently the
-  // unused 'aws-lamda' import removed. `ts.transpileModule` drops imports
-  // whose bindings are only used as types.
+  // ^ JavaScript function arguments carry no types, so the `aws-lambda`
+  // import, whose bindings are only used as types, is removed by
+  // `transpileTSToJS`.
 })
 
 test('creates a .ts file if --typescript=true', async () => {

--- a/packages/cli/src/commands/generate/function/__tests__/function.test.ts
+++ b/packages/cli/src/commands/generate/function/__tests__/function.test.ts
@@ -87,8 +87,9 @@ test('creates a .js file if --javascript=true', async () => {
       )
     ],
   ).toMatchSnapshot()
-  // ^ JS-function-args should be stripped of their types and consequently the unused 'aws-lamda' import removed.
-  // https://babeljs.io/docs/en/babel-plugin-transform-typescript
+  // ^ JS-function-args should be stripped of their types and consequently the
+  // unused 'aws-lamda' import removed. `ts.transpileModule` drops imports
+  // whose bindings are only used as types.
 })
 
 test('creates a .ts file if --typescript=true', async () => {

--- a/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.ts.snap
+++ b/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.ts.snap
@@ -14,9 +14,9 @@ const CatsPage = () => {
         Find me in <code>./web/src/pages/CatsPage/CatsPage.jsx</code>
       </p>
       {/*
-           My default route is named \`cats\`, link to me with:
-           \`<Link to={routes.cats()}>Cats</Link>\`
-        */}
+          My default route is named \`cats\`, link to me with:
+          \`<Link to={routes.cats()}>Cats</Link>\`
+      */}
     </>
   )
 }
@@ -39,9 +39,9 @@ const HomePage = () => {
         Find me in <code>./web/src/pages/HomePage/HomePage.jsx</code>
       </p>
       {/*
-           My default route is named \`home\`, link to me with:
-           \`<Link to={routes.home()}>Home</Link>\`
-        */}
+          My default route is named \`home\`, link to me with:
+          \`<Link to={routes.home()}>Home</Link>\`
+      */}
     </>
   )
 }
@@ -261,9 +261,9 @@ const HomePage = () => {
         Find me in <code>./web/src/pages/HomePage/HomePage.jsx</code>
       </p>
       {/*
-           My default route is named \`home\`, link to me with:
-           \`<Link to={routes.home()}>Home</Link>\`
-        */}
+          My default route is named \`home\`, link to me with:
+          \`<Link to={routes.home()}>Home</Link>\`
+      */}
     </>
   )
 }
@@ -348,9 +348,9 @@ const PostPage = ({ id }) => {
         The parameter passed to me is <code>{id}</code>
       </p>
       {/*
-           My default route is named \`post\`, link to me with:
-           \`<Link to={routes.post({ id: '42' })}>Post 42</Link>\`
-        */}
+          My default route is named \`post\`, link to me with:
+          \`<Link to={routes.post({ id: '42' })}>Post 42</Link>\`
+      */}
     </>
   )
 }
@@ -394,9 +394,9 @@ const ContactUsPage = () => {
         Find me in <code>./web/src/pages/ContactUsPage/ContactUsPage.jsx</code>
       </p>
       {/*
-           My default route is named \`contactUs\`, link to me with:
-           \`<Link to={routes.contactUs()}>ContactUs</Link>\`
-        */}
+          My default route is named \`contactUs\`, link to me with:
+          \`<Link to={routes.contactUs()}>ContactUs</Link>\`
+      */}
     </>
   )
 }
@@ -453,9 +453,9 @@ const PostPage = ({ id }) => {
         The parameter passed to me is <code>{id}</code>
       </p>
       {/*
-           My default route is named \`post\`, link to me with:
-           \`<Link to={routes.post({ id: '42' })}>Post 42</Link>\`
-        */}
+          My default route is named \`post\`, link to me with:
+          \`<Link to={routes.post({ id: '42' })}>Post 42</Link>\`
+      */}
     </>
   )
 }

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.ts.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.ts.snap
@@ -4,7 +4,6 @@ exports[`'use client' directive > creates a new EditPostCell cell with the 'use 
 "'use client'
 
 import { navigate, routes } from '@cedarjs/router'
-
 import { useMutation } from '@cedarjs/web'
 import { toast } from '@cedarjs/web/toast'
 
@@ -92,7 +91,6 @@ exports[`'use client' directive > creates a new NewPost component with the 'use 
 
 import { navigate, routes } from '@cedarjs/router'
 import { useMutation } from '@cedarjs/web'
-
 import { toast } from '@cedarjs/web/toast'
 
 import PostForm from 'src/components/Post/PostForm'
@@ -908,7 +906,6 @@ export default ScaffoldLayout
 exports[`in javascript (default) mode > creates a new component 1`] = `
 "import { navigate, routes } from '@cedarjs/router'
 import { useMutation } from '@cedarjs/web'
-
 import { toast } from '@cedarjs/web/toast'
 
 import PostForm from 'src/components/Post/PostForm'
@@ -955,7 +952,6 @@ export default NewPost
 exports[`in javascript (default) mode > creates a new component with int foreign keys converted in onSave 1`] = `
 "import { navigate, routes } from '@cedarjs/router'
 import { useMutation } from '@cedarjs/web'
-
 import { toast } from '@cedarjs/web/toast'
 
 import UserProfileForm from 'src/components/UserProfile/UserProfileForm'
@@ -1053,7 +1049,6 @@ export const Success = ({ post }) => {
 exports[`in javascript (default) mode > creates a show component 1`] = `
 "import { Link, routes, navigate } from '@cedarjs/router'
 import { useMutation } from '@cedarjs/web'
-
 import { toast } from '@cedarjs/web/toast'
 
 import { checkboxInputTag, jsonDisplay, timeTag } from 'src/lib/formatters.js'
@@ -1588,7 +1583,6 @@ exports[`in javascript (default) mode > creates an edit cell 1`] = `undefined`;
 
 exports[`in javascript (default) mode > creates an edit component with int foreign keys converted in onSave 1`] = `
 "import { navigate, routes } from '@cedarjs/router'
-
 import { useMutation } from '@cedarjs/web'
 import { toast } from '@cedarjs/web/toast'
 
@@ -1713,7 +1707,6 @@ export const Success = ({ posts }) => {
 exports[`in javascript (default) mode > creates an index component 1`] = `
 "import { Link, routes } from '@cedarjs/router'
 import { useMutation } from '@cedarjs/web'
-
 import { toast } from '@cedarjs/web/toast'
 
 import { QUERY } from 'src/components/Post/PostsCell'
@@ -1874,7 +1867,6 @@ const PixelForm = (props) => {
             className="rw-input"
             errorClassName="rw-input rw-input-error"
           />
-
           <div>Red</div>
         </div>
 
@@ -1887,7 +1879,6 @@ const PixelForm = (props) => {
             className="rw-input"
             errorClassName="rw-input rw-input-error"
           />
-
           <div>Green</div>
         </div>
 
@@ -1900,7 +1891,6 @@ const PixelForm = (props) => {
             className="rw-input"
             errorClassName="rw-input rw-input-error"
           />
-
           <div>Blue</div>
         </div>
 
@@ -1923,7 +1913,6 @@ const PixelForm = (props) => {
             className="rw-input"
             errorClassName="rw-input rw-input-error"
           />
-
           <div className="rw-check-radio-item-none">None</div>
         </div>
 
@@ -1936,7 +1925,6 @@ const PixelForm = (props) => {
             className="rw-input"
             errorClassName="rw-input rw-input-error"
           />
-
           <div>Triangular</div>
         </div>
 
@@ -1949,7 +1937,6 @@ const PixelForm = (props) => {
             className="rw-input"
             errorClassName="rw-input rw-input-error"
           />
-
           <div>Stripes</div>
         </div>
 
@@ -1962,7 +1949,6 @@ const PixelForm = (props) => {
             className="rw-input"
             errorClassName="rw-input rw-input-error"
           />
-
           <div>Diagonal</div>
         </div>
 

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffoldNoNest.test.ts.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffoldNoNest.test.ts.snap
@@ -322,7 +322,6 @@ exports[`in javascript (default) mode > creates a new component 1`] = `undefined
 exports[`in javascript (default) mode > creates a new component with int foreign keys converted in onSave 1`] = `
 "import { navigate, routes } from '@cedarjs/router'
 import { useMutation } from '@cedarjs/web'
-
 import { toast } from '@cedarjs/web/toast'
 
 import UserProfileForm from 'src/components/UserProfileForm'
@@ -420,7 +419,6 @@ export const Success = ({ post }) => {
 exports[`in javascript (default) mode > creates a show component 1`] = `
 "import { Link, routes, navigate } from '@cedarjs/router'
 import { useMutation } from '@cedarjs/web'
-
 import { toast } from '@cedarjs/web/toast'
 
 import { checkboxInputTag, jsonDisplay, timeTag } from 'src/lib/formatters.js'
@@ -955,7 +953,6 @@ exports[`in javascript (default) mode > creates an edit cell 1`] = `undefined`;
 
 exports[`in javascript (default) mode > creates an edit component with int foreign keys converted in onSave 1`] = `
 "import { navigate, routes } from '@cedarjs/router'
-
 import { useMutation } from '@cedarjs/web'
 import { toast } from '@cedarjs/web/toast'
 
@@ -1080,7 +1077,6 @@ export const Success = ({ posts }) => {
 exports[`in javascript (default) mode > creates an index component 1`] = `
 "import { Link, routes } from '@cedarjs/router'
 import { useMutation } from '@cedarjs/web'
-
 import { toast } from '@cedarjs/web/toast'
 
 import { QUERY } from 'src/components/PostsCell'

--- a/packages/cli/src/lib/index.ts
+++ b/packages/cli/src/lib/index.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs'
 import https from 'node:https'
 import path from 'node:path'
 
-import * as babel from '@babel/core'
 import boxen from 'boxen'
 import camelcase from 'camelcase'
 import { paramCase } from 'change-case'
@@ -16,7 +15,7 @@ import { format } from 'prettier'
 import type { Options as PrettierOptions } from 'prettier'
 import type { Options as YargsOptions } from 'yargs'
 
-import { colors as c } from '@cedarjs/cli-helpers'
+import { colors as c, transpileTSToJS } from '@cedarjs/cli-helpers'
 import {
   addRootPackages,
   addWorkspacePackages,
@@ -323,30 +322,10 @@ export const transformTSToJS = async (
   filename: string,
   content: string,
 ): Promise<string> => {
-  const result = babel.transform(content, {
-    filename,
-    // If you ran `yarn cedar generate` in `./web` transformSync would import
-    // the `.babelrc.js` file, in `./web` despite us setting `configFile: false`
-    cwd: process.env.NODE_ENV === 'test' ? undefined : getPaths().base,
-    configFile: false,
-    plugins: [
-      [
-        '@babel/plugin-transform-typescript',
-        {
-          isTSX: true,
-          allExtensions: true,
-        },
-      ],
-    ],
-    retainLines: true,
-  })
-
-  if (result?.code == null) {
-    throw new Error(
-      `Could not transform ${filename} from TypeScript to JavaScript`,
-    )
-  }
-  return prettify(filename.replace(/\.ts(x)?$/, '.js$1'), result.code)
+  return prettify(
+    filename.replace(/\.ts(x)?$/, '.js$1'),
+    transpileTSToJS(filename, content),
+  )
 }
 
 /**

--- a/packages/create-cedar-app/package.json
+++ b/packages/create-cedar-app/package.json
@@ -25,8 +25,7 @@
     "ts-to-js": "yarn node ./scripts/tsToJS.js"
   },
   "devDependencies": {
-    "@babel/core": "^7.26.10",
-    "@babel/plugin-transform-typescript": "^7.26.8",
+    "@cedarjs/cli-helpers": "workspace:*",
     "@cedarjs/framework-tools": "workspace:*",
     "@cedarjs/tui": "workspace:*",
     "@opentelemetry/api": "1.9.1",
@@ -34,7 +33,6 @@
     "@opentelemetry/resources": "1.30.1",
     "@opentelemetry/sdk-trace-node": "1.30.1",
     "@opentelemetry/semantic-conventions": "1.41.1",
-    "@types/babel__core": "7.20.5",
     "@types/klaw-sync": "6.0.5",
     "ansis": "4.3.1",
     "ci-info": "4.4.0",

--- a/packages/create-cedar-app/scripts/tsToJS.js
+++ b/packages/create-cedar-app/scripts/tsToJS.js
@@ -3,9 +3,10 @@
 import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
-import { transformFileSync } from '@babel/core'
 import { format } from 'prettier'
 import { glob, path } from 'zx'
+
+import { transpileTSToJS } from '@cedarjs/cli-helpers'
 
 const TS_TEMPLATE_PATH = fileURLToPath(
   new URL('../templates/ts', import.meta.url),
@@ -52,26 +53,11 @@ const { default: prettierConfig } = await import(
 for (const filePath of filePaths) {
   console.log(`• ${filePath}`)
 
-  const result = transformFileSync(filePath, {
-    cwd: TS_TEMPLATE_PATH,
-    configFile: false,
-    plugins: [
-      [
-        '@babel/plugin-transform-typescript',
-        {
-          isTSX: true,
-          allExtensions: true,
-        },
-      ],
-    ],
-    retainLines: true,
-  })
+  const source = await fs.promises.readFile(filePath, 'utf-8')
 
-  if (!result) {
-    throw new Error(`Error: Couldn't transform ${filePath}`)
-  }
+  const code = transpileTSToJS(filePath, source)
 
-  const formattedCode = await format(result.code, {
+  const formattedCode = await format(code, {
     ...prettierConfig,
     parser: 'babel',
   })
@@ -142,12 +128,12 @@ fs.writeFileSync(authFilePath, authFile)
 console.groupEnd()
 
 console.group(
-  'Removing the cell-type-annotations override from eslint.config.mjs',
+  'Removing the cell-type-annotations override from eslint.config.js',
 )
 
 // `cell-type-annotations` only matches `.tsx` Cells, so it can never fire in
 // a JS project -- drop the override rather than ship a dead rule reference.
-const eslintConfigFilePath = path.join(JS_TEMPLATE_PATH, 'eslint.config.mjs')
+const eslintConfigFilePath = path.join(JS_TEMPLATE_PATH, 'eslint.config.js')
 const eslintConfigFile = fs.readFileSync(eslintConfigFilePath, 'utf-8').replace(
   `export default [
   ...(await cedarConfig()),

--- a/packages/create-cedar-app/templates/js/api/src/lib/auth.js
+++ b/packages/create-cedar-app/templates/js/api/src/lib/auth.js
@@ -26,7 +26,7 @@ export const requireAuth = ({ roles }) => {
 
 export const getCurrentUser = async () => {
   throw new Error(
-    'Auth is not set up yet. See https://cedarjs.com/docs/authentication ' +
-      'to get started'
+    'Auth is not set up yet. See https://cedarjs.com/docs/authentication to ' +
+      'get started'
   )
 }

--- a/packages/create-cedar-app/templates/js/web/src/pages/FatalErrorPage/FatalErrorPage.jsx
+++ b/packages/create-cedar-app/templates/js/web/src/pages/FatalErrorPage/FatalErrorPage.jsx
@@ -48,7 +48,6 @@ export default DevFatalErrorPage ||
             `,
         }}
       />
-
       <section>
         <h1>
           <span>Something went wrong</span>

--- a/packages/create-cedar-app/templates/js/web/src/pages/NotFoundPage/NotFoundPage.jsx
+++ b/packages/create-cedar-app/templates/js/web/src/pages/NotFoundPage/NotFoundPage.jsx
@@ -35,7 +35,6 @@ export default () => (
             `,
       }}
     />
-
     <section>
       <h1>
         <span>404 Page Not Found</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,7 +2580,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/cli-helpers@workspace:packages/cli-helpers"
   dependencies:
-    "@babel/core": "npm:^7.26.10"
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/project-config": "workspace:*"
     "@cedarjs/telemetry": "workspace:*"
@@ -14220,8 +14219,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "create-cedar-app@workspace:packages/create-cedar-app"
   dependencies:
-    "@babel/core": "npm:^7.26.10"
-    "@babel/plugin-transform-typescript": "npm:^7.26.8"
+    "@cedarjs/cli-helpers": "workspace:*"
     "@cedarjs/framework-tools": "workspace:*"
     "@cedarjs/tui": "workspace:*"
     "@opentelemetry/api": "npm:1.9.1"
@@ -14229,7 +14227,6 @@ __metadata:
     "@opentelemetry/resources": "npm:1.30.1"
     "@opentelemetry/sdk-trace-node": "npm:1.30.1"
     "@opentelemetry/semantic-conventions": "npm:1.41.1"
-    "@types/babel__core": "npm:7.20.5"
     "@types/klaw-sync": "npm:6.0.5"
     ansis: "npm:4.3.1"
     ci-info: "npm:4.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1669,7 +1669,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typescript@npm:^7.26.8, @babel/plugin-transform-typescript@npm:^7.29.7":
+"@babel/plugin-transform-typescript@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/plugin-transform-typescript@npm:7.29.7"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2604,6 +2604,7 @@ __metadata:
     prompts: "npm:2.4.2"
     semver: "npm:7.8.5"
     smol-toml: "npm:1.8.0"
+    sucrase: "npm:3.35.1"
     termi-link: "npm:1.1.0"
     typescript: "npm:5.9.3"
     vitest: "npm:4.1.10"
@@ -6984,7 +6985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.5":
+"@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.2, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.13
   resolution: "@jridgewell/gen-mapping@npm:0.3.13"
   dependencies:
@@ -13934,6 +13935,13 @@ __metadata:
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
+  languageName: node
+  linkType: hard
+
+"commander@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "commander@npm:4.1.1"
+  checksum: 10c0/84a76c08fe6cc08c9c93f62ac573d2907d8e79138999312c92d4155bc2325d487d64d13f669b2000c9f8caf70493c1be2dac74fec3c51d5a04f8bc3ae1830bab
   languageName: node
   linkType: hard
 
@@ -21534,7 +21542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mz@npm:^2.4.0":
+"mz@npm:^2.4.0, mz@npm:^2.7.0":
   version: 2.7.0
   resolution: "mz@npm:2.7.0"
   dependencies:
@@ -23359,10 +23367,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.4, pirates@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "pirates@npm:4.0.6"
-  checksum: 10c0/00d5fa51f8dded94d7429700fb91a0c1ead00ae2c7fd27089f0c5b63e6eca36197fe46384631872690a66f390c5e27198e99006ab77ae472692ab9c2ca903f36
+"pirates@npm:^4.0.1, pirates@npm:^4.0.4, pirates@npm:^4.0.6":
+  version: 4.0.7
+  resolution: "pirates@npm:4.0.7"
+  checksum: 10c0/a51f108dd811beb779d58a76864bbd49e239fa40c7984cd11596c75a121a8cc789f1c8971d8bb15f0dbf9d48b76c05bb62fcbce840f89b688c0fa64b37e8478a
   languageName: node
   linkType: hard
 
@@ -26348,6 +26356,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sucrase@npm:3.35.1":
+  version: 3.35.1
+  resolution: "sucrase@npm:3.35.1"
+  dependencies:
+    "@jridgewell/gen-mapping": "npm:^0.3.2"
+    commander: "npm:^4.0.0"
+    lines-and-columns: "npm:^1.1.6"
+    mz: "npm:^2.7.0"
+    pirates: "npm:^4.0.1"
+    tinyglobby: "npm:^0.2.11"
+    ts-interface-checker: "npm:^0.1.9"
+  bin:
+    sucrase: bin/sucrase
+    sucrase-node: bin/sucrase-node
+  checksum: 10c0/6fa22329c261371feb9560630d961ad0d0b9c87dce21ea74557c5f3ffbe5c1ee970ea8bcce9962ae9c90c3c47165ffa7dd41865c7414f5d8ea7a40755d612c5c
+  languageName: node
+  linkType: hard
+
 "supertokens-auth-react@npm:0.51.3":
   version: 0.51.3
   resolution: "supertokens-auth-react@npm:0.51.3"
@@ -26704,7 +26730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17":
+"tinyglobby@npm:^0.2.11, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17":
   version: 0.2.17
   resolution: "tinyglobby@npm:0.2.17"
   dependencies:
@@ -26896,6 +26922,13 @@ __metadata:
   version: 2.3.0
   resolution: "ts-dedent@npm:2.3.0"
   checksum: 10c0/bfc3331e0740191c0134fb526e7f01e16657e50955c9395de14703c6ef17119c91651fa044cf558dc9c1dbb0fe1b2a74e303aeebcbd5e3b31acd14f72f545a54
+  languageName: node
+  linkType: hard
+
+"ts-interface-checker@npm:^0.1.9":
+  version: 0.1.13
+  resolution: "ts-interface-checker@npm:0.1.13"
+  checksum: 10c0/232509f1b84192d07b81d1e9b9677088e590ac1303436da1e92b296e9be8e31ea042e3e1fd3d29b1742ad2c959e95afe30f63117b8f1bc3a3850070a5142fea7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The TypeScript→JavaScript conversion that CLI generators and setup commands use on JavaScript projects, and that `create-cedar-app`'s `ts-to-js` script uses to derive the JS template from the TS one, is done with [sucrase](https://github.com/alangpierce/sucrase) instead of `@babel/core` + `@babel/plugin-transform-typescript`.

One shared implementation, `transpileTSToJS(filename, content)` in `@cedarjs/cli-helpers`, is used by:
- `transformTSToJS` in `packages/cli-helpers/src/lib/index.ts` and `packages/cli/src/lib/index.ts` (the Prettier step after it is unchanged)
- `packages/create-cedar-app/scripts/tsToJS.js`

Sucrase options: `transforms: ['typescript', 'jsx']`, `jsxRuntime: 'preserve'`, `disableESTransforms: true`, `keepUnusedImports: false`. The `jsx` transform is required for parsing JSX; with `jsxRuntime: 'preserve'` JSX is emitted verbatim (including multi-line `{/* */}` comments and their indentation) and only JSX type arguments are stripped. `import type`, `type` specifiers and imports whose bindings are only used as types are removed. Whitespace and comments are otherwise preserved 1:1. Sucrase leaves an empty line where a type-only statement was; a small `dropEmptiedLines` step removes lines that are blank in the output but were not in the input, so import blocks don't gain stray blank lines that Prettier would keep.

Dependency changes: `sucrase` added to `cli-helpers`; `@babel/core` removed from `cli-helpers`; `@babel/core`, `@babel/plugin-transform-typescript` and `@types/babel__core` removed from `create-cedar-app`. `cli` keeps `@babel/core` for `src/lib/merge/*` and `testLib/cells.ts`.

The `create-cedar-app` `ts-to-js` script has other, unrelated rot (it targets `eslint.config.mjs` while the template file is `eslint.config.js`, and its `jsconfig`/`vitest.config`/`vite.config.js` steps disagree with the hand-maintained JS template); that is addressed in a follow-up PR on top of this one.


### About the snapshot and template diffs

The changed generator snapshots (`dbAuth`, `page`, `scaffold`, `scaffoldNoNest`) and the three regenerated JS template files are Babel formatting artifacts going away, not new differences. Compared to `main`, the diff consists of:

- 38 removed blank lines that Babel's `retainLines` output left wherever an `import type …` was deleted (and between adjacent JSX elements in the dbAuth forms); the TS templates have no blank line there.
- `{/* … */}` JSX comment bodies in the `page` snapshots indented one column less: Babel's generator shifted them by one space, sucrase keeps the template's indentation.
- The string concatenation in `api/src/lib/auth.js` now splits at the same point as `templates/ts/api/src/lib/auth.ts`.

In every case the new output is closer to the TypeScript source than the old one was. `dropEmptiedLines` only removes the blank line that sucrase itself leaves where a type-only statement was; it does not reproduce the blank lines Babel used to add. A zero diff against `main` would mean deliberately emulating Babel's quirks, which is the opposite of the goal. #2522 (stacked on this PR) makes CI check that `ts-to-js` reproduces the committed JS template byte-for-byte.
