### PR TITLE
feat(web): Format copied errors for coding agents

### DIFF
--- a/packages/web/src/apollo/ApolloProviderWithFetchConfig.tsx
+++ b/packages/web/src/apollo/ApolloProviderWithFetchConfig.tsx
@@ -25,6 +25,7 @@ import type {
   GraphQLClientConfigProp,
 } from './apolloLinkTypes.js'
 import { ErrorBoundary } from './ErrorBoundary.js'
+import { getOperationKind } from './links.js'
 import * as SSELinkExports from './sseLink.js'
 
 // Not sure why we need to import it this way for legacy builds to work
@@ -95,7 +96,10 @@ export function ApolloProviderWithFetchConfig({
 
     data.mostRecentRequest = {}
     data.mostRecentRequest.operationName = operationName
-    data.mostRecentRequest.operationKind = query?.kind.toString()
+    data.mostRecentRequest.operationKind = getOperationKind(
+      query,
+      operationName,
+    )
     data.mostRecentRequest.variables = variables
     data.mostRecentRequest.query = query && print(operation.query)
 

--- a/packages/web/src/apollo/links.test.ts
+++ b/packages/web/src/apollo/links.test.ts
@@ -1,0 +1,25 @@
+import { gql } from '@apollo/client'
+import { describe, expect, it } from 'vitest'
+
+import { getOperationKind } from './links.js'
+
+describe('getOperationKind', () => {
+  it('returns the selected operation type instead of the document kind', () => {
+    const document = gql`
+      query GetUser {
+        user {
+          id
+        }
+      }
+
+      mutation UpdateUser {
+        updateUser {
+          id
+        }
+      }
+    `
+
+    expect(getOperationKind(document, 'GetUser')).toBe('query')
+    expect(getOperationKind(document, 'UpdateUser')).toBe('mutation')
+  })
+})

--- a/packages/web/src/apollo/links.ts
+++ b/packages/web/src/apollo/links.ts
@@ -1,7 +1,16 @@
 import { ApolloLink, HttpLink } from '@apollo/client'
 import { SetContextLink } from '@apollo/client/link/context'
+import type { DocumentNode } from 'graphql'
+import { getOperationAST } from 'graphql'
 import { print } from 'graphql/language/printer.js'
 import { Observable } from 'rxjs'
+
+export function getOperationKind(
+  query: DocumentNode,
+  operationName?: string,
+): string | undefined {
+  return getOperationAST(query, operationName)?.operation
+}
 
 export function createHttpLink(
   uri: string,
@@ -27,7 +36,7 @@ function enhanceError(operation: ApolloLink.Operation, error: any) {
 
   error.__RedwoodEnhancedError = {
     operationName,
-    operationKind: query?.kind.toString(),
+    operationKind: getOperationKind(query, operationName),
     variables,
     query: query && print(query),
   }

--- a/packages/web/src/apollo/links.ts
+++ b/packages/web/src/apollo/links.ts
@@ -1,6 +1,6 @@
 import { ApolloLink, HttpLink } from '@apollo/client'
 import { SetContextLink } from '@apollo/client/link/context'
-import type { DocumentNode } from 'graphql'
+import type { DocumentNode, OperationTypeNode } from 'graphql'
 import { getOperationAST } from 'graphql'
 import { print } from 'graphql/language/printer.js'
 import { Observable } from 'rxjs'
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs'
 export function getOperationKind(
   query: DocumentNode,
   operationName?: string,
-): string | undefined {
+): OperationTypeNode | undefined {
   return getOperationAST(query, operationName)?.operation
 }
 

--- a/packages/web/src/components/DevFatalErrorPage.tsx
+++ b/packages/web/src/components/DevFatalErrorPage.tsx
@@ -43,13 +43,35 @@ type ErrorWithRequestMeta = Error & {
   mostRecentResponse?: any
 }
 
+function formatMarkdownCode(value: string): string {
+  const fence = '`'.repeat(longestBacktickRun(value) + 1)
+  const padding = value.startsWith('`') || value.endsWith('`') ? ' ' : ''
+
+  return `${fence}${padding}${value}${padding}${fence}`
+}
+
+function formatMarkdownCodeBlock(value: string, language: string): string {
+  const fence = '`'.repeat(Math.max(3, longestBacktickRun(value) + 1))
+
+  return `${fence}${language}\n${value}\n${fence}`
+}
+
+function longestBacktickRun(value: string): number {
+  return Array.from(value.matchAll(/`+/g)).reduce(
+    (longest, [run]) => Math.max(longest, run.length),
+    0,
+  )
+}
+
 function formatErrorForClipboard(
   stack: StackTracey,
   typeName: string,
   msg: string,
   errorWithMeta: ErrorWithRequestMeta,
 ): string {
-  const sections = [`## Error\n\n${typeName}: ${msg}`]
+  const sections = [
+    `## Error\n\n${formatMarkdownCode(typeName)}: ${formatMarkdownCode(msg)}`,
+  ]
 
   const mostRecentRequest =
     errorWithMeta.mostRecentRequest ||
@@ -73,15 +95,11 @@ function formatErrorForClipboard(
         '',
         '### Variables',
         '',
-        '```json',
-        variables,
-        '```',
+        formatMarkdownCodeBlock(variables, 'json'),
         '',
         '### Query',
         '',
-        '```graphql',
-        mostRecentRequest.query,
-        '```',
+        formatMarkdownCodeBlock(mostRecentRequest.query, 'graphql'),
       ].join('\n'),
     )
   }
@@ -95,7 +113,7 @@ function formatErrorForClipboard(
       response = 'Unable to stringify response'
     }
 
-    sections.push(`## Response\n\n\`\`\`json\n${response}\n\`\`\``)
+    sections.push(`## Response\n\n${formatMarkdownCodeBlock(response, 'json')}`)
   }
 
   const stackEntries = stack.items.map((entry, i) => {
@@ -116,14 +134,14 @@ function formatErrorForClipboard(
       const start = Math.max(0, lineIndex - window)
       const end = Math.min(sourceFile.lines.length, lineIndex + window + 1)
 
-      lines.push('', '```text')
+      const sourceLines = []
       for (let idx = start; idx < end; idx++) {
         const marker = idx === lineIndex ? '>' : ' '
-        lines.push(
+        sourceLines.push(
           `${marker} ${(idx + 1).toString().padStart(4)} | ${sourceFile.lines[idx]}`,
         )
       }
-      lines.push('```')
+      lines.push('', formatMarkdownCodeBlock(sourceLines.join('\n'), 'text'))
     }
 
     return lines.join('\n')

--- a/packages/web/src/components/DevFatalErrorPage.tsx
+++ b/packages/web/src/components/DevFatalErrorPage.tsx
@@ -44,98 +44,94 @@ type ErrorWithRequestMeta = Error & {
 }
 
 function formatErrorForClipboard(
-  err: Error,
   stack: StackTracey,
   typeName: string,
   msg: string,
   errorWithMeta: ErrorWithRequestMeta,
 ): string {
-  const lines: string[] = []
+  const sections = [`## Error\n\n${typeName}: ${msg}`]
 
-  lines.push('='.repeat(80))
-  lines.push('FATAL ERROR REPORT')
-  lines.push('='.repeat(80))
-  lines.push('')
-
-  // Error summary
-  lines.push(`ERROR TYPE: ${typeName}`)
-  lines.push(`ERROR MESSAGE: ${msg}`)
-  lines.push('')
-
-  // Request details if available
   const mostRecentRequest =
     errorWithMeta.mostRecentRequest ||
     errorWithMeta.errors?.find((gqlErr) => gqlErr.__RedwoodEnhancedError)
       ?.__RedwoodEnhancedError
 
   if (mostRecentRequest) {
-    lines.push('-'.repeat(80))
-    lines.push('REQUEST CONTEXT')
-    lines.push('-'.repeat(80))
-    lines.push(`Operation: ${mostRecentRequest.operationName}`)
-    lines.push(`Kind: ${mostRecentRequest.operationKind}`)
-    lines.push('')
-    lines.push('Variables:')
+    let variables: string
     try {
-      lines.push(JSON.stringify(mostRecentRequest.variables, null, 2))
+      variables =
+        JSON.stringify(mostRecentRequest.variables, null, 2) ?? 'undefined'
     } catch {
-      lines.push('Unable to stringify variables')
+      variables = 'Unable to stringify variables'
     }
-    lines.push('')
-    lines.push('Query:')
-    lines.push(mostRecentRequest.query)
-    lines.push('')
+
+    sections.push(
+      [
+        '## Request',
+        '',
+        `${mostRecentRequest.operationKind} ${mostRecentRequest.operationName}`,
+        '',
+        '### Variables',
+        '',
+        '```json',
+        variables,
+        '```',
+        '',
+        '### Query',
+        '',
+        '```graphql',
+        mostRecentRequest.query,
+        '```',
+      ].join('\n'),
+    )
   }
 
-  // Response details if available
   if (errorWithMeta.mostRecentResponse) {
-    lines.push('-'.repeat(80))
-    lines.push('RESPONSE CONTEXT')
-    lines.push('-'.repeat(80))
+    let response: string
     try {
-      lines.push(JSON.stringify(errorWithMeta.mostRecentResponse, null, 2))
+      response =
+        JSON.stringify(errorWithMeta.mostRecentResponse, null, 2) ?? 'undefined'
     } catch {
-      lines.push('Unable to stringify response')
+      response = 'Unable to stringify response'
     }
-    lines.push('')
+
+    sections.push(`## Response\n\n\`\`\`json\n${response}\n\`\`\``)
   }
 
-  // Stack trace
-  lines.push('-'.repeat(80))
-  lines.push('STACK TRACE')
-  lines.push('-'.repeat(80))
-
-  stack.items.forEach((entry, i) => {
-    const fileShort = entry.fileShort || '[Unknown]'
+  const stackEntries = stack.items.map((entry, i) => {
+    const file = entry.fileShort || '[Unknown]'
     const callee = entry.callee || '[Anonymous]'
-    const line = entry.line || '?'
-    const column = entry.column || '?'
+    const location = `${file}:${entry.line || '?'}:${entry.column || '?'}`
+    const lines = [`${i + 1}. \`${location}\` in \`${callee}\``]
 
-    lines.push(`[${i}] ${fileShort}:${line}:${column} in ${callee}`)
-
-    // Include source code context if available
-    const sourceFile = entry.sourceFile as any
-    if (sourceFile?.lines && sourceFile.lines.length > 0) {
-      const lineIndex = (entry.line || 1) - 1
+    const sourceFile = entry.sourceFile
+    if (
+      sourceFile?.lines.length &&
+      entry.line &&
+      entry.line <= sourceFile.lines.length &&
+      !entry.thirdParty
+    ) {
+      const lineIndex = entry.line - 1
       const window = 2
       const start = Math.max(0, lineIndex - window)
       const end = Math.min(sourceFile.lines.length, lineIndex + window + 1)
 
-      lines.push('  Source context:')
+      lines.push('', '```text')
       for (let idx = start; idx < end; idx++) {
-        const marker = idx === lineIndex ? '> ' : '  '
+        const marker = idx === lineIndex ? '>' : ' '
         lines.push(
-          `  ${marker}${(idx + 1).toString().padStart(4)} | ${sourceFile.lines[idx]}`,
+          `${marker} ${(idx + 1).toString().padStart(4)} | ${sourceFile.lines[idx]}`,
         )
       }
-      lines.push('')
+      lines.push('```')
     }
+
+    return lines.join('\n')
   })
 
-  lines.push('')
-  lines.push('='.repeat(80))
+  sections.push(`## Stack trace\n\n${stackEntries.join('\n\n')}`)
 
-  return lines.join('\n')
+  return sections.join('\n\n')
 }
 
 export const DevFatalErrorPage = (props: { error?: ErrorWithRequestMeta }) => {
@@ -173,7 +169,7 @@ export const DevFatalErrorPage = (props: { error?: ErrorWithRequestMeta }) => {
   ) : null
 
   const handleCopyAll = async () => {
-    const errorText = formatErrorForClipboard(err, stack, typeName, msg, err)
+    const errorText = formatErrorForClipboard(stack, typeName, msg, err)
 
     try {
       await navigator.clipboard.writeText(errorText)

--- a/packages/web/src/components/__tests__/DevFatalErrorPage.test.tsx
+++ b/packages/web/src/components/__tests__/DevFatalErrorPage.test.tsx
@@ -79,7 +79,7 @@ describe('DevFatalErrorPage', () => {
       [
         '## Error',
         '',
-        'Error: Test error message',
+        '`Error`: `Test error message`',
         '',
         '## Stack trace',
         '',
@@ -140,6 +140,34 @@ describe('DevFatalErrorPage', () => {
     )
     expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
       expect.stringContaining('```graphql\nquery GetUser { user { id } }\n```'),
+    )
+  })
+
+  it('uses safe Markdown delimiters for backticks in copied details', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(window.navigator.clipboard, 'writeText')
+
+    const error: any = new Error('Message with `inline` code')
+    error.mostRecentRequest = {
+      query: ['query GetCode {', '  code', '}', '```'].join('\n'),
+      operationName: 'GetCode',
+      operationKind: 'query',
+      variables: { markdown: '```' },
+    }
+
+    render(<DevFatalErrorPage error={error} />)
+    await user.click(screen.getByRole('button', { name: /Copy All/ }))
+
+    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining('`Error`: ``Message with `inline` code``'),
+    )
+    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining('````json\n{\n  "markdown": "```"\n}\n````'),
+    )
+    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '````graphql\nquery GetCode {\n  code\n}\n```\n````',
+      ),
     )
   })
 

--- a/packages/web/src/components/__tests__/DevFatalErrorPage.test.tsx
+++ b/packages/web/src/components/__tests__/DevFatalErrorPage.test.tsx
@@ -76,10 +76,19 @@ describe('DevFatalErrorPage', () => {
 
     expect(window.navigator.clipboard.writeText).toHaveBeenCalledTimes(1)
     expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-      expect.stringContaining('FATAL ERROR REPORT'),
-    )
-    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-      expect.stringContaining('Test error message'),
+      [
+        '## Error',
+        '',
+        'Error: Test error message',
+        '',
+        '## Stack trace',
+        '',
+        '1. `DevFatalErrorPage.test.tsx:1:1` in `test`',
+        '',
+        '```text',
+        '>    1 | // mocked source',
+        '```',
+      ].join('\n'),
     )
   })
 
@@ -124,13 +133,13 @@ describe('DevFatalErrorPage', () => {
 
     expect(window.navigator.clipboard.writeText).toHaveBeenCalledTimes(1)
     expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-      expect.stringContaining('REQUEST CONTEXT'),
+      expect.stringContaining('## Request\n\nquery GetUser'),
     )
     expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-      expect.stringContaining('GetUser'),
+      expect.stringContaining('```json\n{\n  "id": "123"\n}\n```'),
     )
     expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-      expect.stringContaining('"id": "123"'),
+      expect.stringContaining('```graphql\nquery GetUser { user { id } }\n```'),
     )
   })
 

--- a/packages/web/src/components/__tests__/DevFatalErrorPage.test.tsx
+++ b/packages/web/src/components/__tests__/DevFatalErrorPage.test.tsx
@@ -147,13 +147,14 @@ describe('DevFatalErrorPage', () => {
     const user = userEvent.setup()
     vi.spyOn(window.navigator.clipboard, 'writeText')
 
-    const error: any = new Error('Message with `inline` code')
-    error.mostRecentRequest = {
-      query: ['query GetCode {', '  code', '}', '```'].join('\n'),
-      operationName: 'GetCode',
-      operationKind: 'query',
-      variables: { markdown: '```' },
-    }
+    const error = Object.assign(new Error('Message with `inline` code'), {
+      mostRecentRequest: {
+        query: ['query GetCode {', '  code', '}', '```'].join('\n'),
+        operationName: 'GetCode',
+        operationKind: 'query',
+        variables: { markdown: '```' },
+      },
+    })
 
     render(<DevFatalErrorPage error={error} />)
     await user.click(screen.getByRole('button', { name: /Copy All/ }))


### PR DESCRIPTION
Emit compact Markdown with typed request, response, query, and source blocks so copied runtime errors retain useful structure without decorative noise.

Keep the full stack trace while omitting third-party source excerpts to reduce prompt size.