### PR TITLE
fix(cli): dbAuth setup: handle prompts in non-TTY environments

### DIFF
--- a/packages/auth-providers/dbAuth/setup/src/__tests__/setup.test.ts
+++ b/packages/auth-providers/dbAuth/setup/src/__tests__/setup.test.ts
@@ -70,6 +70,10 @@ vi.mock('@cedarjs/cli-helpers', () => {
       bold: (str: string) => str,
       underline: (str: string) => str,
     },
+    // Real implementation is a no-op whenever stdin is a TTY, which it never
+    // is under vitest, so this stub only needs to not block the prompts
+    // these tests are asserting on.
+    requireTTYOrExit: () => undefined,
     // I wish I could have used something like
     // vi.requireActual(@cedarjs/cli-helpers) here, but I couldn't because
     // jest doesn't support ESM

--- a/packages/auth-providers/dbAuth/setup/src/__tests__/setupDataMockDMMF.test.ts
+++ b/packages/auth-providers/dbAuth/setup/src/__tests__/setupDataMockDMMF.test.ts
@@ -67,6 +67,10 @@ vi.mock('@cedarjs/cli-helpers', () => {
       underline: (str: string) => str,
     },
     addEnvVarTask: () => {},
+    // Real implementation is a no-op whenever stdin is a TTY, which it never
+    // is under vitest, so this stub only needs to not block the prompts
+    // these tests are asserting on.
+    requireTTYOrExit: () => undefined,
     // I wish I could have used something like
     // vi.requireActual(@cedarjs/cli-helpers) here, but I couldn't because
     // jest doesn't support ESM

--- a/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
@@ -164,7 +164,7 @@ export async function handler({
  */
 async function shouldIncludeWebAuthn(webauthn: boolean | null) {
   if (webauthn === null) {
-    requireTTYOrExit('--webauthn or --no-webauthn')
+    requireTTYOrExit('--webauthn or --webauthn=false')
 
     const webAuthnResponse = await prompts({
       type: 'confirm',
@@ -195,7 +195,7 @@ async function shouldCreateUserModel(createUserModel: boolean | null) {
   }
 
   if (createUserModel === null && !hasUserModel) {
-    requireTTYOrExit('--createUserModel or --no-createUserModel')
+    requireTTYOrExit('--createUserModel or --createUserModel=false')
 
     const createModelResponse = await prompts({
       type: 'confirm',
@@ -217,7 +217,7 @@ async function shouldCreateUserModel(createUserModel: boolean | null) {
  */
 async function shouldGenerateDbAuthPages(generateAuthPages: boolean | null) {
   if (generateAuthPages === null && !hasAuthPages()) {
-    requireTTYOrExit('--generateAuthPages or --no-generateAuthPages')
+    requireTTYOrExit('--generateAuthPages or --generateAuthPages=false')
 
     const generateAuthPagesResponse = await prompts({
       type: 'confirm',

--- a/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
@@ -3,7 +3,11 @@ import path from 'node:path'
 
 import prompts from 'prompts'
 
-import { getGraphqlPath, standardAuthHandler } from '@cedarjs/cli-helpers'
+import {
+  getGraphqlPath,
+  requireTTYOrExit,
+  standardAuthHandler,
+} from '@cedarjs/cli-helpers'
 
 import {
   apiPackages as oauthApiPackages,
@@ -160,6 +164,8 @@ export async function handler({
  */
 async function shouldIncludeWebAuthn(webauthn: boolean | null) {
   if (webauthn === null) {
+    requireTTYOrExit('--webauthn or --no-webauthn')
+
     const webAuthnResponse = await prompts({
       type: 'confirm',
       name: 'answer',
@@ -189,6 +195,8 @@ async function shouldCreateUserModel(createUserModel: boolean | null) {
   }
 
   if (createUserModel === null && !hasUserModel) {
+    requireTTYOrExit('--createUserModel or --no-createUserModel')
+
     const createModelResponse = await prompts({
       type: 'confirm',
       name: 'answer',
@@ -209,6 +217,8 @@ async function shouldCreateUserModel(createUserModel: boolean | null) {
  */
 async function shouldGenerateDbAuthPages(generateAuthPages: boolean | null) {
   if (generateAuthPages === null && !hasAuthPages()) {
+    requireTTYOrExit('--generateAuthPages or --no-generateAuthPages')
+
     const generateAuthPagesResponse = await prompts({
       type: 'confirm',
       name: 'answer',

--- a/packages/cli-helpers/src/index.ts
+++ b/packages/cli-helpers/src/index.ts
@@ -12,6 +12,7 @@ export {
 export * from './lib/paths.js'
 export * from './lib/project.js'
 export * from './lib/transpileTSToJS.js'
+export * from './lib/tty.js'
 export * from './lib/version.js'
 export * from './auth/setupHelpers.js'
 export type { AuthHandlerArgs, AuthGeneratorCtx } from './auth/setupHelpers.js'

--- a/packages/cli-helpers/src/lib/__tests__/tty.test.ts
+++ b/packages/cli-helpers/src/lib/__tests__/tty.test.ts
@@ -26,7 +26,7 @@ describe('requireTTYOrExit', () => {
       throw new Error('process.exit called')
     })
 
-    expect(() => requireTTYOrExit('--foo=true or --foo=false')).not.toThrow()
+    expect(() => requireTTYOrExit('--foo or --no-foo')).not.toThrow()
     expect(exitSpy).not.toHaveBeenCalled()
   })
 
@@ -37,7 +37,7 @@ describe('requireTTYOrExit', () => {
     })
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    expect(() => requireTTYOrExit('--foo=true or --foo=false')).toThrow(
+    expect(() => requireTTYOrExit('--foo or --no-foo')).toThrow(
       'process.exit called',
     )
 
@@ -47,7 +47,7 @@ describe('requireTTYOrExit', () => {
       ),
     )
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('--foo=true or --foo=false'),
+      expect.stringContaining('--foo or --no-foo'),
     )
     expect(exitSpy).toHaveBeenCalledWith(1)
     expect(errorTelemetry).toHaveBeenCalled()

--- a/packages/cli-helpers/src/lib/__tests__/tty.test.ts
+++ b/packages/cli-helpers/src/lib/__tests__/tty.test.ts
@@ -1,0 +1,55 @@
+import { vi, describe, it, expect, afterEach } from 'vitest'
+
+// mock Telemetry for CLI commands so they don't try to spawn a process
+vi.mock('@cedarjs/telemetry', () => {
+  return {
+    errorTelemetry: vi.fn(),
+    timedTelemetry: () => vi.fn(),
+  }
+})
+
+import { errorTelemetry } from '@cedarjs/telemetry'
+
+import { requireTTYOrExit } from '../tty.js'
+
+describe('requireTTYOrExit', () => {
+  const originalIsTTY = process.stdin.isTTY
+
+  afterEach(() => {
+    process.stdin.isTTY = originalIsTTY
+    vi.restoreAllMocks()
+  })
+
+  it('does nothing when stdin is a TTY', () => {
+    process.stdin.isTTY = true
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+
+    expect(() => requireTTYOrExit('--foo=true or --foo=false')).not.toThrow()
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('prints the given flag hint and exits when stdin is not a TTY', () => {
+    process.stdin.isTTY = false
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => requireTTYOrExit('--foo=true or --foo=false')).toThrow(
+      'process.exit called',
+    )
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Cannot prompt for confirmation in a non-interactive terminal',
+      ),
+    )
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('--foo=true or --foo=false'),
+    )
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(errorTelemetry).toHaveBeenCalled()
+  })
+})

--- a/packages/cli-helpers/src/lib/tty.ts
+++ b/packages/cli-helpers/src/lib/tty.ts
@@ -1,0 +1,26 @@
+import { errorTelemetry } from '@cedarjs/telemetry'
+
+import { colors } from './colors.js'
+
+/**
+ * Prompting libraries (e.g. `prompts`) hang indefinitely when stdin isn't a
+ * TTY - piped input, CI, or a backgrounded process never sends a keypress,
+ * so the prompt neither resolves nor throws.
+ *
+ * Call this immediately before any interactive confirm/prompt that's only
+ * reached when a flag was left unset, so a non-interactive invocation exits
+ * with a clear, actionable error instead of hanging.
+ */
+export function requireTTYOrExit(flagHint: string): void {
+  if (process.stdin.isTTY) {
+    return
+  }
+
+  const error = new Error(
+    'Cannot prompt for confirmation in a non-interactive terminal. ' +
+      `Please pass ${flagHint} explicitly.`,
+  )
+  errorTelemetry(process.argv, error.message)
+  console.error(colors.error(error.message))
+  process.exit(1)
+}

--- a/packages/cli/src/commands/setup/neon/__tests__/neonHandler.test.ts
+++ b/packages/cli/src/commands/setup/neon/__tests__/neonHandler.test.ts
@@ -64,6 +64,17 @@ vi.mock('@cedarjs/cli-helpers', () => ({
     scripts: path.join(BASE_PATH, 'scripts'),
   }),
   installPackages: { title: 'Installing packages...', task: async () => {} },
+  requireTTYOrExit: (flagHint: string) => {
+    if (process.stdin.isTTY) {
+      return
+    }
+
+    console.error(
+      'Cannot prompt for confirmation in a non-interactive terminal. ' +
+        `Please pass ${flagHint} explicitly.`,
+    )
+    process.exit(1)
+  },
 }))
 
 const { handler } = await import('../neonHandler.js')

--- a/packages/cli/src/commands/setup/neon/__tests__/neonHandler.test.ts
+++ b/packages/cli/src/commands/setup/neon/__tests__/neonHandler.test.ts
@@ -5,6 +5,8 @@ import path from 'node:path'
 import { vol, fs as memfsFs } from 'memfs'
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 
+import type * as CliHelpers from '@cedarjs/cli-helpers'
+
 import '../../../../lib/mockTelemetry.js'
 
 import { globSyncByExtension } from '../../../../__tests__/globSyncStub.js'
@@ -37,45 +39,39 @@ vi.mock('@cedarjs/cli-helpers/packageManager', () => ({
 
 const BASE_PATH = '/path/to/project'
 
-vi.mock('@cedarjs/cli-helpers', () => ({
-  colors: Object.fromEntries(
-    [
-      'error',
-      'warning',
-      'highlight',
-      'success',
-      'info',
-      'bold',
-      'underline',
-      'note',
-      'tip',
-      'important',
-      'caution',
-      'link',
-    ].map((k) => [k, (s: string) => s]),
-  ),
-  getPaths: () => ({
-    base: BASE_PATH,
-    api: {
-      base: path.join(BASE_PATH, 'api'),
-      src: path.join(BASE_PATH, 'api', 'src'),
-      lib: path.join(BASE_PATH, 'api', 'src', 'lib'),
-    },
-    scripts: path.join(BASE_PATH, 'scripts'),
-  }),
-  installPackages: { title: 'Installing packages...', task: async () => {} },
-  requireTTYOrExit: (flagHint: string) => {
-    if (process.stdin.isTTY) {
-      return
-    }
+vi.mock('@cedarjs/cli-helpers', async (importOriginal) => {
+  const original = await importOriginal<typeof CliHelpers>()
 
-    console.error(
-      'Cannot prompt for confirmation in a non-interactive terminal. ' +
-        `Please pass ${flagHint} explicitly.`,
-    )
-    process.exit(1)
-  },
-}))
+  return {
+    ...original,
+    colors: Object.fromEntries(
+      [
+        'error',
+        'warning',
+        'highlight',
+        'success',
+        'info',
+        'bold',
+        'underline',
+        'note',
+        'tip',
+        'important',
+        'caution',
+        'link',
+      ].map((k) => [k, (s: string) => s]),
+    ),
+    getPaths: () => ({
+      base: BASE_PATH,
+      api: {
+        base: path.join(BASE_PATH, 'api'),
+        src: path.join(BASE_PATH, 'api', 'src'),
+        lib: path.join(BASE_PATH, 'api', 'src', 'lib'),
+      },
+      scripts: path.join(BASE_PATH, 'scripts'),
+    }),
+    installPackages: { title: 'Installing packages...', task: async () => {} },
+  }
+})
 
 const { handler } = await import('../neonHandler.js')
 

--- a/packages/cli/src/commands/setup/neon/neonHandler.ts
+++ b/packages/cli/src/commands/setup/neon/neonHandler.ts
@@ -5,7 +5,12 @@ import execa from 'execa'
 import { Listr } from 'listr2'
 import prompts from 'prompts'
 
-import { colors, getPaths, installPackages } from '@cedarjs/cli-helpers'
+import {
+  colors,
+  getPaths,
+  installPackages,
+  requireTTYOrExit,
+} from '@cedarjs/cli-helpers'
 import { prettyPrintCedarCommand } from '@cedarjs/cli-helpers/packageManager'
 import { errorTelemetry } from '@cedarjs/telemetry'
 
@@ -108,15 +113,7 @@ export async function handler({ force, migrations, verbose }: Args) {
   // unconditionally skipped otherwise, so prompting would be pointless.
   let runMigrations = migrations
   if (!skipProvisioning && runMigrations === undefined) {
-    if (!process.stdin.isTTY) {
-      const error = new Error(
-        'Cannot prompt for confirmation in a non-interactive terminal. ' +
-          'Please pass --migrations or --no-migrations explicitly.',
-      )
-      errorTelemetry(process.argv, error.message)
-      console.error(colors.error(error.message))
-      process.exit(1)
-    }
+    requireTTYOrExit('--migrations or --no-migrations')
 
     const response = await prompts({
       type: 'toggle',


### PR DESCRIPTION
- `yarn cedar setup auth dbAuth`'s confirm prompts (WebAuthn, User model, auth pages) never resolve when stdin isn't a TTY - the `prompts` library only resolves on a keypress, so a piped/CI/backgrounded invocation hangs indefinitely instead of failing fast.
- Extracts the TTY guard already used by `setup neon` (`neonHandler.ts`) into a shared `requireTTYOrExit(flagHint)` helper in `@cedarjs/cli-helpers`, and applies it in `setup neon` and all three dbAuth setup prompts.
- A non-interactive invocation now exits immediately with a message naming the exact flag(s) to pass instead (`--webauthn`/`--no-webauthn`, `--createUserModel`/`--no-createUserModel`, `--generateAuthPages`/`--no-generateAuthPages`).
