### PR TITLE
fix(graphql-server): Call getCurrentUser when no authDecoder is configured

### DIFF
--- a/docs/docs/auth/custom.md
+++ b/docs/docs/auth/custom.md
@@ -269,6 +269,34 @@ export const handler = createGraphQLHandler({
 ```
 
 That should be enough; now, things should just work.
+
+:::info Providers with opaque tokens
+
+`authDecoder` is optional. If your provider hands out opaque access tokens (GitLab's OAuth tokens, for example), there's nothing to decode locally, so leave `authDecoder` out and validate the raw token in `getCurrentUser` instead. Cedar still calls `getCurrentUser` for every request that carries the `auth-provider` header. `decoded` is `null`, and the raw token is in the second argument:
+
+```ts title="api/src/lib/auth.ts"
+export const getCurrentUser = async (
+  _decoded: null,
+  { token, type }: { token: string; type: string }
+) => {
+  if (type !== 'custom-auth') {
+    return null
+  }
+
+  const response = await fetch('https://gitlab.com/api/v4/user', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  if (!response.ok) {
+    return null
+  }
+
+  return response.json()
+}
+```
+
+:::
+
 Let's make sure: if this is a brand new project, generate a home page.
 There we'll try to sign up by destructuring `signUp` from the `useAuth` hook (import that from `'src/auth'`). We'll also destructure and display `isAuthenticated` to see if it worked:
 

--- a/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
+++ b/docs/implementation-docs/2026-03-26-cedarjs-project-overview.md
@@ -72,7 +72,9 @@
 │  <PrivateSet> → checks isAuthenticated, redirects if false  │
 └──────────────────────────────────────────────────────────────┘
 
-DECODER INTERFACE (all providers implement this):
+DECODER INTERFACE (all built-in providers implement this; optional for a
+custom provider with opaque tokens, whose getCurrentUser validates the raw
+token itself and receives decoded = null):
   (token: string, type: string, req: {event}) → Promise<decoded | null>
 
 PROVIDERS: dbAuth(cookie), Auth0/Clerk/SuperTokens(JWKS), Firebase(admin SDK),

--- a/packages/api-server/src/__tests__/graphqlPlugin.test.ts
+++ b/packages/api-server/src/__tests__/graphqlPlugin.test.ts
@@ -13,9 +13,13 @@ import {
   expect,
 } from 'vitest'
 
+import { buildCedarContext } from '@cedarjs/api/runtime'
 import { createGraphQLYoga } from '@cedarjs/graphql-server'
 import type * as GraphqlServerModule from '@cedarjs/graphql-server'
-import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
+import type {
+  CedarGraphQLServer,
+  GraphQLYogaOptions,
+} from '@cedarjs/graphql-server'
 
 import type { createServer } from '../createServer.js'
 import type { CreateServerOptions } from '../createServerHelpers.js'
@@ -38,13 +42,15 @@ vi.mock('@cedarjs/graphql-server', async (importOriginal) => {
   }
 })
 
-// Test double: `cedarFastifyGraphQLServer` only reads `yoga.graphqlEndpoint`
-// and calls `yoga.handle`, so that's all this fake needs to implement. Safe
+// Test double: `cedarFastifyGraphQLServer` only reads `yoga.graphqlEndpoint`,
+// calls `yoga.handle`, and builds the context to hand it with
+// `buildRequestContext`, so that's all this fake needs to implement. Safe
 // because it's only ever passed to the mocked `createGraphQLYoga` above.
 function fakeYogaResult(handle: () => Promise<Response>) {
   return {
     yoga: { graphqlEndpoint: '/graphql', handle },
-  } as Awaited<ReturnType<typeof createGraphQLYoga>>
+    buildRequestContext: (request: Request) => buildCedarContext(request),
+  } as CedarGraphQLServer
 }
 
 // createGraphQLYoga is mocked in these tests, so its input is never actually

--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -10,7 +10,6 @@ import type {
   HTTPMethods,
 } from 'fastify'
 
-import { buildCedarContext } from '@cedarjs/api/runtime'
 import type { GlobalContext } from '@cedarjs/context'
 import { getAsyncStoreInstance } from '@cedarjs/context/dist/store'
 import { coerceRootPath } from '@cedarjs/fastify-web/dist/helpers.js'
@@ -87,9 +86,9 @@ export async function cedarFastifyGraphQLServer(
       method.push('PUT')
     }
 
-    const { yoga } = await createGraphQLYoga(graphqlOptions)
+    const graphqlServer = await createGraphQLYoga(graphqlOptions)
 
-    const graphqlEndpoint = trimSlashes(yoga.graphqlEndpoint)
+    const graphqlEndpoint = trimSlashes(graphqlServer.yoga.graphqlEndpoint)
 
     const routePaths = ['', '/health', '/readiness', '/stream']
     for (const routePath of routePaths) {
@@ -98,9 +97,7 @@ export async function cedarFastifyGraphQLServer(
         method,
         handler: async (req, reply) => {
           const request = createFetchRequest(req, reply)
-          const cedarContext = await buildCedarContext(request, {
-            authDecoder: graphqlOptions.authDecoder,
-          })
+          const cedarContext = await graphqlServer.buildRequestContext(request)
 
           // Phase 1 of transitional context bridge: pass both the Fetch-native
           // fields (request, cedarContext) and the legacy bridge fields
@@ -119,7 +116,7 @@ export async function cedarFastifyGraphQLServer(
           // connected. This is the fetch-native adapter pattern described in
           // the Universal Deploy integration plan.
           try {
-            return await yoga.handle(request, {
+            return await graphqlServer.yoga.handle(request, {
               request,
               cedarContext,
               event: lambdaEventForFastifyRequest(req),

--- a/packages/api/src/__tests__/runtime.test.ts
+++ b/packages/api/src/__tests__/runtime.test.ts
@@ -62,13 +62,14 @@ describe('buildCedarContext', () => {
     expect(ctx.query.getAll('tag')).toEqual(['cedar', 'framework'])
   })
 
-  // Function routes never pass an auth decoder, so there's nothing to decode
-  // and no reason to parse the `Authorization` header. Consumers that always
-  // send `auth-provider` used to get a 500 out of routes that don't use auth.
-  it('skips auth state for routes without an auth decoder', async () => {
+  // Resolving auth state parses the `Authorization` header, and consumers
+  // that always send `auth-provider` would get a 500 out of routes that don't
+  // use auth. The GraphQL server resolves auth state for its own requests.
+  it('never resolves auth state, even for a request carrying auth headers', async () => {
     const request = new Request('http://localhost:8911/tokenFromApiKey', {
       headers: {
         'auth-provider': 'custom',
+        cookie: 'auth-provider=custom; session=token-123',
       },
     })
 
@@ -77,103 +78,6 @@ describe('buildCedarContext', () => {
     })
 
     expect(ctx.serverAuthState).toBeUndefined()
-  })
-
-  it('skips auth state when the auth decoder array is empty', async () => {
-    const request = new Request('http://localhost:8911/tokenFromApiKey', {
-      headers: {
-        'auth-provider': 'custom',
-      },
-    })
-
-    const ctx = await buildCedarContext(request, { authDecoder: [] })
-
-    expect(ctx.serverAuthState).toBeUndefined()
-  })
-
-  it('hydrates auth state when an auth decoder is provided', async () => {
-    const authDecoder = vi.fn(async (token: string, type: string) => {
-      expect(token).toBe('auth-provider=test; session=token-123')
-      expect(type).toBe('test')
-
-      return {
-        sub: 'user-1',
-      }
-    })
-
-    const request = new Request('http://localhost:8911/graphql', {
-      headers: {
-        cookie: 'auth-provider=test; session=token-123',
-      },
-    })
-
-    const ctx = await buildCedarContext(request, {
-      authDecoder,
-    })
-
-    expect(authDecoder).toHaveBeenCalledTimes(1)
-    expect(ctx.serverAuthState).toEqual([
-      {
-        sub: 'user-1',
-      },
-      {
-        type: 'test',
-        schema: 'cookie',
-        token: 'auth-provider=test; session=token-123',
-      },
-      {
-        event: {
-          body: null,
-          headers: {
-            cookie: 'auth-provider=test; session=token-123',
-            'x-forwarded-proto': 'http',
-          },
-          httpMethod: 'GET',
-          isBase64Encoded: false,
-          multiValueHeaders: {
-            cookie: ['auth-provider=test; session=token-123'],
-          },
-          multiValueQueryStringParameters: null,
-          path: '/graphql',
-          pathParameters: null,
-          queryStringParameters: {},
-          requestContext: {
-            accountId: 'cedar',
-            apiId: 'cedar',
-            authorizer: undefined,
-            httpMethod: 'GET',
-            identity: {
-              accessKey: null,
-              accountId: null,
-              apiKey: null,
-              apiKeyId: null,
-              caller: null,
-              clientCert: null,
-              cognitoAuthenticationProvider: null,
-              cognitoAuthenticationType: null,
-              cognitoIdentityId: null,
-              cognitoIdentityPoolId: null,
-              principalOrgId: null,
-              sourceIp: '',
-              user: null,
-              userAgent: null,
-              userArn: null,
-            },
-            path: '/graphql',
-            protocol: 'HTTP/1.1',
-            requestId: 'cedar-request',
-            requestTimeEpoch: expect.any(Number),
-            resourceId: 'cedar',
-            resourcePath: '/graphql',
-            stage: '',
-          },
-          resource: '/graphql',
-          stageVariables: null,
-        },
-        request,
-        context: undefined,
-      },
-    ])
   })
 })
 

--- a/packages/api/src/__tests__/runtime.test.ts
+++ b/packages/api/src/__tests__/runtime.test.ts
@@ -62,14 +62,16 @@ describe('buildCedarContext', () => {
     expect(ctx.query.getAll('tag')).toEqual(['cedar', 'framework'])
   })
 
-  // Resolving auth state parses the `Authorization` header, and consumers
-  // that always send `auth-provider` would get a 500 out of routes that don't
-  // use auth. The GraphQL server resolves auth state for its own requests.
-  it('never resolves auth state, even for a request carrying auth headers', async () => {
+  // Resolving auth state parses the `Authorization` header, which throws when
+  // the header is missing or malformed. A request that carries `auth-provider`
+  // without a well-formed `Authorization` header would then 500 on a route
+  // that doesn't use auth at all, which is what consumers that always send
+  // `auth-provider` ran into. The GraphQL server resolves auth state for its
+  // own requests. See https://github.com/cedarjs/cedar/pull/2270
+  it('never resolves auth state, even for a request carrying auth-provider', async () => {
     const request = new Request('http://localhost:8911/tokenFromApiKey', {
       headers: {
         'auth-provider': 'custom',
-        cookie: 'auth-provider=custom; session=token-123',
       },
     })
 

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -113,24 +113,6 @@ export type AuthContextPayload = [
   },
 ]
 
-/**
- * Whether a project has auth configured.
- *
- * An empty decoder array counts as no auth: there's nothing to decode with, so
- * auth state can never be resolved. Anything deciding whether auth is set up
- * has to agree with `buildCedarContext` on this, or they'll disagree about
- * whether a request should have had auth state resolved.
- */
-export function hasAuthDecoder(
-  authDecoder: Decoder | Decoder[] | undefined,
-): authDecoder is Decoder | Decoder[] {
-  if (Array.isArray(authDecoder)) {
-    return authDecoder.length > 0
-  }
-
-  return !!authDecoder
-}
-
 export type Decoder = (
   token: string,
   type: string,

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -7,14 +7,21 @@ import type {
 import * as cookie from 'cookie'
 import { parse } from 'picoquery'
 
-import { getAuthenticationContext, hasAuthDecoder } from './auth/index.js'
+import type { AuthContextPayload } from './auth/index.js'
 import { requestToBaseEvent } from './transforms.js'
 
 export interface CedarRequestContext {
   params: Record<string, string>
   query: URLSearchParams
   cookies: ReadonlyMap<string, string>
-  serverAuthState?: Awaited<ReturnType<typeof getAuthenticationContext>>
+  /**
+   * The auth state the request carries, for `getCurrentUser` to turn into a
+   * current user. Only GraphQL requests have one: the GraphQL server resolves
+   * it, through the `buildRequestContext` that `createGraphQLYoga` returns,
+   * because it's the only thing that reads it. `buildCedarContext` leaves it
+   * unset.
+   */
+  serverAuthState?: AuthContextPayload
 }
 
 export type CedarHandler = (
@@ -42,7 +49,6 @@ export interface CedarRouteRecord {
 
 export interface BuildCedarContextOptions {
   params?: Record<string, string>
-  authDecoder?: Parameters<typeof getAuthenticationContext>[0]['authDecoder']
   lambdaContext?: LambdaContext
 }
 
@@ -98,29 +104,14 @@ export async function buildCedarContext(
   )
   const params = options.params ?? {}
 
-  // Only GraphQL consumes `serverAuthState`, and it's the only caller that
-  // supplies an auth decoder. Computing it for plain function routes is wasted
-  // work — without a decoder nothing can be decoded, so the payload could only
-  // ever come back with `decoded` set to `null` — and it lets `Authorization`
-  // header parse errors escape and turn requests to functions that don't use
-  // auth at all into 500s.
-  //
-  // This is also the only place auth state is resolved. It runs before the
-  // GraphQL server reads the request body, which is what keeps building the
-  // Lambda-style event here safe.
-  const serverAuthState = hasAuthDecoder(options.authDecoder)
-    ? await getAuthenticationContext({
-        authDecoder: options.authDecoder,
-        event: request,
-        context: options.lambdaContext,
-      })
-    : undefined
-
+  // Auth state is deliberately not resolved here. Plain function routes never
+  // read it, and resolving it parses the `Authorization` header, which would
+  // turn a request carrying a stray `auth-provider` header into a 500 on a
+  // function that doesn't use auth at all.
   return {
     params,
     query,
     cookies,
-    serverAuthState,
   }
 }
 

--- a/packages/api/src/runtime.ts
+++ b/packages/api/src/runtime.ts
@@ -105,9 +105,11 @@ export async function buildCedarContext(
   const params = options.params ?? {}
 
   // Auth state is deliberately not resolved here. Plain function routes never
-  // read it, and resolving it parses the `Authorization` header, which would
-  // turn a request carrying a stray `auth-provider` header into a 500 on a
-  // function that doesn't use auth at all.
+  // read it, and resolving it parses the `Authorization` header, which throws
+  // when that header is missing or malformed. A request carrying
+  // `auth-provider` without a well-formed `Authorization` header would then
+  // 500 on a function that doesn't use auth at all.
+  // See https://github.com/cedarjs/cedar/pull/2270
   return {
     params,
     query,

--- a/packages/graphql-server/src/__tests__/getCurrentUserWithoutAuthDecoder.test.ts
+++ b/packages/graphql-server/src/__tests__/getCurrentUserWithoutAuthDecoder.test.ts
@@ -1,0 +1,110 @@
+import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createLogger } from '@cedarjs/api/logger'
+
+import { createGraphQLYoga } from '../createGraphQLYoga.js'
+import { createGraphQLHandler } from '../functions/graphql.js'
+import type { GetCurrentUser } from '../types.js'
+
+/**
+ * Regression tests for https://github.com/cedarjs/cedar/issues/2592
+ *
+ * A project whose auth provider hands out opaque tokens has nothing to decode
+ * locally, so it configures `getCurrentUser` without an `authDecoder` and
+ * validates the raw token itself. Every entry point has to call
+ * `getCurrentUser` for such a project, with `null` as the decoded value and
+ * the raw token alongside it.
+ */
+
+const CURRENT_USER_QUERY = 'query CurrentUser { cedar { currentUser } }'
+
+const AUTH_HEADERS = {
+  'auth-provider': 'custom-auth',
+  authorization: 'Bearer opaque-token',
+}
+
+const getCurrentUser: GetCurrentUser = vi.fn(
+  async (decoded, { token, type }) => {
+    if (type !== 'custom-auth') {
+      return null
+    }
+
+    return { id: 'user-1', token, decoded }
+  },
+)
+
+const yogaOptions = {
+  loggerConfig: { logger: createLogger({}), options: {} },
+  sdls: {},
+  services: {},
+  getCurrentUser,
+}
+
+describe('getCurrentUser without an authDecoder', () => {
+  it('is called on the fetch-native path, with the raw token', async () => {
+    const { yoga, buildRequestContext } = await createGraphQLYoga(yogaOptions)
+
+    // The global `Request` is what the Fastify, dev and universal-deploy
+    // entry points hand `yoga.handle`. Its body can only be read once, which
+    // is why the context has to be built first.
+    const request = new globalThis.Request('http://localhost:8911/graphql', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ query: CURRENT_USER_QUERY }),
+    })
+
+    const cedarContext = await buildRequestContext(request)
+    const response = await yoga.handle(request, { request, cedarContext })
+
+    expect(getCurrentUser).toHaveBeenCalledWith(
+      null,
+      { type: 'custom-auth', schema: 'Bearer', token: 'opaque-token' },
+      expect.objectContaining({ request }),
+    )
+
+    const body = await response.json()
+
+    expect(body.data).toEqual({
+      cedar: {
+        currentUser: { id: 'user-1', token: 'opaque-token', decoded: null },
+      },
+    })
+  })
+
+  it('is called on the serverless path, with the raw token', async () => {
+    const handler = createGraphQLHandler(yogaOptions)
+
+    const event: APIGatewayProxyEvent = {
+      headers: { 'content-type': 'application/json', ...AUTH_HEADERS },
+      body: JSON.stringify({ query: CURRENT_USER_QUERY }),
+      httpMethod: 'POST',
+      multiValueQueryStringParameters: null,
+      isBase64Encoded: false,
+      multiValueHeaders: {},
+      path: '/graphql',
+      pathParameters: null,
+      stageVariables: null,
+      queryStringParameters: null,
+      // Only the fields above are read on this path
+      requestContext: null as unknown as APIGatewayProxyEvent['requestContext'],
+      resource: '/graphql',
+    }
+
+    const response = await handler(event, {} as Context)
+
+    expect(getCurrentUser).toHaveBeenCalledWith(
+      null,
+      { type: 'custom-auth', schema: 'Bearer', token: 'opaque-token' },
+      expect.objectContaining({ event }),
+    )
+
+    const body = JSON.parse(response.body)
+
+    expect(body.data).toEqual({
+      cedar: {
+        currentUser: { id: 'user-1', token: 'opaque-token', decoded: null },
+      },
+    })
+  })
+})

--- a/packages/graphql-server/src/__tests__/serverAuthState.test.ts
+++ b/packages/graphql-server/src/__tests__/serverAuthState.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { resolveServerAuthState } from '../serverAuthState.js'
+
+const getCurrentUser = vi.fn()
+
+function authenticatedRequest() {
+  return new Request('http://localhost:8911/graphql', {
+    headers: {
+      'auth-provider': 'custom-auth',
+      authorization: 'Bearer opaque-token',
+    },
+  })
+}
+
+describe('resolveServerAuthState', () => {
+  it('resolves nothing when there is no getCurrentUser to resolve for', async () => {
+    // Without a `getCurrentUser` nothing reads the auth state, and the
+    // malformed `Authorization` header here would throw if it were parsed
+    const request = new Request('http://localhost:8911/graphql', {
+      headers: {
+        'auth-provider': 'custom-auth',
+        authorization: 'no-schema',
+      },
+    })
+
+    await expect(
+      resolveServerAuthState({ authDecoder: undefined }, request),
+    ).resolves.toBeUndefined()
+  })
+
+  it('resolves nothing for an unauthenticated request', async () => {
+    const request = new Request('http://localhost:8911/graphql')
+
+    await expect(
+      resolveServerAuthState({ getCurrentUser }, request),
+    ).resolves.toBeUndefined()
+  })
+
+  // Opaque tokens can't be decoded locally, so a project validates the raw
+  // token in `getCurrentUser` instead of configuring a decoder
+  it('hands getCurrentUser the raw token when there is no decoder', async () => {
+    const authState = await resolveServerAuthState(
+      { getCurrentUser },
+      authenticatedRequest(),
+    )
+
+    expect(authState?.[0]).toBeNull()
+    expect(authState?.[1]).toEqual({
+      type: 'custom-auth',
+      schema: 'Bearer',
+      token: 'opaque-token',
+    })
+  })
+
+  it('treats an empty decoder array the same as no decoder', async () => {
+    const authState = await resolveServerAuthState(
+      { getCurrentUser, authDecoder: [] },
+      authenticatedRequest(),
+    )
+
+    expect(authState?.[0]).toBeNull()
+    expect(authState?.[1].token).toBe('opaque-token')
+  })
+
+  it('runs the decoder when there is one', async () => {
+    const authDecoder = vi.fn(async (token: string, type: string) => ({
+      token,
+      type,
+    }))
+
+    const authState = await resolveServerAuthState(
+      { getCurrentUser, authDecoder },
+      authenticatedRequest(),
+    )
+
+    expect(authDecoder).toHaveBeenCalledTimes(1)
+    expect(authState?.[0]).toEqual({
+      token: 'opaque-token',
+      type: 'custom-auth',
+    })
+  })
+})

--- a/packages/graphql-server/src/createGraphQLYoga.ts
+++ b/packages/graphql-server/src/createGraphQLYoga.ts
@@ -8,7 +8,11 @@ import {
   createYoga,
   useExecutionCancellation,
 } from 'graphql-yoga'
-import type { Plugin } from 'graphql-yoga'
+import type { Plugin, YogaServerInstance } from 'graphql-yoga'
+
+import type { Logger } from '@cedarjs/api/logger'
+import { buildCedarContext } from '@cedarjs/api/runtime'
+import type { CedarRequestContext } from '@cedarjs/api/runtime'
 
 import { mapRwCorsOptionsToYoga } from './cors.js'
 import { makeDirectivesForPlugin } from './directives/makeDirectives.js'
@@ -30,9 +34,36 @@ import type {
   UseCedarDirectiveReturn,
   DirectivePluginOptions,
 } from './plugins/useRedwoodDirective.js'
+import { resolveServerAuthState } from './serverAuthState.js'
 import { makeSubscriptions } from './subscriptions/makeSubscriptions.js'
 import type { CedarSubscription } from './subscriptions/makeSubscriptions.js'
 import type { GraphQLYogaOptions, CedarGraphQLContext } from './types.js'
+
+/**
+ * The server context Yoga is created with. The Fastify entry point adds the
+ * request and reply it's handling; every entry point adds `cedarContext`.
+ */
+type CedarYogaServerContext = {
+  req: FastifyRequest
+  reply: FastifyReply
+} & CedarGraphQLContext
+
+/**
+ * A configured Cedar GraphQL server: the Yoga instance, the logger it logs
+ * with, and the builder for the request context `yoga.handle` needs to be
+ * given. They belong together: the context the builder produces carries the
+ * auth state that this instance's plugins read.
+ */
+export interface CedarGraphQLServer {
+  yoga: YogaServerInstance<CedarYogaServerContext, Record<string, never>>
+  logger: Logger
+  /**
+   * Builds the `cedarContext` to hand `yoga.handle` for a request, with the
+   * auth state this server's `getCurrentUser` needs already resolved. Call
+   * it before `yoga.handle`, which reads the request body.
+   */
+  buildRequestContext: (request: Request) => Promise<CedarRequestContext>
+}
 
 export const createGraphQLYoga = async ({
   healthCheckId = 'yoga',
@@ -58,7 +89,7 @@ export const createGraphQLYoga = async ({
   trustedDocuments,
   openTelemetryOptions,
   includeScalars,
-}: GraphQLYogaOptions) => {
+}: GraphQLYogaOptions): Promise<CedarGraphQLServer> => {
   let schema: GraphQLSchema
   let cedarDirectivePlugins: Plugin[] = []
   const logger = loggerConfig.logger
@@ -134,7 +165,7 @@ export const createGraphQLYoga = async ({
     }
 
     // Custom Cedar plugins
-    plugins.push(useCedarAuthContext(getCurrentUser, authDecoder))
+    plugins.push(useCedarAuthContext(getCurrentUser))
     plugins.push(useCedarGlobalContextSetter())
 
     if (context) {
@@ -207,12 +238,7 @@ export const createGraphQLYoga = async ({
     // so can process any data added to results and extensions
     plugins.push(useCedarLogger(loggerConfig))
 
-    const yoga = createYoga<
-      {
-        req: FastifyRequest
-        reply: FastifyReply
-      } & CedarGraphQLContext
-    >({
+    const yoga = createYoga<CedarYogaServerContext>({
       id: healthCheckId,
       landingPage: isDevEnv,
       schema,
@@ -234,7 +260,21 @@ export const createGraphQLYoga = async ({
       },
     })
 
-    return { yoga, logger }
+    const buildRequestContext = async (
+      request: Request,
+    ): Promise<CedarRequestContext> => {
+      const cedarContext = await buildCedarContext(request)
+
+      return {
+        ...cedarContext,
+        serverAuthState: await resolveServerAuthState(
+          { authDecoder, getCurrentUser },
+          request,
+        ),
+      }
+    }
+
+    return { yoga, logger, buildRequestContext }
   } catch (e) {
     if (onException) {
       onException()

--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -5,11 +5,11 @@ import type {
 } from 'aws-lambda'
 import * as cookie from 'cookie'
 
-import { getAuthenticationContext } from '@cedarjs/api'
 import type { GlobalContext } from '@cedarjs/context'
 import { getAsyncStoreInstance } from '@cedarjs/context/dist/store'
 
 import { createGraphQLYoga } from '../createGraphQLYoga.js'
+import { resolveServerAuthState } from '../serverAuthState.js'
 import type { GraphQLHandlerOptions } from '../types.js'
 
 function lambdaQueryToSearchParams(
@@ -157,11 +157,11 @@ export const createGraphQLHandler = ({
             params: event.pathParameters ?? {},
             query: lambdaQueryToSearchParams(event),
             cookies: parseLambdaCookies(event),
-            serverAuthState: await getAuthenticationContext({
-              authDecoder,
+            serverAuthState: await resolveServerAuthState(
+              { authDecoder, getCurrentUser },
               event,
-              context: requestContext,
-            }),
+              requestContext,
+            ),
           },
         },
       )

--- a/packages/graphql-server/src/plugins/__tests__/useCedarAuthContext.test.ts
+++ b/packages/graphql-server/src/plugins/__tests__/useCedarAuthContext.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { AuthContextPayload, Decoder } from '@cedarjs/api'
+import type { AuthContextPayload } from '@cedarjs/api'
 
 import { useCedarAuthContext } from '../useCedarAuthContext.js'
-
-const authDecoder: Decoder = async (token: string) => ({ token })
 
 const MOCK_AUTH_CONTEXT_PAYLOAD: AuthContextPayload = [
   { sub: '1', email: 'ba@zin.ga' },
@@ -53,7 +51,7 @@ describe('useCedarAuthContext', () => {
     }
 
     const mockedGetCurrentUser = vi.fn().mockResolvedValue(mockUser)
-    const plugin = useCedarAuthContext(mockedGetCurrentUser, authDecoder)
+    const plugin = useCedarAuthContext(mockedGetCurrentUser)
     const onContextBuilding = plugin.onContextBuilding
 
     if (!onContextBuilding) {
@@ -90,7 +88,7 @@ describe('useCedarAuthContext', () => {
       .fn()
       .mockRejectedValue(new Error('Could not fetch user from db.'))
 
-    const plugin = useCedarAuthContext(mockedGetCurrentUser, authDecoder)
+    const plugin = useCedarAuthContext(mockedGetCurrentUser)
     const onContextBuilding = plugin.onContextBuilding
 
     if (!onContextBuilding) {
@@ -117,7 +115,7 @@ describe('useCedarAuthContext', () => {
 
   it('leaves the request unauthenticated when there is no auth state', async () => {
     const mockedGetCurrentUser = vi.fn()
-    const plugin = useCedarAuthContext(mockedGetCurrentUser, authDecoder)
+    const plugin = useCedarAuthContext(mockedGetCurrentUser)
     const onContextBuilding = plugin.onContextBuilding
 
     if (!onContextBuilding) {
@@ -140,8 +138,8 @@ describe('useCedarAuthContext', () => {
 
   // An entry point that doesn't build a context would otherwise serve every
   // request as unauthenticated, with nothing to show for it
-  it('throws when no cedarContext was built and auth is configured', async () => {
-    const plugin = useCedarAuthContext(vi.fn(), authDecoder)
+  it('throws when no cedarContext was built and getCurrentUser is configured', async () => {
+    const plugin = useCedarAuthContext(vi.fn())
     const onContextBuilding = plugin.onContextBuilding
 
     if (!onContextBuilding) {
@@ -159,31 +157,9 @@ describe('useCedarAuthContext', () => {
     ).rejects.toThrow(/no `cedarContext`/)
   })
 
-  // `buildCedarContext` treats an empty decoder array as no auth configured,
-  // so this guard has to agree — otherwise it throws on a setup that never had
-  // auth state to resolve in the first place
-  it('does not throw without a cedarContext for an empty decoder array', async () => {
-    const plugin = useCedarAuthContext(vi.fn(), [])
-    const onContextBuilding = plugin.onContextBuilding
-
-    if (!onContextBuilding) {
-      throw new Error('Expected onContextBuilding hook to be defined')
-    }
-
-    const extendContext = vi.fn()
-
-    await onContextBuilding({
-      context: contextWithoutCedarContext,
-      extendContext,
-      breakContextBuilding() {
-        return undefined
-      },
-    })
-
-    expect(extendContext).not.toHaveBeenCalled()
-  })
-
-  it('does not throw without a cedarContext when auth is not configured', async () => {
+  // `getCurrentUser` is the only consumer of auth state, so a server without
+  // one never had any to resolve in the first place
+  it('does not throw without a cedarContext when getCurrentUser is not configured', async () => {
     const plugin = useCedarAuthContext(undefined)
     const onContextBuilding = plugin.onContextBuilding
 

--- a/packages/graphql-server/src/plugins/useCedarAuthContext.ts
+++ b/packages/graphql-server/src/plugins/useCedarAuthContext.ts
@@ -1,7 +1,6 @@
 import type { Plugin } from 'graphql-yoga'
 
-import type { AuthContextPayload, Decoder } from '@cedarjs/api'
-import { hasAuthDecoder } from '@cedarjs/api'
+import type { AuthContextPayload } from '@cedarjs/api'
 
 import type { CedarGraphQLContext, GraphQLHandlerOptions } from '../types.js'
 
@@ -11,7 +10,6 @@ import type { CedarGraphQLContext, GraphQLHandlerOptions } from '../types.js'
  */
 export const useCedarAuthContext = (
   getCurrentUser: GraphQLHandlerOptions['getCurrentUser'],
-  authDecoder?: Decoder | Decoder[],
 ): Plugin<CedarGraphQLContext> => {
   return {
     async onContextBuilding({ context, extendContext }) {
@@ -22,14 +20,15 @@ export const useCedarAuthContext = (
       //
       // Every Cedar entry point builds a context. One that doesn't would serve
       // every request as unauthenticated, with nothing to show for it, so say
-      // so instead.
-      if (!context.cedarContext && hasAuthDecoder(authDecoder)) {
+      // so instead. `getCurrentUser` is the only thing that reads the auth
+      // state, so a server without one is left alone.
+      if (!context.cedarContext && getCurrentUser) {
         throw new Error(
           'Auth state is resolved when a request enters Cedar and passed on ' +
             'the GraphQL context, but this context has no `cedarContext`. ' +
-            'Whatever is invoking `yoga.handle` needs to build one with ' +
-            '`buildCedarContext` from `@cedarjs/api/runtime` and pass it as ' +
-            '`cedarContext`.',
+            'Whatever is invoking `yoga.handle` needs to build one with the ' +
+            '`buildRequestContext` returned by `createGraphQLYoga` and pass ' +
+            'it as `cedarContext`.',
         )
       }
 

--- a/packages/graphql-server/src/serverAuthState.ts
+++ b/packages/graphql-server/src/serverAuthState.ts
@@ -1,0 +1,42 @@
+import type { APIGatewayProxyEvent, Context as LambdaContext } from 'aws-lambda'
+
+import { getAuthenticationContext } from '@cedarjs/api'
+import type { AuthContextPayload } from '@cedarjs/api'
+
+import type { GraphQLYogaOptions } from './types.js'
+
+export type ServerAuthOptions = Pick<
+  GraphQLYogaOptions,
+  'authDecoder' | 'getCurrentUser'
+>
+
+/**
+ * Resolves the auth state a GraphQL request carries: the token and provider
+ * type from its `Authorization`/`auth-provider` headers or cookies, plus what
+ * the configured decoders make of the token. `getCurrentUser` turns that into
+ * the current user.
+ *
+ * `getCurrentUser` is the only consumer, so when a server has none there is
+ * nothing to resolve for. That also spares a server without auth from failing
+ * a request that carries a stray `auth-provider` header but no usable
+ * `Authorization` header.
+ *
+ * Decoders are optional. A project whose tokens can't be decoded locally, such
+ * as opaque OAuth access tokens, has `getCurrentUser` validate the raw token
+ * it's handed instead, and the decoded value it receives is `null`.
+ *
+ * On fetch-native paths this has to run before the GraphQL server reads the
+ * request body: the payload carries a Lambda-style event built from the
+ * `Request`, and building it reads the body.
+ */
+export async function resolveServerAuthState(
+  { authDecoder, getCurrentUser }: ServerAuthOptions,
+  event: APIGatewayProxyEvent | Request,
+  context?: LambdaContext,
+): Promise<AuthContextPayload | undefined> {
+  if (!getCurrentUser) {
+    return undefined
+  }
+
+  return getAuthenticationContext({ authDecoder, event, context })
+}

--- a/packages/vite/src/apiDevMiddleware.ts
+++ b/packages/vite/src/apiDevMiddleware.ts
@@ -29,7 +29,10 @@ import {
 } from '@cedarjs/babel-config'
 import { getAsyncStoreInstance } from '@cedarjs/context/dist/store'
 import { createGraphQLYoga } from '@cedarjs/graphql-server'
-import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
+import type {
+  CedarGraphQLServer,
+  GraphQLYogaOptions,
+} from '@cedarjs/graphql-server'
 import { applyGqlormInject } from '@cedarjs/internal/dist/build/api-graphql-transforms.js'
 import { getConfig, getPaths } from '@cedarjs/project-config'
 
@@ -63,22 +66,11 @@ function resolveWithExtensions(id: string): string {
 
 const LAMBDA_FUNCTIONS: Record<string, CedarHandler> = {}
 
-interface YogaInstance {
-  handle(request: Request, context: Record<string, unknown>): Promise<Response>
-  graphqlEndpoint: string
-}
-
-interface LoadedGraphqlServer {
-  yoga: YogaInstance
-  options: GraphQLYogaOptions
-}
-
-// The Yoga instance together with the options it was built from. The request
-// handler needs the options too, to build a Cedar context from their auth
-// decoder – and it has to be the decoder that belongs to this exact instance,
-// so a reload (HMR) replaces both at once and the handler reads them as one
-// value
-let loadedGraphqlServer: LoadedGraphqlServer | null = null
+// The Yoga instance together with the `buildRequestContext` that belongs to
+// it. The context it builds carries auth state resolved with this exact
+// instance's options, so a reload (HMR) replaces both at once and the handler
+// reads them as one value
+let loadedGraphqlServer: CedarGraphQLServer | null = null
 
 let loadApiFunctionsInFlight: Promise<void> | null = null
 let needsReloadAfterInFlight = false
@@ -196,8 +188,7 @@ async function internalLoadApiFunctions(viteServer: ViteDevServer) {
   await Promise.all(imports)
 
   if (extractedGraphqlOptions) {
-    const { yoga } = await createGraphQLYoga(extractedGraphqlOptions)
-    loadedGraphqlServer = { yoga, options: extractedGraphqlOptions }
+    loadedGraphqlServer = await createGraphQLYoga(extractedGraphqlOptions)
   } else {
     // Reset so deleted/missing graphql.ts is reflected immediately (i.e. during
     // a dev session)
@@ -535,8 +526,8 @@ export function createApiFetchHandler() {
     // GraphQL routes
     if (pathname === '/graphql' || pathname.startsWith('/graphql/')) {
       // Read once. A reload can replace this while the request is in flight,
-      // and the Yoga instance and the auth decoder used to build the context
-      // for it have to come from the same load.
+      // and the Yoga instance and the `buildRequestContext` used to build the
+      // context for it have to come from the same load.
       const graphqlServer = loadedGraphqlServer
 
       if (!graphqlServer) {
@@ -548,14 +539,12 @@ export function createApiFetchHandler() {
 
       return getAsyncStoreInstance().run(new Map(), async () => {
         try {
-          // `buildCedarContext` resolves auth state, and the auth payload
+          // `buildRequestContext` resolves auth state, and the auth payload
           // carries a Lambda-style event built by reading the request body.
-          // This has to happen before Yoga consumes it otherwise
-          // `buildCedarContext` would try to build the event from a `Request`
-          // that's already been consumed, which would throw.
-          const cedarContext = await buildCedarContext(request, {
-            authDecoder: graphqlServer.options.authDecoder,
-          })
+          // This has to happen before Yoga consumes it, otherwise
+          // `buildRequestContext` would try to build the event from a
+          // `Request` that's already been consumed, which would throw.
+          const cedarContext = await graphqlServer.buildRequestContext(request)
 
           return await graphqlServer.yoga.handle(request, {
             request,

--- a/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
+++ b/packages/vite/src/plugins/vite-plugin-cedar-universal-deploy.ts
@@ -11,8 +11,11 @@ import type {
   CedarRouteRecord,
   LegacyHandler,
 } from '@cedarjs/api/runtime'
-import type * as graphqlServer from '@cedarjs/graphql-server'
-import type { GraphQLYogaOptions } from '@cedarjs/graphql-server'
+import type * as graphqlServerModule from '@cedarjs/graphql-server'
+import type {
+  CedarGraphQLServer,
+  GraphQLYogaOptions,
+} from '@cedarjs/graphql-server'
 import { findApiServerFunctions } from '@cedarjs/internal/dist/files.js'
 import { getPaths } from '@cedarjs/project-config'
 
@@ -429,7 +432,7 @@ async function generateFunctionModule(distPath: string): Promise<string> {
 declare const buildCedarContext: typeof apiRuntime.buildCedarContext
 declare const requestToLegacyEvent: typeof apiRuntime.requestToLegacyEvent
 declare const wrapLegacyHandler: typeof apiRuntime.wrapLegacyHandler
-declare const createGraphQLYoga: typeof graphqlServer.createGraphQLYoga
+declare const createGraphQLYoga: typeof graphqlServerModule.createGraphQLYoga
 
 /**
  * The default export of a compiled Cedar api function, as seen from the
@@ -535,21 +538,19 @@ function createFunctionFetch(cedarHandler: CedarHandler) {
 }
 
 function createGraphQLFetch(graphqlOptions: GraphQLYogaOptions) {
-  let yogaInitPromise: ReturnType<typeof createGraphQLYoga> | null = null
+  let graphqlServerPromise: Promise<CedarGraphQLServer> | null = null
 
-  function getYoga() {
-    if (!yogaInitPromise) {
-      yogaInitPromise = createGraphQLYoga(graphqlOptions)
+  function getGraphQLServer() {
+    if (!graphqlServerPromise) {
+      graphqlServerPromise = createGraphQLYoga(graphqlOptions)
     }
 
-    return yogaInitPromise
+    return graphqlServerPromise
   }
 
   return async function fetch(request: Request) {
-    const { yoga } = await getYoga()
-    const cedarContext = await buildCedarContext(request, {
-      authDecoder: graphqlOptions?.authDecoder,
-    })
+    const graphqlServer = await getGraphQLServer()
+    const cedarContext = await graphqlServer.buildRequestContext(request)
     const event = await requestToLegacyEvent(request, cedarContext)
 
     // Wrap yoga.handle in an AsyncLocalStorage run so directive validators
@@ -562,7 +563,7 @@ function createGraphQLFetch(graphqlOptions: GraphQLYogaOptions) {
 
     try {
       const response = await store.run(new Map(), () => {
-        return yoga.handle(request, {
+        return graphqlServer.yoga.handle(request, {
           request,
           cedarContext,
           event,


### PR DESCRIPTION
Fixes #2592

## Problem

A project that configures `getCurrentUser` without an `authDecoder` gets `currentUser: null` for every GraphQL request on `cedar dev`, `cedar serve` and universal-deploy builds, with no error. `getCurrentUser` is never called on those paths, because auth state is only resolved when a decoder is present. The serverless handler resolves it unconditionally, so the same project works on Netlify, Vercel and Lambda.

Providers with opaque access tokens (GitLab OAuth, for example) have nothing to decode locally. Their `getCurrentUser` validates the raw token itself, and relies on being called with `decoded === null` and the token in the second argument. That is what `GetCurrentUser`'s type has always allowed.

## Fix

Auth state is resolved by the GraphQL server, gated on `getCurrentUser` rather than on the decoder:

- `createGraphQLYoga` returns a `CedarGraphQLServer`: the Yoga instance, its logger, and `buildRequestContext(request)`, which builds the `cedarContext` that instance's `yoga.handle` needs, with auth state resolved from the same `getCurrentUser` and `authDecoder` the instance was built from. The Fastify plugin, the Vite dev middleware and the universal-deploy GraphQL module call it before `yoga.handle` reads the body.
- The serverless handler shares the rule through `resolveServerAuthState`.
- `getCurrentUser` is the only consumer of the auth state, so a server without one skips resolution entirely. That keeps a stray `auth-provider` header without a usable `Authorization` header from failing requests on a server that doesn't do auth.
- `buildCedarContext` builds params, query and cookies only. Plain function routes never read auth state, and resolving it would parse the `Authorization` header and turn a stray `auth-provider` header into a 500 on a function that doesn't use auth. Its `authDecoder` option and the `hasAuthDecoder` helper are removed, since their only callers were Cedar's own entry points.
- The Vite dev middleware stores the `CedarGraphQLServer` whole, so a reload replaces the Yoga instance and its request-context builder as one value.

The design keeps auth resolution at the entry point, before the request body is read, and avoids a control flag on `buildCedarContext`, a no-op decoder, and request-body capture.

## Docs

The custom auth page gets a note on providers with opaque tokens, showing `getCurrentUser` validating the raw token with `authDecoder` left out.

## Testing

- New `getCurrentUserWithoutAuthDecoder.test.ts` runs the reporter's `cedar { currentUser }` query through the fetch-native path (native `Request` through `buildRequestContext` and `yoga.handle`) and the serverless handler, asserting `getCurrentUser` is called with `null` and the raw Bearer token on both.
- New `serverAuthState.test.ts` covers no consumer, unauthenticated, no decoder, empty decoder array and a real decoder.
- `@cedarjs/api` 83, `@cedarjs/graphql-server` 157, `@cedarjs/api-server` 140, `@cedarjs/vite` 240, `tasks/ud-tests` 9, all passing.
- Type builds for `graphql-server`, `api-server` and `vite`, ESLint and Prettier clean.
