### PR TITLE
docs(plans): Sharpen the uploads & storage plan

### DIFF
--- a/docs/implementation-plans/uploads-storage-implementation-plan.md
+++ b/docs/implementation-plans/uploads-storage-implementation-plan.md
@@ -1218,20 +1218,27 @@ export async function deleteFile(
  * longer complete.
  *
  * Claimed rows are kept as `failed` tombstones rather than deleted, and
- * each sweep re-attempts byte deletion for recent `failed` rows whose
- * object still exists in storage. That makes byte deletion retryable —
- * a `target.delete()` that errors is retried on the next run — and it
- * catches the pathological in-flight upload whose bytes land after the
- * row was claimed. The default `olderThan` (1 hour) sits far above the
- * presigned URL expiry (5 minutes), so a claimed row's upload window
- * is long closed by the time it is swept. Run it from a recurring
- * `@cedarjs/jobs` job; the setup command's next-steps output shows the
- * job.
+ * each sweep re-attempts byte deletion for `failed` rows younger than
+ * `retryWindow` (default: 24 hours) whose object still exists in
+ * storage. That makes byte deletion retryable — a `target.delete()`
+ * that errors is retried on the next run — and it catches the
+ * pathological in-flight upload whose bytes land after the row was
+ * claimed. The windows are chosen against the upload timeline: a
+ * presigned PUT must start within the URL's 5-minute validity, so
+ * `olderThan` (1 hour) claims rows whose upload window is long closed,
+ * and an upload would have to stay in flight for a full `retryWindow`
+ * after issuance to land bytes after the final deletion attempt —
+ * beyond any realistic client or S3 connection lifetime. Operators
+ * with unusual transfer profiles raise `retryWindow` to match. Run it
+ * from a recurring `@cedarjs/jobs` job; the setup command's next-steps
+ * output shows the job.
  */
 export async function cleanupStaleUploads(options: {
   db: PrismaClient
   targets: Record<string, StorageProvider>
   olderThan?: number
+  /** How long `failed` tombstones stay in the re-check set — default: 24 hours */
+  retryWindow?: number
 }): Promise<{ deleted: number }>
 ```
 
@@ -1271,9 +1278,13 @@ interface UploadPluginOptions {
    * Resolve the authenticated user for a request (e.g. from the app's
    * auth header). Upload routes reject tokens whose `sub` — or, in
    * multi-tenant apps, `organizationId` — belongs to someone else, so
-   * one user cannot spend another user's token. The setup command wires
-   * this to the app's `getCurrentUser` for apps with auth; without it,
-   * the token itself is the only identity on the route.
+   * one user cannot spend another user's token. The setup command
+   * builds this callback with `createUploadAuthenticator({ authDecoder,
+   * getCurrentUser })`, which decodes the request's auth header with
+   * the app's auth decoder and passes the decoded auth data to the
+   * app's `getCurrentUser` — the same pipeline the GraphQL server
+   * uses. Without it, the token itself is the only identity on the
+   * route.
    */
   authenticate?: (
     req: FastifyRequest
@@ -1299,7 +1310,8 @@ async function cedarUploadsPlugin(
 
 ```ts
 import { createServer } from '@cedarjs/api-server'
-import { cedarUploadsPlugin } from '@cedarjs/uploads'
+import { authDecoder } from '@cedarjs/auth-dbauth-api'
+import { cedarUploadsPlugin, createUploadAuthenticator } from '@cedarjs/uploads'
 
 import { getCurrentUser } from 'src/lib/auth'
 import { logger } from 'src/lib/logger'
@@ -1315,10 +1327,14 @@ async function main() {
     tokenSecret: process.env.UPLOAD_TOKEN_SECRET!,
     targets,
     db,
-    // Binds upload tokens to the requesting user — the setup command
-    // generates this line for apps with auth, so user binding is on in
-    // the default setup, not an opt-in extra
-    authenticate: (req) => getCurrentUser(req),
+    // Binds upload tokens to the requesting user. The authenticator
+    // mirrors the GraphQL server's auth pipeline: it decodes the
+    // request's auth header with the app's auth decoder, then resolves
+    // the user with the app's getCurrentUser — getCurrentUser itself
+    // takes decoded auth data, not a raw request. The setup command
+    // generates these lines for apps with auth, so user binding is on
+    // in the default setup, not an opt-in extra.
+    authenticate: createUploadAuthenticator({ authDecoder, getCurrentUser }),
   })
 
   await server.start()

--- a/docs/implementation-plans/uploads-storage-implementation-plan.md
+++ b/docs/implementation-plans/uploads-storage-implementation-plan.md
@@ -876,9 +876,10 @@ server.
      token's `sub`, `organizationId` and `tokenId` from the token's
      claims, and `size` set to the declared size after validating it
      against the token's `maxFileSize` — completion-time verification
-     compares the real object against this value. The create runs in a
-     transaction that counts the token's existing records and refuses
-     the request once `maxFiles` is reached
+     compares the real object against this value. The count of the
+     token's existing records and the insert are one atomic
+     count-and-create (a serialized transaction keyed on `tokenId`), so
+     concurrent requests sharing one token cannot exceed `maxFiles`
    - Returns `{ uploadId, url, method, headers }` — this shape is exactly
      what Uppy's `@uppy/aws-s3` plugin expects from `getUploadParameters()`
 
@@ -965,7 +966,10 @@ filesystem. Protected by JWT upload tokens.
    - Generates a storage key: `<cuid>.<ext>`
    - Creates the `Upload` record with status `pending`, `userId` from
      the token's `sub`, and `organizationId`/`tokenId` from the token's
-     claims. Row-first ordering means a crash between record and write
+     claims — using the same atomic count-and-create against `tokenId`
+     as the presign path, so `maxFiles` holds token-wide across
+     requests and under concurrency, not just per multipart batch.
+     Row-first ordering means a crash between record and write
      leaves a pending row the cleanup job can find — bytes-first would
      leave an object on disk that nothing references
    - Calls `target.write(key, data, { contentType })` to save to disk
@@ -1022,6 +1026,10 @@ Fastify routes needed — data flows through GraphQL as base64-encoded strings.
        filename: input.filename,
        mimeType: input.mimeType,
        data: Buffer.from(input.data, 'base64'),
+       // The avatar belongs to the requesting user — persisting the
+       // owner keeps the signed-URL ownership checks effective for
+       // files stored through storeFile() too
+       userId: context.currentUser.id,
      })
 
      return db.user.update({
@@ -1084,6 +1092,14 @@ interface StoreFileOptions {
    * unlimited for object-storage targets.
    */
   maxSize?: number
+  /**
+   * Owner of the file, when it belongs to a user. Persisted onto the
+   * Upload row so the ownership checks that guard user uploads apply
+   * to server-stored files too.
+   */
+  userId?: string
+  /** Owning organization, for multi-tenant apps (#2544). */
+  organizationId?: string
 }
 
 /**
@@ -1095,7 +1111,8 @@ export async function storeFile(
   target: StorageProvider,
   options: StoreFileOptions
 ): Promise<Upload> {
-  const { db, filename, mimeType, data, maxSize } = options
+  const { db, filename, mimeType, data, maxSize, userId, organizationId } =
+    options
   const ext = mime.extension(mimeType)
   const key = ext ? `${createId()}.${ext}` : createId()
 
@@ -1121,6 +1138,8 @@ export async function storeFile(
       size: BigInt(data.length),
       storageKey: isDbProvider ? null : key,
       data: isDbProvider ? data : null,
+      userId: userId ?? null,
+      organizationId: organizationId ?? null,
     },
   })
 }
@@ -1188,16 +1207,24 @@ export async function deleteFile(
 ): Promise<void>
 
 /**
- * Delete `pending` Upload rows older than `olderThan` (default: 1 hour)
- * along with any bytes that did land in storage. Covers presigned
- * uploads that were issued but never completed, and FS uploads that
- * crashed between row creation and write. The sweep is race-safe: each
- * row is first claimed with a conditional update (`pending` → `failed`,
- * filtered on status and age), and only rows the claim actually matched
- * have their bytes and row removed. Because the completion paths flip
- * `pending` → `completed` with the same conditional pattern, a row that
- * completes mid-sweep is skipped (its claim matches zero rows) and a
- * claimed row can no longer complete. Run it from a recurring
+ * Sweep stale uploads. Claims `pending` Upload rows older than
+ * `olderThan` (default: 1 hour) with a conditional `pending` → `failed`
+ * update, then deletes any bytes that did land in storage. Covers
+ * presigned uploads that were issued but never completed, and FS
+ * uploads that crashed between row creation and write. The sweep is
+ * race-safe: because the completion paths flip `pending` → `completed`
+ * with the same conditional pattern, a row that completes mid-sweep is
+ * skipped (its claim matches zero rows) and a claimed row can no
+ * longer complete.
+ *
+ * Claimed rows are kept as `failed` tombstones rather than deleted, and
+ * each sweep re-attempts byte deletion for recent `failed` rows whose
+ * object still exists in storage. That makes byte deletion retryable —
+ * a `target.delete()` that errors is retried on the next run — and it
+ * catches the pathological in-flight upload whose bytes land after the
+ * row was claimed. The default `olderThan` (1 hour) sits far above the
+ * presigned URL expiry (5 minutes), so a claimed row's upload window
+ * is long closed by the time it is swept. Run it from a recurring
  * `@cedarjs/jobs` job; the setup command's next-steps output shows the
  * job.
  */
@@ -1231,17 +1258,26 @@ interface UploadPluginOptions {
   /** Route prefix — default: '/upload' */
   prefix?: string
 
-  /** Body limit for FS uploads — default: 50MB */
+  /**
+   * Hard outer ceiling on FS upload request size — default: 500 MB.
+   * The effective per-request bound comes from the token (`maxFiles` ×
+   * `maxFileSize` plus a multipart-envelope allowance), so this only
+   * needs to sit above the largest FS profile's aggregate — a
+   * profile-valid batch is never rejected by the outer ceiling.
+   */
   bodyLimit?: number
 
   /**
    * Resolve the authenticated user for a request (e.g. from the app's
-   * auth header). When provided, upload routes reject tokens whose
-   * `sub` is a different user, so one user cannot spend another user's
-   * token. Without it, the token itself is the only identity on the
-   * route.
+   * auth header). Upload routes reject tokens whose `sub` — or, in
+   * multi-tenant apps, `organizationId` — belongs to someone else, so
+   * one user cannot spend another user's token. The setup command wires
+   * this to the app's `getCurrentUser` for apps with auth; without it,
+   * the token itself is the only identity on the route.
    */
-  authenticate?: (req: FastifyRequest) => Promise<{ id: string } | null>
+  authenticate?: (
+    req: FastifyRequest
+  ) => Promise<{ id: string; organizationId?: string } | null>
 }
 
 async function cedarUploadsPlugin(
@@ -1265,6 +1301,7 @@ async function cedarUploadsPlugin(
 import { createServer } from '@cedarjs/api-server'
 import { cedarUploadsPlugin } from '@cedarjs/uploads'
 
+import { getCurrentUser } from 'src/lib/auth'
 import { logger } from 'src/lib/logger'
 import { db } from 'src/lib/db'
 import { targets } from 'src/lib/uploads'
@@ -1278,6 +1315,10 @@ async function main() {
     tokenSecret: process.env.UPLOAD_TOKEN_SECRET!,
     targets,
     db,
+    // Binds upload tokens to the requesting user — the setup command
+    // generates this line for apps with auth, so user binding is on in
+    // the default setup, not an opt-in extra
+    authenticate: (req) => getCurrentUser(req),
   })
 
   await server.start()
@@ -1376,10 +1417,17 @@ const validate: ValidatorDirectiveFunc = ({ context }) => {
     process.env.UPLOAD_TOKEN_SECRET!
   )
 
-  // A token is bound to the user it was issued to — an authenticated
-  // user cannot spend someone else's token
+  // A token is bound to the user (and, in multi-tenant apps, the
+  // organization) it was issued to — an authenticated user cannot
+  // spend someone else's token or carry one across organizations
   if (context.currentUser && String(context.currentUser.id) !== payload.sub) {
     throw new Error('Upload token was issued to a different user')
+  }
+  if (
+    payload.organizationId &&
+    payload.organizationId !== context.currentUser?.organizationId
+  ) {
+    throw new Error('Upload token was issued for a different organization')
   }
 
   // Attach the validated payload to context for use in resolvers
@@ -1872,14 +1920,19 @@ async function handleS3Webhook(
   // 2. Validate SNS signature (prevent spoofing)
   // 3. Extract S3 event from notification
   // 4. For each s3:ObjectCreated event:
-  //    a. Extract the bucket and object key
+  //    a. Extract the bucket and the URL-encoded object key, and
+  //       decode the key
   //    b. Resolve the target whose config matches the event's bucket
-  //       (via getConfig()), then find the Upload record by target +
-  //       storageKey — storageKey alone is not guaranteed unique across
-  //       targets
-  //    c. Compare the actual S3 object size against the size recorded at
-  //       presign time — on mismatch, delete the object, mark the record
-  //       "failed", and stop (see "Size Enforcement")
+  //       and key prefix (via getConfig()), strip the prefix, and find
+  //       the Upload record by target + storageKey with status
+  //       "pending" — an exact bucket-plus-effective-key match
+  //       (storageKey alone is not guaranteed unique across targets,
+  //       and providers store it without the keyPrefix), and duplicate
+  //       notifications for already-settled rows are ignored
+  //    c. Compare the actual S3 object size against the size recorded
+  //       at presign time — on mismatch, claim the row "pending" →
+  //       "failed" (conditional update), delete the object only when
+  //       the claim matched, and stop (see "Size Enforcement")
   //    d. Flip status "pending" → "completed" (conditional update — a
   //       row the cleanup job already claimed stays untouched) and
   //       record the actual object size
@@ -1955,11 +2008,16 @@ export const confirmUpload = async ({ uploadId }) => {
   // cannot prove the object is within the profile's limit.
   const actualSize = await target.getObjectSize(upload.storageKey)
   if (actualSize === null || BigInt(actualSize) !== upload.size) {
-    await target.delete(upload.storageKey)
-    return db.upload.update({
-      where: { id: uploadId },
+    // Claim the row before touching bytes — if a concurrent path
+    // settled it first, skip deletion and leave the settled state
+    const { count } = await db.upload.updateMany({
+      where: { id: uploadId, status: 'pending' },
       data: { status: 'failed' },
     })
+    if (count === 1) {
+      await target.delete(upload.storageKey)
+    }
+    return db.upload.findUniqueOrThrow({ where: { id: uploadId } })
   }
 
   // Conditional transition — a row the cleanup job already claimed

--- a/docs/implementation-plans/uploads-storage-implementation-plan.md
+++ b/docs/implementation-plans/uploads-storage-implementation-plan.md
@@ -62,9 +62,18 @@
    storage key. This gives a single source of truth.
 
 5. **Manual lifecycle management.** Developers explicitly call storage
-   operations in their services. No automatic Prisma extension magic. This is
-   more boilerplate but dramatically simpler to reason about, debug, and
-   customize.
+   operations in their services. No automatic Prisma extension magic. The
+   criterion for ambient magic (#2595): it must both prevent an omission
+   that would fail silently and catastrophically, and stay pure and
+   transactional with respect to the query. Storage hooks fail both gates:
+   a forgotten storage call is a visible bug (the file is missing), and
+   file I/O inside a query hook is non-transactional external work with
+   its own failure modes. Explicit calls are more boilerplate but
+   dramatically simpler to reason about, debug, and customize. (The
+   tenancy extension in #2544 passes both gates — omission would be a
+   silent cross-tenant leak, and where-clause injection is pure query
+   rewriting — which is why these two designs land on opposite sides of
+   the same principle.)
 
 6. **Uppy on the frontend.** Uppy's pluggable architecture maps perfectly
    onto our providers: `@uppy/aws-s3` for presigned uploads,
@@ -169,6 +178,15 @@ export interface StorageProvider {
   /** Name of this provider instance, set by defineStorageTargets() */
   name: string
 
+  /**
+   * 'db' is the only value the framework branches on — it marks the
+   * provider that stores file content inline in the Upload row. All
+   * other values ('s3', 'fs', 'azure', …) are treated identically as
+   * object storage. See "Provider Type Discrimination" under
+   * Implementation Notes.
+   */
+  providerType: 'db' | string
+
   /** Write bytes to storage, return nothing (key is provided) */
   write(key: string, data: Buffer, opts: { contentType: string }): Promise<void>
 
@@ -180,6 +198,9 @@ export interface StorageProvider {
 
   /** Check if an object exists */
   exists(key: string): Promise<boolean>
+
+  /** Size in bytes of a stored object, or null when the provider cannot know */
+  getObjectSize(key: string): Promise<number | null>
 
   /** Generate a time-limited URL for reading/downloading */
   getSignedReadUrl(key: string, expiresIn?: number): Promise<string>
@@ -583,8 +604,10 @@ model Upload {
   /// MIME type (e.g., "image/png")
   mimeType   String
 
-  /// File size in bytes
-  size       Int
+  /// File size in bytes. BigInt because Prisma's Int is signed 32-bit,
+  /// which caps at 2 GB — too small for the multipart and tus futures
+  /// this plan anticipates. Exposed through GraphQL as the BigInt scalar.
+  size       BigInt
 
   /// Provider-specific storage reference.
   /// S3: the object key (e.g., "avatars/clx123.png")
@@ -596,6 +619,20 @@ model Upload {
 
   /// Inline binary data — only for the DB provider
   data       Bytes?
+
+  /// The user this file belongs to. Nullable so apps without auth are
+  /// unaffected. Stamped from the upload token's `sub` claim for user
+  /// uploads; set explicitly for server-generated files when relevant.
+  /// See "Upload Ownership (`userId`)" under Implementation Notes.
+  userId     String?
+
+  /// The organization this file belongs to, for apps using multi-tenancy
+  /// (#2544). When the tenancy extension counts Upload as tenant-owned,
+  /// every lookup in the serving directives is scoped automatically —
+  /// which closes the hole where a cross-tenant Upload id stored in a
+  /// field would otherwise yield a signed URL. Nullable so single-tenant
+  /// apps are unaffected.
+  organizationId String?
 
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
@@ -680,6 +717,9 @@ the developer uses), ensuring all existing Cedar auth tooling is leveraged.
 // packages/uploads/core/src/uploadToken.ts
 
 interface UploadTokenPayload {
+  /** The upload profile this token was issued for */
+  profile: string
+
   /** Allowed MIME types (e.g., ["image/png", "image/jpeg"]) */
   allowedMimeTypes: string[]
 
@@ -691,8 +731,50 @@ interface UploadTokenPayload {
 
   /** Target name — which storage target this token authorizes */
   target: string
+
+  /**
+   * Subject — the id of the user the token was issued to (from
+   * context.currentUser). Stamped onto the Upload record as userId and
+   * checked by confirmUpload, so a leaked token is bound to one account
+   * for its short lifetime instead of being bearer-anyone.
+   */
+  sub: string
 }
 ```
+
+#### Upload Profiles
+
+Constraints are server-defined, never client-supplied. The client names a
+**profile**; the server owns what that profile allows. Without this, the
+token query would merely notarize whatever constraints the client asked
+for — any authenticated user could request a token for any target at any
+size, and `@requireAuth` gates *who*, not *what*.
+
+Profiles live next to the targets in `api/src/lib/uploads.ts`:
+
+```ts
+import { defineUploadProfiles } from '@cedarjs/uploads'
+
+export const profiles = defineUploadProfiles({
+  avatar: {
+    target: 'avatars',
+    allowedMimeTypes: ['image/png', 'image/jpeg'],
+    maxFileSize: 5 * 1024 * 1024,
+    maxFiles: 1,
+  },
+  attachment: {
+    target: 'local',
+    allowedMimeTypes: ['application/pdf', 'image/png', 'image/jpeg'],
+    maxFileSize: 25 * 1024 * 1024,
+    maxFiles: 10,
+  },
+})
+```
+
+The generated `requestUploadToken(profile: String!)` resolver looks the
+profile up, refuses unknown names, and signs the profile's constraints
+plus the current user's id into the token. Per-user or per-role variation
+(pro accounts get bigger limits) is plain code in that resolver.
 
 #### Token Issuance
 
@@ -736,7 +818,10 @@ server.
    - Looks up the target from the validated token payload
    - Generates a storage key (e.g., `avatars/clx123abc.png`)
    - Calls `target.getPresignedUploadUrl(key, { contentType, ... })`
-   - Creates an `Upload` record with status `pending`
+   - Creates an `Upload` record with status `pending`, `userId` from the
+     token's `sub`, and `size` set to the declared size after validating
+     it against the token's `maxFileSize` — completion-time verification
+     compares the real object against this value
    - Returns `{ uploadId, url, method, headers }` — this shape is exactly
      what Uppy's `@uppy/aws-s3` plugin expects from `getUploadParameters()`
 
@@ -751,6 +836,23 @@ server.
    Alternatively, for development or simpler setups, the **client confirms**
    via a `confirmUpload` mutation and the server verifies the object exists
    before marking it completed.
+
+#### Size Enforcement
+
+A presigned PUT pins only the headers that were signed — it cannot cap the
+body size, so `maxFileSize` is not enforceable at upload time on this
+path. Two complementary mechanisms cover it:
+
+- **Post-hoc verification (built in).** The pending `Upload` row records
+  the declared, token-validated `size`. Both completion paths — the S3
+  webhook and `confirmUpload` — compare the actual object size against
+  it; a mismatch deletes the object and marks the row `failed`. An
+  oversized object lives in the bucket only until confirmation and is
+  never marked `completed` or served.
+- **Presigned POST policies (documented alternative).** S3's POST policy
+  supports `content-length-range`, which rejects oversized bodies during
+  the upload itself. Uppy's `@uppy/aws-s3` supports POST policies; the
+  how-to shows the swap for apps that want hard enforcement at the edge.
 
 #### Presigned URL Generation
 
@@ -786,12 +888,16 @@ filesystem. Protected by JWT upload tokens.
 3. **Fastify route handler:**
    - Validates the JWT token (checks expiry, resolves target)
    - Checks `Content-Length` against `maxFileSize` from token — rejects
-     before buffering if too large
+     before buffering when the header is present and too large. The
+     header can be absent (chunked encoding) or dishonest, so
+     `@fastify/multipart` is also configured with a per-file `fileSize`
+     limit from the token, which aborts the stream mid-flight
    - Processes the multipart stream via `@fastify/multipart`
    - Validates MIME type against `allowedMimeTypes` from token
    - Generates a storage key: `<cuid>.<ext>`
    - Calls `target.write(key, data, { contentType })` to save to disk
-   - Creates an `Upload` record with status `completed`
+   - Creates an `Upload` record with status `completed`, `userId` from
+     the token's `sub`
    - Returns the upload record as JSON
 
 #### File Serving
@@ -803,7 +909,14 @@ serving:
 2. Looks up the `Upload` record
 3. Resolves the target provider
 4. Streams the file from disk with appropriate `Content-Type`,
-   `Cache-Control`, and `ETag` headers
+   `Cache-Control`, and `ETag` headers — plus
+   `X-Content-Type-Options: nosniff` and, by default,
+   `Content-Disposition: attachment`. Inline rendering is opt-in, because
+   the stored MIME type is client-asserted: an "image" allowlist that
+   admits `image/svg+xml` is admitting a scriptable document, and inline
+   SVG served from the app's origin is stored XSS. Apps that want inline
+   images should restrict inline serving to raster types or verify magic
+   bytes at upload time
 
 The HMAC signing reuses the same `UPLOAD_TOKEN_SECRET`. The FS provider's
 `getSignedReadUrl()` generates these token URLs.
@@ -845,6 +958,16 @@ Fastify routes needed — data flows through GraphQL as base64-encoded strings.
      })
    }
    ```
+
+#### Size Cap
+
+This path is the deliberate exception to design principle 1: the base64
+payload rides through GraphQL, which buffers the whole request before any
+directive runs. That trade is acceptable only because these files are
+small — so "small" gets a number. DB-target profiles default to a
+`maxFileSize` of 1 MB, enforced in `useDbUpload` on the client and again
+in `storeFile()` for `providerType: 'db'` targets on the server. Files
+that can exceed it belong on an FS or S3 target.
 
 #### Serving DB Files
 
@@ -891,10 +1014,9 @@ export async function storeFile(
   const ext = mime.extension(mimeType)
   const key = ext ? `${createId()}.${ext}` : createId()
 
-  // For DB provider, data goes in the Upload.data column
+  // For the DB provider, data goes in the Upload.data column
   // For S3/FS/etc., data goes to external storage via the provider
-  const isDbProvider =
-    !target.getConfig().uploadDir && !target.getConfig().bucket
+  const isDbProvider = target.providerType === 'db'
 
   if (!isDbProvider) {
     await target.write(key, data, { contentType: mimeType })
@@ -954,6 +1076,40 @@ understanding provider internals, generating keys, creating Upload records,
 and wiring it all together. `storeFile()` reduces it to a single call:
 target + metadata + bytes → Upload record. This makes the "storage without
 uploads" workflow just as easy as the user-upload workflow.
+
+### Deleting Files (`deleteFile`) and Stale-Upload Cleanup
+
+Manual lifecycle cuts both ways: deleting an `Upload` row does nothing to
+the bytes, by design. The two pieces of boilerplate every app then needs
+ship in the package rather than being reimplemented per app:
+
+```ts
+/**
+ * Delete a stored file: bytes first, then the Upload record. Bytes-first
+ * ordering means a crash between the two steps leaves a dangling row
+ * that cleanup can find — the reverse order leaves an unreachable orphan
+ * file that nothing can find. A missing object is tolerated, so the call
+ * is idempotent.
+ */
+export async function deleteFile(
+  target: StorageProvider,
+  options: { db: PrismaClient; upload: Upload }
+): Promise<void>
+
+/**
+ * Delete `pending` Upload rows older than `olderThan` (default: 1 hour)
+ * along with any bytes that did land in storage. Covers presigned
+ * uploads that were issued but never completed, and FS uploads that
+ * crashed between write and record. Run it from a recurring
+ * `@cedarjs/jobs` job; the setup command's next-steps output shows the
+ * job.
+ */
+export async function cleanupStaleUploads(options: {
+  db: PrismaClient
+  targets: Record<string, StorageProvider>
+  olderThan?: number
+}): Promise<{ deleted: number }>
+```
 
 ### Fastify Upload Plugin
 
@@ -1037,6 +1193,14 @@ everything comes from the targets map.
 
 type UploadToken {
   token: String!
+  """
+  The profile's constraints, echoed for client-side UX (file-picker
+  filters, pre-upload validation). The authoritative copy is inside the
+  signed token.
+  """
+  allowedMimeTypes: [String!]!
+  maxFileSize: Int!
+  maxFiles: Int!
 }
 
 type PresignedUploadUrl {
@@ -1046,13 +1210,6 @@ type PresignedUploadUrl {
   headers: JSON!
 }
 
-input RequestUploadTokenInput {
-  target: String! # target name from targets config
-  allowedMimeTypes: [String!]!
-  maxFileSize: Int!
-  maxFiles: Int
-}
-
 input CreatePresignedUploadUrlInput {
   filename: String!
   contentType: String!
@@ -1060,7 +1217,12 @@ input CreatePresignedUploadUrlInput {
 }
 
 type Query {
-  requestUploadToken(input: RequestUploadTokenInput!): UploadToken! @requireAuth
+  """
+  The profile name must match a key in the app's upload-profiles config.
+  Constraints come from that server-side profile — the client never
+  supplies them. See "Upload Profiles".
+  """
+  requestUploadToken(profile: String!): UploadToken! @requireAuth
 }
 
 type Mutation {
@@ -1177,6 +1339,21 @@ the target from the Upload record and resolves the right provider
 automatically. This means the directive works identically for S3, FS, DB,
 and any future provider.
 
+Two implementation requirements keep the directive safe on list queries:
+
+- **Batch the lookups.** A transformer directive runs per field per row —
+  a 100-row list with one decorated field is 100 `findUnique` calls
+  unless the directive resolves through a per-request DataLoader keyed on
+  upload id. URL signing itself is local crypto (the S3 presigner, the FS
+  HMAC) and needs no batching.
+- **Never fetch `data` for non-DB targets.** `Upload.data` holds the
+  inline bytes for DB targets; an unqualified `findUnique` drags the blob
+  into memory for every S3/FS row too. The lookup selects everything
+  except `data`, then fetches `data` only when the resolved target has
+  `providerType === 'db'`. And because the DB path embeds a full base64
+  data URI into the response, DB-target fields belong on detail queries,
+  not list queries — the DB size cap keeps the worst case bounded.
+
 #### `@withDataUri` Directive
 
 A **transformer directive** that always returns a data URI, regardless of
@@ -1248,16 +1425,17 @@ function createUppy(options: CreateUppyOptions): Uppy
 #### `useUploadToken`
 
 Fetches an upload token from the GraphQL API. Uses Apollo's `useLazyQuery`
-so the token is only fetched when needed (not on mount).
+with `fetchPolicy: 'no-cache'` — tokens expire, so Apollo's cache must
+never answer this query — and only fetches when needed (not on mount).
+The response carries the profile's constraints for client-side UX, and
+the hook exposes them alongside the token.
 
 ```ts
 // packages/uploads/web/src/hooks/useUploadToken.ts
 
 interface UseUploadTokenOptions {
-  target: string
-  allowedMimeTypes: string[]
-  maxFileSize: number
-  maxFiles?: number
+  /** Name of a server-defined upload profile — see "Upload Profiles" */
+  profile: string
 }
 
 interface UseUploadTokenResult {
@@ -1283,11 +1461,8 @@ management for S3 direct uploads.
 // packages/uploads/web/src/hooks/useS3Upload.ts
 
 interface UseS3UploadOptions {
-  /** Target name from the storage targets config */
-  target: string
-  allowedMimeTypes: string[]
-  maxFileSize: number
-  maxFiles?: number
+  /** Name of a server-defined upload profile — see "Upload Profiles" */
+  profile: string
   onUploadComplete?: (uploadIds: string[]) => void
   onUploadError?: (error: Error) => void
 }
@@ -1321,11 +1496,8 @@ Fastify upload route.
 // packages/uploads/web/src/hooks/useFsUpload.ts
 
 interface UseFsUploadOptions {
-  /** Target name from the storage targets config */
-  target: string
-  allowedMimeTypes: string[]
-  maxFileSize: number
-  maxFiles?: number
+  /** Name of a server-defined upload profile — see "Upload Profiles" */
+  profile: string
   endpoint?: string // default: '/upload/fs'
   onUploadComplete?: (uploadIds: string[]) => void
   onUploadError?: (error: Error) => void
@@ -1398,7 +1570,10 @@ function useDbUpload(options: UseDbUploadOptions): UseDbUploadResult
 ```
 
 This hook validates file type/size client-side and returns base64-encoded
-data that the developer passes to their GraphQL mutation.
+data that the developer passes to their GraphQL mutation. The client-side
+checks are UX only — the service is the enforcement point (`storeFile()`
+applies the DB size cap, and the developer's resolver validates the MIME
+type against the profile).
 
 ### React Components
 
@@ -1411,11 +1586,8 @@ above.
 // packages/uploads/web/src/components/S3Uploader.tsx
 
 interface S3UploaderProps {
-  /** Target name from the storage targets config */
-  target: string
-  allowedMimeTypes: string[]
-  maxFileSize: number
-  maxFiles?: number
+  /** Name of a server-defined upload profile — see "Upload Profiles" */
+  profile: string
   onUploadComplete?: (uploadIds: string[]) => void
   onUploadError?: (error: Error) => void
   /** "dashboard" | "drag-drop" | "file-input" — default: "dashboard" */
@@ -1470,7 +1642,8 @@ accordingly.
    - `defineStorageTargets()` call with selected providers
    - S3 client setup (if an S3 target is selected)
    - FS config (if an FS target is selected)
-   - Export of `targets`
+   - `defineUploadProfiles()` with one starter profile per selected target
+   - Export of `targets` and `profiles`
 
 3. **Creates `api/src/graphql/uploads.sdl.ts`** — SDL with upload token
    query, presigned URL mutation, confirm mutation, and directives
@@ -1564,8 +1737,10 @@ async function handleS3Webhook(
   // 4. For each s3:ObjectCreated event:
   //    a. Extract the bucket and object key
   //    b. Find the matching Upload record by storageKey
-  //    c. Update status to "completed"
-  //    d. Update size from the actual S3 object size
+  //    c. Compare the actual S3 object size against the size recorded at
+  //       presign time — on mismatch, delete the object, mark the record
+  //       "failed", and stop (see "Size Enforcement")
+  //    d. Update status to "completed" and size from the actual object
 }
 ```
 
@@ -1604,6 +1779,11 @@ export const confirmUpload = async ({ uploadId }) => {
     where: { id: uploadId },
   })
 
+  // Only the user the upload token was issued to can confirm it
+  if (upload.userId && upload.userId !== context.currentUser.id) {
+    throw new ForbiddenError("You don't have access to this upload")
+  }
+
   const target = resolveTarget(targets, upload.target)
 
   // Verify the object actually exists in storage
@@ -1611,6 +1791,17 @@ export const confirmUpload = async ({ uploadId }) => {
 
   if (!exists) {
     throw new Error('Upload not found in storage')
+  }
+
+  // Verify the object matches what the token authorized — a presigned
+  // PUT cannot cap body size (see "Size Enforcement")
+  const actualSize = await target.getObjectSize(upload.storageKey!)
+  if (actualSize !== null && actualSize !== Number(upload.size)) {
+    await target.delete(upload.storageKey!)
+    return db.upload.update({
+      where: { id: uploadId },
+      data: { status: 'failed' },
+    })
   }
 
   return db.upload.update({
@@ -1865,8 +2056,10 @@ the Prisma Upload model work end to end.
 - [ ] `createFsProvider()` implementation
 - [ ] `createDbProvider()` implementation
 - [ ] `defineStorageTargets()` and `resolveTarget()`
-- [ ] `storeFile()` utility
-- [ ] Upload token JWT creation and validation
+- [ ] `storeFile()`, `deleteFile()` and `cleanupStaleUploads()` utilities
+- [ ] `defineUploadProfiles()` and profile-based token issuance
+- [ ] Upload token JWT creation and validation (profile constraints +
+      `sub` claim)
 - [ ] Fastify upload plugin with FS upload route (`POST /upload/fs`)
 - [ ] Fastify file serving route (`GET /upload/serve/:token`) with HMAC
       signed URLs
@@ -1890,7 +2083,8 @@ the Prisma Upload model work end to end.
 - [ ] `getPresignedUploadUrl()` in S3 provider
 - [ ] `getSignedReadUrl()` in S3 provider (native S3 presigned GET)
 - [ ] `createPresignedUploadUrl` GraphQL mutation and service
-- [ ] `confirmUpload` mutation and service (client-side confirmation)
+- [ ] `confirmUpload` mutation and service (client-side confirmation
+      with ownership and size verification)
 - [ ] S3 webhook handler (SNS message parsing and signature validation)
 - [ ] `@withSignedUrl` directive — works with S3 targets automatically
 - [ ] CLI: S3 target option in setup command
@@ -1952,9 +2146,10 @@ provider.
 
 ### Provider Type Discrimination
 
-The `StorageProvider` interface must include an explicit `providerType: string`
-property. The current `storeFile()` heuristic of inspecting `getConfig()` output
-to detect the DB provider is fragile and should be replaced.
+The `StorageProvider` interface includes an explicit `providerType: string`
+property, and `storeFile()` branches on it. Inspecting `getConfig()` output
+to detect the DB provider is not an option: config shapes are
+provider-defined and offer no stable signal.
 
 The framework only ever branches on a single special value — `'db'` — which
 identifies the database-backed provider that stores file content inline. Every
@@ -1977,7 +2172,7 @@ Built-in values: `'db'`, `'s3'`, `'fs'`.
 
 ### Upload Ownership (`userId`)
 
-Add a nullable `userId` field to the `Upload` model. Implicit ownership via a
+The `Upload` model carries a nullable `userId`. Implicit ownership via a
 FK on the application model (e.g. `user.avatarId`) works for the simplest cases
 but breaks down as soon as you need to answer "show all files uploaded by user X"
 or enforce download authorisation without traversing every possible join.
@@ -1990,8 +2185,9 @@ A `userId` on `Upload` directly:
   (`db.upload.findMany({ where: { userId: currentUser.id } })`).
 - Is nullable, so applications that don't use auth are completely unaffected.
 
-Developers should populate it from `context.currentUser.id` in their mutation
-resolvers or in the token-issuance endpoint.
+For token-based uploads the framework stamps it from the token's `sub`
+claim. For `storeFile()` calls, developers set it explicitly when the
+file belongs to a user.
 
 ### Large File Uploads (S3 Multipart, >5 GB)
 

--- a/docs/implementation-plans/uploads-storage-implementation-plan.md
+++ b/docs/implementation-plans/uploads-storage-implementation-plan.md
@@ -1924,8 +1924,13 @@ Alternative: S3 → SNS (direct, without EventBridge). Both work.
 interface S3WebhookHandlerOptions {
   db: PrismaClient
   targets: Record<string, StorageProvider>
-  /** SNS topic ARN for message validation */
-  topicArn?: string
+  /**
+   * The trusted SNS topic. Required — the handler rejects any
+   * notification whose TopicArn does not exactly match, so a valid
+   * signature from an attacker-controlled topic is not enough to feed
+   * the webhook events.
+   */
+  topicArn: string
 }
 
 async function handleS3Webhook(
@@ -1933,7 +1938,9 @@ async function handleS3Webhook(
   options: S3WebhookHandlerOptions
 ): Promise<void> {
   // 1. Parse SNS message (handles SubscriptionConfirmation + Notification)
-  // 2. Validate SNS signature (prevent spoofing)
+  // 2. Validate SNS signature (prevent spoofing) AND require the
+  //    message's TopicArn to exactly match the configured topicArn —
+  //    a validly signed message from an untrusted topic is rejected
   // 3. Extract S3 event from notification
   // 4. For each s3:ObjectCreated event:
   //    a. Extract the bucket and the URL-encoded object key, and

--- a/docs/implementation-plans/uploads-storage-implementation-plan.md
+++ b/docs/implementation-plans/uploads-storage-implementation-plan.md
@@ -199,11 +199,25 @@ export interface StorageProvider {
   /** Check if an object exists */
   exists(key: string): Promise<boolean>
 
-  /** Size in bytes of a stored object, or null when the provider cannot know */
+  /**
+   * Size in bytes of a stored object, or null when the provider cannot
+   * know. Completion-time verification treats null as a failed check —
+   * a provider that cannot report size cannot prove the object is
+   * within the profile's limit.
+   */
   getObjectSize(key: string): Promise<number | null>
 
-  /** Generate a time-limited URL for reading/downloading */
-  getSignedReadUrl(key: string, expiresIn?: number): Promise<string>
+  /**
+   * Generate a time-limited URL for reading/downloading. Defaults to
+   * attachment disposition wherever the provider controls response
+   * headers (S3 response overrides, the FS serve route) — the stored
+   * MIME type is client-asserted, so inline rendering is opt-in. See
+   * "File Serving".
+   */
+  getSignedReadUrl(
+    key: string,
+    opts?: { expiresIn?: number; disposition?: 'attachment' | 'inline' }
+  ): Promise<string>
 
   /**
    * Generate a presigned URL for direct client upload.
@@ -308,12 +322,16 @@ export function createS3Provider(opts: S3ProviderOptions): StorageProvider {
       }
     },
 
-    async getSignedReadUrl(key, expiresIn = 3600) {
+    async getSignedReadUrl(key, opts = {}) {
+      const { expiresIn = 3600, disposition = 'attachment' } = opts
       return getSignedUrl(
         client,
         new GetObjectCommand({
           Bucket: bucket,
           Key: `${keyPrefix}${key}`,
+          // Safe serving default, mirroring the FS serve route — the
+          // stored MIME type is client-asserted, so inline is opt-in
+          ResponseContentDisposition: disposition,
         }),
         { expiresIn }
       )
@@ -364,9 +382,11 @@ export function createFsProvider(opts: FsProviderOptions): StorageProvider
 ```
 
 The FS provider's `getSignedReadUrl` generates an HMAC-signed token URL
-pointing to the Fastify file-serving route. Its `getPresignedUploadUrl`
-throws — FS uploads go through the Fastify `POST /upload/fs` route, not
-direct-to-storage.
+pointing to the Fastify file-serving route; the requested disposition is
+encoded into the signed token, so inline serving is granted per-URL by
+the code that signs the URL, never chosen by the requester. Its
+`getPresignedUploadUrl` throws — FS uploads go through the Fastify
+`POST /upload/fs` route, not direct-to-storage.
 
 #### DB Provider
 
@@ -626,6 +646,11 @@ model Upload {
   /// See "Upload Ownership (`userId`)" under Implementation Notes.
   userId     String?
 
+  /// Id (`jti`) of the upload token that created this row. Null for
+  /// server-generated files. Counting a token's rows is how the server
+  /// enforces the profile's `maxFiles` across requests.
+  tokenId    String?
+
   /// The organization this file belongs to, for apps using multi-tenancy
   /// (#2544). When the tenancy extension counts Upload as tenant-owned,
   /// every lookup in the serving directives is scoped automatically —
@@ -697,9 +722,14 @@ provider's storage key is just another string in the `storageKey` column.
 
 For S3 presigned uploads, the record starts as `pending` and transitions to
 `completed` when the S3 event notification webhook fires (or when the client
-confirms and the server verifies). For FS, DB, and server-generated files,
-the record goes directly to `completed` (the server has the bytes and saves
-synchronously).
+confirms and the server verifies). FS uploads also pass through `pending`:
+the row is created before the bytes are written and flipped to `completed`
+in the same request (see "Local FS Provider"). DB and server-generated
+files go directly to `completed` (the server has the bytes and saves
+synchronously). Every `pending` → `completed`/`failed` transition is a
+conditional update (`updateMany` filtered on the current status), so the
+webhook, `confirmUpload`, and the stale-upload cleanup job cannot race
+each other into inconsistent states.
 
 ---
 
@@ -739,6 +769,19 @@ interface UploadTokenPayload {
    * for its short lifetime instead of being bearer-anyone.
    */
   sub: string
+
+  /**
+   * Unique token id. Stamped onto Upload records as tokenId; counting a
+   * token's records is how the server enforces maxFiles across requests.
+   */
+  jti: string
+
+  /**
+   * The organization the token was issued under, for apps using
+   * multi-tenancy (#2544). Stamped onto Upload records and checked at
+   * confirmation, mirroring sub. Absent in single-tenant apps.
+   */
+  organizationId?: string
 }
 ```
 
@@ -748,7 +791,7 @@ Constraints are server-defined, never client-supplied. The client names a
 **profile**; the server owns what that profile allows. Without this, the
 token query would merely notarize whatever constraints the client asked
 for — any authenticated user could request a token for any target at any
-size, and `@requireAuth` gates *who*, not *what*.
+size, and `@requireAuth` gates _who_, not _what_.
 
 Profiles live next to the targets in `api/src/lib/uploads.ts`:
 
@@ -773,8 +816,10 @@ export const profiles = defineUploadProfiles({
 
 The generated `requestUploadToken(profile: String!)` resolver looks the
 profile up, refuses unknown names, and signs the profile's constraints
-plus the current user's id into the token. Per-user or per-role variation
-(pro accounts get bigger limits) is plain code in that resolver.
+into the token together with the current user's id (`sub`), a fresh
+token id (`jti`), and — in multi-tenant apps (#2544) — the current
+organization id. Per-user or per-role variation (pro accounts get bigger
+limits) is plain code in that resolver.
 
 #### Token Issuance
 
@@ -794,6 +839,11 @@ function verifyUploadToken(token: string, secret: string): UploadTokenPayload
 
 The secret is stored in an environment variable (`UPLOAD_TOKEN_SECRET`). The
 CLI setup command generates a random secret and adds it to `.env`.
+
+Token responses are sent with `Cache-Control: no-store`. The token varies
+per user and expires in minutes; the web side's `fetchPolicy: 'no-cache'`
+only bypasses Apollo's client cache, so this response header is what keeps
+HTTP intermediaries from ever storing or replaying a token.
 
 #### Token Header
 
@@ -815,13 +865,20 @@ server.
 2. **Client requests presigned URL** via GraphQL (`createPresignedUploadUrl`
    mutation, protected by `@requireUploadToken`). The server:
    - Validates the JWT from the `x-upload-token` header
+   - Validates the requested `contentType` against the token's
+     `allowedMimeTypes` — a disallowed type is refused before anything
+     is signed, and the presigned PUT pins the `Content-Type` header it
+     was signed with, so S3 rejects an upload that swaps it
    - Looks up the target from the validated token payload
    - Generates a storage key (e.g., `avatars/clx123abc.png`)
    - Calls `target.getPresignedUploadUrl(key, { contentType, ... })`
    - Creates an `Upload` record with status `pending`, `userId` from the
-     token's `sub`, and `size` set to the declared size after validating
-     it against the token's `maxFileSize` — completion-time verification
-     compares the real object against this value
+     token's `sub`, `organizationId` and `tokenId` from the token's
+     claims, and `size` set to the declared size after validating it
+     against the token's `maxFileSize` — completion-time verification
+     compares the real object against this value. The create runs in a
+     transaction that counts the token's existing records and refuses
+     the request once `maxFiles` is reached
    - Returns `{ uploadId, url, method, headers }` — this shape is exactly
      what Uppy's `@uppy/aws-s3` plugin expects from `getUploadParameters()`
 
@@ -863,11 +920,16 @@ which uses `@aws-sdk/s3-request-presigner` directly.
 #### Reading Files Back (Signed Download URLs)
 
 The S3 provider's `getSignedReadUrl()` generates native S3 presigned GET
-URLs using `@aws-sdk/s3-request-presigner`. These are used by the
+URLs using `@aws-sdk/s3-request-presigner`, signing
+`ResponseContentDisposition: attachment` by default so S3 serves the
+object with the same safe defaults as the FS serve route (see "File
+Serving" for why inline is opt-in). These are used by the
 `@withSignedUrl` directive and can be called directly in services:
 
 ```ts
-const url = await targets.avatars.getSignedReadUrl(upload.storageKey!, 3600)
+const url = await targets.avatars.getSignedReadUrl(upload.storageKey!, {
+  expiresIn: 3600,
+})
 ```
 
 ### Local FS Provider
@@ -887,18 +949,28 @@ filesystem. Protected by JWT upload tokens.
 
 3. **Fastify route handler:**
    - Validates the JWT token (checks expiry, resolves target)
-   - Checks `Content-Length` against `maxFileSize` from token — rejects
-     before buffering when the header is present and too large. The
-     header can be absent (chunked encoding) or dishonest, so
-     `@fastify/multipart` is also configured with a per-file `fileSize`
-     limit from the token, which aborts the stream mid-flight
+   - When the plugin's `authenticate` option is configured, resolves the
+     requesting user and rejects a token whose `sub` is a different user
+     — one user cannot spend another user's token
+   - Checks `Content-Length` against the batch bound — the token's
+     `maxFiles × maxFileSize` plus an allowance for the multipart
+     envelope — and rejects before buffering when the header is present
+     and too large. The header can be absent (chunked encoding) or
+     dishonest, and it measures the whole request rather than any one
+     file, so `@fastify/multipart` is also configured with the per-file
+     `fileSize` limit and the `files` count limit from the token, which
+     abort the stream mid-flight
    - Processes the multipart stream via `@fastify/multipart`
    - Validates MIME type against `allowedMimeTypes` from token
    - Generates a storage key: `<cuid>.<ext>`
+   - Creates the `Upload` record with status `pending`, `userId` from
+     the token's `sub`, and `organizationId`/`tokenId` from the token's
+     claims. Row-first ordering means a crash between record and write
+     leaves a pending row the cleanup job can find — bytes-first would
+     leave an object on disk that nothing references
    - Calls `target.write(key, data, { contentType })` to save to disk
-   - Creates an `Upload` record with status `completed`, `userId` from
-     the token's `sub`
-   - Returns the upload record as JSON
+   - Flips the record `pending` → `completed` (conditional update) and
+     returns it as JSON
 
 #### File Serving
 
@@ -966,14 +1038,21 @@ payload rides through GraphQL, which buffers the whole request before any
 directive runs. That trade is acceptable only because these files are
 small — so "small" gets a number. DB-target profiles default to a
 `maxFileSize` of 1 MB, enforced in `useDbUpload` on the client and again
-in `storeFile()` for `providerType: 'db'` targets on the server. Files
-that can exceed it belong on an FS or S3 target.
+in `storeFile()` for `providerType: 'db'` targets on the server, which
+rejects the decoded buffer before anything is persisted. The GraphQL
+endpoint's request body limit is the outer guard on how much a single
+request can buffer at all — configure it with the cap in mind (1 MB of
+file data is ~1.4 MB of base64). Files that can exceed the cap belong on
+an FS or S3 target.
 
 #### Serving DB Files
 
 DB uploads are served as data URIs (for inline display) via the
 `@withDataUri` GraphQL directive, or the provider's `getSignedReadUrl()`
-which also returns a `data:` URI:
+which also returns a `data:` URI. Browsers render `data:` URIs in an
+opaque origin and refuse top-level `data:` navigation, so this path does
+not carry the same-origin stored-XSS risk that makes the FS serve route
+default to attachment disposition:
 
 ```ts
 function toDataUri(mimeType: string, data: Buffer): string {
@@ -999,6 +1078,12 @@ interface StoreFileOptions {
   filename: string
   mimeType: string
   data: Buffer
+  /**
+   * Reject `data` larger than this many bytes. Defaults to the 1 MB DB
+   * size cap for `providerType: 'db'` targets (see "Size Cap") and to
+   * unlimited for object-storage targets.
+   */
+  maxSize?: number
 }
 
 /**
@@ -1010,13 +1095,18 @@ export async function storeFile(
   target: StorageProvider,
   options: StoreFileOptions
 ): Promise<Upload> {
-  const { db, filename, mimeType, data } = options
+  const { db, filename, mimeType, data, maxSize } = options
   const ext = mime.extension(mimeType)
   const key = ext ? `${createId()}.${ext}` : createId()
 
   // For the DB provider, data goes in the Upload.data column
   // For S3/FS/etc., data goes to external storage via the provider
   const isDbProvider = target.providerType === 'db'
+
+  const cap = maxSize ?? (isDbProvider ? DB_MAX_FILE_SIZE : undefined)
+  if (cap !== undefined && data.length > cap) {
+    throw new Error(`File exceeds the ${cap} byte limit`)
+  }
 
   if (!isDbProvider) {
     await target.write(key, data, { contentType: mimeType })
@@ -1028,7 +1118,7 @@ export async function storeFile(
       status: 'completed',
       filename,
       mimeType,
-      size: data.length,
+      size: BigInt(data.length),
       storageKey: isDbProvider ? null : key,
       data: isDbProvider ? data : null,
     },
@@ -1086,10 +1176,11 @@ ship in the package rather than being reimplemented per app:
 ```ts
 /**
  * Delete a stored file: bytes first, then the Upload record. Bytes-first
- * ordering means a crash between the two steps leaves a dangling row
- * that cleanup can find — the reverse order leaves an unreachable orphan
- * file that nothing can find. A missing object is tolerated, so the call
- * is idempotent.
+ * ordering means a crash between the two steps leaves a row whose object
+ * is gone — visible to the app and fixed by retrying the call — where
+ * the reverse order leaves an unreachable orphan object that nothing
+ * references. A missing object is tolerated, so the call is idempotent
+ * and safe to retry.
  */
 export async function deleteFile(
   target: StorageProvider,
@@ -1100,7 +1191,13 @@ export async function deleteFile(
  * Delete `pending` Upload rows older than `olderThan` (default: 1 hour)
  * along with any bytes that did land in storage. Covers presigned
  * uploads that were issued but never completed, and FS uploads that
- * crashed between write and record. Run it from a recurring
+ * crashed between row creation and write. The sweep is race-safe: each
+ * row is first claimed with a conditional update (`pending` → `failed`,
+ * filtered on status and age), and only rows the claim actually matched
+ * have their bytes and row removed. Because the completion paths flip
+ * `pending` → `completed` with the same conditional pattern, a row that
+ * completes mid-sweep is skipped (its claim matches zero rows) and a
+ * claimed row can no longer complete. Run it from a recurring
  * `@cedarjs/jobs` job; the setup command's next-steps output shows the
  * job.
  */
@@ -1136,6 +1233,15 @@ interface UploadPluginOptions {
 
   /** Body limit for FS uploads — default: 50MB */
   bodyLimit?: number
+
+  /**
+   * Resolve the authenticated user for a request (e.g. from the app's
+   * auth header). When provided, upload routes reject tokens whose
+   * `sub` is a different user, so one user cannot spend another user's
+   * token. Without it, the token itself is the only identity on the
+   * route.
+   */
+  authenticate?: (req: FastifyRequest) => Promise<{ id: string } | null>
 }
 
 async function cedarUploadsPlugin(
@@ -1199,7 +1305,7 @@ type UploadToken {
   signed token.
   """
   allowedMimeTypes: [String!]!
-  maxFileSize: Int!
+  maxFileSize: BigInt!
   maxFiles: Int!
 }
 
@@ -1213,7 +1319,7 @@ type PresignedUploadUrl {
 input CreatePresignedUploadUrlInput {
   filename: String!
   contentType: String!
-  size: Int!
+  size: BigInt!
 }
 
 type Query {
@@ -1233,6 +1339,11 @@ type Mutation {
   confirmUpload(uploadId: String!): Upload! @requireAuth
 }
 ```
+
+`size` and `maxFileSize` use the `BigInt` scalar that ships with Cedar's
+GraphQL server, matching `Upload.size` — GraphQL's `Int` is signed 32-bit
+and caps at 2 GB, which the multipart and tus futures this plan
+anticipates would outgrow.
 
 #### `@requireUploadToken` Directive
 
@@ -1264,6 +1375,12 @@ const validate: ValidatorDirectiveFunc = ({ context }) => {
     tokenHeader,
     process.env.UPLOAD_TOKEN_SECRET!
   )
+
+  // A token is bound to the user it was issued to — an authenticated
+  // user cannot spend someone else's token
+  if (context.currentUser && String(context.currentUser.id) !== payload.sub) {
+    throw new Error('Upload token was issued to a different user')
+  }
 
   // Attach the validated payload to context for use in resolvers
   context.uploadTokenPayload = payload
@@ -1307,15 +1424,19 @@ export const schema = gql`
   directive @withSignedUrl on FIELD_DEFINITION
 `
 
-const transform: TransformerDirectiveFunc = async ({ resolvedValue }) => {
+const transform: TransformerDirectiveFunc = async ({
+  context,
+  resolvedValue,
+}) => {
   if (!resolvedValue) {
     return null
   }
 
-  // resolvedValue is an Upload ID
-  const upload = await db.upload.findUnique({
-    where: { id: resolvedValue },
-  })
+  // resolvedValue is an Upload ID. One DataLoader per request batches
+  // the row lookups (a transformer directive runs per field per row),
+  // and its batch query selects every column except `data`, so S3/FS
+  // rows never drag inline blobs into memory.
+  const upload = await uploadLoader(context).load(resolvedValue)
 
   if (!upload || upload.status !== 'completed') {
     return null
@@ -1323,9 +1444,14 @@ const transform: TransformerDirectiveFunc = async ({ resolvedValue }) => {
 
   const target = resolveTarget(targets, upload.target)
 
-  if (upload.data) {
-    // DB provider — return data URI
-    return `data:${upload.mimeType};base64,${upload.data.toString('base64')}`
+  if (target.providerType === 'db') {
+    // Fetch `data` only now that the target is known to be the DB
+    // provider — return a data URI
+    const { data } = await db.upload.findUniqueOrThrow({
+      where: { id: upload.id },
+      select: { data: true },
+    })
+    return `data:${upload.mimeType};base64,${data!.toString('base64')}`
   }
 
   return target.getSignedReadUrl(upload.storageKey!)
@@ -1339,20 +1465,22 @@ the target from the Upload record and resolves the right provider
 automatically. This means the directive works identically for S3, FS, DB,
 and any future provider.
 
-Two implementation requirements keep the directive safe on list queries:
+Two implementation requirements — both visible in the example above —
+keep the directive safe on list queries:
 
 - **Batch the lookups.** A transformer directive runs per field per row —
-  a 100-row list with one decorated field is 100 `findUnique` calls
-  unless the directive resolves through a per-request DataLoader keyed on
-  upload id. URL signing itself is local crypto (the S3 presigner, the FS
-  HMAC) and needs no batching.
+  a 100-row list with one decorated field is 100 single-row queries
+  unless the directive resolves through `uploadLoader`, a per-request
+  DataLoader keyed on upload id. URL signing itself is local crypto (the
+  S3 presigner, the FS HMAC) and needs no batching.
 - **Never fetch `data` for non-DB targets.** `Upload.data` holds the
-  inline bytes for DB targets; an unqualified `findUnique` drags the blob
-  into memory for every S3/FS row too. The lookup selects everything
-  except `data`, then fetches `data` only when the resolved target has
-  `providerType === 'db'`. And because the DB path embeds a full base64
-  data URI into the response, DB-target fields belong on detail queries,
-  not list queries — the DB size cap keeps the worst case bounded.
+  inline bytes for DB targets; an unqualified lookup drags the blob
+  into memory for every S3/FS row too. The loader's batch query selects
+  everything except `data`; the directive fetches `data` only when the
+  resolved target has `providerType === 'db'`. And because the DB path
+  embeds a full base64 data URI into the response, DB-target fields
+  belong on detail queries, not list queries — the DB size cap keeps the
+  worst case bounded.
 
 #### `@withDataUri` Directive
 
@@ -1443,6 +1571,15 @@ interface UseUploadTokenResult {
   requestToken: () => Promise<string>
   /** The current token (null if not yet fetched) */
   token: string | null
+  /**
+   * The profile's constraints, echoed by the server alongside the token
+   * for client-side UX. Null until the first successful fetch.
+   */
+  constraints: {
+    allowedMimeTypes: string[]
+    maxFileSize: number
+    maxFiles: number
+  } | null
   /** Loading state */
   loading: boolean
   /** Error state */
@@ -1573,7 +1710,7 @@ This hook validates file type/size client-side and returns base64-encoded
 data that the developer passes to their GraphQL mutation. The client-side
 checks are UX only — the service is the enforcement point (`storeFile()`
 applies the DB size cap, and the developer's resolver validates the MIME
-type against the profile).
+type and file count against the profile).
 
 ### React Components
 
@@ -1736,11 +1873,16 @@ async function handleS3Webhook(
   // 3. Extract S3 event from notification
   // 4. For each s3:ObjectCreated event:
   //    a. Extract the bucket and object key
-  //    b. Find the matching Upload record by storageKey
+  //    b. Resolve the target whose config matches the event's bucket
+  //       (via getConfig()), then find the Upload record by target +
+  //       storageKey — storageKey alone is not guaranteed unique across
+  //       targets
   //    c. Compare the actual S3 object size against the size recorded at
   //       presign time — on mismatch, delete the object, mark the record
   //       "failed", and stop (see "Size Enforcement")
-  //    d. Update status to "completed" and size from the actual object
+  //    d. Flip status "pending" → "completed" (conditional update — a
+  //       row the cleanup job already claimed stays untouched) and
+  //       record the actual object size
 }
 ```
 
@@ -1779,35 +1921,55 @@ export const confirmUpload = async ({ uploadId }) => {
     where: { id: uploadId },
   })
 
-  // Only the user the upload token was issued to can confirm it
+  // Only the user (and, in multi-tenant apps, the organization) the
+  // upload token was issued to can confirm it
   if (upload.userId && upload.userId !== context.currentUser.id) {
     throw new ForbiddenError("You don't have access to this upload")
+  }
+  if (
+    upload.organizationId &&
+    upload.organizationId !== context.currentUser.organizationId
+  ) {
+    throw new ForbiddenError("You don't have access to this upload")
+  }
+
+  // Only pending object-storage uploads await confirmation. DB uploads
+  // have no storageKey and complete synchronously; a row that is not
+  // pending is already settled.
+  if (upload.status !== 'pending' || !upload.storageKey) {
+    throw new Error('Upload is not awaiting confirmation')
   }
 
   const target = resolveTarget(targets, upload.target)
 
   // Verify the object actually exists in storage
-  const exists = await target.exists(upload.storageKey!)
+  const exists = await target.exists(upload.storageKey)
 
   if (!exists) {
     throw new Error('Upload not found in storage')
   }
 
   // Verify the object matches what the token authorized — a presigned
-  // PUT cannot cap body size (see "Size Enforcement")
-  const actualSize = await target.getObjectSize(upload.storageKey!)
-  if (actualSize !== null && actualSize !== Number(upload.size)) {
-    await target.delete(upload.storageKey!)
+  // PUT cannot cap body size (see "Size Enforcement"). An unknown size
+  // counts as a failed verification: a provider that cannot report size
+  // cannot prove the object is within the profile's limit.
+  const actualSize = await target.getObjectSize(upload.storageKey)
+  if (actualSize === null || BigInt(actualSize) !== upload.size) {
+    await target.delete(upload.storageKey)
     return db.upload.update({
       where: { id: uploadId },
       data: { status: 'failed' },
     })
   }
 
-  return db.upload.update({
-    where: { id: uploadId },
+  // Conditional transition — a row the cleanup job already claimed
+  // stays failed instead of being resurrected
+  await db.upload.updateMany({
+    where: { id: uploadId, status: 'pending' },
     data: { status: 'completed' },
   })
+
+  return db.upload.findUniqueOrThrow({ where: { id: uploadId } })
 }
 ```
 
@@ -1879,7 +2041,9 @@ const upload = await db.upload.findUniqueOrThrow({
   where: { id: uploadId },
 })
 const target = resolveTarget(targets, upload.target)
-const signedUrl = await target.getSignedReadUrl(upload.storageKey!, 600)
+const signedUrl = await target.getSignedReadUrl(upload.storageKey!, {
+  expiresIn: 600,
+})
 
 // Feed the signed URL to Cloudflare Images
 const response = await fetch(
@@ -1959,7 +2123,7 @@ const tusServer = new TusServer({
         status: 'completed',
         filename: upload.metadata?.filename ?? 'unknown',
         mimeType: upload.metadata?.filetype ?? 'application/octet-stream',
-        size: upload.size ?? 0,
+        size: BigInt(upload.size ?? 0),
         storageKey: upload.id, // tus-s3-store uses the upload ID as S3 key
       },
     })


### PR DESCRIPTION
Sharpens the uploads & storage implementation plan. Design-doc changes only — no code. Ranked by how much they matter:

**Security / correctness**

- **Server-defined upload profiles.** `requestUploadToken` takes a `profile: String!` naming a server-side entry in `api/src/lib/uploads.ts` (`defineUploadProfiles`), instead of an input where the client supplies `target`/`allowedMimeTypes`/`maxFileSize` and the server signs whatever was asked. Constraints are server-imposed; `@requireAuth` gates *who*, the profile gates *what*. The `UploadToken` response echoes the constraints for client UX; the authoritative copy stays inside the JWT. Web hooks and components identify uploads by `profile` accordingly.
- **Tokens and uploads are user-bound.** The token payload carries a `sub` claim; the Upload row is stamped with it as `userId`; `confirmUpload` checks ownership. A leaked token is bound to one account for its short lifetime instead of being bearer-anyone.
- **`maxFileSize` is actually enforced on the S3 path.** A presigned PUT cannot cap body size, so the plan now records the token-validated declared size on the pending row and verifies it on both completion paths (webhook and `confirmUpload`), deleting violating objects and marking the row `failed`; presigned POST policies (`content-length-range`) are documented as the hard-enforcement alternative. The FS route pairs the `Content-Length` pre-check with a streaming `fileSize` limit in `@fastify/multipart`, since the header can be absent or dishonest.
- **Serve-route hardening.** `X-Content-Type-Options: nosniff` and `Content-Disposition: attachment` by default, with inline as opt-in — the stored MIME type is client-asserted, and `image/svg+xml` on an "image" allowlist is a scriptable document (stored XSS when served inline from the app's origin).
- **Tenancy stance for `Upload`.** Nullable `organizationId` referencing the multi-tenancy plan (#2544): with Upload tenant-owned, the tenancy extension scopes the serving directives' lookups automatically, closing the cross-tenant signed-URL hole.

**API completeness / robustness**

- **`deleteFile()` and `cleanupStaleUploads()` ship in the package.** Manual lifecycle means deleting a row never deletes bytes — so the two pieces of boilerplate every app needs (bytes-first deletion, pending-row sweep) are framework utilities, not per-app reimplementations. Added to Phase 1 deliverables.
- **`@withSignedUrl` list-safety requirements.** Per-request DataLoader batching (a transformer directive runs per field per row), and `select` that excludes `Upload.data` unless the resolved target is the DB provider — an unqualified `findUnique` drags inline blobs into memory for every S3/FS row.
- **`size` is `BigInt`.** Prisma `Int` is signed 32-bit (2 GB cap); the plan itself anticipates multipart/tus futures beyond that.
- **The DB path's exception to Principle 1 gets a number.** Base64-through-GraphQL is the buffering pattern Principle 1 exists to avoid; the plan now caps DB-target profiles at 1 MB by default, enforced client- and server-side.
- **`useUploadToken` uses `fetchPolicy: 'no-cache'`** — tokens expire, so Apollo's cache must never answer that query.
- **`providerType` is part of the `StorageProvider` contract** and `storeFile()` branches on it; the main text and the Implementation Notes section now agree. Added `getObjectSize()` to the contract for completion-time verification.

**Philosophy**

- Design Principle 5 states *why* explicit lifecycle wins here without indicting the tenancy extension: the two-gate criterion from #2595 (ambient magic must prevent a silent, catastrophic omission *and* stay pure/transactional w.r.t. the query — storage hooks fail both gates, tenant scoping passes both).

**Testing:** docs-only; rendered the markdown and checked anchors/links locally.

Refs #2595, relates to #2544.
