### PR TITLE
feat(api)!: Upgrade redis to v6

### DIFF
--- a/.changesets/2585.md
+++ b/.changesets/2585.md
@@ -1,26 +1,26 @@
 - fix(api): Upgrade redis to v6 by @lisa-assistant
 
 `@cedarjs/api`'s optional Redis cache client (`RedisClient`) was pinned to the
-`redis` npm package v5.12.1, which is behind the latest v6.2.1 release.
-Renovate flags major bumps for manual approval, so this one had been sitting
-unapplied since redis v6 stabilized.
+`redis` npm package v5.12.1, which is behind the latest v6.2.1 release. Renovate
+flags major bumps for manual approval, so this one had been sitting unapplied
+since redis v6 stabilized.
 
 **This one does have user-visible behavior changes**, unlike recent internal
-major bumps (Express, Pino): `redis` v6 switches the default wire protocol
-from RESP2 to RESP3, and introduces a 5 second default command timeout
-(previously unlimited) and a longer default `keepAliveInitialDelay` (30s, up
-from 5s). None of these affect `RedisClient`'s own `get`/`set`/`del` calls
-(string replies are unchanged under RESP3 — only geospatial, stream, and
-search/timeseries command replies change shape), but **Cedar apps connecting
-to a Redis server that's slow to respond to individual commands may now see
-timeouts where they previously didn't**. Apps that need the old behavior can
-pass `commandOptions: { timeout: 0 }` (or a custom value) through
-`RedisClientOptions` when configuring the cache client, or pin `RESP: 2` to
-opt back into the v5 wire protocol.
+major bumps (Express, Pino): `redis` v6 switches the default wire protocol from
+RESP2 to RESP3, and introduces a 5 second default command timeout (previously
+unlimited) and a longer default `keepAliveInitialDelay` (30s, up from 5s). None
+of these affect `RedisClient`'s own `get`/`set`/`del` calls (string replies are
+unchanged under RESP3 — only geospatial, stream, and search/timeseries command
+replies change shape), but **Cedar apps connecting to a Redis server that's slow
+to respond to individual commands may now see timeouts where they previously
+didn't**. Apps that need the old behavior can pass
+`commandOptions: { timeout: 0 }` (or a custom value) through
+`RedisClientOptions` when configuring the cache client, or pin `RESP: 2` to opt
+back into the v5 wire protocol.
 
-The `as RedisClientType` type assertion in `RedisClient.connect()` is removed
-- `redis` v6 fixed the type mismatch between `createClient()`'s return type
-and `RedisClientType` that made the assertion necessary in v5.
+The `as RedisClientType` type assertion in `RedisClient.connect()` is removed,
+since `redis` v6 fixed the type mismatch between `createClient()`'s return
+type and `RedisClientType` that made the assertion necessary in v5.
 
 `redis` is an optional peer dependency, so this only affects Cedar apps that
 have opted into the Redis cache client.

--- a/.changesets/2585.md
+++ b/.changesets/2585.md
@@ -1,0 +1,26 @@
+- fix(api): Upgrade redis to v6 by @lisa-assistant
+
+`@cedarjs/api`'s optional Redis cache client (`RedisClient`) was pinned to the
+`redis` npm package v5.12.1, which is behind the latest v6.2.1 release.
+Renovate flags major bumps for manual approval, so this one had been sitting
+unapplied since redis v6 stabilized.
+
+**This one does have user-visible behavior changes**, unlike recent internal
+major bumps (Express, Pino): `redis` v6 switches the default wire protocol
+from RESP2 to RESP3, and introduces a 5 second default command timeout
+(previously unlimited) and a longer default `keepAliveInitialDelay` (30s, up
+from 5s). None of these affect `RedisClient`'s own `get`/`set`/`del` calls
+(string replies are unchanged under RESP3 — only geospatial, stream, and
+search/timeseries command replies change shape), but **Cedar apps connecting
+to a Redis server that's slow to respond to individual commands may now see
+timeouts where they previously didn't**. Apps that need the old behavior can
+pass `commandOptions: { timeout: 0 }` (or a custom value) through
+`RedisClientOptions` when configuring the cache client, or pin `RESP: 2` to
+opt back into the v5 wire protocol.
+
+The `as RedisClientType` type assertion in `RedisClient.connect()` is removed
+- `redis` v6 fixed the type mismatch between `createClient()`'s return type
+and `RedisClientType` that made the assertion necessary in v5.
+
+`redis` is an optional peer dependency, so this only affects Cedar apps that
+have opted into the Redis cache client.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -93,7 +93,7 @@
     "concurrently": "9.2.4",
     "memjs": "1.3.2",
     "publint": "0.3.24",
-    "redis": "5.12.1",
+    "redis": "6.2.1",
     "split2": "4.2.0",
     "ts-toolbelt": "9.6.0",
     "typescript": "5.9.3",
@@ -101,7 +101,7 @@
   },
   "peerDependencies": {
     "memjs": "1.3.2",
-    "redis": "5.12.1"
+    "redis": "6.2.1"
   },
   "peerDependenciesMeta": {
     "memjs": {

--- a/packages/api/src/cache/clients/RedisClient.ts
+++ b/packages/api/src/cache/clients/RedisClient.ts
@@ -29,8 +29,7 @@ export class RedisClient extends BaseClient {
     // async import to make sure Redis isn't imported for MemCache
     const { createClient } = await import('redis')
 
-    // NOTE: type in redis client does not match the return type of createClient
-    this.client = createClient(this.redisOptions) as RedisClientType
+    this.client = createClient(this.redisOptions)
     this.client.on(
       'error',
       (err: Error) => this.logger?.error(err) || console.error(err),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,7 +2035,7 @@ __metadata:
     picoquery: "npm:2.5.0"
     pino: "npm:9.7.0"
     publint: "npm:0.3.24"
-    redis: "npm:5.12.1"
+    redis: "npm:6.2.1"
     split2: "npm:4.2.0"
     title-case: "npm:3.0.3"
     ts-toolbelt: "npm:9.6.0"
@@ -2043,7 +2043,7 @@ __metadata:
     vitest: "npm:4.1.11"
   peerDependencies:
     memjs: 1.3.2
-    redis: 5.12.1
+    redis: 6.2.1
   peerDependenciesMeta:
     memjs:
       optional: true
@@ -9294,18 +9294,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redis/bloom@npm:5.12.1":
-  version: 5.12.1
-  resolution: "@redis/bloom@npm:5.12.1"
+"@redis/bloom@npm:6.2.1":
+  version: 6.2.1
+  resolution: "@redis/bloom@npm:6.2.1"
   peerDependencies:
-    "@redis/client": ^5.12.1
-  checksum: 10c0/b267b1a80568beb188d89a9f2f07db16c88e4bfd2258873126d13b7ed722616dbb21fffdab0797d54a8547845fe3e4c5dc212d1af94f22a21c2a2a12bae71976
+    "@redis/client": ^6.2.1
+  checksum: 10c0/d218c60e560da60670b1e81601598777bc481c34fc21f4545ad9198bf901b0cd05ea846da10488a0436e125d418568bf7763e8118be198d2a46aedd32ce8d3f6
   languageName: node
   linkType: hard
 
-"@redis/client@npm:5.12.1":
-  version: 5.12.1
-  resolution: "@redis/client@npm:5.12.1"
+"@redis/client@npm:6.2.1":
+  version: 6.2.1
+  resolution: "@redis/client@npm:6.2.1"
   dependencies:
     cluster-key-slot: "npm:1.1.2"
   peerDependencies:
@@ -9316,34 +9316,34 @@ __metadata:
       optional: true
     "@opentelemetry/api":
       optional: true
-  checksum: 10c0/f475aa936b7cf73c3d2166862377d3502f16deaf5423d31f6899f6387440195aa2524c74d1df26da591a61b4ac0122a1e1f8d783b770e7630c5f7444445c41b0
+  checksum: 10c0/fe1f784343778e04f31637ec13484318cdcb19c3565b64e4a501bdfe4e0a8012fad41fc88604fba29d2d1f8425c470bb98691d2105d8502ae6570daab7b6925a
   languageName: node
   linkType: hard
 
-"@redis/json@npm:5.12.1":
-  version: 5.12.1
-  resolution: "@redis/json@npm:5.12.1"
+"@redis/json@npm:6.2.1":
+  version: 6.2.1
+  resolution: "@redis/json@npm:6.2.1"
   peerDependencies:
-    "@redis/client": ^5.12.1
-  checksum: 10c0/c02a94e148944c47c2995bb8df61c6cde51c7a4e380e7f4832fb56ff586754e5cc788edf0a470e5eee3cf19af8ad0b85c94bc759f91c93986d14b52fa1829200
+    "@redis/client": ^6.2.1
+  checksum: 10c0/3e0b2c0c8916d4a3d6385b6496eb566a5f92f4f3abaa5f8206eafc7acffaef73ce8c70018c49b6c46a01898193071b6cf6fa63e15713a3793d32bf095ba25842
   languageName: node
   linkType: hard
 
-"@redis/search@npm:5.12.1":
-  version: 5.12.1
-  resolution: "@redis/search@npm:5.12.1"
+"@redis/search@npm:6.2.1":
+  version: 6.2.1
+  resolution: "@redis/search@npm:6.2.1"
   peerDependencies:
-    "@redis/client": ^5.12.1
-  checksum: 10c0/1dfe70e173e4544ae7c8d8a172e069fbf47f525066fcd43952628f037b61137673ef2dad1454982c9508e4575ec63626f4dc3793c20eef65b61b8b195cc75289
+    "@redis/client": ^6.2.1
+  checksum: 10c0/94c3b406dd8ec30ee633140a4590b553d7b2459cabdc6769b09289ca8abd210bb88a901412b3351a7d61ca86c68347d0f9a57a77713bb8d5011093786b0abe88
   languageName: node
   linkType: hard
 
-"@redis/time-series@npm:5.12.1":
-  version: 5.12.1
-  resolution: "@redis/time-series@npm:5.12.1"
+"@redis/time-series@npm:6.2.1":
+  version: 6.2.1
+  resolution: "@redis/time-series@npm:6.2.1"
   peerDependencies:
-    "@redis/client": ^5.12.1
-  checksum: 10c0/8d450fdaa370e3ab7bff31197bf3e5102b3cfccbd0e0997a6d17b00e51f67447c355ae2cd76268e83f9459f1a23f606286eab2e81b57fded147fae6c5438b4ca
+    "@redis/client": ^6.2.1
+  checksum: 10c0/ef1039952ec17c66d6aeb8f292bddb9dee818dd10d71b6e6327f139cd2784924862c57dc0e1e01b10cbc763faf96fe28e9ed848e3c1e5b660c6b103fe2283d40
   languageName: node
   linkType: hard
 
@@ -25121,16 +25121,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redis@npm:5.12.1":
-  version: 5.12.1
-  resolution: "redis@npm:5.12.1"
+"redis@npm:6.2.1":
+  version: 6.2.1
+  resolution: "redis@npm:6.2.1"
   dependencies:
-    "@redis/bloom": "npm:5.12.1"
-    "@redis/client": "npm:5.12.1"
-    "@redis/json": "npm:5.12.1"
-    "@redis/search": "npm:5.12.1"
-    "@redis/time-series": "npm:5.12.1"
-  checksum: 10c0/ad80825241bced474b104279339f26207b9bb0e6f4d425061f0ccfe7935576c8d70272389c30f49a77bd06fe8e791a09756dbb9280099f358ce63c79efe0b99e
+    "@redis/bloom": "npm:6.2.1"
+    "@redis/client": "npm:6.2.1"
+    "@redis/json": "npm:6.2.1"
+    "@redis/search": "npm:6.2.1"
+    "@redis/time-series": "npm:6.2.1"
+  checksum: 10c0/57a83500e28a3f2f74d566ce11706f8f3d8dc5e05b2c89c8ec9c26eab46bc4c5863b877add941164b95c1f76716db1c70c8a74737b6c0f47a26a3be9003ee33b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the optional `redis` cache-client dependency 5.12.1 → 6.2.1 in `@cedarjs/api` (devDependencies + peerDependencies).

Renovate flags major version bumps for manual dashboard approval, so this one had been sitting unapplied. Following up on #2583 (Express 5) and #2584 (Pino 10), which were both internal-only bumps — this one **does** carry a real behavior change for end-user Cedar apps, which Tobbe flagged as fine to take on now while a bigger breaking release is already in flight.

⚠️ `redis` v6's breaking changes ([migration guide](https://github.com/redis/node-redis/blob/master/docs/v5-to-v6.md)):
- switches the default wire protocol from RESP2 to RESP3, and introduces a 5s default command timeout (previously unlimited) plus a longer default
- `keepAliveInitialDelay` (30s, up from 5s). `RedisClient`'s `get`/`set`/`del` calls are unaffected by the RESP3 switch (string replies are unchanged — only geospatial/stream/search/timeseries command replies change shape), but Cedar apps talking to a slow Redis server may now hit the new command timeout where they previously wouldn't have. 

Breaking changes are documented in the changeset along with the opt-out (`commandOptions: { timeout: 0 }` or pinning `RESP: 2`).

Also removes a now-unnecessary `as RedisClientType` type assertion in `RedisClient.connect()` — v6 fixed the `createClient()` return-type mismatch that made it necessary in v5.

`redis` is an optional peer dependency (behind `peerDependenciesMeta`), so this only affects Cedar apps that have opted into the Redis cache client.