### PR TITLE
fix(dbAuth): Reject unverified WebAuthn assertions

### DIFF
--- a/.changesets/2508-security-fix.md
+++ b/.changesets/2508-security-fix.md
@@ -1,0 +1,13 @@
+- fix(dbAuth): Reject unverified WebAuthn assertions in `webAuthnAuthenticate`
+
+`DbAuthHandler.webAuthnAuthenticate()` issued the login cookies and returned
+200 whether or not the assertion signature matched the stored public key.
+`SimpleWebAuthn`'s `verifyAuthenticationResponse()` throws for most failure
+modes, but a signature mismatch comes back as `{ verified: false }` with no
+error — so an unverified assertion was answered with a valid session for the
+credential's owner.
+
+It now throws a `WebAuthnError` before anything is issued, matching how
+`webAuthnRegister()` already handles its own `verified` check. The only
+information an attacker needs to reach the affected path is a credential ID
+for the victim; those are not secret in the WebAuthn model.

--- a/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
+++ b/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
@@ -862,19 +862,26 @@ export class DbAuthHandler<
 
     const { verified, authenticationInfo } = verification
 
-    if (verified) {
-      // update counter in credentials
-      await this.dbCredentialAccessor.update({
-        where: {
-          [webAuthnOptions.credentialFields.id]:
-            credential[webAuthnOptions.credentialFields.id],
-        },
-        data: {
-          [webAuthnOptions.credentialFields.counter]:
-            authenticationInfo.newCounter,
-        },
-      })
+    // `verifyAuthenticationResponse()` throws for most failure modes, but a
+    // response whose signature simply does not match the stored public key
+    // comes back as `verified: false` with no error. Bail out before issuing
+    // any cookies — otherwise an unverified assertion is answered with a
+    // valid session for the credential's owner.
+    if (!verified) {
+      throw new DbAuthError.WebAuthnError('Authentication failed')
     }
+
+    // update counter in credentials
+    await this.dbCredentialAccessor.update({
+      where: {
+        [webAuthnOptions.credentialFields.id]:
+          credential[webAuthnOptions.credentialFields.id],
+      },
+      data: {
+        [webAuthnOptions.credentialFields.counter]:
+          authenticationInfo.newCounter,
+      },
+    })
 
     // get the regular `login` cookies
     const [, headers] = this._loginResponse(user)

--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.fetch.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.fetch.test.js
@@ -1,6 +1,18 @@
 import crypto from 'node:crypto'
 import path from 'node:path'
 
+vi.mock('@simplewebauthn/server', async (importOriginal) => {
+  const original = await importOriginal()
+  // Delegate to the real verifier by default.
+  // Individual tests can override the result with `vi.mocked(...).mockImplementation(...)`.
+  return {
+    ...original,
+    verifyAuthenticationResponse: vi.fn((opts) =>
+      original.verifyAuthenticationResponse(opts),
+    ),
+  }
+})
+
 import {
   vi,
   describe,
@@ -2244,6 +2256,17 @@ describe('dbAuth', () => {
         },
       })
 
+      // Return `verified: true` so this test exercises a successfully
+      // verified assertion without depending on a cryptographic fixture.
+      const { verifyAuthenticationResponse } =
+        await import('@simplewebauthn/server')
+      vi.mocked(verifyAuthenticationResponse).mockImplementationOnce(
+        async () => ({
+          verified: true,
+          authenticationInfo: { newCounter: 1 },
+        }),
+      )
+
       const req = new Request('http://localhost:8910/_rw_mw', {
         method: 'POST',
         body: '{"method":"webAuthnAuthenticate","id":"CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA","rawId":"CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA","response":{"authenticatorData":"SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MFAAAAAA","clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTHRnV3BoWUtfZU41clhjX0hkdlVMdk9xcFBXeW9SdmJtbDJQbzAwVUhhZyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODkxMCIsImNyb3NzT3JpZ2luIjpmYWxzZSwib3RoZXJfa2V5c19jYW5fYmVfYWRkZWRfaGVyZSI6ImRvIG5vdCBjb21wYXJlIGNsaWVudERhdGFKU09OIGFnYWluc3QgYSB0ZW1wbGF0ZS4gU2VlIGh0dHBzOi8vZ29vLmdsL3lhYlBleCJ9","signature":"MEUCIQD3NOM7Aw0HxPw6EFGf86iwf2yd3p4NncNNLcjd-86zgwIgHuh80bLNV7EcwBi4IAcH57iueLg0X2gLtO5_Y6PMCFE","userHandle":"2"},"type":"public-key","clientExtensionResults":{}}',
@@ -2255,11 +2278,18 @@ describe('dbAuth', () => {
 
       const [body, headers] = await dbAuth.webAuthnAuthenticate()
 
-      expect(body).toEqual(false)
+      expect(body).toEqual(true)
 
       expect(headers.get('set-cookie')).toMatch(
         'webAuthn=CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA',
       )
+
+      const credential = await db.userCredential.findUnique({
+        where: {
+          id: 'CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA',
+        },
+      })
+      expect(credential.counter).toEqual(1)
     })
   })
 

--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
@@ -1,6 +1,19 @@
 import crypto from 'node:crypto'
 import path from 'node:path'
 
+vi.mock('@simplewebauthn/server', async (importOriginal) => {
+  const original = await importOriginal()
+  // Wrap the real verifier so the existing tests keep their current behavior.
+  // Individual tests can override with `vi.mocked(...).mockImplementation(...)`
+  // when they need to control the return value.
+  return {
+    ...original,
+    verifyAuthenticationResponse: vi.fn((opts) =>
+      original.verifyAuthenticationResponse(opts),
+    ),
+  }
+})
+
 import {
   vi,
   describe,
@@ -2088,6 +2101,58 @@ describe('dbAuth', () => {
       expect(headers.get('set-cookie')).toMatch(
         'webAuthn=CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA',
       )
+    })
+
+    it('returns 400 and issues no cookies when the assertion does not verify', async () => {
+      const user = await createDbUser({
+        webAuthnChallenge: 'LtgWphYK_eN5rXc_HdvULvOqpPWyoRvbml2Po00UHag',
+      })
+      await db.userCredential.create({
+        data: {
+          id: 'CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA',
+          userId: user.id,
+          publicKey: new Uint8Array([
+            165, 1, 2, 3, 38, 32, 1, 33, 88, 32, 24, 136, 169, 77, 11, 126, 129,
+            202, 3, 60, 234, 86, 233, 152, 222, 252, 11, 253, 11, 79, 163, 89,
+            189, 145, 216, 240, 102, 92, 146, 75, 249, 207, 34, 88, 32, 187,
+            235, 12, 104, 222, 236, 198, 241, 195, 234, 111, 64, 60, 86, 40,
+            254, 118, 163, 27, 172, 76, 173, 16, 120, 238, 20, 235, 98, 67, 103,
+            109, 240,
+          ]),
+          transports: null,
+          counter: 0,
+        },
+      })
+
+      // Force the verifier to return `verified: false` without throwing, so
+      // the new `if (!verified) throw` guard is the only thing that can
+      // produce the 400 response. A real signature mismatch against this
+      // public key would also resolve with `verified: false`, but mocking
+      // keeps the test focused on the new branch instead of a real
+      // key/signature fixture.
+      const { verifyAuthenticationResponse } = await import(
+        '@simplewebauthn/server'
+      )
+      vi.mocked(verifyAuthenticationResponse).mockImplementationOnce(
+        async () => ({
+          verified: false,
+          authenticationInfo: { newCounter: 0 },
+        }),
+      )
+
+      event = {
+        httpMethod: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"method":"webAuthnAuthenticate","id":"CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA","rawId":"CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA","response":{"authenticatorData":"SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MFAAAAAA","clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTHRnV3BoWUtfZU41clhjX0hkdlVMdk9xcFBXeW9SdmJtbDJQbzAwVUhhZyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODkxMCIsImNyb3NzT3JpZ2luIjpmYWxzZSwib3RoZXJfa2V5c19jYW5fYmVfYWRkZWRfaGVyZSI6ImRvIG5vdCBjb21wYXJlIGNsaWVudERhdGFKU09OIGFnYWluc3QgYSB0ZW1wbGF0ZS4gU2VlIGh0dHBzOi8vZ29vLmdsL3lhYlBleCJ9","signature":"MEUCIQD3NOM7Aw0HxPw6EFGf86iwf2yd3p4NncNNLcjd-86zgwIgHuh80bLNV7EcwBi4IAcH57iueLg0X2gLtO5_Y6PMCFE","userHandle":"2"},"type":"public-key","clientExtensionResults":{}}',
+      }
+      const dbAuth = new DbAuthHandler(event, context, options)
+      const response = await dbAuth.invoke()
+
+      const setCookie = [].concat(response?.headers?.['set-cookie'] ?? [])
+
+      expect(response.statusCode).toEqual(400)
+      expect(setCookie.join('\n')).not.toMatch(/session=/)
+      expect(setCookie.join('\n')).not.toMatch(/webAuthn=/)
     })
   })
 

--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
@@ -3,9 +3,8 @@ import path from 'node:path'
 
 vi.mock('@simplewebauthn/server', async (importOriginal) => {
   const original = await importOriginal()
-  // Wrap the real verifier so the existing tests keep their current behavior.
-  // Individual tests can override with `vi.mocked(...).mockImplementation(...)`
-  // when they need to control the return value.
+  // Delegate to the real verifier by default.
+  // Individual tests can override the result with `vi.mocked(...).mockImplementation(...)`.
   return {
     ...original,
     verifyAuthenticationResponse: vi.fn((opts) =>
@@ -2124,15 +2123,10 @@ describe('dbAuth', () => {
         },
       })
 
-      // Force the verifier to return `verified: false` without throwing, so
-      // the new `if (!verified) throw` guard is the only thing that can
-      // produce the 400 response. A real signature mismatch against this
-      // public key would also resolve with `verified: false`, but mocking
-      // keeps the test focused on the new branch instead of a real
-      // key/signature fixture.
-      const { verifyAuthenticationResponse } = await import(
-        '@simplewebauthn/server'
-      )
+      // Return `verified: false` without throwing to exercise the rejection
+      // path without depending on a cryptographic fixture.
+      const { verifyAuthenticationResponse } =
+        await import('@simplewebauthn/server')
       vi.mocked(verifyAuthenticationResponse).mockImplementationOnce(
         async () => ({
           verified: false,
@@ -2153,6 +2147,13 @@ describe('dbAuth', () => {
       expect(response.statusCode).toEqual(400)
       expect(setCookie.join('\n')).not.toMatch(/session=/)
       expect(setCookie.join('\n')).not.toMatch(/webAuthn=/)
+
+      const credential = await db.userCredential.findUnique({
+        where: {
+          id: 'CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA',
+        },
+      })
+      expect(credential.counter).toEqual(0)
     })
   })
 

--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
@@ -2087,6 +2087,17 @@ describe('dbAuth', () => {
         },
       })
 
+      // Return `verified: true` so this test exercises a successfully
+      // verified assertion without depending on a cryptographic fixture.
+      const { verifyAuthenticationResponse } =
+        await import('@simplewebauthn/server')
+      vi.mocked(verifyAuthenticationResponse).mockImplementationOnce(
+        async () => ({
+          verified: true,
+          authenticationInfo: { newCounter: 1 },
+        }),
+      )
+
       event = {
         headers: { 'Content-Type': 'application/json' },
         body: '{"method":"webAuthnAuthenticate","id":"CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA","rawId":"CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA","response":{"authenticatorData":"SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MFAAAAAA","clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTHRnV3BoWUtfZU41clhjX0hkdlVMdk9xcFBXeW9SdmJtbDJQbzAwVUhhZyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODkxMCIsImNyb3NzT3JpZ2luIjpmYWxzZSwib3RoZXJfa2V5c19jYW5fYmVfYWRkZWRfaGVyZSI6ImRvIG5vdCBjb21wYXJlIGNsaWVudERhdGFKU09OIGFnYWluc3QgYSB0ZW1wbGF0ZS4gU2VlIGh0dHBzOi8vZ29vLmdsL3lhYlBleCJ9","signature":"MEUCIQD3NOM7Aw0HxPw6EFGf86iwf2yd3p4NncNNLcjd-86zgwIgHuh80bLNV7EcwBi4IAcH57iueLg0X2gLtO5_Y6PMCFE","userHandle":"2"},"type":"public-key","clientExtensionResults":{}}',
@@ -2096,10 +2107,17 @@ describe('dbAuth', () => {
 
       const [body, headers] = await dbAuth.webAuthnAuthenticate()
 
-      expect(body).toEqual(false)
+      expect(body).toEqual(true)
       expect(headers.get('set-cookie')).toMatch(
         'webAuthn=CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA',
       )
+
+      const credential = await db.userCredential.findUnique({
+        where: {
+          id: 'CxMJqILwYufSaEQsJX6rKHw_LkMXAGU64PaKU55l6ejZ4FNO5kBLiA',
+        },
+      })
+      expect(credential.counter).toEqual(1)
     })
 
     it('returns 400 and issues no cookies when the assertion does not verify', async () => {


### PR DESCRIPTION
`DbAuthHandler.webAuthnAuthenticate()` issued the login cookies and returned 200 whether or not the assertion signature matched the stored public key. `SimpleWebAuthn`'s `verifyAuthenticationResponse()` throws for most failure modes, but a signature mismatch comes back as `{ verified: false }` with no error — so an unverified assertion was answered with a valid session for the credential's owner.

The only information an attacker needs to reach the affected path is a credential ID for the victim; those are not secret in the WebAuthn model. See the report at https://github.com/cedarjs/cedar/pull/2508 for details.

Throw a `WebAuthnError` before anything is issued, mirroring how `webAuthnRegister()` already handles its own `verified` check.