### PR TITLE
fix(cli): Support compound `@@id` models in generated service resolvers

### DIFF
--- a/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdlStubs.test.ts.snap
+++ b/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdlStubs.test.ts.snap
@@ -23,3 +23,57 @@ export const schema = gql\`
 \`
 "
 `;
+
+exports[`files with stubs > stubs a related model with a compound \`@@id\` without crashing 1`] = `
+"// Generated as a read-only stub by \`cedar generate sdl Warehouse\`,
+// because Warehouse has a relation to PartStock, which had no SDL yet.
+// Run \`cedar generate sdl PartStock\` to replace this stub with the real thing.
+// If you edit this file, the hash below will stop matching and you'll
+// need to pass \`--force\` to overwrite it.
+// @cedar-generator-stub-hash 4ac4a06a9c219999
+
+import type { QueryResolvers, PartStockRelationResolvers } from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const partStocks: QueryResolvers['partStocks'] = () => {
+  return db.partStock.findMany()
+}
+
+export const partStock: QueryResolvers['partStock'] = ({
+  partId,
+  warehouseId,
+}) => {
+  return db.partStock.findUnique({
+    where: { partId_warehouseId: { partId, warehouseId } },
+  })
+}
+
+export const PartStock: PartStockRelationResolvers = {
+  part: (_obj, { root }) => {
+    return db.partStock
+      .findUnique({
+        where: {
+          partId_warehouseId: {
+            partId: root?.partId,
+            warehouseId: root?.warehouseId,
+          },
+        },
+      })
+      .part()
+  },
+  warehouse: (_obj, { root }) => {
+    return db.partStock
+      .findUnique({
+        where: {
+          partId_warehouseId: {
+            partId: root?.partId,
+            warehouseId: root?.warehouseId,
+          },
+        },
+      })
+      .warehouse()
+  },
+}
+"
+`;

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/schema.prisma
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/schema.prisma
@@ -127,3 +127,27 @@ model Account {
   resetTokenExpiresAt DateTime?
   webAuthnChallenge   String?   @unique
 }
+
+// A junction table with a compound `@@id`, used to test that generating SDL
+// for a *neighboring* model (Warehouse) doesn't crash when it stubs out a
+// related model that has no single `@id` field.
+model Part {
+  id    Int         @id @default(autoincrement())
+  name  String
+  stock PartStock[]
+}
+
+model Warehouse {
+  id    Int         @id @default(autoincrement())
+  name  String      @unique
+  stock PartStock[]
+}
+
+model PartStock {
+  partId      Int
+  warehouseId Int
+  part        Part      @relation(fields: [partId], references: [id])
+  warehouse   Warehouse @relation(fields: [warehouseId], references: [id])
+
+  @@id([partId, warehouseId])
+}

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdlStubs.test.ts
@@ -138,6 +138,32 @@ describe('files with stubs', () => {
 
     expect(files).toEqual({})
   })
+
+  // https://github.com/cedarjs/cedar/issues/2429 -- generating SDL for a
+  // model that merely *neighbors* a compound-`@@id` model used to crash,
+  // because the stub service's relation resolvers interpolated an
+  // undefined id name into `where: { : root?. }`.
+  test('stubs a related model with a compound `@@id` without crashing', async () => {
+    const missingModels = await missingRelatedModels('Warehouse')
+    expect(missingModels).toEqual(['PartStock', 'Part'])
+
+    const files = {
+      ...(await sdlHandler.files({
+        name: 'Warehouse',
+        crud: false,
+        tests: true,
+        typescript: true,
+      })),
+      ...(await sdlHandler.stubFiles(missingModels, 'Warehouse', {
+        typescript: true,
+      })),
+    }
+
+    const stubService = files[servicePath('partStocks/partStocks.ts')]
+    expect(stubService).toBeDefined()
+    expect(stubService).not.toContain('where: { : ')
+    expect(stubService).toMatchSnapshot()
+  })
 })
 
 describe('isPristineStub', () => {

--- a/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.ts.snap
+++ b/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.ts.snap
@@ -1,5 +1,131 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`compound \`@@id\` models > generates a query resolver and relation resolvers without crashing 1`] = `
+"import type { QueryResolvers, PartStockRelationResolvers } from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const partStocks: QueryResolvers['partStocks'] = () => {
+  return db.partStock.findMany()
+}
+
+export const partStock: QueryResolvers['partStock'] = ({
+  partId,
+  warehouseId,
+}) => {
+  return db.partStock.findUnique({
+    where: { partId_warehouseId: { partId, warehouseId } },
+  })
+}
+
+export const PartStock: PartStockRelationResolvers = {
+  part: (_obj, { root }) => {
+    return db.partStock
+      .findUnique({
+        where: {
+          partId_warehouseId: {
+            partId: root?.partId,
+            warehouseId: root?.warehouseId,
+          },
+        },
+      })
+      .part()
+  },
+  warehouse: (_obj, { root }) => {
+    return db.partStock
+      .findUnique({
+        where: {
+          partId_warehouseId: {
+            partId: root?.partId,
+            warehouseId: root?.warehouseId,
+          },
+        },
+      })
+      .warehouse()
+  },
+}
+"
+`;
+
+exports[`compound \`@@id\` models > generates working composite CRUD mutations when requested directly 1`] = `
+"import type {
+  QueryResolvers,
+  MutationResolvers,
+  PartStockRelationResolvers,
+} from 'types/graphql'
+
+import { db } from 'src/lib/db'
+
+export const partStocks: QueryResolvers['partStocks'] = () => {
+  return db.partStock.findMany()
+}
+
+export const partStock: QueryResolvers['partStock'] = ({
+  partId,
+  warehouseId,
+}) => {
+  return db.partStock.findUnique({
+    where: { partId_warehouseId: { partId, warehouseId } },
+  })
+}
+
+export const createPartStock: MutationResolvers['createPartStock'] = ({
+  input,
+}) => {
+  return db.partStock.create({
+    data: input,
+  })
+}
+
+export const updatePartStock: MutationResolvers['updatePartStock'] = ({
+  partId,
+  warehouseId,
+  input,
+}) => {
+  return db.partStock.update({
+    data: input,
+    where: { partId_warehouseId: { partId, warehouseId } },
+  })
+}
+
+export const deletePartStock: MutationResolvers['deletePartStock'] = ({
+  partId,
+  warehouseId,
+}) => {
+  return db.partStock.delete({
+    where: { partId_warehouseId: { partId, warehouseId } },
+  })
+}
+
+export const PartStock: PartStockRelationResolvers = {
+  part: (_obj, { root }) => {
+    return db.partStock
+      .findUnique({
+        where: {
+          partId_warehouseId: {
+            partId: root?.partId,
+            warehouseId: root?.warehouseId,
+          },
+        },
+      })
+      .part()
+  },
+  warehouse: (_obj, { root }) => {
+    return db.partStock
+      .findUnique({
+        where: {
+          partId_warehouseId: {
+            partId: root?.partId,
+            warehouseId: root?.warehouseId,
+          },
+        },
+      })
+      .warehouse()
+  },
+}
+"
+`;
+
 exports[`in javascript mode > creates a multi word service file 1`] = `
 "import { db } from 'src/lib/db'
 

--- a/packages/cli/src/commands/generate/service/__tests__/fixtures/schema.prisma
+++ b/packages/cli/src/commands/generate/service/__tests__/fixtures/schema.prisma
@@ -88,3 +88,26 @@ model ScalarType{
   integer   Int
   boolean   Boolean
 }
+
+// A junction table with a compound `@@id`, used to test that the service
+// generator supports models with no single `@id` field.
+model Part {
+  id    Int         @id @default(autoincrement())
+  name  String
+  stock PartStock[]
+}
+
+model Warehouse {
+  id    Int         @id @default(autoincrement())
+  name  String      @unique
+  stock PartStock[]
+}
+
+model PartStock {
+  partId      Int
+  warehouseId Int
+  part        Part      @relation(fields: [partId], references: [id])
+  warehouse   Warehouse @relation(fields: [warehouseId], references: [id])
+
+  @@id([partId, warehouseId])
+}

--- a/packages/cli/src/commands/generate/service/__tests__/service.test.ts
+++ b/packages/cli/src/commands/generate/service/__tests__/service.test.ts
@@ -543,3 +543,64 @@ test("doesn't include test file when --tests is set to false", async () => {
     path.normalize('/path/to/project/api/src/services/users/users.js'),
   ])
 })
+
+describe('compound `@@id` models', () => {
+  test('generates a query resolver and relation resolvers without crashing', async () => {
+    const files = await serviceHandler.files({
+      ...getDefaultArgs(service.getDefaultOptions()),
+      typescript: true,
+      name: 'PartStock',
+      relations: ['part', 'warehouse'],
+      crud: false,
+      tests: false,
+    })
+
+    const serviceContent =
+      files[
+        path.normalize(
+          '/path/to/project/api/src/services/partStocks/partStocks.ts',
+        )
+      ]
+
+    expect(serviceContent).toBeDefined()
+    expect(serviceContent).toMatchSnapshot()
+
+    // The exact bug from #2429: an empty `where` key from an unhandled
+    // compound id.
+    expect(serviceContent).not.toContain('where: { : ')
+  })
+
+  test('generates working composite CRUD mutations when requested directly', async () => {
+    const files = await serviceHandler.files({
+      ...getDefaultArgs(service.getDefaultOptions()),
+      typescript: true,
+      name: 'PartStock',
+      crud: true,
+      tests: false,
+    })
+
+    const serviceContent =
+      files[
+        path.normalize(
+          '/path/to/project/api/src/services/partStocks/partStocks.ts',
+        )
+      ]
+
+    expect(serviceContent).toContain(
+      'where: { partId_warehouseId: { partId, warehouseId } }',
+    )
+    expect(serviceContent).toMatchSnapshot()
+  })
+
+  test('throws a clear error instead of generating broken CRUD tests', async () => {
+    await expect(
+      serviceHandler.files({
+        ...getDefaultArgs(service.getDefaultOptions()),
+        typescript: true,
+        name: 'PartStock',
+        crud: true,
+        tests: true,
+      }),
+    ).rejects.toThrow(/compound primary key/)
+  })
+})

--- a/packages/cli/src/commands/generate/service/serviceHandler.ts
+++ b/packages/cli/src/commands/generate/service/serviceHandler.ts
@@ -13,7 +13,18 @@ interface ServiceModel {
   name: string
   documentation?: string
   fields: PrismaField[]
-  primaryKey?: { fields: string[] }
+  primaryKey?: { fields: string[]; name?: string | null } | null
+}
+
+/**
+ * Describes a model's compound `@@id([...])` primary key, as opposed to a
+ * single field with `@id`. `whereArg` is the Prisma Client `where` key for
+ * looking a record up by its compound id: the user-supplied `@@id(name:
+ * "...")`, or Prisma's default of joining the field names with `_`.
+ */
+export interface CompositeIdName {
+  fields: string[]
+  whereArg: string
 }
 
 function isServiceModel(schema: unknown): schema is ServiceModel {
@@ -384,11 +395,20 @@ export const fieldsToUpdate = async (model: string) => {
   return { [fieldName]: newValue }
 }
 
-const getIdName = async (model: string): Promise<string | undefined> => {
+const getIdName = async (
+  model: string,
+): Promise<string | CompositeIdName | undefined> => {
   const schemaResult = await getSchema(model)
 
   if (!isServiceModel(schemaResult)) {
     return undefined
+  }
+
+  // Compound `@@id([a, b])` keys don't have a single field with `isId: true`
+  // -- Prisma puts them on `primaryKey.fields` instead.
+  if (schemaResult.primaryKey?.fields.length) {
+    const { fields, name } = schemaResult.primaryKey
+    return { fields, whereArg: name || fields.join('_') }
   }
 
   return schemaResult.fields.find((field: PrismaField) => field.isId)?.name
@@ -412,6 +432,24 @@ export const files = async ({
   const componentName = camelcase(pluralize(name))
   const model = name
   const idName = await getIdName(model)
+
+  // The query/mutation/relation-resolver blocks in service.ts.template
+  // support compound `@@id([...])` keys, but the generated test file's
+  // CRUD scenarios don't know how to build a compound `where` value or
+  // scenario id lookup yet -- so give a clear error instead of emitting
+  // broken tests.
+  if (
+    tests &&
+    rest.crud &&
+    idName !== undefined &&
+    typeof idName !== 'string'
+  ) {
+    throw new Error(
+      `Cannot generate CRUD tests for "${model}": it has a compound primary ` +
+        `key (@@id([${idName.fields.join(', ')}])), which isn't supported ` +
+        'by the generated test file yet. Re-run with `--tests=false`.',
+    )
+  }
 
   const prismaImportSource = 'src/lib/db'
 
@@ -442,48 +480,54 @@ export const files = async ({
     },
   })
 
-  const testFile = await templateForFile({
-    name,
-    side: 'api',
-    sidePathSection: 'services',
-    generator: 'service',
-    outputPath: path.join(componentName, componentName + '.test.ts'),
-    templatePath: 'test.ts.template',
-    templateVars: {
-      relations: relations || [],
-      create: await fieldsToInput(model),
-      update: await fieldsToUpdate(model),
-      types: await fieldTypes(model),
-      prismaImport: (await parseSchema(model)).scalarFields.some(
-        (field: PrismaField) => field.type === 'Decimal',
-      ),
-      prismaModel: model,
-      idName,
-      prismaImportSource,
-      ...rest,
-    },
-  })
-
-  const scenariosFile = await templateForFile({
-    name,
-    side: 'api',
-    sidePathSection: 'services',
-    generator: 'service',
-    outputPath: path.join(componentName, componentName + '.scenarios.ts'),
-    templatePath: 'scenarios.ts.template',
-    templateVars: {
-      scenario: await buildScenario(model),
-      stringifiedScenario: await buildStringifiedScenario(model),
-      prismaModel: model,
-      idName,
-      relations: modelRelations,
-      prismaImportSource,
-      ...rest,
-    },
-  })
-
   const files = [serviceFile]
+
+  // Only render the test/scenarios templates when they're actually needed --
+  // besides being wasted work, `test.ts.template` interpolates `idName`
+  // directly (unlike `service.ts.template`, it doesn't support compound
+  // `@@id([...])` keys), so rendering it unconditionally would blow up on
+  // the compound-id models the guard above is meant to protect against.
   if (tests) {
+    const testFile = await templateForFile({
+      name,
+      side: 'api',
+      sidePathSection: 'services',
+      generator: 'service',
+      outputPath: path.join(componentName, componentName + '.test.ts'),
+      templatePath: 'test.ts.template',
+      templateVars: {
+        relations: relations || [],
+        create: await fieldsToInput(model),
+        update: await fieldsToUpdate(model),
+        types: await fieldTypes(model),
+        prismaImport: (await parseSchema(model)).scalarFields.some(
+          (field: PrismaField) => field.type === 'Decimal',
+        ),
+        prismaModel: model,
+        idName,
+        prismaImportSource,
+        ...rest,
+      },
+    })
+
+    const scenariosFile = await templateForFile({
+      name,
+      side: 'api',
+      sidePathSection: 'services',
+      generator: 'service',
+      outputPath: path.join(componentName, componentName + '.scenarios.ts'),
+      templatePath: 'scenarios.ts.template',
+      templateVars: {
+        scenario: await buildScenario(model),
+        stringifiedScenario: await buildStringifiedScenario(model),
+        prismaModel: model,
+        idName,
+        relations: modelRelations,
+        prismaImportSource,
+        ...rest,
+      },
+    })
+
     files.push(testFile)
     files.push(scenariosFile)
   }

--- a/packages/cli/src/commands/generate/service/templates/service.ts.template
+++ b/packages/cli/src/commands/generate/service/templates/service.ts.template
@@ -1,14 +1,28 @@
 import type { QueryResolvers<% if (crud) { %>, MutationResolvers<% } %><% if (relations.length) { %>, ${singularPascalName}RelationResolvers<% } %> } from 'types/graphql'
 
 import { db } from 'src/lib/db'
-
+<%
+  // A compound `@@id([...])` key comes through as `{ fields, whereArg }`
+  // instead of a single field name -- build the destructure/where-clause
+  // snippets for both shapes here so the rest of the template can stay
+  // shape-agnostic.
+  const idIsComposite = idName != null && typeof idName === 'object'
+  const idFields = idIsComposite ? idName.fields : [idName]
+  const idArgs = idFields.join(', ')
+  const idWhere = idIsComposite
+    ? `${idName.whereArg}: { ${idFields.join(', ')} }`
+    : idName
+  const idWhereFromRoot = idIsComposite
+    ? `${idName.whereArg}: { ${idFields.map((f) => `${f}: root?.${f}`).join(', ')} }`
+    : `${idName}: root?.${idName}`
+%>
 export const ${pluralCamelName}: QueryResolvers['${pluralCamelName}'] = () => {
   return db.${singularCamelName}.findMany()
 }<% if (crud || relations.length) { %>
 
-export const ${singularCamelName}: QueryResolvers['${singularCamelName}'] = ({ ${idName} }) => {
+export const ${singularCamelName}: QueryResolvers['${singularCamelName}'] = ({ ${idArgs} }) => {
   return db.${singularCamelName}.findUnique({
-    where: { ${idName} },
+    where: { ${idWhere} },
   })
 }<% } %><% if (crud) { %>
 
@@ -18,21 +32,21 @@ export const create${singularPascalName}: MutationResolvers['create${singularPas
   })
 }
 
-export const update${singularPascalName}: MutationResolvers['update${singularPascalName}'] = ({ ${idName}, input }) => {
+export const update${singularPascalName}: MutationResolvers['update${singularPascalName}'] = ({ ${idArgs}, input }) => {
   return db.${singularCamelName}.update({
     data: input,
-    where: { ${idName} },
+    where: { ${idWhere} },
   })
 }
 
-export const delete${singularPascalName}: MutationResolvers['delete${singularPascalName}'] = ({ ${idName} }) => {
+export const delete${singularPascalName}: MutationResolvers['delete${singularPascalName}'] = ({ ${idArgs} }) => {
   return db.${singularCamelName}.delete({
-    where: { ${idName} },
+    where: { ${idWhere} },
   })
 }<% } %><% if (relations.length) { %>
 
 export const ${singularPascalName}: ${singularPascalName}RelationResolvers = {<% relations.forEach(relation => { %>
   ${relation}: (_obj, { root }) => {
-    return db.${singularCamelName}.findUnique({ where: { ${idName}: root?.${idName} } }).${relation}()
+    return db.${singularCamelName}.findUnique({ where: { ${idWhereFromRoot} } }).${relation}()
   },<% }) %>
 }<% } %>


### PR DESCRIPTION
`yarn cedar g sdl Warehouse --no-crud` (and `g scaffold Warehouse`) crashed when `Warehouse` had a relation to `PartStock`, a model with a compound `@@id([partId, warehouseId])` primary key instead of a single `@id` field. The generated service's relation-resolver interpolated the (undefined) single id name into `where: { : root?. }`, which fails to parse.

- `service.ts.template`'s query/mutation/relation-resolver blocks now build their `where` clause from either a single id field or a compound key, using Prisma's default `field_field` where-arg name (or a `@@id(name: "...")` override).
- `getIdName()` in `serviceHandler.ts` now returns `{ fields, whereArg }` for compound keys instead of blowing up downstream.
- Generating a service directly with `--crud --tests` for a compound-PK model now throws a clear error instead of emitting broken test files, since `test.ts.template`/`scenarios.ts.template` don't support compound ids yet. That's explicitly out of scope for this issue ("This issue deliberately does not propose scaffolding CRUD for compound-PK models").
- Also fixed a latent bug where `serviceHandler.ts`'s `files()` always rendered the test/scenarios templates even when `tests: false` was passed, only skipping them when assembling the returned file list. This meant the new error guard could be silently bypassed by passing `tests: false`.

The "Part 2" of the issue (`g scaffold` leaving a dangling GraphQL type reference when a related model has no SDL) turned out to already be handled by the existing stub-file generation in `sdl/stubFiles.ts` (shared by both `sdlHandler.ts` and `scaffoldHandler.ts`) -- it just needed Part 1's crash fixed first, since stubbing a compound-PK related model hit the same bug. Added a regression test for this in `sdlStubs.test.ts`.

Fixes #2429