### PR TITLE
docs(plans): Multi tenancy

### DIFF
--- a/docs/implementation-plans/2026-07-18-prerender-rewrite.md
+++ b/docs/implementation-plans/2026-07-18-prerender-rewrite.md
@@ -308,6 +308,13 @@ const apolloState = client.extract()
   hit the restored cache and render data immediately on hydration — no
   client streaming/Suspense support required, so this does not depend on
   Cedar's experimental streaming work.
+- The per-route client is the outermost client only. A nested `ApolloProvider`
+  rendered inside `Routes` shadows it for its subtree, and that subtree's
+  queries bypass `inProcessGqlLink` and `client.extract()`. The
+  [multi-tenancy plan](./2026-08-26-multi-tenancy.md)'s `OrgScope` is such a
+  provider, so organization routes are outside the per-route-client model and
+  must not be marked `prerender`; the tenancy plan states the same from its
+  side.
 
 ### 2.2 Orchestration: concurrency and memory
 

--- a/docs/implementation-plans/2026-07-20-rsc-rewrite.md
+++ b/docs/implementation-plans/2026-07-20-rsc-rewrite.md
@@ -364,8 +364,9 @@ raises "why isn't Prisma under `api/` anymore" with no answer.
   Router. v1: it discriminates renderers. Stage D: it is the authoritative
   router for RSC-routed apps (redirects, private routes, 404s resolved
   server-side). Route params resolved here have consumers outside the router:
-  the [multi-tenancy plan](./2026-08-26-multi-tenancy.md) sets
-  `context.currentOrg` from them per request and provides a per-organization
+  the [multi-tenancy plan](./2026-08-26-multi-tenancy.md) resolves
+  `context.currentOrg` from them per request through its
+  membership-validating `setCurrentOrg` and provides a per-organization
   Apollo client under the matched route, so the dispatcher exposes its match to
   the render tree rather than leaving the client `Router` to re-derive it (the
   streaming-SSR plan's open question 8).

--- a/docs/implementation-plans/2026-07-20-rsc-rewrite.md
+++ b/docs/implementation-plans/2026-07-20-rsc-rewrite.md
@@ -363,7 +363,12 @@ raises "why isn't Prisma under `api/` anymore" with no answer.
 - **Server side:** the dispatcher in the web Fetchable is the server-side Cedar
   Router. v1: it discriminates renderers. Stage D: it is the authoritative
   router for RSC-routed apps (redirects, private routes, 404s resolved
-  server-side).
+  server-side). Route params resolved here have consumers outside the router:
+  the [multi-tenancy plan](./2026-08-26-multi-tenancy.md) sets
+  `context.currentOrg` from them per request and provides a per-organization
+  Apollo client under the matched route, so the dispatcher exposes its match to
+  the render tree rather than leaving the client `Router` to re-derive it (the
+  streaming-SSR plan's open question 8).
 - **Client side:** the thin shell — link interception, history integration,
   flight re-fetch on navigation (the `no-ssr` example's `listenNavigation`
   pattern, owned by Cedar Router). For SPA/stage B routes, today's client router
@@ -384,6 +389,11 @@ raises "why isn't Prisma under `api/` anymore" with no answer.
    `CedarApolloProvider` living in the client shell above the payload. Define
    the supported level for v1 (probably: works, no SSR'd cache transport) and
    how it relates to Apollo's own RSC integration (`PreloadQuery` etc.) later.
+   A shell-level client is not the only client an island may use: the
+   [multi-tenancy plan](./2026-08-26-multi-tenancy.md) provides a
+   per-organization Apollo client from a `Set wrap` component under the route
+   match, so the v1 answer must allow a nested `ApolloProvider` inside the
+   payload's client tree to shadow the shell's.
 3. **Server function key management.** plugin-rsc encrypts closures with a
    build-time key (`defineEncryptionKey`); multi-function/multi-region deploys
    and rebuilds need a stable-key story (env var, UD-provided).

--- a/docs/implementation-plans/2026-07-20-streaming-ssr-rewrite.md
+++ b/docs/implementation-plans/2026-07-20-streaming-ssr-rewrite.md
@@ -422,6 +422,20 @@ path stops being opt-out for streaming projects.
    without it before deleting the legacy branch — self-host is covered twice
    over (`cedar serve` via srvx, custom servers via the Fastify bridge), since
    both host the same built Fetchable.
+8. **Route params above `App`.** The handler matches the route (1.1) before
+   rendering, then renders `<App><Routes /></App>`, inside which the client
+   `Router` matches again to produce `useParams()`. Anything rendered between
+   the two — the per-request store, providers in `App.tsx` — cannot see the
+   params. The first consumer that needs them there is the
+   [multi-tenancy plan](./2026-08-26-multi-tenancy.md): it sets
+   `context.currentOrg` from the route param in the server entry and builds a
+   per-organization Apollo client in a `Set wrap` component during SSR. Decide
+   whether the handler's match result flows into the tree (a provider beside
+   `LocationProvider` that `Router` consumes instead of re-matching) or whether
+   the client `Router` is split into a route-analysis half that can sit above
+   `App`'s providers and a page-rendering half below them. Tenancy is a
+   consumer of either answer, not the reason to pick one; the dispatcher design
+   under the RSC plan is.
 
 ---
 
@@ -449,6 +463,12 @@ path stops being opt-out for streaming projects.
   is the concrete, near-term motivation for landing the first wave of the
   [RSC plan's `/db/` move](./2026-07-20-rsc-rewrite.md#the-db-move) ahead of
   RSC v1 itself, rather than waiting for it.
+- **Route params and per-request consumers:** the
+  [multi-tenancy plan](./2026-08-26-multi-tenancy.md) needs the matched route's
+  params on the server before rendering starts (to set `context.currentOrg`)
+  and inside the tree under `App` (to build a per-organization Apollo client
+  from a `Set wrap`). Its steps 1–3 work without any of this plan; its SSR
+  support depends on open question 8 being answered.
 
 ---
 

--- a/docs/implementation-plans/2026-07-20-streaming-ssr-rewrite.md
+++ b/docs/implementation-plans/2026-07-20-streaming-ssr-rewrite.md
@@ -431,8 +431,9 @@ path stops being opt-out for streaming projects.
    resolves the route param through its `setCurrentOrg`, which derives the
    role from the authenticated user's memberships and refuses an organization
    the user has no membership in, and it builds a per-organization Apollo
-   client in a `Set wrap` component during SSR — the param names the
-   organization, membership authorizes it. Decide
+   client in its `OrgScope` component (mounted through the router's
+   `Set wrap`) during SSR — the param names the organization, membership
+   authorizes it. Decide
    whether the handler's match result flows into the tree (a provider beside
    `LocationProvider` that `Router` consumes instead of re-matching) or whether
    the client `Router` is split into a route-analysis half that can sit above
@@ -470,8 +471,8 @@ path stops being opt-out for streaming projects.
   [multi-tenancy plan](./2026-08-26-multi-tenancy.md) needs the matched route's
   params on the server before rendering starts (to resolve
   `context.currentOrg` through its membership-validating `setCurrentOrg`) and
-  inside the tree under `App` (to build a per-organization Apollo client from
-  a `Set wrap`). Its steps 1–3 work without any of this plan; its SSR
+  inside the tree under `App` (to build a per-organization Apollo client in
+  its `OrgScope` component). Its steps 1–3 work without any of this plan; its SSR
   support depends on open question 8 being answered.
 
 ---

--- a/docs/implementation-plans/2026-07-20-streaming-ssr-rewrite.md
+++ b/docs/implementation-plans/2026-07-20-streaming-ssr-rewrite.md
@@ -427,9 +427,12 @@ path stops being opt-out for streaming projects.
    `Router` matches again to produce `useParams()`. Anything rendered between
    the two — the per-request store, providers in `App.tsx` — cannot see the
    params. The first consumer that needs them there is the
-   [multi-tenancy plan](./2026-08-26-multi-tenancy.md): it sets
-   `context.currentOrg` from the route param in the server entry and builds a
-   per-organization Apollo client in a `Set wrap` component during SSR. Decide
+   [multi-tenancy plan](./2026-08-26-multi-tenancy.md): in the server entry it
+   resolves the route param through its `setCurrentOrg`, which derives the
+   role from the authenticated user's memberships and refuses an organization
+   the user has no membership in, and it builds a per-organization Apollo
+   client in a `Set wrap` component during SSR — the param names the
+   organization, membership authorizes it. Decide
    whether the handler's match result flows into the tree (a provider beside
    `LocationProvider` that `Router` consumes instead of re-matching) or whether
    the client `Router` is split into a route-analysis half that can sit above
@@ -465,9 +468,10 @@ path stops being opt-out for streaming projects.
   RSC v1 itself, rather than waiting for it.
 - **Route params and per-request consumers:** the
   [multi-tenancy plan](./2026-08-26-multi-tenancy.md) needs the matched route's
-  params on the server before rendering starts (to set `context.currentOrg`)
-  and inside the tree under `App` (to build a per-organization Apollo client
-  from a `Set wrap`). Its steps 1–3 work without any of this plan; its SSR
+  params on the server before rendering starts (to resolve
+  `context.currentOrg` through its membership-validating `setCurrentOrg`) and
+  inside the tree under `App` (to build a per-organization Apollo client from
+  a `Set wrap`). Its steps 1–3 work without any of this plan; its SSR
   support depends on open question 8 being answered.
 
 ---

--- a/docs/implementation-plans/2026-07-21-rendering-db-rollout-sequencing.md
+++ b/docs/implementation-plans/2026-07-21-rendering-db-rollout-sequencing.md
@@ -73,6 +73,17 @@ No blocking dependencies between these; all can proceed concurrently.
 
 ---
 
+## Consumers outside the four plans
+
+- [2026-08-26-multi-tenancy.md](./2026-08-26-multi-tenancy.md) — steps 1–3
+  (runtime package, setup command, docs) depend on none of the above and can
+  land in Phase 0. Its SSR/RSC support depends on the dispatcher exposing
+  matched route params to the render tree (streaming-SSR open question 8), so
+  it follows Phase 3. Organization routes are not prerenderable by design, so
+  it has no dependency on the prerender tracks.
+
+---
+
 ## Key sequencing decisions baked into this order
 
 - The unified plan is additive-only by design (`api.prismaConfig` keeps working

--- a/docs/implementation-plans/2026-07-21-rendering-db-rollout-sequencing.md
+++ b/docs/implementation-plans/2026-07-21-rendering-db-rollout-sequencing.md
@@ -77,9 +77,10 @@ No blocking dependencies between these; all can proceed concurrently.
 
 - [2026-08-26-multi-tenancy.md](./2026-08-26-multi-tenancy.md) — steps 1–3
   (how-to as spec, runtime package, setup command) depend on none of the above
-  and can land in Phase 0. Its SSR/RSC support depends on the dispatcher exposing
-  matched route params to the render tree (streaming-SSR open question 8), so
-  it follows Phase 3. Organization routes are not prerenderable by design, so
+  and can land in Phase 0. Its SSR support follows the resolution of the
+  streaming-SSR plan's open question 8 (matched route params exposed to the
+  render tree), which sits with the Phase 0 streaming-SSR tracks; its RSC
+  support follows Phase 3, where the dispatcher owns that exposure. Organization routes are not prerenderable by design, so
   it has no dependency on the prerender tracks.
 
 ---

--- a/docs/implementation-plans/2026-07-21-rendering-db-rollout-sequencing.md
+++ b/docs/implementation-plans/2026-07-21-rendering-db-rollout-sequencing.md
@@ -76,8 +76,8 @@ No blocking dependencies between these; all can proceed concurrently.
 ## Consumers outside the four plans
 
 - [2026-08-26-multi-tenancy.md](./2026-08-26-multi-tenancy.md) — steps 1–3
-  (runtime package, setup command, docs) depend on none of the above and can
-  land in Phase 0. Its SSR/RSC support depends on the dispatcher exposing
+  (how-to as spec, runtime package, setup command) depend on none of the above
+  and can land in Phase 0. Its SSR/RSC support depends on the dispatcher exposing
   matched route params to the render tree (streaming-SSR open question 8), so
   it follows Phase 3. Organization routes are not prerenderable by design, so
   it has no dependency on the prerender tracks.

--- a/docs/implementation-plans/2026-08-26-multi-tenancy.md
+++ b/docs/implementation-plans/2026-08-26-multi-tenancy.md
@@ -385,9 +385,17 @@ from `CedarApolloProvider`.
 
 The organization client is the app client's link chain with a `cedar-org`
 header added, and its own `InMemoryCache` built from the app's `cacheConfig`.
-Clients are kept in a module-level `Map<slug, client>` so returning to an
-organization reuses its cache; they share the HTTP transport and the auth
-link, so the cost per organization visited in a tab is one cache. This design
+Clients are kept in a module-level map keyed by `currentUser.id` and slug so
+returning to an organization reuses its cache; they share the HTTP transport
+and the auth link, so the cost per organization visited in a tab is one cache.
+The map is tied to the authenticated user, not to the tab: when
+`useAuth().isAuthenticated` turns false or `currentUser.id` changes, every
+client in it is dropped after `clearStore()`. Keying by user id means a second
+user in the same tab can never be handed the first user's client even if the
+teardown is missed, and the teardown frees the memory. The app client from
+`CedarApolloProvider` has no logout teardown of its own; the how-to tells apps
+to call `clearStore()` from `useCache()` on logout for the same reason, but
+the organization clients do not depend on the app doing so. This design
 is chosen over a shared client with a header set from a store for one reason
 that has nothing to do with how the header is set: the Apollo cache is keyed by
 field name and arguments, not by request headers. With one shared client,
@@ -607,7 +615,9 @@ same shape as `uploads.md`.
   separate caches, so a Cell that ran `projects` under the first never shows
   that list under the second; returning to the first reuses its client; a slug
   with no membership renders the not-a-member state and issues no query; a
-  tenant-scoped query issued above `OrgScope` carries no `cedar-org` header.
+  tenant-scoped query issued above `OrgScope` carries no `cedar-org` header;
+  logging out and logging in as another user in the same tab yields a fresh
+  client for the same slug with an empty cache.
 - `resolveCurrentOrg` / `setCurrentOrg`: header, `variables.orgId`,
   `variables.orgSlug`, slug/id lookup, non-member rejection, and a resolver
   that returns a forged `role: 'owner'` for a viewer membership (the context

--- a/docs/implementation-plans/2026-08-26-multi-tenancy.md
+++ b/docs/implementation-plans/2026-08-26-multi-tenancy.md
@@ -368,11 +368,17 @@ where route params exist:
 </Set>
 ```
 
-`OrgScope` reads `orgSlug` with `useParams()` and writes it to the store on
-change, so navigating between organizations updates the header before the next
-query. Apps that prefer a stored selection instead of a URL segment call
-`setOrg` from their own switcher and omit the `Set`. Multiple tabs on different
-organizations work because the header, not the session, carries the choice.
+`OrgScope` reads `orgSlug` with `useParams()` and writes it to the store
+synchronously during render, before its children render, not in an effect. A
+parent's effects run after its children's, and a Cell starts its Apollo query
+as soon as it mounts, so an effect would let the first request after mounting
+or switching organizations go out with no `cedar-org` header or with the
+previous organization's. The write is a plain assignment of a string that is
+already known, so repeating it on every render is harmless, and the link reads
+the store at request time rather than capturing it. Apps that prefer a stored
+selection instead of a URL segment call `setOrg` from their own switcher and
+omit the `Set`. Multiple tabs on different organizations work because the
+header, not the session, carries the choice.
 
 ### Jobs and scripts
 
@@ -405,26 +411,39 @@ Steps performed:
    read-only. If the file cannot be codemodded safely, print the snippet to add
    instead of guessing.
 5. Codemod `api/src/functions/graphql.ts`: add a `context` function that calls
-   `ensureDefaultOrganization(currentUser)` (see step 8) and then
-   `resolveCurrentOrg({ event, variables, currentUser, lookupOrg })`, where
-   `variables` are the parsed operation variables the GraphQL context exposes.
-   A first-class `currentOrg` option on `createGraphQLHandler` may replace this
+   `ensureDefaultOrganization({ currentUser, invitationToken })` (see step 8),
+   which returns the user's memberships as they are after any write it made,
+   and then
+   `resolveCurrentOrg({ event, variables, currentUser: { ...currentUser, memberships }, lookupOrg })`,
+   where `variables` are the parsed operation variables the GraphQL context
+   exposes. The memberships passed to `resolveCurrentOrg` must be the returned
+   ones: `getCurrentUser()` ran before `ensureDefaultOrganization`, so on a
+   first login the memberships on `currentUser` are empty and membership
+   validation would refuse the organization that was just created.
+   `invitationToken` is read from the `cedar-invitation-token` request header,
+   which the Apollo link sends while the web store holds a token; the store
+   picks the token up from the `invitationToken` URL query parameter on the
+   invitation landing page and clears it once a request has claimed it. A
+   first-class `currentOrg` option on `createGraphQLHandler` may replace this
    boilerplate; see open questions.
 6. Generate `api/src/directives/requireMembership/` with its test.
 7. Generate `api/src/services/organizations/` (create org, invite, accept
    invitation, list memberships) and matching SDL, all scoped with
    `@requireMembership` / `@requireAuth` as appropriate.
-8. Generate `ensureDefaultOrganization(user)` in the organizations service. It
-   is idempotent: it returns early when the user has any membership, otherwise
-   creates the organization with the deterministic slug `user-<userId>` and an
-   `owner` membership in one transaction, and treats a unique-constraint
-   failure on that slug (two concurrent first requests) as "already created"
-   and refetches. When a pending membership matches an `invitationToken` on the
-   request, it attaches that membership instead of creating an organization.
-   For dbAuth the `signup.handler` in `api/src/functions/auth.ts` is codemodded
-   to call it; for every provider the GraphQL `context` function from step 5
-   calls it too, so first login through any provider ends with a membership
-   before `resolveCurrentOrg` runs.
+8. Generate `ensureDefaultOrganization({ currentUser, invitationToken })` in
+   the organizations service. It returns the user's memberships
+   (`{ id, organizationId, role }[]`) as they are after it ran, so callers
+   never continue with a list read before the write. It is idempotent: it
+   returns the existing memberships when the user has any, otherwise creates
+   the organization with the deterministic slug `user-<userId>` and an `owner`
+   membership in one transaction, and treats a unique-constraint failure on
+   that slug (two concurrent first requests) as "already created" and
+   refetches. When `invitationToken` matches a pending membership, it attaches
+   that membership instead of creating an organization. For dbAuth the
+   `signup.handler` in `api/src/functions/auth.ts` is codemodded to call it
+   with the token from the signup form's `userAttributes`; for every provider
+   the GraphQL `context` function from step 5 calls it too, so first login
+   through any provider ends with a membership before `resolveCurrentOrg` runs.
 9. Generate a data migration (`yarn cedar data-migrate`, in
    `api/db/dataMigrations/`) that runs `ensureDefaultOrganization` for every
    existing `User` without a membership, in batches. Existing users otherwise
@@ -486,12 +505,19 @@ tracked in `sdl-stub-followups`; it is sequenced after those.
      subset, with a chosen role). Agency staff working in a client is the
      ordinary org switch; `context.currentOrg` is the client and every query is
      scoped to it.
-   - Provenance: an optional `viaOrganizationId String?` on `Membership`
-     records that a membership exists because the user is staff at the parent.
-     Removing someone from the agency then cascades to the client memberships
-     they hold through it, and a client can tell agency staff apart from its own
-     members. This is the detail that is hard to add after the fact, so it is
-     shown as part of the pattern rather than as an afterthought.
+   - Provenance: an optional `viaMembershipId String?` on `Membership`, a
+     second self-relation (beside `Inviter`) that points at the agency
+     membership the client membership was derived from, declared with
+     `onDelete: Cascade`. Deleting the agency membership then deletes every
+     client membership derived from it at the database level, so no service,
+     admin tool or script can revoke agency access and leave client access
+     behind. Memberships a client grants directly have `viaMembershipId` null
+     and are untouched; a client that wants to keep a specific agency person
+     after the agency relationship ends sets the column to null, which turns
+     the row into a direct membership. The column also lets a client tell
+     agency staff apart from its own members. This is shown as part of the
+     pattern because retrofitting provenance onto existing memberships means
+     guessing which ones were derived.
    - Cross-client work: agency-level reporting or bulk operations over all
      clients run `db.$forOrg(child.id)` per child, looked up through the
      `children` relation on plain `db`. There is no parent scope that sees

--- a/docs/implementation-plans/2026-08-26-multi-tenancy.md
+++ b/docs/implementation-plans/2026-08-26-multi-tenancy.md
@@ -132,8 +132,8 @@ needs the compound selector, and the scaffold generators do not produce that
 shape. The default is therefore the loose model (`id` primary key,
 `organizationId` indexed column) with scoping enforced by the Prisma extension
 below. The how-to documents the compound-PK variant for apps that want
-database-level enforcement of parent/child `organizationId` agreement, which the
-extension cannot check for relation `connect`s.
+database-level enforcement of parent/child `organizationId` agreement
+independent of application code.
 
 ## Architecture decisions
 
@@ -155,8 +155,10 @@ extension cannot check for relation `connect`s.
    on the operation. Apps can replace this with their own `resolveCurrentOrg`
    function. The web client sends the header from `useCurrentOrg()`, which
    derives it from the URL by default.
-4. **Membership is validated when the org is resolved.** `setCurrentOrg` refuses
-   an organization the current user has no membership in, so
+4. **Membership is validated when the org is resolved.** `setCurrentOrg` takes
+   only the organization's identity and derives `role` and `membershipId` from
+   the authenticated user's memberships; it refuses an organization the user has
+   no membership in. A custom resolver therefore cannot grant a role, and
    `context.currentOrg` is trustworthy by the time any service runs. Unauthed
    requests get no `currentOrg`, and public tenant data must be read through the
    explicit `db.$forOrg(id)` escape hatch.
@@ -191,21 +193,28 @@ Behavior, implemented with `$allModels.$allOperations`. Every operation keeps
 its own method; the extension only adds an `organizationId` equality to the
 arguments:
 
-| Operation                                                                                                | Injection                                                  |
-| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `findUnique`, `findUniqueOrThrow`, `update`, `delete`, `upsert`                                          | `where.organizationId = tenantId` beside the unique field  |
-| `findFirst`, `findFirstOrThrow`, `findMany`, `count`, `aggregate`, `groupBy`, `updateMany`, `deleteMany` | `where.organizationId = tenantId` merged with `AND`        |
-| `create`, `createMany`, `upsert.create`                                                                  | `data.organizationId = tenantId` (error if set to another) |
-| Nested `create`/`createMany` under a tenant-owned relation                                               | same `data` injection, recursively                         |
+| Operation                                                                                                                       | Injection                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `findUnique`, `findUniqueOrThrow`, `update`, `delete`, `upsert`                                                                 | `where.organizationId = tenantId` beside the unique field                                                         |
+| `findFirst`, `findFirstOrThrow`, `findMany`, `count`, `aggregate`, `groupBy`, `updateMany`, `updateManyAndReturn`, `deleteMany` | `where.organizationId = tenantId` merged with `AND`                                                               |
+| `create`, `createMany`, `createManyAndReturn`, `upsert.create`                                                                  | `data.organizationId = tenantId` on every row (`data` may be one object or an array); error if a row sets another |
+| `update`, `updateMany`, `updateManyAndReturn`, `upsert.update`                                                                  | `data.organizationId` rejected unless equal to `tenantId`; a row can never move to another organization           |
+| Nested `create`/`createMany`/`update`/`updateMany`/`upsert` under a tenant-owned relation                                       | same `data` rules, recursively                                                                                    |
+| Nested `connect`/`connectOrCreate`/`disconnect`/`set` targeting a tenant-owned model                                            | `organizationId` added to the `where` (`{ id, organizationId }`); `connectOrCreate.create` gets `data` injection  |
+| Nested list `include`/`select`/`_count` of a tenant-owned relation (from any model, including global ones)                      | `where.organizationId = tenantId` merged into the relation arguments                                              |
+| `$queryRaw`, `$executeRaw`, `$queryRawUnsafe`, `$executeRawUnsafe` on a scoped client                                           | `TenantScopeError`; raw SQL is only available on `db.$withoutTenant()`                                            |
 
-The first row relies on `WhereUniqueInput` accepting non-unique filter fields
+The `where` rows rely on `WhereUniqueInput` accepting non-unique filter fields
 next to the unique one (`{ id, organizationId }`), which Prisma supports since
-5.0. The query stays a primary-key lookup with one extra equality check; no
-operation is rewritten to a different one.
-
-Not covered, and stated in the docs: `connect`/`connectOrCreate` to a row in a
-different organization, and raw queries. Both are the compound-PK / RLS
-territory.
+5.0 and which applies to `connect` as well. The query stays a primary-key lookup
+with one extra equality check; no operation is rewritten to a different one,
+and a `connect` to a row in another organization fails with Prisma's
+record-not-found error. Relation targets are resolved from `Prisma.dmmf`, so
+the extension knows which relations point at tenant-owned models without
+configuration. The one shape left to the compound-PK variant is a to-one
+relation from a global model directly to a tenant-owned row; the how-to calls
+that out as a modeling smell (assign to memberships, which are per
+organization).
 
 ### Escape hatches: `$forOrg` and `$withoutTenant`
 
@@ -267,17 +276,35 @@ export interface CurrentOrg {
   membershipId: string
 }
 
-export function setCurrentOrg(org: CurrentOrg): void
+interface Memberships {
+  memberships: Array<{ organizationId: string; role: string; id: string }>
+}
+
+// Takes only the organization identity; role and membershipId are derived
+// from currentUser.memberships, never from the caller, so a custom resolver
+// cannot grant privileges. Throws ForbiddenError when there is no membership.
+export function setCurrentOrg(
+  org: { id: string; slug: string },
+  currentUser: Memberships
+): CurrentOrg
 export function getCurrentOrg(): CurrentOrg | undefined
 export function requireCurrentOrg(): CurrentOrg // throws TenantScopeError
 export function resolveCurrentOrg(args: {
   event: APIGatewayProxyEvent | Request
-  currentUser: {
-    memberships: Array<{ organizationId: string; role: string; id: string }>
-  }
+  variables?: Record<string, unknown> // parsed GraphQL variables, when available
+  currentUser: Memberships
   lookupOrg: (idOrSlug: string) => Promise<{ id: string; slug: string } | null>
 }): Promise<CurrentOrg | undefined>
+export function withTenancy<H extends Handler>(handler: H): H
 ```
+
+`resolveCurrentOrg` reads the `cedar-org` header first and, when absent and
+`variables` is provided, `variables.orgId` / `variables.orgSlug`. It calls
+`setCurrentOrg` itself, so the derived `role`/`membershipId` are the only ones
+that ever reach the context. `withTenancy` is for plain `api/src/functions/*`
+handlers, which do not go through the GraphQL context: it runs `getCurrentUser`
+via the existing auth helpers, then `resolveCurrentOrg` with the request
+headers, then the wrapped handler inside that context.
 
 `GlobalContext` in `@cedarjs/context` gains an optional `currentOrg` via
 declaration merging from this package.
@@ -316,10 +343,25 @@ export function useCurrentOrg(): { org: CurrentOrgSummary | undefined; membershi
 export function hasOrgRole(roles, organizationId?): boolean   // reads useAuth().currentUser.memberships
 ```
 
-Plus an Apollo link that sets `cedar-org` from `useCurrentOrg()`. The default
-source of truth for the active org is a `:orgSlug` route param; `setOrg` is for
-apps that prefer a stored selection. Multiple tabs on different orgs work
-because the header, not the session, carries the choice.
+The active organization is held in a small module-level store, not in React
+context alone, so two things that live at different depths of the tree can use
+it: an Apollo link (installed in `App.tsx`, above the router) reads the store to
+set the `cedar-org` header on every request, and `useCurrentOrg()` subscribes to
+it. The store is written by `<OrgScope>`, which is placed inside the router
+where route params exist:
+
+```tsx
+// web/src/Routes.tsx
+<Set wrap={OrgScope} path="/org/{orgSlug}">
+  <Route path="/org/{orgSlug}/projects" page={ProjectsPage} name="projects" />
+</Set>
+```
+
+`OrgScope` reads `orgSlug` with `useParams()` and writes it to the store on
+change, so navigating between organizations updates the header before the next
+query. Apps that prefer a stored selection instead of a URL segment call
+`setOrg` from their own switcher and omit the `Set`. Multiple tabs on different
+organizations work because the header, not the session, carries the choice.
 
 ### Jobs and scripts
 
@@ -343,31 +385,48 @@ Steps performed:
    model does not exist (the app needs auth set up first) or if
    `Organization`/`Membership` already exist.
 3. Codemod `api/src/lib/db.ts`: wrap the client in
-   `.$extends(createTenancyExtension({ models: { allExcept: ['User', 'Organization', 'Membership'] } }))`.
-   The `allExcept` form is the default because new models are then scoped
-   automatically; forgetting to list a model fails closed.
+   `.$extends(createTenancyExtension({ tenantField, models: { allExcept: ['User', 'Organization', 'Membership'] } }))`,
+   where `tenantField` is the `--tenant-field` value and is omitted when it is
+   the default. The `allExcept` form is the default because new models are then
+   scoped automatically; forgetting to list a model fails closed.
 4. Codemod `api/src/lib/auth.ts`: include `memberships` in `getCurrentUser()`
-   and re-export `hasOrgRole` / `requireMembership`. If the file cannot be
-   codemodded safely, print the snippet to add instead of guessing.
-5. Codemod `api/src/functions/graphql.ts`: add
-   `context: async ({ event, context }) => ({ currentOrg: await resolveCurrentOrg(...) })`
-   (or a `currentOrg` option on `createGraphQLHandler` if that turns out
-   cleaner; see open questions).
+   and re-export `hasOrgRole` / `requireMembership`. `getCurrentUser()` stays
+   read-only. If the file cannot be codemodded safely, print the snippet to add
+   instead of guessing.
+5. Codemod `api/src/functions/graphql.ts`: add a `context` function that calls
+   `ensureDefaultOrganization(currentUser)` (see step 8) and then
+   `resolveCurrentOrg({ event, variables, currentUser, lookupOrg })`, where
+   `variables` are the parsed operation variables the GraphQL context exposes.
+   A first-class `currentOrg` option on `createGraphQLHandler` may replace this
+   boilerplate; see open questions.
 6. Generate `api/src/directives/requireMembership/` with its test.
 7. Generate `api/src/services/organizations/` (create org, invite, accept
    invitation, list memberships) and matching SDL, all scoped with
    `@requireMembership` / `@requireAuth` as appropriate.
-8. Create the default organization on signup. For dbAuth, codemod the
-   `signup.handler` in `api/src/functions/auth.ts` to call
-   `createOrganizationForUser(user)` (exported from the generated organizations
-   service; creates the org and an `owner` membership, or attaches a pending
-   membership when `invitationToken` is present). For other providers,
-   `getCurrentUser()` calls the same helper when the user has no memberships, so
-   first login creates the org.
-9. Wrap `web/src/App.tsx` providers with `<CurrentOrgProvider>` and add the
-   Apollo link.
-10. Print next steps: run the migration, add `organizationId` to existing
-    models, add `:orgSlug` to routes.
+8. Generate `ensureDefaultOrganization(user)` in the organizations service. It
+   is idempotent: it returns early when the user has any membership, otherwise
+   creates the organization with the deterministic slug `user-<userId>` and an
+   `owner` membership in one transaction, and treats a unique-constraint
+   failure on that slug (two concurrent first requests) as "already created"
+   and refetches. When a pending membership matches an `invitationToken` on the
+   request, it attaches that membership instead of creating an organization.
+   For dbAuth the `signup.handler` in `api/src/functions/auth.ts` is codemodded
+   to call it; for every provider the GraphQL `context` function from step 5
+   calls it too, so first login through any provider ends with a membership
+   before `resolveCurrentOrg` runs.
+9. Generate a data migration (`yarn cedar data-migrate`, in
+   `api/db/dataMigrations/`) that runs `ensureDefaultOrganization` for every
+   existing `User` without a membership, in batches. Existing users otherwise
+   have no `currentOrg` and every tenant-owned query for them fails by design.
+   The setup output says to run `yarn cedar prisma migrate dev` and then
+   `yarn cedar data-migrate up`, in that order.
+10. Add the Apollo link to `web/src/App.tsx` and generate
+    `web/src/components/OrgScope/OrgScope.tsx`. Routes are not edited; the
+    printed next steps show the `<Set wrap={OrgScope} path="/org/{orgSlug}">`
+    shape.
+11. Print next steps: run the migrations, add `organizationId` to existing
+    models, wrap organization routes in `OrgScope`, use `withTenancy` on any
+    plain function that touches tenant-owned models.
 
 Flags: `--tenant-field <name>` (default `organizationId`), `--force`.
 
@@ -413,11 +472,24 @@ same shape as `uploads.md`.
 ## Testing
 
 - `packages/tenancy`: unit tests for the query-argument rewriting on every
-  operation in the table above, nested writes, `$forOrg`, `$withoutTenant`, and
-  the `TenantScopeError` path. Run against a real SQLite Prisma client generated
-  from a fixture schema (the `storage` package does the same), not against
-  mocks, so Prisma's argument shapes are exercised for real.
-- `resolveCurrentOrg`: header, variable, slug/id lookup, non-member rejection.
+  operation in the table above, including `createManyAndReturn` /
+  `updateManyAndReturn`, `createMany.data` as an object and as an array with
+  one conflicting row, an `update` that tries to change `organizationId`,
+  nested writes, `connect` to a row in another organization (must fail), nested
+  list `include`/`select`/`_count` reached from a global model (must be
+  scoped), raw queries on the scoped client (must throw), `$forOrg`,
+  `$withoutTenant`, and the `TenantScopeError` path. Run against a real SQLite
+  Prisma client generated from a fixture schema (the `storage` package does the
+  same), not against mocks, so Prisma's argument shapes are exercised for real.
+- `resolveCurrentOrg` / `setCurrentOrg`: header, `variables.orgId`,
+  `variables.orgSlug`, slug/id lookup, non-member rejection, and a resolver
+  that returns a forged `role: 'owner'` for a viewer membership (the context
+  must hold `viewer`).
+- `ensureDefaultOrganization`: idempotent on repeat calls, two concurrent
+  first calls produce one organization, invitation token attaches instead of
+  creating.
+- The generated data migration: users with and without memberships, batch
+  boundaries.
 - `packages/cli` setup command: codemod tests under `__codemod_tests__` with
   `__testfixtures__` for the default `db.ts`, an already-extended `db.ts`
   (uploads), and a `db.ts` the codemod refuses to touch.
@@ -450,10 +522,6 @@ that plan lands, and the hardcoded path until then.
   `currentOrg` option on the handler (like `getCurrentUser`) would be cleaner
   and would let the `@cedarjs/graphql-server` cache the lookup. Decide during
   step 1.
-- **Non-GraphQL functions.** Plain `api/src/functions/*` handlers do not go
-  through the GraphQL context. They need an explicit
-  `await resolveCurrentOrg(...)` call; document it, or provide a
-  `withTenancy(handler)` wrapper.
 - **RSC / server-rendered routes.** When the streaming SSR rewrite
   (`2026-07-20-streaming-ssr-rewrite.md`) gives server code direct `db` access,
   the same `context.currentOrg` needs to be set from the route param in the

--- a/docs/implementation-plans/2026-08-26-multi-tenancy.md
+++ b/docs/implementation-plans/2026-08-26-multi-tenancy.md
@@ -375,10 +375,51 @@ as soon as it mounts, so an effect would let the first request after mounting
 or switching organizations go out with no `cedar-org` header or with the
 previous organization's. The write is a plain assignment of a string that is
 already known, so repeating it on every render is harmless, and the link reads
-the store at request time rather than capturing it. Apps that prefer a stored
-selection instead of a URL segment call `setOrg` from their own switcher and
-omit the `Set`. Multiple tabs on different organizations work because the
-header, not the session, carries the choice.
+the store at request time rather than capturing it. The URL owns the current
+organization; the store is a bridge that lets the link, which is not a
+component and sits above the router, read a value only the router can derive.
+It is not a second source of truth. Apps that prefer a stored selection instead
+of a URL segment call `setOrg` from their own switcher and omit the `Set`.
+Multiple tabs on different organizations work because the header, not the
+session, carries the choice.
+
+The store has two halves that are updated separately. The render-phase write
+updates the readable value and nothing else; notifying subscribers from inside
+another component's render is a React error ("cannot update a component while
+rendering a different component"). Notification runs in a `useLayoutEffect` in
+`OrgScope`. Components below `OrgScope` render after it in the same pass, read
+the new value directly and do not need the notification; components above it
+(a navigation bar with an organization switcher) rendered with the old value
+and are re-rendered by the notification.
+
+`useCurrentOrg()` subscribes with `useSyncExternalStore`, not a hand-rolled
+`useState` plus `useEffect` subscription, for two reasons:
+
+- Tearing. Under concurrent rendering a manual subscription lets two components
+  in the same tree render with different store values. For tenant identity that
+  is the worst inconsistency available: half a page rendered for one
+  organization, half for another. `useSyncExternalStore` compares the snapshot
+  at render and at commit and forces a synchronous re-render when they differ,
+  so every committed frame agrees on the organization. This is also what makes
+  the deferred notification above safe: a component that rendered before the
+  render-phase write is caught by the consistency check even if the
+  notification has not fired yet.
+- Server snapshot. `getServerSnapshot` is where the organization comes from
+  when there is no `window`. When server rendering gives server code direct
+  `db` access (see open questions), seeding the store from the route param on
+  the server is a `getServerSnapshot` implementation, not a redesign of the
+  web side.
+
+`currentUser.memberships` on the web is a snapshot taken at authentication, not
+live data. The API validates against fresh memberships on every request because
+`getCurrentUser()` runs per request, so a removed member is refused immediately
+on the API side; the web side keeps believing in the membership until
+`reauthenticate()` runs. The same staleness hides a newly accepted invitation or
+a newly created organization from the org switcher and from `hasOrgRole()`.
+Web-side callers of any membership-changing mutation (`createOrganization`,
+`acceptInvitation`, role changes, member removal) call `reauthenticate()` from
+`useAuth()` in the mutation's `onCompleted`; the generated organization services
+document this on their SDL, and the how-to states it as a rule.
 
 ### Jobs and scripts
 
@@ -490,7 +531,11 @@ tracked in `sdl-stub-followups`; it is sequenced after those.
 3. `setup tenancy` walkthrough with the resulting diff.
 4. Request flow: URL → header → `resolveCurrentOrg` → `context.currentOrg` →
    extension.
-5. Services, directives, web hooks, with examples.
+5. Services, directives, web hooks, with examples. Includes the rule that
+   web-side callers of membership-changing mutations call `reauthenticate()`
+   in `onCompleted`, with the API-fresh / web-stale distinction: the API
+   re-reads memberships per request, the web reads them once per
+   authentication.
 6. Jobs, scripts, seeds and `$forOrg` / `$withoutTenant`.
 7. Strict variant: compound primary keys, and Postgres RLS as a second layer.
 8. Agencies and parent/child organizations. One organization (an agency,
@@ -584,7 +629,9 @@ that plan lands, and the hardcoded path until then.
 - **RSC / server-rendered routes.** When the streaming SSR rewrite
   (`2026-07-20-streaming-ssr-rewrite.md`) gives server code direct `db` access,
   the same `context.currentOrg` needs to be set from the route param in the
-  server entry. Note it there; no work in this plan.
+  server entry, and the web store's `getServerSnapshot` needs to return that
+  same organization so the server-rendered tree agrees with the API. Note it
+  there; no work in this plan.
 - **Role source.** `role` as a free string on `Membership` versus a
   `MembershipRole` enum in the generated schema. Free string is the default in
   this plan; revisit if the generated organization services want exhaustive

--- a/docs/implementation-plans/2026-08-26-multi-tenancy.md
+++ b/docs/implementation-plans/2026-08-26-multi-tenancy.md
@@ -68,6 +68,11 @@ logging out. Tenant scoping is enforced at the Prisma layer so that forgetting
   as any other access: a `Membership` in that organization. The how-to documents
   the pattern.
 - Changing any auth provider's session or token format.
+- Prerendering organization routes. They are per-user by nature, and
+  `OrgScope`'s nested `ApolloProvider` shadows the per-route client that the
+  [prerender rewrite](./2026-07-18-prerender-rewrite.md) injects above `App`,
+  so its queries would not go through the in-process GraphQL link. Routes under
+  `OrgScope` must not carry `prerender`.
 
 ## The model
 

--- a/docs/implementation-plans/2026-08-26-multi-tenancy.md
+++ b/docs/implementation-plans/2026-08-26-multi-tenancy.md
@@ -55,7 +55,18 @@ logging out. Tenant scoping is enforced at the Prisma layer so that forgetting
 - Organization types, nested organizations (parent/child) and
   organization-to-organization collaboration. All three are additive columns or
   relations on `Organization`/`Membership` that an app can add; the tooling does
-  not generate them.
+  not generate them. Parent/child in particular (agencies serving client
+  organizations, resellers, franchises) is a common need, but the column is the
+  trivial part: a nullable `parentId` self-relation can be added by any app at
+  any time with no data to migrate. What the framework deliberately does not do
+  is make scoping hierarchy-aware. The extension, `setCurrentOrg` and
+  `context.currentOrg` all rest on one organization per request; a parent scope
+  that reads or writes child rows would have to answer which organization owns a
+  `create`, whether an `update` from parent scope may touch a child row and what
+  role a parent member holds in a child, and every answer weakens the fail-closed
+  guarantee. Access to a child organization is therefore expressed the same way
+  as any other access: a `Membership` in that organization. The how-to documents
+  the pattern.
 - Changing any auth provider's session or token format.
 
 ## The model
@@ -463,7 +474,29 @@ tracked in `sdl-stub-followups`; it is sequenced after those.
 5. Services, directives, web hooks, with examples.
 6. Jobs, scripts, seeds and `$forOrg` / `$withoutTenant`.
 7. Strict variant: compound primary keys, and Postgres RLS as a second layer.
-8. Pitfalls from the article restated for Cedar: mixed auth methods per org,
+8. Agencies and parent/child organizations. One organization (an agency,
+   reseller or franchisor) onboards and serves other organizations (its
+   clients). The pattern keeps the runtime untouched:
+   - Schema: `parentId String?` on `Organization` with a `parent` /
+     `children` self-relation. The link is metadata for navigation, billing
+     roll-ups and the org switcher; it has no effect on scoping.
+   - Access: a `createClientOrganization` service, callable by agency members
+     with a suitable role, creates the child organization and fans out
+     `Membership` rows in it for the agency's staff (all of them, or a chosen
+     subset, with a chosen role). Agency staff working in a client is the
+     ordinary org switch; `context.currentOrg` is the client and every query is
+     scoped to it.
+   - Provenance: an optional `viaOrganizationId String?` on `Membership`
+     records that a membership exists because the user is staff at the parent.
+     Removing someone from the agency then cascades to the client memberships
+     they hold through it, and a client can tell agency staff apart from its own
+     members. This is the detail that is hard to add after the fact, so it is
+     shown as part of the pattern rather than as an afterthought.
+   - Cross-client work: agency-level reporting or bulk operations over all
+     clients run `db.$forOrg(child.id)` per child, looked up through the
+     `children` relation on plain `db`. There is no parent scope that sees
+     child rows in one query.
+9. Pitfalls from the article restated for Cedar: mixed auth methods per org,
    assigning to users instead of memberships, analytics group ids.
 
 `docs/docs/tenancy.md` (reference page) is added when the package ships, in the

--- a/docs/implementation-plans/2026-08-26-multi-tenancy.md
+++ b/docs/implementation-plans/2026-08-26-multi-tenancy.md
@@ -164,8 +164,9 @@ independent of application code.
    `cedar-org` request header (no `X-` prefix, per RFC 6648, and matching the
    existing `auth-provider` header), then `orgId` / `orgSlug` GraphQL variable
    on the operation. Apps can replace this with their own `resolveCurrentOrg`
-   function. The web client sends the header from `useCurrentOrg()`, which
-   derives it from the URL by default.
+   function. On the web the header is baked into a per-organization Apollo
+   client that `OrgScope` provides under the organization routes; see
+   [Web side](#web-side-packagestenancysrcweb).
 4. **Membership is validated when the org is resolved.** `setCurrentOrg` takes
    only the organization's identity and derives `role` and `membershipId` from
    the authenticated user's memberships; it refuses an organization the user has
@@ -354,61 +355,69 @@ export function useCurrentOrg(): { org: CurrentOrgSummary | undefined; membershi
 export function hasOrgRole(roles, organizationId?): boolean   // reads useAuth().currentUser.memberships
 ```
 
-The active organization is held in a small module-level store, not in React
-context alone, so two things that live at different depths of the tree can use
-it: an Apollo link (installed in `App.tsx`, above the router) reads the store to
-set the `cedar-org` header on every request, and `useCurrentOrg()` subscribes to
-it. The store is written by `<OrgScope>`, which is placed inside the router
-where route params exist:
+The current organization is a per-organization Apollo client, provided by
+`<OrgScope>` under the organization routes with the router's own per-subtree
+provider mechanism, `Set wrap`:
 
 ```tsx
 // web/src/Routes.tsx
-<Set wrap={OrgScope}>
+<Set wrap={[OrgScope, OrgLayout]}>
   <Route path="/org/{orgSlug}/projects" page={ProjectsPage} name="projects" />
 </Set>
 ```
 
-`OrgScope` reads `orgSlug` with `useParams()` and writes it to the store
-synchronously during render, before its children render, not in an effect. A
-parent's effects run after its children's, and a Cell starts its Apollo query
-as soon as it mounts, so an effect would let the first request after mounting
-or switching organizations go out with no `cedar-org` header or with the
-previous organization's. The write is a plain assignment of a string that is
-already known, so repeating it on every render is harmless, and the link reads
-the store at request time rather than capturing it. The URL owns the current
-organization; the store is a bridge that lets the link, which is not a
-component and sits above the router, read a value only the router can derive.
-It is not a second source of truth. Apps that prefer a stored selection instead
-of a URL segment call `setOrg` from their own switcher and omit the `Set`.
-Multiple tabs on different organizations work because the header, not the
-session, carries the choice.
+`OrgScope` reads `orgSlug` with `useParams()`, finds the matching entry in
+`useAuth().currentUser.memberships` (which `getCurrentUser()` returns with
+`organization: { id, slug, name }` for this reason, so no bootstrap query is
+needed), and renders a nested `<ApolloProvider client={orgClient}>` plus an
+`OrgContext` that `useCurrentOrg()` reads. When there is no matching
+membership it renders the app's not-a-member state instead of its children.
+Apollo resolves the nearest provider, so every Cell, `useQuery` and
+`useMutation` under the organization routes uses the organization's client,
+and everything above `OrgScope` (the app shell, the organization switcher, the
+create-organization and accept-invitation pages) keeps using the app client
+from `CedarApolloProvider`.
 
-The store has two halves that are updated separately. The render-phase write
-updates the readable value and nothing else; notifying subscribers from inside
-another component's render is a React error ("cannot update a component while
-rendering a different component"). Notification runs in a `useLayoutEffect` in
-`OrgScope`. Components below `OrgScope` render after it in the same pass, read
-the new value directly and do not need the notification; components above it
-(a navigation bar with an organization switcher) rendered with the old value
-and are re-rendered by the notification.
+The organization client is the app client's link chain with a `cedar-org`
+header added, and its own `InMemoryCache` built from the app's `cacheConfig`.
+Clients are kept in a module-level `Map<slug, client>` so returning to an
+organization reuses its cache; they share the HTTP transport and the auth
+link, so the cost per organization visited in a tab is one cache. This design
+is chosen over a shared client with a header set from a store for one reason
+that has nothing to do with how the header is set: the Apollo cache is keyed by
+field name and arguments, not by request headers. With one shared client,
+`query { projects { id name } }` under `/org/acme` and under `/org/globex`
+normalize to the same `ROOT_QUERY.projects` entry, and a `cache-first` Cell
+mounted after switching renders the first organization's list for the second
+one with no network request to blame. Tenant identity has to be visible to the
+cache, not only to the transport; a client per organization is the direct way
+to make it so.
 
-`useCurrentOrg()` subscribes with `useSyncExternalStore`, not a hand-rolled
-`useState` plus `useEffect` subscription, for two reasons:
+Consequences of the client being the tenant:
 
-- Tearing. Under concurrent rendering a manual subscription lets two components
-  in the same tree render with different store values. For tenant identity that
-  is the worst inconsistency available: half a page rendered for one
-  organization, half for another. `useSyncExternalStore` compares the snapshot
-  at render and at commit and forces a synchronous re-render when they differ,
-  so every committed frame agrees on the organization. This is also what makes
-  the deferred notification above safe: a component that rendered before the
-  render-phase write is caught by the consistency check even if the
-  notification has not fired yet.
-- Server snapshot. `getServerSnapshot` is where the organization comes from
-  when there is no `window`. When server rendering gives server code direct
-  `db` access (see open questions), seeding the store from the route param on
-  the server is a `getServerSnapshot` implementation, not a redesign of the
-  web side.
+- There is no store, no render-phase write and no subscription to reason about.
+  React context is consistent within a committed frame, and a Cell under
+  `OrgScope` cannot mount before `OrgScope` has rendered its provider.
+- A tenant-scoped query issued outside `OrgScope` goes through the app client,
+  carries no `cedar-org` header, and is refused by the API with
+  `TenantScopeError`. Forgetting to put organization pages under the `Set`
+  fails closed on the web side the same way a missing `organizationId` fails
+  closed on the API side.
+- Multiple tabs on different organizations work because each tab's client
+  carries its own header; nothing is stored in the session.
+- Apps that select the organization from state rather than a URL segment
+  render `<OrgScope orgSlug={selected}>` themselves with the same component;
+  the route param is the default source, a prop overrides it. `setOrg` from
+  `useCurrentOrg()` is `navigate(routes.<same route>({ orgSlug }))` in the URL
+  model and a state setter in the other.
+
+Building the organization client needs the app client's link chain and cache
+configuration. `CedarApolloProvider` assembles those internally (auth link,
+SSE link, fragment registry, `cacheConfig`, user `graphQLClientConfig`), so
+`@cedarjs/web/apollo` gains a helper that builds a second client from the same
+configuration with additional headers. The helper is the framework change this
+layer needs; `OrgScope` itself is generated app code that calls it. Its exact
+shape is decided in step 2 of the sequencing.
 
 `currentUser.memberships` on the web is a snapshot taken at authentication, not
 live data. The API validates against fresh memberships on every request because
@@ -461,12 +470,16 @@ Steps performed:
    ones: `getCurrentUser()` ran before `ensureDefaultOrganization`, so on a
    first login the memberships on `currentUser` are empty and membership
    validation would refuse the organization that was just created.
-   `invitationToken` is read from the `cedar-invitation-token` request header,
-   which the Apollo link sends while the web store holds a token; the store
-   picks the token up from the `invitationToken` URL query parameter on the
-   invitation landing page and clears it once a request has claimed it. A
-   first-class `currentOrg` option on `createGraphQLHandler` may replace this
-   boilerplate; see open questions.
+   `invitationToken` is read from the `cedar-invitation-token` request header.
+   Only one operation ever carries it: the generated invitation landing page
+   (`/invite/{token}`, outside `OrgScope`) calls the `acceptInvitation`
+   mutation with the token as a variable and as that header through Apollo's
+   per-operation `context: { headers }`. The context function reads the
+   header, so `ensureDefaultOrganization` attaches the pending membership
+   before the resolver runs, and the resolver returns the organization,
+   idempotently when the membership is already attached. A first-class
+   `currentOrg` option on `createGraphQLHandler` may replace this boilerplate;
+   see open questions.
 6. Generate `api/src/directives/requireMembership/` with its test.
 7. Generate `api/src/services/organizations/` (create org, invite, accept
    invitation, list memberships) and matching SDL, all scoped with
@@ -491,10 +504,10 @@ Steps performed:
    have no `currentOrg` and every tenant-owned query for them fails by design.
    The setup output says to run `yarn cedar prisma migrate dev` and then
    `yarn cedar data-migrate up`, in that order.
-10. Add the Apollo link to `web/src/App.tsx` and generate
-    `web/src/components/OrgScope/OrgScope.tsx`. Routes are not edited; the
-    printed next steps show the `<Set wrap={OrgScope}>`
-    shape.
+10. Generate `web/src/components/OrgScope/OrgScope.tsx` (per-organization
+    Apollo client, `OrgContext`, not-a-member state) and the invitation landing
+    page. `web/src/App.tsx` and `Routes.tsx` are not edited; the printed next
+    steps show the `<Set wrap={OrgScope}>` shape and the invitation route.
 11. Print next steps: run the migrations, add `organizationId` to existing
     models, wrap organization routes in `OrgScope`, use `withTenancy` on any
     plain function that touches tenant-owned models.
@@ -585,6 +598,11 @@ same shape as `uploads.md`.
   `$withoutTenant`, and the `TenantScopeError` path. Run against a real SQLite
   Prisma client generated from a fixture schema (the `storage` package does the
   same), not against mocks, so Prisma's argument shapes are exercised for real.
+- `OrgScope` (web): two organizations visited in sequence get two clients with
+  separate caches, so a Cell that ran `projects` under the first never shows
+  that list under the second; returning to the first reuses its client; a slug
+  with no membership renders the not-a-member state and issues no query; a
+  tenant-scoped query issued above `OrgScope` carries no `cedar-org` header.
 - `resolveCurrentOrg` / `setCurrentOrg`: header, `variables.orgId`,
   `variables.orgSlug`, slug/id lookup, non-member rejection, and a resolver
   that returns a forged `role: 'owner'` for a viewer membership (the context
@@ -607,9 +625,10 @@ same shape as `uploads.md`.
 
 1. How-to as spec (`docs/docs/how-to/multi-tenancy.md`). Review the API on paper
    before writing code.
-2. `packages/tenancy`: extension, context helpers, auth helpers, web hooks.
-   Publishable on its own; usable by hand-wiring before the setup command
-   exists.
+2. `packages/tenancy`: extension, context helpers, auth helpers, web hooks,
+   plus the `@cedarjs/web/apollo` helper that builds an organization client
+   from `CedarApolloProvider`'s configuration. Publishable on its own; usable
+   by hand-wiring before the setup command exists.
 3. `setup tenancy` command with codemods and generated services/directive.
 4. Reference docs page and a `local-testing-project` run through the full flow
    (create org, invite, accept, scoped CRUD, two orgs in two tabs).
@@ -629,9 +648,13 @@ that plan lands, and the hardcoded path until then.
 - **RSC / server-rendered routes.** When the streaming SSR rewrite
   (`2026-07-20-streaming-ssr-rewrite.md`) gives server code direct `db` access,
   the same `context.currentOrg` needs to be set from the route param in the
-  server entry, and the web store's `getServerSnapshot` needs to return that
-  same organization so the server-rendered tree agrees with the API. Note it
-  there; no work in this plan.
+  server entry, and `OrgScope` needs to construct its organization client
+  during server rendering from that same param so the server-rendered tree
+  agrees with the API. Both require route matching to happen before rendering
+  starts, which is a split of the router into route analysis and page
+  rendering that the SSR rewrite may want for its own reasons (per-route
+  dispatch); tenancy is a consumer of that split, not a reason to do it. Note
+  it there; no work in this plan.
 - **Role source.** `role` as a free string on `Membership` versus a
   `MembershipRole` enum in the generated schema. Free string is the default in
   this plan; revisit if the generated organization services want exhaustive

--- a/docs/implementation-plans/2026-08-26-multi-tenancy.md
+++ b/docs/implementation-plans/2026-08-26-multi-tenancy.md
@@ -443,8 +443,11 @@ live data. The API validates against fresh memberships on every request because
 on the API side; the web side keeps believing in the membership until
 `reauthenticate()` runs. The same staleness hides a newly accepted invitation or
 a newly created organization from the org switcher and from `hasOrgRole()`.
-Web-side callers of any membership-changing mutation (`createOrganization`,
-`acceptInvitation`, role changes, member removal) call `reauthenticate()` from
+Web-side callers of any mutation that changes memberships or the
+organizations they point at (`createOrganization`, `acceptInvitation`, role
+changes, member removal, organization renames — the snapshot carries the slug
+`OrgScope` matches routes against, so a stale slug renders the not-a-member
+state for an organization the user belongs to) call `reauthenticate()` from
 `useAuth()` in the mutation's `onCompleted`; the generated organization services
 document this on their SDL, and the how-to states it as a rule.
 
@@ -628,8 +631,10 @@ same shape as `uploads.md`.
   logging out and logging in as another user in the same tab yields a fresh
   client for the same slug with an empty cache; a role change or membership
   removal surfaced by a memberships refresh drops that organization's client;
-  a renamed organization keeps its client (same id), while a new organization
-  reusing a deleted organization's slug gets a fresh one.
+  a renamed organization keeps its client (same id) once the memberships
+  snapshot is refreshed, and matches the new slug only after that refresh,
+  while a new organization reusing a deleted organization's slug gets a fresh
+  one.
 - `resolveCurrentOrg` / `setCurrentOrg`: header, `variables.orgId`,
   `variables.orgSlug`, slug/id lookup, non-member rejection, and a resolver
   that returns a forged `role: 'owner'` for a viewer membership (the context

--- a/docs/implementation-plans/2026-08-26-multi-tenancy.md
+++ b/docs/implementation-plans/2026-08-26-multi-tenancy.md
@@ -352,7 +352,7 @@ where route params exist:
 
 ```tsx
 // web/src/Routes.tsx
-<Set wrap={OrgScope} path="/org/{orgSlug}">
+<Set wrap={OrgScope}>
   <Route path="/org/{orgSlug}/projects" page={ProjectsPage} name="projects" />
 </Set>
 ```
@@ -422,7 +422,7 @@ Steps performed:
    `yarn cedar data-migrate up`, in that order.
 10. Add the Apollo link to `web/src/App.tsx` and generate
     `web/src/components/OrgScope/OrgScope.tsx`. Routes are not edited; the
-    printed next steps show the `<Set wrap={OrgScope} path="/org/{orgSlug}">`
+    printed next steps show the `<Set wrap={OrgScope}>`
     shape.
 11. Print next steps: run the migrations, add `organizationId` to existing
     models, wrap organization routes in `OrgScope`, use `withTenancy` on any

--- a/docs/implementation-plans/2026-08-26-multi-tenancy.md
+++ b/docs/implementation-plans/2026-08-26-multi-tenancy.md
@@ -385,14 +385,19 @@ from `CedarApolloProvider`.
 
 The organization client is the app client's link chain with a `cedar-org`
 header added, and its own `InMemoryCache` built from the app's `cacheConfig`.
-Clients are kept in a module-level map keyed by `currentUser.id` and slug so
-returning to an organization reuses its cache; they share the HTTP transport
-and the auth link, so the cost per organization visited in a tab is one cache.
-The map is tied to the authenticated user, not to the tab: when
-`useAuth().isAuthenticated` turns false or `currentUser.id` changes, every
-client in it is dropped after `clearStore()`. Keying by user id means a second
-user in the same tab can never be handed the first user's client even if the
-teardown is missed, and the teardown frees the memory. The app client from
+Clients are kept in a module-level map keyed by `currentUser.id` and
+`organizationId` — the immutable id, not the slug, which is routing input that
+an organization rename or a deleted organization's reused slug can point at a
+different tenant — so returning to an organization reuses its cache; they
+share the HTTP transport and the auth link, so the cost per organization
+visited in a tab is one cache. The map is tied to the authenticated user's
+memberships, not to the tab: when `useAuth().isAuthenticated` turns false or
+`currentUser.id` changes, every client in it is dropped after `clearStore()`,
+and when a memberships refresh (`reauthenticate()`) shows a membership gone or
+its role changed, that organization's client is dropped the same way, so data
+cached under the previous authorization does not outlive it. Keying by user id
+means a second user in the same tab can never be handed the first user's
+client even if the teardown is missed, and the teardown frees the memory. The app client from
 `CedarApolloProvider` has no logout teardown of its own; the how-to tells apps
 to call `clearStore()` from `useCache()` on logout for the same reason, but
 the organization clients do not depend on the app doing so. This design
@@ -473,7 +478,8 @@ Steps performed:
    and re-export `hasOrgRole` / `requireMembership`. `getCurrentUser()` stays
    read-only. If the file cannot be codemodded safely, print the snippet to add
    instead of guessing.
-5. Codemod `api/src/functions/graphql.ts`: add a `context` function that calls
+5. Codemod `api/src/functions/graphql.ts`: add a `context` function that, only
+   when there is a `currentUser`, calls
    `ensureDefaultOrganization({ currentUser, invitationToken })` (see step 8),
    which returns the user's memberships as they are after any write it made,
    and then
@@ -483,6 +489,9 @@ Steps performed:
    ones: `getCurrentUser()` ran before `ensureDefaultOrganization`, so on a
    first login the memberships on `currentUser` are empty and membership
    validation would refuse the organization that was just created.
+   An anonymous request skips both calls and leaves `context.currentOrg`
+   undefined, consistent with architecture decision 4: public tenant data is
+   read through `db.$forOrg(id)`, never through an anonymously resolved scope.
    `invitationToken` is read from the `cedar-invitation-token` request header.
    Only one operation ever carries it: the generated invitation landing page
    (`/invite/{token}`, outside `OrgScope`) calls the `acceptInvitation`
@@ -617,7 +626,10 @@ same shape as `uploads.md`.
   with no membership renders the not-a-member state and issues no query; a
   tenant-scoped query issued above `OrgScope` carries no `cedar-org` header;
   logging out and logging in as another user in the same tab yields a fresh
-  client for the same slug with an empty cache.
+  client for the same slug with an empty cache; a role change or membership
+  removal surfaced by a memberships refresh drops that organization's client;
+  a renamed organization keeps its client (same id), while a new organization
+  reusing a deleted organization's slug gets a fresh one.
 - `resolveCurrentOrg` / `setCurrentOrg`: header, `variables.orgId`,
   `variables.orgSlug`, slug/id lookup, non-member rejection, and a resolver
   that returns a forged `role: 'owner'` for a viewer membership (the context

--- a/docs/implementation-plans/2026-08-26-multi-tenancy.md
+++ b/docs/implementation-plans/2026-08-26-multi-tenancy.md
@@ -1,0 +1,493 @@
+# Multi-Tenancy Support ("Linear-style" organizations)
+
+Opt-in, layered multi-tenancy for Cedar apps, modeled on the "Linear" access
+pattern from
+[The Ultimate Guide to Multi-Tenant SaaS Data Modeling](https://www.ravion.com/blog/ultimate-guide-to-multi-tenant-saas-data-modeling):
+one user account can belong to many organizations, each membership carries its
+own role, and a user can be active in several organizations at once without
+logging out. Tenant scoping is enforced at the Prisma layer so that forgetting
+`organizationId` on a query is an error, not a data leak.
+
+## Table of Contents
+
+- [Goals](#goals)
+- [Non-Goals](#non-goals)
+- [The model](#the-model)
+- [Architecture decisions](#architecture-decisions)
+- [Layer 1: `@cedarjs/tenancy` runtime](#layer-1-cedarjstenancy-runtime)
+- [Layer 2: `yarn cedar setup tenancy`](#layer-2-yarn-cedar-setup-tenancy)
+- [Layer 3: generator awareness](#layer-3-generator-awareness)
+- [Documentation](#documentation)
+- [Testing](#testing)
+- [Sequencing](#sequencing)
+- [Open questions](#open-questions)
+- [References](#references)
+
+## Goals
+
+- A Cedar app can add organizations, memberships, per-organization roles and
+  tenant-scoped database access with one setup command and a migration.
+- Every database read and write on a tenant-owned model is scoped to the current
+  organization automatically. Code that runs with no organization in scope fails
+  loudly.
+- Role checks per organization work on both sides: `requireMembership()` /
+  `hasOrgRole()` in services and directives on the API side, `useCurrentOrg()` /
+  `hasOrgRole()` on the web side.
+- The current organization is resolved per request, so a user can hold several
+  organizations open in different tabs.
+- Works with every auth provider Cedar supports, because all provider-specific
+  work stays in the app-owned `getCurrentUser()`.
+- Single-tenant apps are unaffected: nothing is added to `create-cedar-app`
+  templates and nothing runs unless the setup command has been used.
+
+## Non-Goals
+
+- Choosing a tenancy model for users. The "Google" (separate account per org)
+  and "GitHub" (must exist before invitation) models from the article are
+  documented as variants in the how-to but not supported by the tooling.
+- Database-per-tenant or schema-per-tenant isolation. This plan is row-level
+  (shared schema, `organizationId` column).
+- Postgres row-level security policies. RLS can be layered on by the app; the
+  how-to mentions it, the tooling does not generate it.
+- Billing, plans, seats, org-level settings UI. Those are app features that
+  build on the `Organization` model; the how-to notes that the subscription
+  belongs to the organization and that per-seat quantity is `memberships.count`.
+- Organization types, nested organizations (parent/child) and
+  organization-to-organization collaboration. All three are additive columns or
+  relations on `Organization`/`Membership` that an app can add; the tooling does
+  not generate them.
+- Changing any auth provider's session or token format.
+
+## The model
+
+Three framework-known models. Everything else in the app is either tenant-owned
+(has `organizationId`) or global.
+
+```prisma
+model Organization {
+  id          String       @id @default(cuid())
+  name        String
+  slug        String       @unique
+  createdAt   DateTime     @default(now())
+  memberships Membership[]
+}
+
+model Membership {
+  id              String       @id @default(cuid())
+  role            String
+  // Null while the membership is a pending invitation.
+  userId          String?
+  organizationId  String
+  invitedById     String?
+  invitationToken String?      @unique
+  createdAt       DateTime     @default(now())
+  user            User?        @relation(fields: [userId], references: [id])
+  organization    Organization @relation(fields: [organizationId], references: [id])
+  invitedBy       Membership?  @relation("Inviter", fields: [invitedById], references: [id])
+  invitees        Membership[] @relation("Inviter")
+
+  @@unique([userId, organizationId])
+  @@index([organizationId])
+}
+```
+
+`User` is the app's existing model; the setup command adds
+`memberships Membership[]` to it. Rules carried over from the article, stated as
+Cedar conventions:
+
+- Every tenant-owned model has `organizationId String` plus
+  `@@index([organizationId])`. `User`, `Organization` and `Membership` are the
+  only models without it.
+- Work is assigned to a `Membership`, not a `User` (`assigneeId` references
+  `Membership.id`). This is what makes assigning to a not-yet-accepted invitee
+  possible and keeps user-level assignment an intentional choice.
+- An invitation is a `Membership` with `userId = null` and an `invitationToken`.
+  Signup or login with `?invitationToken=` attaches the user to that row.
+- `role` is a string, not an enum, so apps can add roles without a migration.
+  The how-to shows how to swap in a Prisma enum.
+- `Organization.slug` exists for URLs (`/org/:slug/...`). Resolving the current
+  org by `id` or `slug` are both supported.
+- Every user belongs to an organization from signup. Signup either claims a
+  pending invitation or creates an `Organization` named after the user plus an
+  `owner` `Membership`, so an app never has user-owned resources that later need
+  moving into an org. The test for what belongs on the user rather than the org
+  is "what if the user wants an assistant to help with this?"; if the answer is
+  "they should", it is org-owned. Retrofitting orgs onto user-owned data is the
+  expensive migration this feature exists to avoid.
+- An invitation is claimable by any user, not only one whose email matches the
+  address it was sent to. The `invitationToken` is the credential; the email is
+  delivery. An existing user accepting an invitation gets the membership
+  attached to their account, so one account can sit on both sides of a
+  marketplace-style app through different memberships.
+- `Membership` is app-extendable. Per-membership permissions beyond `role`
+  (feature flags, resource-level access) are columns the app adds to the model;
+  the framework only reads `role`.
+
+### Enforcement: loose by default, strict as an opt-in
+
+The article's "strict" variant makes `(organizationId, id)` the primary key of
+every tenant-owned table. Prisma supports it (`@@id([organizationId, id])`), but
+every relation then needs a compound `@relation(fields: [...])`, `findUnique`
+needs the compound selector, and the scaffold generators do not produce that
+shape. The default is therefore the loose model (`id` primary key,
+`organizationId` indexed column) with scoping enforced by the Prisma extension
+below. The how-to documents the compound-PK variant for apps that want
+database-level enforcement of parent/child `organizationId` agreement, which the
+extension cannot check for relation `connect`s.
+
+## Architecture decisions
+
+1. **New package `packages/tenancy` (`@cedarjs/tenancy`).** The runtime is a
+   Prisma client extension plus context helpers. A separate package, in the
+   style of `@cedarjs/storage`, keeps it out of `@cedarjs/api`'s bundle for
+   single-tenant apps and stays clear of the `/db/` move
+   (`unified-prisma-db-module-plan.md`), which only changes where the client is
+   imported from.
+2. **Current organization lives in request context, not the session.** The
+   session (via `currentUser.memberships`) carries the list of
+   `{ organizationId, role }` the user can access; each request names the
+   organization it targets. `context.currentOrg` is set once per request and
+   read lazily by the extension through `@cedarjs/context`'s `AsyncLocalStorage`
+   proxy, so nothing has to be threaded through service arguments.
+3. **Organization resolution is pluggable with one default.** Default order:
+   `cedar-org` request header (no `X-` prefix, per RFC 6648, and matching the
+   existing `auth-provider` header), then `orgId` / `orgSlug` GraphQL variable
+   on the operation. Apps can replace this with their own `resolveCurrentOrg`
+   function. The web client sends the header from `useCurrentOrg()`, which
+   derives it from the URL by default.
+4. **Membership is validated when the org is resolved.** `setCurrentOrg` refuses
+   an organization the current user has no membership in, so
+   `context.currentOrg` is trustworthy by the time any service runs. Unauthed
+   requests get no `currentOrg`, and public tenant data must be read through the
+   explicit `db.$forOrg(id)` escape hatch.
+5. **Missing tenant scope throws.** `TenantScopeError` is raised when a
+   tenant-owned model is queried with no `currentOrg` and no explicit
+   `$forOrg`/`$withoutTenant`. Background jobs, scripts and seeds must opt in
+   explicitly. A loud error in development is preferable to a silent
+   cross-tenant read.
+6. **Nothing is provider-specific.** `getCurrentUser()` is app-owned code in
+   every auth setup, so the only change is to include memberships in the
+   returned user. `hasRole()` keeps working unchanged for global roles;
+   `hasOrgRole()` is added beside it.
+
+## Layer 1: `@cedarjs/tenancy` runtime
+
+### `packages/tenancy/src/prismaExtension.ts`
+
+```ts
+export interface TenancyConfig<TClient> {
+  /** Column name on tenant-owned models. Default: 'organizationId'. */
+  tenantField?: string
+  /** Either an explicit list of tenant-owned models, or everything except these. */
+  models: ModelNamesFor<TClient>[] | { allExcept: ModelNamesFor<TClient>[] }
+  /** Returns the current tenant id or undefined. Default reads context.currentOrg?.id. */
+  getTenantId?: () => string | undefined
+}
+
+export function createTenancyExtension<TClient>(config: TenancyConfig<TClient>)
+```
+
+Behavior, implemented with `$allModels.$allOperations`. Every operation keeps
+its own method; the extension only adds an `organizationId` equality to the
+arguments:
+
+| Operation                                                                                                | Injection                                                  |
+| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `findUnique`, `findUniqueOrThrow`, `update`, `delete`, `upsert`                                          | `where.organizationId = tenantId` beside the unique field  |
+| `findFirst`, `findFirstOrThrow`, `findMany`, `count`, `aggregate`, `groupBy`, `updateMany`, `deleteMany` | `where.organizationId = tenantId` merged with `AND`        |
+| `create`, `createMany`, `upsert.create`                                                                  | `data.organizationId = tenantId` (error if set to another) |
+| Nested `create`/`createMany` under a tenant-owned relation                                               | same `data` injection, recursively                         |
+
+The first row relies on `WhereUniqueInput` accepting non-unique filter fields
+next to the unique one (`{ id, organizationId }`), which Prisma supports since
+5.0. The query stays a primary-key lookup with one extra equality check; no
+operation is rewritten to a different one.
+
+Not covered, and stated in the docs: `connect`/`connectOrCreate` to a row in a
+different organization, and raw queries. Both are the compound-PK / RLS
+territory.
+
+### Escape hatches: `$forOrg` and `$withoutTenant`
+
+Client-level helpers added by the extension:
+
+```ts
+db.$forOrg(organizationId) // returns a client scoped to that org, ignoring context
+db.$withoutTenant() // returns an unscoped client for system code
+```
+
+Request handling never needs either: the extension reads `context.currentOrg`
+lazily, so `db.project.findMany()` in a service is already scoped. The two
+helpers are for code that runs with no request context or that deliberately
+works across organizations:
+
+| Situation                                                                                | Helper                                    | Why the default scope does not apply                                             |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------- |
+| Background job (`@cedarjs/jobs`), cron, `cedar exec` script                              | `db.$forOrg(orgId)`                       | No request, so no `currentOrg`; the job receives `organizationId` as an argument |
+| Seed script, data migration, admin dashboard, cross-tenant reporting                     | `db.$withoutTenant()`                     | Intentionally not scoped to one organization                                     |
+| Webhook or inbound-email handler that identifies the tenant from the payload             | `db.$forOrg(orgId)`                       | The tenant is known but is not in the auth context                               |
+| Public page reading one organization's data for an unauthenticated visitor               | `db.$forOrg(orgId)`                       | No user, so `setCurrentOrg` refuses to set a `currentOrg`                        |
+| One request that must touch two organizations (org-to-org transfer, "copy to other org") | `db.$forOrg(otherId)` for the second side | Context holds one organization at a time                                         |
+
+`Organization`, `Membership` and `User` are not tenant-owned, so lookups on
+them, including the `resolveCurrentOrg` bootstrap query, go through plain `db`.
+
+Both helpers return new clients from `$extends`; the shared client is not
+mutated, so they are safe inside a request that is scoped to some other
+organization. This is the pattern Prisma documents for per-request clients
+("each HTTP request has its own client with its own RLS extension"): an extended
+client is a proxy over the same engine and connection pool, and all extended
+clients share that pool, so creating one per job or per request costs nothing
+measurable. Create it once per unit of work (`const orgDb = db.$forOrg(id)` at
+the top of `perform()`), not per query in a loop. The cost that is real is
+TypeScript's: every distinct `$extends` produces a large derived type, which is
+why the helpers return the same extended type with a different tenant source
+instead of layering another extension.
+
+Caveats:
+
+- `$on` must be attached to the base client before `$extends`; the `db.ts`
+  template already orders it that way and the codemod keeps that order.
+- Query extensions run inside interactive transactions, so
+  `db.$transaction(async (tx) => tx.project.create(...))` stays scoped.
+  `$forOrg`/`$withoutTenant` clients have their own `$transaction`; do not mix a
+  `tx` from one client with queries on another.
+- `$withoutTenant()` disables the only check that turns a missing
+  `organizationId` into an error. Code using it is responsible for every `where`
+  it writes, which is why seeds and admin code are the intended callers and
+  services are not.
+
+### `packages/tenancy/src/context.ts`
+
+```ts
+export interface CurrentOrg {
+  id: string
+  slug: string
+  role: string
+  membershipId: string
+}
+
+export function setCurrentOrg(org: CurrentOrg): void
+export function getCurrentOrg(): CurrentOrg | undefined
+export function requireCurrentOrg(): CurrentOrg // throws TenantScopeError
+export function resolveCurrentOrg(args: {
+  event: APIGatewayProxyEvent | Request
+  currentUser: {
+    memberships: Array<{ organizationId: string; role: string; id: string }>
+  }
+  lookupOrg: (idOrSlug: string) => Promise<{ id: string; slug: string } | null>
+}): Promise<CurrentOrg | undefined>
+```
+
+`GlobalContext` in `@cedarjs/context` gains an optional `currentOrg` via
+declaration merging from this package.
+
+### `packages/tenancy/src/auth.ts`
+
+```ts
+export function hasOrgRole(
+  roles: string | string[],
+  organizationId?: string
+): boolean
+export function requireMembership(options?: { roles?: string | string[] }): void
+```
+
+`requireMembership` throws `AuthenticationError` when there is no current user,
+`ForbiddenError` when there is no membership in `context.currentOrg` or the role
+does not match. Same error types `requireAuth` uses so existing error handling
+on the web side applies.
+
+### Directive
+
+`api/src/directives/requireMembership/requireMembership.ts` is generated by
+setup (not exported from the package) so it is app-owned like `requireAuth`:
+
+```graphql
+directive @requireMembership(roles: [String]) on FIELD_DEFINITION
+```
+
+built with `createValidatorDirective` from `@cedarjs/graphql-server`, calling
+`requireMembership({ roles })`.
+
+### Web side (`packages/tenancy/src/web/`)
+
+```ts
+export function useCurrentOrg(): { org: CurrentOrgSummary | undefined; memberships: [...]; setOrg(idOrSlug) }
+export function hasOrgRole(roles, organizationId?): boolean   // reads useAuth().currentUser.memberships
+```
+
+Plus an Apollo link that sets `cedar-org` from `useCurrentOrg()`. The default
+source of truth for the active org is a `:orgSlug` route param; `setOrg` is for
+apps that prefer a stored selection. Multiple tabs on different orgs work
+because the header, not the session, carries the choice.
+
+### Jobs and scripts
+
+`@cedarjs/jobs` executes outside a request, so `context.currentOrg` is unset.
+The documented pattern is to pass `organizationId` as a job argument and use
+`db.$forOrg(organizationId)` inside `perform`. `cedar exec` scripts and
+`seed.ts` use `db.$withoutTenant()`. See
+[Escape hatches](#escape-hatches-fororg-and-withouttenant) for the full list of
+situations and the cost model.
+
+## Layer 2: `yarn cedar setup tenancy`
+
+`packages/cli/src/commands/setup/tenancy/`, following `setup/uploads` (command,
+handler, `dbCodemod.ts`, templates, codemod tests).
+
+Steps performed:
+
+1. Add `@cedarjs/tenancy` to `api/package.json` and `web/package.json`.
+2. Append `Organization` and `Membership` models to `api/db/schema.prisma` and
+   add `memberships Membership[]` to `User`. Abort with a message if a `User`
+   model does not exist (the app needs auth set up first) or if
+   `Organization`/`Membership` already exist.
+3. Codemod `api/src/lib/db.ts`: wrap the client in
+   `.$extends(createTenancyExtension({ models: { allExcept: ['User', 'Organization', 'Membership'] } }))`.
+   The `allExcept` form is the default because new models are then scoped
+   automatically; forgetting to list a model fails closed.
+4. Codemod `api/src/lib/auth.ts`: include `memberships` in `getCurrentUser()`
+   and re-export `hasOrgRole` / `requireMembership`. If the file cannot be
+   codemodded safely, print the snippet to add instead of guessing.
+5. Codemod `api/src/functions/graphql.ts`: add
+   `context: async ({ event, context }) => ({ currentOrg: await resolveCurrentOrg(...) })`
+   (or a `currentOrg` option on `createGraphQLHandler` if that turns out
+   cleaner; see open questions).
+6. Generate `api/src/directives/requireMembership/` with its test.
+7. Generate `api/src/services/organizations/` (create org, invite, accept
+   invitation, list memberships) and matching SDL, all scoped with
+   `@requireMembership` / `@requireAuth` as appropriate.
+8. Create the default organization on signup. For dbAuth, codemod the
+   `signup.handler` in `api/src/functions/auth.ts` to call
+   `createOrganizationForUser(user)` (exported from the generated organizations
+   service; creates the org and an `owner` membership, or attaches a pending
+   membership when `invitationToken` is present). For other providers,
+   `getCurrentUser()` calls the same helper when the user has no memberships, so
+   first login creates the org.
+9. Wrap `web/src/App.tsx` providers with `<CurrentOrgProvider>` and add the
+   Apollo link.
+10. Print next steps: run the migration, add `organizationId` to existing
+    models, add `:orgSlug` to routes.
+
+Flags: `--tenant-field <name>` (default `organizationId`), `--force`.
+
+## Layer 3: generator awareness
+
+Separate, later PR. `g sdl` and `g scaffold` get a `--tenant` flag that:
+
+- adds `organizationId String` + relation + `@@index` to the model when
+  `g model`-style schema editing is involved (scaffold only reads the schema
+  today, so this may reduce to a validation that the field exists),
+- replaces `@requireAuth` with `@requireMembership` in the generated SDL,
+- omits `organizationId` from create/update input types and forms (the extension
+  injects it),
+- seeds an organization and sets `context.currentOrg` in generated service tests
+  via a `mockCurrentOrg()` helper exported from `@cedarjs/testing`.
+
+This interacts with SDL field redaction (#2285) and the scaffold stub work
+tracked in `sdl-stub-followups`; it is sequenced after those.
+
+## Documentation
+
+`docs/docs/how-to/multi-tenancy.md`, written first as the spec for Layers 1–2:
+
+1. Which tenancy model this is and why (Linear vs. GitHub vs. Google, in the
+   article's terms), and why to run `setup tenancy` before the first user-owned
+   model exists rather than after.
+2. Schema and the conventions (org id everywhere, assign to memberships,
+   invitations are memberships, org on signup, the "assistant" test for
+   org-owned vs user-owned), with a marketplace-style example where one user is
+   a member on both sides.
+3. `setup tenancy` walkthrough with the resulting diff.
+4. Request flow: URL → header → `resolveCurrentOrg` → `context.currentOrg` →
+   extension.
+5. Services, directives, web hooks, with examples.
+6. Jobs, scripts, seeds and `$forOrg` / `$withoutTenant`.
+7. Strict variant: compound primary keys, and Postgres RLS as a second layer.
+8. Pitfalls from the article restated for Cedar: mixed auth methods per org,
+   assigning to users instead of memberships, analytics group ids.
+
+`docs/docs/tenancy.md` (reference page) is added when the package ships, in the
+same shape as `uploads.md`.
+
+## Testing
+
+- `packages/tenancy`: unit tests for the query-argument rewriting on every
+  operation in the table above, nested writes, `$forOrg`, `$withoutTenant`, and
+  the `TenantScopeError` path. Run against a real SQLite Prisma client generated
+  from a fixture schema (the `storage` package does the same), not against
+  mocks, so Prisma's argument shapes are exercised for real.
+- `resolveCurrentOrg`: header, variable, slug/id lookup, non-member rejection.
+- `packages/cli` setup command: codemod tests under `__codemod_tests__` with
+  `__testfixtures__` for the default `db.ts`, an already-extended `db.ts`
+  (uploads), and a `db.ts` the codemod refuses to touch.
+- `__fixtures__/test-project`: not changed. A new step in `tasks/test-project`
+  is not added until Layer 3, to keep the fixture byte-clean check unaffected.
+- Type tests: `db.project.findMany()` result types are unchanged by the
+  extension; `data.organizationId` is optional on create for tenant-owned
+  models.
+
+## Sequencing
+
+1. How-to as spec (`docs/docs/how-to/multi-tenancy.md`). Review the API on paper
+   before writing code.
+2. `packages/tenancy`: extension, context helpers, auth helpers, web hooks.
+   Publishable on its own; usable by hand-wiring before the setup command
+   exists.
+3. `setup tenancy` command with codemods and generated services/directive.
+4. Reference docs page and a `local-testing-project` run through the full flow
+   (create org, invite, accept, scoped CRUD, two orgs in two tabs).
+5. Layer 3 generator flag, after #2285 and the scaffold stub work.
+
+Steps 1–2 do not depend on the `/db/` move; step 3's codemod targets
+`api/src/lib/db.ts` by the path from `getPaths().api.db`-style resolution once
+that plan lands, and the hardcoded path until then.
+
+## Open questions
+
+- **Where `resolveCurrentOrg` hooks in.** A `context` function on
+  `createGraphQLHandler` works today but is app-owned boilerplate; a first-class
+  `currentOrg` option on the handler (like `getCurrentUser`) would be cleaner
+  and would let the `@cedarjs/graphql-server` cache the lookup. Decide during
+  step 1.
+- **Non-GraphQL functions.** Plain `api/src/functions/*` handlers do not go
+  through the GraphQL context. They need an explicit
+  `await resolveCurrentOrg(...)` call; document it, or provide a
+  `withTenancy(handler)` wrapper.
+- **RSC / server-rendered routes.** When the streaming SSR rewrite
+  (`2026-07-20-streaming-ssr-rewrite.md`) gives server code direct `db` access,
+  the same `context.currentOrg` needs to be set from the route param in the
+  server entry. Note it there; no work in this plan.
+- **Role source.** `role` as a free string on `Membership` versus a
+  `MembershipRole` enum in the generated schema. Free string is the default in
+  this plan; revisit if the generated organization services want exhaustive
+  switch statements.
+- **Prisma 8.** The extension targets Prisma 7 Client Extensions (`$extends`).
+  Prisma 8 is a rewrite (release candidate as of 2026-08-26; PostgreSQL and
+  MongoDB only, SQLite planned) with a different client and no `$extends`, so
+  the extension has to be reimplemented when Cedar moves to Prisma 8. Nothing in
+  this plan is designed around Prisma 8 before that move is planned.
+- **Naming.** `organization` vs `workspace` vs `team` vs `tenant` for the model
+  and the `tenantField` default. The article uses `organization`, Linear itself
+  says `workspace`, Bullet Train says `team`. Never `account`: users read that
+  word as their login. `organization` unless there is a strong preference.
+- **Default organization on signup.** Creating an org for every user keeps the
+  model uniform but produces one-member orgs that count as seats and that an
+  invited user may never use. The alternative is to create the org only when the
+  user is not accepting an invitation. The plan does the latter (step 8 of
+  setup); confirm during the how-to review.
+
+## References
+
+- [The Ultimate Guide to Multi-Tenant SaaS Data Modeling](https://www.ravion.com/blog/ultimate-guide-to-multi-tenant-saas-data-modeling)
+  (Ravion) — the "Linear" access model, membership-based assignment, invitations
+  as memberships, and the loose/strict enforcement variants.
+- [Teams Should Be an MVP Feature](https://blog.bullettrain.co/teams-should-be-an-mvp-feature/)
+  (Andrew Culver, Bullet Train) — organizations from day one, the "assistant"
+  test for org-owned resources, invitations claimable by any account, and
+  `Membership` as the extension point for per-member permissions.
+- [Prisma Client extensions](https://www.prisma.io/docs/orm/prisma-client/client-extensions)
+  and the
+  [row-level-security example](https://github.com/prisma/prisma-client-extensions/tree/main/row-level-security)
+  — per-request extended clients sharing one connection pool, the basis for
+  `$forOrg` / `$withoutTenant`.


### PR DESCRIPTION
Implementation plan for opt-in, row-level multi-tenancy in Cedar apps, modeled on the "Linear" access pattern (one account, many organizations, a role per membership, several organizations open at once). Scoping is enforced in a Prisma client extension so that a tenant-owned query with no organization in scope throws rather than leaking.

The plan covers three layers:

- `@cedarjs/tenancy` runtime: the Prisma extension, `$forOrg` / `$withoutTenant` escape hatches, `context.currentOrg` resolution and validation, `requireMembership` / `hasOrgRole` on the API side, `OrgScope` and `useCurrentOrg` on the web side.
- `yarn cedar setup tenancy`: schema models, `db.ts` / `auth.ts` / `graphql.ts` codemods, generated organization services, directive, data migration, and `OrgScope`.
- Generator awareness (`--tenant` on `g sdl` / `g scaffold`), sequenced after the SDL field-redaction and scaffold-stub work.

Design points worth reviewing:

- Tenant scope is one organization per request; parent/child organizations (agencies serving client organizations) are a documented app-level pattern using memberships with a `viaMembershipId` cascade, not a hierarchy-aware scope.
- On the web, the current organization is a per-organization Apollo client provided from a `Set wrap`, because the Apollo cache is keyed by field and arguments, not request headers; a shared client with a tenant header serves one organization's cached data to another. This needs one small framework addition: a helper in `@cedarjs/web/apollo` to build a second client from `CedarApolloProvider`'s configuration.
- `ensureDefaultOrganization` returns post-write memberships so first login validates against the membership it just created.

The PR also adds short cross-references in four rendering plans (`streaming-ssr-rewrite`, `rsc-rewrite`, `prerender-rewrite`, `rendering-db-rollout-sequencing`) recording that tenancy consumes matched route params on the server and under `App`, and that organization routes are not prerenderable. Tenancy's steps 1–3 depend on none of the rendering work.
