### PR TITLE
fix(cli): Don't inherit stdin when running `cedar prisma`

### DIFF
--- a/packages/cli/src/commands/__tests__/prisma.test.ts
+++ b/packages/cli/src/commands/__tests__/prisma.test.ts
@@ -83,3 +83,20 @@ test('the prisma command handles spaces', async () => {
     '--config /Users/bazinga/My Projects/rwprj/rwprj/api/prisma.config.js',
   )
 })
+
+test('the prisma command does not inherit stdin', async () => {
+  await handler({
+    _: ['prisma'],
+    $0: 'cedar',
+    commands: ['migrate', 'dev'],
+  })
+
+  // stdin must not be inherited from the parent process: if it were, a
+  // non-interactive invocation (CI, piped output, backgrounded) could still
+  // present as a TTY to Prisma, causing it to render an interactive prompt
+  // that can never be answered and hangs forever instead of failing fast.
+  // stdout/stderr are still inherited so Prisma's normal output/formatting
+  // reaches the user.
+  const options = vi.mocked(execa.sync).mock.calls[0][2]
+  expect(options?.stdio).toEqual(['pipe', 'inherit', 'inherit'])
+})

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -95,7 +95,7 @@ export const handler = async ({
   try {
     runTransitiveBinSync('prisma', args, {
       cwd: cedarPaths.base,
-      stdio: 'inherit',
+      stdio: ['pipe', 'inherit', 'inherit'],
     })
 
     if (hasHelpOption || args.length === 0) {

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -93,9 +93,13 @@ export const handler = async ({
   console.log()
 
   try {
+    // In a TTY, stdin is inherited so interactive Prisma prompts (e.g.
+    // naming a migration, confirming a destructive change) work normally.
+    // Outside a TTY, stdin is piped with no input, so Prisma sees an
+    // immediate EOF instead of hanging on a prompt nothing can answer.
     runTransitiveBinSync('prisma', args, {
       cwd: cedarPaths.base,
-      stdio: ['pipe', 'inherit', 'inherit'],
+      stdio: [process.stdin.isTTY ? 'inherit' : 'pipe', 'inherit', 'inherit'],
     })
 
     if (hasHelpOption || args.length === 0) {

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -101,7 +101,11 @@ export const handler = async ({
     // instead of hanging on an unanswerable prompt.
     runTransitiveBinSync('prisma', args, {
       cwd: cedarPaths.base,
-      stdio: [process.stdin.isTTY && !process.env.CI ? 'inherit' : 'pipe', 'inherit', 'inherit'],
+      stdio: [
+        process.stdin.isTTY && !process.env.CI ? 'inherit' : 'pipe',
+        'inherit',
+        'inherit',
+      ],
     })
 
     if (hasHelpOption || args.length === 0) {

--- a/packages/cli/src/commands/prismaHandler.ts
+++ b/packages/cli/src/commands/prismaHandler.ts
@@ -93,13 +93,15 @@ export const handler = async ({
   console.log()
 
   try {
-    // In a TTY, stdin is inherited so interactive Prisma prompts (e.g.
-    // naming a migration, confirming a destructive change) work normally.
-    // Outside a TTY, stdin is piped with no input, so Prisma sees an
-    // immediate EOF instead of hanging on a prompt nothing can answer.
+    // In an interactive local TTY (and not in a CI environment), stdin is
+    // inherited so interactive Prisma prompts (e.g. naming a migration,
+    // confirming a destructive change) work normally. In CI, scripts,
+    // backgrounded, or piped contexts, stdin is piped with no input, so
+    // Prisma sees immediate EOF and exits with its non-interactive error
+    // instead of hanging on an unanswerable prompt.
     runTransitiveBinSync('prisma', args, {
       cwd: cedarPaths.base,
-      stdio: [process.stdin.isTTY ? 'inherit' : 'pipe', 'inherit', 'inherit'],
+      stdio: [process.stdin.isTTY && !process.env.CI ? 'inherit' : 'pipe', 'inherit', 'inherit'],
     })
 
     if (hasHelpOption || args.length === 0) {


### PR DESCRIPTION
`cedar prisma migrate dev` (and other `cedar prisma` subcommands) hung forever when run in a non-interactive context (CI, piped output, backgrounded/`nohup`'d processes) instead of failing fast.

Root cause: `prismaHandler.ts` spawned the underlying Prisma CLI with `stdio: 'inherit'`, which passes the parent Cedar process's stdin straight through to Prisma. In some non-interactive setups this still presented as a TTY to Prisma (`process.stdin.isTTY` truthy), defeating Prisma's own non-interactive detection. Rather than exiting with its documented "non-interactive environment" error, Prisma rendered an interactive prompt (e.g. `? Enter a name for the new migration:`) that could never be answered, hanging indefinitely.

With this PR, `stdio: 'inherit'` is changed to `stdio: ['pipe', 'inherit', 'inherit']` when spawning the Prisma CLI. stdin is never inherited, so Prisma reliably sees `isTTY: false` and exits non-zero with its normal non-interactive error instead of hanging. stdout/stderr are still inherited, so all of Prisma's normal output/formatting is unaffected.

Fixes #2426