### PR TITLE
feat(babel-config)!: Resolve api-side Babel from the project

### DIFF
--- a/.changesets/release_notes_v7.md
+++ b/.changesets/release_notes_v7.md
@@ -91,3 +91,16 @@ spreading, `Object.keys()`, the `in` operator and `JSON.stringify()` all work
 as expected, but calling `options.params.hasOwnProperty(...)` or
 `options.params.toString()` throws a `TypeError`. Use
 `Object.hasOwn(options.params, key)` for ownership checks.
+
+## `api/babel.config.js` needs Babel installed in the api workspace
+
+`@cedarjs/babel-config` lists `@babel/core` and `@babel/preset-typescript` as
+optional peer dependencies and resolves them from the project's api workspace
+when `api/babel.config.js` exists. Projects without a custom api-side Babel
+config are unaffected. Projects that have an `api/babel.config.js` must
+install the two packages themselves, or the api build fails with an error
+pointing to this command:
+
+```shell
+yarn workspace api add -D @babel/core@^7 @babel/preset-typescript@^7
+```

--- a/docs/docs/project-configuration-dev-test-build.mdx
+++ b/docs/docs/project-configuration-dev-test-build.mdx
@@ -9,54 +9,57 @@ import ReactPlayer from './ReactPlayer'
 
 ## Babel
 
-Out of the box Cedar configures [Babel](https://babeljs.io/) so that you can write modern JavaScript and TypeScript without needing to worry about transpilation at all.
+Out of the box Cedar compiles your modern JavaScript and TypeScript without you needing to worry about transpilation at all.
 GraphQL tags, JSX, SVG imports—all of it's handled for you.
 
-For those well-versed in Babel config, you can find Cedar's in [@cedarjs/internal](https://github.com/cedarjs/cedar/tree/main/packages/internal/src/build/babel).
+For those well-versed in Babel config, you can find Cedar's in [@cedarjs/babel-config](https://github.com/cedarjs/cedar/tree/main/packages/babel-config).
 
 ### Configuring Babel
 
-For most projects, you won't need to configure Babel at all, but if you need to you can configure each side (web, api) individually using side-specific `babel.config.js` files.
+For most projects, you won't need to configure Babel at all. When you do, the two sides are configured differently:
+
+- **api**: put your config in `api/babel.config.js`. Cedar merges it with its own api-side config when it builds your api side (`yarn cedar build`, `yarn cedar dev` and the Vite-based api pipeline).
+- **web**: Vite doesn't apply `web/babel.config.js`. Pass custom plugins and presets through the `cedar()` Vite plugin's `babel` option instead, see [Custom Babel plugins](vite-configuration.md#custom-babel-plugins).
 
 > **Heads up**
 >
 > `.babelrc{.js}` files are ignored.
-> You have to put your custom config in the appropriate side's `babel.config.js`: `web/babel.config.js` for web and `api/babel.config.js` for api.
+> Api-side config has to live in `api/babel.config.js`.
 
-Let's go over an example.
+#### Installing Babel for the api side
 
-#### Example: Adding Emotion
-
-Let's say we want to add the styling library [emotion](https://emotion.sh), which requires adding a Babel plugin.
-
-1. Create a `babel.config.js` file in `web`:
+Cedar itself doesn't need Babel to build your api side, so `@cedarjs/babel-config` treats `@babel/core` and `@babel/preset-typescript` as optional peer dependencies and doesn't install them for you. An `api/babel.config.js` is only applied when both packages are installed in your api workspace. Cedar's api-side config is written for Babel 7, so pin that major:
 
 ```shell
-touch web/babel.config.js
+yarn workspace api add -D @babel/core@^7 @babel/preset-typescript@^7
+```
+
+If `api/babel.config.js` exists but either package is missing, the api build fails with an error telling you to run that command.
+
+#### Example: Removing `console` calls on the api side
+
+Let's say we want to strip `console.*` calls from the api side using [babel-plugin-transform-remove-console](https://www.npmjs.com/package/babel-plugin-transform-remove-console).
+
+1. Install Babel and the plugin in the api workspace:
+
+```shell
+yarn workspace api add -D @babel/core@^7 @babel/preset-typescript@^7 babel-plugin-transform-remove-console
 ```
 
 <br />
 
-2. Add the `@emotion/babel-plugin` as a dependency:
+2. Create `api/babel.config.js` and add the plugin:
 
-```shell
-yarn workspace web add --dev @emotion/babel-plugin
-```
-
-<br />
-
-3. Add the plugin to `web/babel.config.js`:
-
-```jsx title="web/babel.config.js"
-module.exports = {
-  plugins: ['@emotion'], // 👈 add the emotion plugin
+```js title="api/babel.config.js"
+export default {
+  plugins: ['transform-remove-console'], // 👈 add the plugin
 }
 
 // ℹ️ Notice how we don't need the `extends` property
 ```
 
 That's it!
-Now your custom web-side Babel config will be merged with Cedar's.
+Your custom api-side Babel config is merged with Cedar's.
 
 ## Vitest
 

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -26,12 +26,10 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@babel/core": "^7.26.10",
     "@babel/parser": "7.29.8",
     "@babel/plugin-transform-react-jsx": "7.29.7",
     "@babel/preset-env": "7.29.7",
     "@babel/preset-react": "7.29.7",
-    "@babel/preset-typescript": "7.29.7",
     "@babel/register": "7.29.7",
     "@babel/traverse": "7.29.8",
     "@cedarjs/project-config": "workspace:*",
@@ -43,6 +41,8 @@
     "typescript": "5.9.3"
   },
   "devDependencies": {
+    "@babel/core": "^7.26.10",
+    "@babel/preset-typescript": "7.29.7",
     "@cedarjs/framework-tools": "workspace:*",
     "@types/babel-plugin-tester": "11.0.0",
     "@types/babel__core": "7.20.5",
@@ -50,6 +50,18 @@
     "@types/node": "24.10.4",
     "babel-plugin-tester": "11.0.4",
     "vitest": "4.1.10"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.26.10",
+    "@babel/preset-typescript": "^7.29.7"
+  },
+  "peerDependenciesMeta": {
+    "@babel/core": {
+      "optional": true
+    },
+    "@babel/preset-typescript": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=24"

--- a/packages/babel-config/src/__tests__/resolveFromProject.test.ts
+++ b/packages/babel-config/src/__tests__/resolveFromProject.test.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  getMissingApiBabelPackageMessage,
+  getUnsupportedApiBabelVersionMessage,
+  loadBabelCoreFromProject,
+  resolveFromProject,
+} from '../resolveFromProject.js'
+
+const FIXTURE_PATH = path.join(__dirname, '__fixtures__/cedar-app')
+
+afterEach(() => {
+  delete process.env.CEDAR_CWD
+})
+
+describe('resolveFromProject', () => {
+  it('resolves packages that are installed above the project', () => {
+    // The fixture has no node_modules of its own, so Node's lookup walks up
+    // into the monorepo's install, which does have @babel/core
+    process.env.CEDAR_CWD = FIXTURE_PATH
+
+    const resolved = resolveFromProject('@babel/core')
+
+    expect(path.isAbsolute(resolved)).toBe(true)
+    expect(resolved).toMatch(/[\\/]@babel[\\/]core[\\/]/)
+    expect(typeof loadBabelCoreFromProject().transformAsync).toBe('function')
+  })
+
+  it('throws an actionable error when the package is not installed', () => {
+    // A project outside of any node_modules tree, with nothing installed
+    const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'cedar-app-'))
+    fs.writeFileSync(path.join(projectPath, 'cedar.toml'), '')
+    process.env.CEDAR_CWD = projectPath
+
+    expect(() => resolveFromProject('@babel/core')).toThrow(
+      getMissingApiBabelPackageMessage('@babel/core'),
+    )
+    expect(() => loadBabelCoreFromProject()).toThrow(
+      getMissingApiBabelPackageMessage('@babel/core'),
+    )
+    expect(() => resolveFromProject('@babel/preset-typescript')).toThrow(
+      getMissingApiBabelPackageMessage('@babel/preset-typescript'),
+    )
+  })
+
+  it('tells the user which packages to install and how', () => {
+    expect(
+      getMissingApiBabelPackageMessage('@babel/core'),
+    ).toMatchInlineSnapshot(
+      `"api/babel.config.js was found, but @babel/core is not installed. Custom Babel configuration for the api side needs @babel/core and @babel/preset-typescript: run \`yarn workspace api add -D @babel/core@^7 @babel/preset-typescript@^7\`."`,
+    )
+    expect(
+      getUnsupportedApiBabelVersionMessage('@babel/core', '8.0.1'),
+    ).toMatchInlineSnapshot(
+      `"api/babel.config.js was found, but the installed @babel/core (8.0.1) is not supported. Custom Babel configuration for the api side needs @babel/core and @babel/preset-typescript 7.x: run \`yarn workspace api add -D @babel/core@^7 @babel/preset-typescript@^7\`."`,
+    )
+  })
+})

--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs'
-import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import type * as BabelCore from '@babel/core'
@@ -26,7 +25,6 @@ export const TARGETS_NODE = '24'
 
 // Resolves packages from this package's own dependency tree, i.e. the copies
 // the framework ships (through @cedarjs/cli, @cedarjs/vite, ...).
-const frameworkRequire = createRequire(import.meta.url)
 
 interface ApiSideBabelPresetsOptions {
   presetEnv?: boolean
@@ -272,11 +270,10 @@ export const registerApiSideBabelHook = ({
  * project's `api/babel.config.js` when there is one.
  *
  * `@babel/core` and `@babel/preset-typescript` are optional peer dependencies
- * of this package. When the project has an `api/babel.config.js` they are
- * resolved from the project's api workspace and a missing install fails with
- * an actionable error. Without a custom config (the route hooks build is the
- * remaining caller then) they are resolved from the framework's own
- * dependency tree.
+ * of this package, resolved from the project's api workspace; a missing
+ * install fails with an actionable error. Every caller checks for
+ * `api/babel.config.js` before calling this, so Babel is only ever loaded for
+ * projects that opted into a custom api-side Babel config.
  */
 export const transformWithBabel = async (
   sourceCode: string,
@@ -291,12 +288,8 @@ export const transformWithBabel = async (
 ) => {
   const customConfigPath = getApiSideBabelConfigPath()
 
-  const babel: typeof BabelCore = customConfigPath
-    ? loadBabelCoreFromProject()
-    : frameworkRequire('@babel/core')
-  const resolvePreset = customConfigPath
-    ? resolveFromProject
-    : (packageName: string) => frameworkRequire.resolve(packageName)
+  const babel: typeof BabelCore = loadBabelCoreFromProject()
+  const resolvePreset = resolveFromProject
 
   const result = babel.transformAsync(sourceCode, {
     presets: getApiSideBabelPresets({ resolvePreset }),

--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -1,8 +1,9 @@
 import fs from 'node:fs'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 
+import type * as BabelCore from '@babel/core'
 import type { PluginOptions, PluginTarget, TransformOptions } from '@babel/core'
-import { transformAsync } from '@babel/core'
 import { resolvePath } from 'babel-plugin-module-resolver'
 
 import { getPaths } from '@cedarjs/project-config'
@@ -16,15 +17,34 @@ import {
 import pluginRedwoodDirectoryNamedImport from './plugins/babel-plugin-redwood-directory-named-import.js'
 import pluginRedwoodImportDir from './plugins/babel-plugin-redwood-import-dir.js'
 import pluginRedwoodJobPathInjector from './plugins/babel-plugin-redwood-job-path-injector.js'
+import {
+  loadBabelCoreFromProject,
+  resolveFromProject,
+} from './resolveFromProject.js'
 
 export const TARGETS_NODE = '24'
 
-export const getApiSideBabelPresets = (
-  { presetEnv } = { presetEnv: false },
-) => {
+// Resolves packages from this package's own dependency tree, i.e. the copies
+// the framework ships (through @cedarjs/cli, @cedarjs/vite, ...).
+const frameworkRequire = createRequire(import.meta.url)
+
+interface ApiSideBabelPresetsOptions {
+  presetEnv?: boolean
+  /**
+   * Maps a preset's package name to what is put in the `presets` option.
+   * Babel resolves bare package names relative to the file it compiles;
+   * passing a resolver that returns absolute paths makes resolution explicit.
+   */
+  resolvePreset?: (packageName: string) => string
+}
+
+export const getApiSideBabelPresets = ({
+  presetEnv = false,
+  resolvePreset = (packageName) => packageName,
+}: ApiSideBabelPresetsOptions = {}) => {
   return [
     [
-      '@babel/preset-typescript',
+      resolvePreset('@babel/preset-typescript'),
       {
         isTSX: true,
         allExtensions: true,
@@ -33,7 +53,7 @@ export const getApiSideBabelPresets = (
     ],
     // Preset-env is required when we are not doing the transpilation with esbuild
     presetEnv && [
-      '@babel/preset-env',
+      resolvePreset('@babel/preset-env'),
       {
         targets: {
           node: TARGETS_NODE,
@@ -247,6 +267,17 @@ export const registerApiSideBabelHook = ({
   })
 }
 
+/**
+ * Runs `sourceCode` through Babel with Cedar's api-side config plus the
+ * project's `api/babel.config.js` when there is one.
+ *
+ * `@babel/core` and `@babel/preset-typescript` are optional peer dependencies
+ * of this package. When the project has an `api/babel.config.js` they are
+ * resolved from the project's api workspace and a missing install fails with
+ * an actionable error. Without a custom config (the route hooks build is the
+ * remaining caller then) they are resolved from the framework's own
+ * dependency tree.
+ */
 export const transformWithBabel = async (
   sourceCode: string,
   filename: string,
@@ -258,10 +289,19 @@ export const transformWithBabel = async (
   // the result maps all the way back to the original source.
   inputSourceMap: TransformOptions['inputSourceMap'] = undefined,
 ) => {
-  const result = transformAsync(sourceCode, {
-    presets: getApiSideBabelPresets(),
+  const customConfigPath = getApiSideBabelConfigPath()
+
+  const babel: typeof BabelCore = customConfigPath
+    ? loadBabelCoreFromProject()
+    : frameworkRequire('@babel/core')
+  const resolvePreset = customConfigPath
+    ? resolveFromProject
+    : (packageName: string) => frameworkRequire.resolve(packageName)
+
+  const result = babel.transformAsync(sourceCode, {
+    presets: getApiSideBabelPresets({ resolvePreset }),
     overrides: getApiSideBabelOverrides({ forVite }),
-    extends: getApiSideBabelConfigPath(),
+    extends: customConfigPath,
     babelrc: false,
     ignore: ['node_modules'],
     cwd: getPaths().api.base,

--- a/packages/babel-config/src/resolveFromProject.ts
+++ b/packages/babel-config/src/resolveFromProject.ts
@@ -1,0 +1,118 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+
+import type * as BabelCore from '@babel/core'
+
+import { getPaths } from '@cedarjs/project-config'
+
+/**
+ * The packages a project has to install in its api workspace to use a custom
+ * `api/babel.config.js`. They are optional peer dependencies of
+ * `@cedarjs/babel-config`, so projects without a custom config never pay for
+ * them.
+ */
+export const API_BABEL_CONFIG_PACKAGES = [
+  '@babel/core',
+  '@babel/preset-typescript',
+] as const
+
+/**
+ * The Babel major Cedar's api-side config is written for. The
+ * `@babel/preset-typescript` options Cedar passes (`isTSX`, `allExtensions`)
+ * only exist in this major.
+ */
+export const SUPPORTED_BABEL_MAJOR = 7
+
+const INSTALL_COMMAND = `yarn workspace api add -D ${API_BABEL_CONFIG_PACKAGES.map(
+  (packageName) => `${packageName}@^${SUPPORTED_BABEL_MAJOR}`,
+).join(' ')}`
+
+/**
+ * Builds the error thrown when `api/babel.config.js` exists but one of the
+ * packages it needs is missing from the project.
+ */
+export function getMissingApiBabelPackageMessage(packageName: string) {
+  return (
+    `api/babel.config.js was found, but ${packageName} is not installed. ` +
+    'Custom Babel configuration for the api side needs ' +
+    `${API_BABEL_CONFIG_PACKAGES.join(' and ')}: run \`${INSTALL_COMMAND}\`.`
+  )
+}
+
+/**
+ * Builds the error thrown when `api/babel.config.js` exists but the installed
+ * package is from a Babel major Cedar's api-side config doesn't support.
+ */
+export function getUnsupportedApiBabelVersionMessage(
+  packageName: string,
+  version: string,
+) {
+  return (
+    `api/babel.config.js was found, but the installed ${packageName} ` +
+    `(${version}) is not supported. Custom Babel configuration for the api ` +
+    `side needs ${API_BABEL_CONFIG_PACKAGES.join(' and ')} ` +
+    `${SUPPORTED_BABEL_MAJOR}.x: run \`${INSTALL_COMMAND}\`.`
+  )
+}
+
+/**
+ * Returns a `require` rooted in the project's api workspace. Node walks from
+ * `api/node_modules` up to the project root, so both workspace-local and
+ * hoisted installs are found.
+ */
+function createProjectRequire() {
+  return createRequire(path.join(getPaths().api.base, 'package.json'))
+}
+
+function assertSupportedMajor(packageName: string, resolvedPath: string) {
+  // Requiring from the resolved file's own location guarantees the
+  // package.json belongs to the same copy of the package that was resolved.
+  const packageJson: unknown = createRequire(resolvedPath)(
+    `${packageName}/package.json`,
+  )
+
+  const version =
+    typeof packageJson === 'object' &&
+    packageJson !== null &&
+    'version' in packageJson &&
+    typeof packageJson.version === 'string'
+      ? packageJson.version
+      : undefined
+
+  if (version && Number(version.split('.')[0]) !== SUPPORTED_BABEL_MAJOR) {
+    throw new Error(getUnsupportedApiBabelVersionMessage(packageName, version))
+  }
+}
+
+/**
+ * Resolves `packageName` to an absolute path from the project's api
+ * workspace. Throws an actionable error when the package isn't installed
+ * there (so the failure mode is the same no matter how the package manager
+ * laid out `node_modules`) or when it's from an unsupported Babel major.
+ */
+export function resolveFromProject(packageName: string) {
+  const projectRequire = createProjectRequire()
+
+  let resolvedPath: string
+
+  try {
+    resolvedPath = projectRequire.resolve(packageName)
+  } catch {
+    throw new Error(getMissingApiBabelPackageMessage(packageName))
+  }
+
+  assertSupportedMajor(packageName, resolvedPath)
+
+  return resolvedPath
+}
+
+/**
+ * Loads the project's copy of `@babel/core`. Resolving from the project
+ * rather than from this package keeps `@babel/core` out of projects that
+ * don't use `api/babel.config.js`.
+ */
+export function loadBabelCoreFromProject(): typeof BabelCore {
+  // `@babel/core` is CommonJS; `require` gives a synchronous load with the
+  // same module shape a static import would have.
+  return createProjectRequire()(resolveFromProject('@babel/core'))
+}

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -48,6 +48,7 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
+    "@babel/core": "^7.26.10",
     "@babel/generator": "7.29.8",
     "@babel/parser": "7.29.8",
     "@babel/preset-typescript": "7.29.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2549,6 +2549,14 @@ __metadata:
     graphql: "npm:16.14.2"
     typescript: "npm:5.9.3"
     vitest: "npm:4.1.10"
+  peerDependencies:
+    "@babel/core": ^7.26.10
+    "@babel/preset-typescript": ^7.29.7
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@babel/preset-typescript":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3485,6 +3493,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@cedarjs/vite@workspace:packages/vite"
   dependencies:
+    "@babel/core": "npm:^7.26.10"
     "@babel/generator": "npm:7.29.8"
     "@babel/parser": "npm:7.29.8"
     "@babel/preset-typescript": "npm:7.29.7"


### PR DESCRIPTION
Cedar projects can keep an `api/babel.config.js` to run custom Babel plugins on api-side code. That feature is unchanged in behaviour, but `@cedarjs/babel-config` no longer hard-depends on `@babel/core` and `@babel/preset-typescript` for it: when `api/babel.config.js` exists, both are resolved **from the project** (`createRequire(<api>/package.json)`) and declared as optional peer dependencies.

- `resolveFromProject(name)` resolves from the api workspace (walking up to the project root) and throws an actionable error when missing:
  > `api/babel.config.js was found, but @babel/core is not installed. Custom Babel configuration for the api side needs @babel/core and @babel/preset-typescript: run \`yarn workspace api add -D @babel/core@^7 @babel/preset-typescript@^7\`.`
- It also rejects a resolved `@babel/core` that isn't 7.x, because a bare `yarn add @babel/core` installs Babel 8 today, whose `preset-typescript` rejects the `isTSX`/`allExtensions` options Cedar passes:
  > `api/babel.config.js was found, but the installed @babel/core (8.0.1) is not supported. ... 7.x ...`
- `transformWithBabel` passes absolute preset paths so resolution is deterministic and the error stays ours. `getApiSideBabelPresets` takes an optional `resolvePreset` callback (identity by default, so ESLint/prerender snapshots are unchanged).
- Docs: "Configuring Babel" in `project-configuration-dev-test-build.mdx` now describes the api-side file and the install step, and points web users at the `cedar()` `babel` option (the previous Emotion example described `web/babel.config.js`, which Vite does not apply). Release note added to `release_notes_v7.md`: projects that already have `api/babel.config.js` must install the two packages.

### What this does and does not save

`@cedarjs/babel-config` itself no longer requires `@babel/core`. Projects still receive it today through `@cedarjs/cli` (`lib/merge/*`, `testLib/cells.ts`), `@cedarjs/internal` (`ast.ts`, `jsx.ts`), `@cedarjs/vite` and `@vitejs/plugin-react`. `@cedarjs/vite` declares `@babel/core` in this PR because `vite-plugin-rsc-transform-server.ts` imports it directly (it previously relied on hoisting). The remaining hard `@babel/core` consumers (`cli`, `internal`, `vite`'s RSC server-action transform) are the parse/AST-toolkit sites tracked separately.

With route hooks now built by Vite (#2520), every caller of `transformWithBabel` checks for `api/babel.config.js` first, so the function always resolves Babel from the project and has no framework-resolution path.

The other Babel packages in `@cedarjs/babel-config` (`preset-env`, `register`, `preset-react`, `plugin-transform-react-jsx`, `babel-plugin-{module-resolver,auto-import,graphql-tag}`) stay hard dependencies: they are reached by `cedar prerender` (`registerApiSideBabelHook`) regardless of `api/babel.config.js`.
