### PR TITLE
feat(cli): opt a package out of the "missing watch script" warning

### DIFF
--- a/.changesets/2420.md
+++ b/.changesets/2420.md
@@ -1,4 +1,5 @@
-- feat(cli): Add `skipWatchWarning` opt-out for `cedar dev` package-watch warning by @lisa-assistant
+- feat(cli): Add `skipWatchWarning` opt-out for `cedar dev` package-watch
+  warning by @lisa-assistant
 
 `cedar dev`'s experimental `packagesWorkspace` feature warns on every startup
 for any `packages/*` workspace that lacks a `watch` script. That warning is
@@ -14,7 +15,8 @@ This adds a per-package opt-out in `cedar.toml`:
   skipWatchWarning = true
 ```
 
-`getPackageWatchCommands()` (`packages/cli/src/commands/dev/packageWatchCommands.ts`)
-now checks this config before adding a package to the warned-about list. The
-package is still excluded from the set of watched packages (it has no watch
-script to run), only the warning is suppressed.
+`getPackageWatchCommands()`
+(`packages/cli/src/commands/dev/packageWatchCommands.ts`) now checks this config
+before adding a package to the warned-about list. The package is still excluded
+from the set of watched packages (it has no watch script to run), only the
+warning is suppressed.

--- a/.changesets/2420.md
+++ b/.changesets/2420.md
@@ -1,0 +1,20 @@
+- feat(cli): Add `skipWatchWarning` opt-out for `cedar dev` package-watch warning by @lisa-assistant
+
+`cedar dev`'s experimental `packagesWorkspace` feature warns on every startup
+for any `packages/*` workspace that lacks a `watch` script. That warning is
+unresolvable for packages that are deliberately watch-less (e.g. a script/CLI
+package run directly with `node`, with no build step), so there was no way to
+say "yes, I know" short of living with permanent noise or adding a fake no-op
+`watch` script.
+
+This adds a per-package opt-out in `cedar.toml`:
+
+```toml
+[experimental.packagesWorkspace.pipeline]
+  skipWatchWarning = true
+```
+
+`getPackageWatchCommands()` (`packages/cli/src/commands/dev/packageWatchCommands.ts`)
+now checks this config before adding a package to the warned-about list. The
+package is still excluded from the set of watched packages (it has no watch
+script to run), only the warning is suppressed.

--- a/packages/cli/src/commands/dev/__tests__/packageWatchCommands.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/packageWatchCommands.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 
 import { vi, afterEach, describe, it, expect, beforeEach } from 'vitest'
 
-import { getConfig } from '@cedarjs/project-config'
+import { DEFAULT_CONFIG, getConfig } from '@cedarjs/project-config'
 import type * as ProjectConfig from '@cedarjs/project-config'
 
 import { getPackageWatchCommands } from '../packageWatchCommands.js'
@@ -69,8 +69,12 @@ describe('getWatchPackagesCommands', () => {
     )
     vi.mocked(console).warn = vi.fn()
     vi.mocked(getConfig).mockReturnValue({
-      experimental: { packagesWorkspace: { enabled: true } },
-    } as ReturnType<typeof getConfig>)
+      ...DEFAULT_CONFIG,
+      experimental: {
+        ...DEFAULT_CONFIG.experimental,
+        packagesWorkspace: { enabled: true },
+      },
+    })
   })
 
   it('expands packages/* to all packages', async () => {
@@ -188,13 +192,15 @@ describe('getWatchPackagesCommands', () => {
 
   it('does not warn about a package with skipWatchWarning set', async () => {
     vi.mocked(getConfig).mockReturnValue({
+      ...DEFAULT_CONFIG,
       experimental: {
+        ...DEFAULT_CONFIG.experimental,
         packagesWorkspace: {
           enabled: true,
           bar: { skipWatchWarning: true },
         },
       },
-    } as ReturnType<typeof getConfig>)
+    })
 
     vi.mocked(fs.promises.glob).mockReturnValue(
       (async function* () {

--- a/packages/cli/src/commands/dev/__tests__/packageWatchCommands.test.ts
+++ b/packages/cli/src/commands/dev/__tests__/packageWatchCommands.test.ts
@@ -2,6 +2,9 @@ import fs from 'node:fs'
 
 import { vi, afterEach, describe, it, expect, beforeEach } from 'vitest'
 
+import { getConfig } from '@cedarjs/project-config'
+import type * as ProjectConfig from '@cedarjs/project-config'
+
 import { getPackageWatchCommands } from '../packageWatchCommands.js'
 
 vi.mock('node:fs', () => {
@@ -30,6 +33,19 @@ vi.mock('../../../lib/index.js', () => {
   }
 })
 
+vi.mock('@cedarjs/project-config', async (importOriginal) => {
+  const originalProjectConfig = await importOriginal<typeof ProjectConfig>()
+
+  return {
+    ...originalProjectConfig,
+    getConfig: vi.fn(() => ({
+      experimental: {
+        packagesWorkspace: { enabled: true },
+      },
+    })),
+  }
+})
+
 vi.mock('../../../lib/colors.js', () => ({
   default: {
     warning: (str: string) => `Warning: ${str}`,
@@ -52,6 +68,9 @@ describe('getWatchPackagesCommands', () => {
       }),
     )
     vi.mocked(console).warn = vi.fn()
+    vi.mocked(getConfig).mockReturnValue({
+      experimental: { packagesWorkspace: { enabled: true } },
+    } as ReturnType<typeof getConfig>)
   })
 
   it('expands packages/* to all packages', async () => {
@@ -165,6 +184,61 @@ describe('getWatchPackagesCommands', () => {
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringMatching(/Warning: .*skipped: .*bar.*/),
     )
+  })
+
+  it('does not warn about a package with skipWatchWarning set', async () => {
+    vi.mocked(getConfig).mockReturnValue({
+      experimental: {
+        packagesWorkspace: {
+          enabled: true,
+          bar: { skipWatchWarning: true },
+        },
+      },
+    } as ReturnType<typeof getConfig>)
+
+    vi.mocked(fs.promises.glob).mockReturnValue(
+      (async function* () {
+        yield '/mocked/project/packages/foo'
+        yield '/mocked/project/packages/bar'
+        return undefined
+      })(),
+    )
+
+    vi.mocked(fs).readFileSync.mockImplementation((filePath) => {
+      const pathStr = filePath.toString()
+
+      if (pathStr.includes('foo')) {
+        return JSON.stringify({
+          name: 'foo',
+          scripts: { watch: 'tsc --watch' },
+        })
+      }
+
+      if (pathStr.includes('bar')) {
+        return JSON.stringify({
+          name: 'bar',
+          scripts: {
+            // No watch script
+            build: 'tsc',
+          },
+        })
+      }
+
+      return '{}'
+    })
+
+    const commands = await getPackageWatchCommands(['packages/*'])
+
+    expect(commands).toEqual([
+      {
+        name: 'foo',
+        command: 'yarn watch',
+        cwd: '/mocked/project/packages/foo',
+      },
+    ])
+
+    // Should not warn about 'bar' since it opted out
+    expect(console.warn).not.toHaveBeenCalled()
   })
 
   it('returns an empty array when no watchable packages exist', async () => {

--- a/packages/cli/src/commands/dev/packageWatchCommands.ts
+++ b/packages/cli/src/commands/dev/packageWatchCommands.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { colors as c } from '@cedarjs/cli-helpers'
-import { importStatementPath } from '@cedarjs/project-config'
+import { getConfig, importStatementPath } from '@cedarjs/project-config'
 
 // @ts-expect-error - Types not available for JS files
 import { getPaths } from '../../lib/index.js'
@@ -40,6 +40,8 @@ export async function getPackageWatchCommands(
         return importStatementPath(workspacePath)
       })
 
+  const packagesWorkspaceConfig = getConfig().experimental.packagesWorkspace
+
   // Filter to only packages that have a watch script
   const watchablePackages: string[] = []
   const packagesWithoutWatch: (string | undefined)[] = []
@@ -57,7 +59,15 @@ export async function getPackageWatchCommands(
     if (packageJson.scripts?.watch) {
       watchablePackages.push(workspacePath)
     } else {
-      packagesWithoutWatch.push(packageName)
+      const packageConfig =
+        packageName && packagesWorkspaceConfig[packageName]
+
+      const skipWatchWarning =
+        typeof packageConfig === 'object' && packageConfig.skipWatchWarning
+
+      if (!skipWatchWarning) {
+        packagesWithoutWatch.push(packageName)
+      }
     }
   }
 

--- a/packages/cli/src/commands/dev/packageWatchCommands.ts
+++ b/packages/cli/src/commands/dev/packageWatchCommands.ts
@@ -59,8 +59,7 @@ export async function getPackageWatchCommands(
     if (packageJson.scripts?.watch) {
       watchablePackages.push(workspacePath)
     } else {
-      const packageConfig =
-        packageName && packagesWorkspaceConfig[packageName]
+      const packageConfig = packageName && packagesWorkspaceConfig[packageName]
 
       const skipWatchWarning =
         typeof packageConfig === 'object' && packageConfig.skipWatchWarning

--- a/packages/project-config/cedar-toml-schema-2.0.json
+++ b/packages/project-config/cedar-toml-schema-2.0.json
@@ -191,8 +191,19 @@
         },
         "packagesWorkspace": {
           "type": "object",
+          "description": "Configuration for the experimental `cedar g package` workspace feature. Besides the `enabled` gate, this can hold a named sub-table per package, keyed by package name, for per-package cedar dev behavior.",
           "properties": {
             "enabled": { "type": "boolean" }
+          },
+          "additionalProperties": {
+            "type": "object",
+            "description": "Per-package config, keyed by package name.",
+            "properties": {
+              "skipWatchWarning": {
+                "type": "boolean",
+                "description": "Suppress cedar dev's \"missing watch script\" warning for this package."
+              }
+            }
           }
         },
         "gqlorm": {

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -148,7 +148,8 @@ export interface PackageWorkspaceOptions {
 /**
  * Config for the experimental `cedar g package` workspace feature. Besides
  * the `enabled` gate, this can hold a named sub-table per package, keyed by
- * package name, e.g.:
+ * package name, which also defines per-package `cedar dev` behavior (e.g.
+ * `skipWatchWarning`), e.g.:
  *
  * ```toml
  * [experimental.packagesWorkspace.pipeline]

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -120,9 +120,7 @@ export interface Config {
       enabled: boolean
       lintOnly: boolean
     }
-    packagesWorkspace: {
-      enabled: boolean
-    }
+    packagesWorkspace: PackagesWorkspaceConfig
     gqlorm: {
       enabled: boolean
       organizationModel?: string
@@ -136,6 +134,30 @@ export interface Config {
 export interface CLIPlugin {
   package: string
   enabled?: boolean
+}
+
+export interface PackageWorkspaceOptions {
+  /**
+   * Suppress `cedar dev`'s "missing watch script" warning for this package.
+   * Useful for packages that are intentionally watch-less, e.g. a
+   * script/CLI package run directly with `node` and no build step.
+   */
+  skipWatchWarning?: boolean
+}
+
+/**
+ * Config for the experimental `cedar g package` workspace feature. Besides
+ * the `enabled` gate, this can hold a named sub-table per package, keyed by
+ * package name, e.g.:
+ *
+ * ```toml
+ * [experimental.packagesWorkspace.pipeline]
+ *   skipWatchWarning = true
+ * ```
+ */
+export interface PackagesWorkspaceConfig {
+  enabled: boolean
+  [packageName: string]: boolean | PackageWorkspaceOptions | undefined
 }
 
 export const DEFAULT_CONFIG: Config = {


### PR DESCRIPTION
`cedar dev`'s experimental `packagesWorkspace` feature warns on every startup for any `packages/*` workspace that lacks a `watch` script, with no way to acknowledge and suppress it. That's permanent, unresolvable noise for a package that's deliberately watch-less — e.g. a script/CLI package run directly with `node`, with no build step at all.

Adds a per-package opt-out in `cedar.toml`, following the same named-sub-table shape used by every other `[experimental.X]` section:

```toml
[experimental.packagesWorkspace.pipeline]
  skipWatchWarning = true
```

`getPackageWatchCommands()` checks this before adding a package to the warned-about list. The package is still excluded from the watched-packages list (it has no watch script to run) — only the warning is suppressed.

Scoped to just the opt-out mechanism (the issue's core ask). The issue also suggests a `cedar check` staleness rule for stale `packagesWorkspace.<name>` entries and an "only warn if depended-on by api/web" refinement — both explicitly framed as optional follow-ons, left out of this PR to keep it focused.

Fixes #2420