### PR TITLE
chore(ccrsca): Use cedar naming for tmp dir

### DIFF
--- a/packages/create-cedar-rsc-app/src/download.ts
+++ b/packages/create-cedar-rsc-app/src/download.ts
@@ -13,7 +13,7 @@ export async function downloadTemplate(config: Config) {
 
   const tmpDir = path.join(
     os.tmpdir(),
-    'rx-rsc-app',
+    'cedar-rsc-app',
     // ":" is problematic with paths
     new Date().toISOString().split(':').join('-'),
   )


### PR DESCRIPTION
Just to be more consistent in naming