### PR TITLE
docs(auth): Name the OAuthStrategy interface instead of an escape hatch

### DIFF
--- a/docs/docs/how-to/oauth.md
+++ b/docs/docs/how-to/oauth.md
@@ -8,7 +8,7 @@ If you haven't set up dbAuth yet, start with the [dbAuth docs](../auth/dbauth.md
 
 - **Google and GitHub, built in.** Both ship as complete strategies — OIDC discovery and id_token verification for Google, GitHub's OAuth-app-plus-userinfo flow for GitHub.
 - **Any OIDC-compliant provider**, via `createOidcStrategy` and an issuer URL — no per-provider code needed for anything that speaks standard OpenID Connect (Keycloak, Auth0, GitLab, Azure AD, ...).
-- **A custom-strategy escape hatch** for anything else (Apple, Facebook, or an internal SSO system) — implement the `OAuthStrategy` interface and you're done. Cedar's own Google and GitHub strategies are written against this exact interface, so nothing is off-limits to a userland strategy.
+- **Custom provider strategies** for anything else (Apple, Facebook, or an internal SSO system) — implement the `OAuthStrategy` interface and you're done. Cedar's own Google and GitHub strategies are written against this exact interface, so nothing is off-limits to a userland strategy.
 - **Login, signup, link, and unlink**, with guards that stop a user from ever accidentally creating a duplicate account by logging in with a provider they haven't linked yet.
 - **PKCE, `state`, and (for OIDC) `nonce` handled for you** for every provider, built on [`oauth4webapi`](https://github.com/panva/oauth4webapi). Provider access/refresh tokens are never persisted.
 - **Zero impact on apps that don't opt in.** If you never pass `--oauth`, nothing changes about dbAuth's username/password flow.

--- a/packages/auth-providers/dbAuth/setup/src/__tests__/oauth.setupData.test.ts
+++ b/packages/auth-providers/dbAuth/setup/src/__tests__/oauth.setupData.test.ts
@@ -83,11 +83,13 @@ describe('parseOAuthProviders', () => {
     expect(() => parseOAuthProviders('')).toThrow(/at least one provider/)
   })
 
-  it('throws for unknown providers, naming the custom-strategy escape hatch', () => {
+  it('throws for unknown providers, naming the `OAuthStrategy` interface', () => {
     expect(() => parseOAuthProviders('facebook')).toThrow(
-      /custom-strategy escape hatch/,
+      /implement the `OAuthStrategy` interface/,
     )
-    expect(() => parseOAuthProviders('facebook')).toThrow(/OAuthStrategy/)
+    expect(() => parseOAuthProviders('facebook')).toThrow(
+      /@cedarjs\/auth-dbauth-oauth/,
+    )
   })
 })
 

--- a/packages/auth-providers/dbAuth/setup/src/__tests__/oauthSetupHandler.test.ts
+++ b/packages/auth-providers/dbAuth/setup/src/__tests__/oauthSetupHandler.test.ts
@@ -116,7 +116,7 @@ describe('dbAuth setup command -- --oauth', () => {
     ])
   })
 
-  it('rejects an unknown provider, naming the custom-strategy escape hatch', async () => {
+  it('rejects an unknown provider, naming the `OAuthStrategy` interface', async () => {
     await expect(
       handler({
         webauthn: false,
@@ -125,7 +125,7 @@ describe('dbAuth setup command -- --oauth', () => {
         generateAuthPages: true,
         force: false,
       }),
-    ).rejects.toThrow(/custom-strategy escape hatch/)
+    ).rejects.toThrow(/implement the `OAuthStrategy` interface/)
   })
 
   it('rejects an empty --oauth value', async () => {

--- a/packages/auth-providers/dbAuth/setup/src/oauth.setupData.ts
+++ b/packages/auth-providers/dbAuth/setup/src/oauth.setupData.ts
@@ -8,8 +8,8 @@ import { addModels, functionsPath, hasModel, libPath } from './shared.js'
 
 /**
  * The OAuth providers `cedar setup auth dbAuth --oauth` knows how to
- * configure out of the box. Anything else is served by the custom-strategy
- * escape hatch documented at
+ * configure out of the box. Anything else is served by implementing the
+ * `OAuthStrategy` interface, documented at
  * https://cedarjs.com/docs/auth/dbauth#oauth-custom-strategies
  */
 export const KNOWN_OAUTH_PROVIDERS = ['google', 'github'] as const
@@ -59,9 +59,8 @@ export function parseOAuthProviders(
         `Cedar ships built-in support for ${KNOWN_OAUTH_PROVIDERS.join(
           ', ',
         )}. ` +
-        'For any other provider, use the custom-strategy escape hatch ' +
-        '(implement the `OAuthStrategy` interface from ' +
-        '`@cedarjs/auth-dbauth-oauth`) -- see ' +
+        'For any other provider, implement the `OAuthStrategy` interface ' +
+        'from `@cedarjs/auth-dbauth-oauth` -- see ' +
         'https://cedarjs.com/docs/auth/dbauth#oauth-custom-strategies',
     )
   }


### PR DESCRIPTION
Custom OAuth providers are first-class, not a fallback: the built-in Google and GitHub strategies are written against the same public `OAuthStrategy` interface that userland strategies implement. The how-to's feature bullet, the setup command's unknown-provider error message, and its JSDoc now name the interface directly instead of describing it as an escape hatch. The `#oauth-custom-strategies` docs anchor the CLI links to is unchanged.

Tested with `CI=1 yarn workspace @cedarjs/auth-dbauth-setup test` (48 passing, including the two updated error-message expectations).