### PR TITLE
chore(prettier): Ignore extensionless .gitignore in local test fixtures

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,6 +19,11 @@ packages/testing/config
 /local-testing-project-live/api/types/graphql.d.ts
 /local-testing-project-live/web/types/graphql.d.ts
 
+# .gitignore has no file extension, and these fixtures' own prettier config
+# doesn't have a plugin that can infer a parser for it
+/local-testing-project/.gitignore
+/local-testing-project-live/.gitignore
+
 # Ignore the certain files in /docs
 /docs/.docusaurus
 /docs/build


### PR DESCRIPTION
## Summary

- Adds `/local-testing-project/.gitignore` and `/local-testing-project-live/.gitignore` to `.prettierignore`.

Both files have no extension, and neither fixture's own Prettier config registers a plugin that lets Prettier infer a parser for an extensionless file, so running Prettier over either one fails with "No parser could be inferred for file ...".

## Test plan

- [x] `npx prettier --check local-testing-project/.gitignore local-testing-project-live/.gitignore` now passes (previously errored with "No parser could be inferred").