### PR TITLE
fix(graphql-server): Declare `params` on the GraphQL context type

### DIFF
--- a/.changesets/graphql-context-params.md
+++ b/.changesets/graphql-context-params.md
@@ -1,0 +1,15 @@
+- fix(graphql-server): Declare `params` on the GraphQL context type
+
+A `context` function passed to `createGraphQLHandler` runs after Yoga has parsed
+the request, so the context it receives carries the operation's query, variables
+and operation name on `params`. The type did not say so, and the interface's
+index signature widened it to `unknown`, so reading a variable meant casting:
+
+```ts
+const params = gqlContext.params as
+  { variables?: Record<string, unknown> } | undefined
+```
+
+`CedarGraphQLContext` now declares `params: GraphQLParams`, so the cast is
+unnecessary. Tests pin both the variables and the request being available to a
+`context` function.

--- a/packages/graphql-server/src/__tests__/contextFunction.test.ts
+++ b/packages/graphql-server/src/__tests__/contextFunction.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { createLogger } from '@cedarjs/api/logger'
+
+import { createGraphQLYoga } from '../createGraphQLYoga.js'
+import type { CedarGraphQLContext } from '../types.js'
+
+const sdls = {
+  greet: {
+    schema: `
+      type Query {
+        greet(name: String!): String!
+      }
+    `,
+  },
+}
+
+const services = {
+  greet: { greet: ({ name }: { name: string }) => `hi ${name}` },
+}
+
+async function contextSeenBy(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
+  const seen: CedarGraphQLContext[] = []
+
+  const { yoga } = await createGraphQLYoga({
+    loggerConfig: { logger: createLogger({}) },
+    // The SDL and service shapes here are the minimum a query needs, not the
+    // full generated ones these options are typed for.
+    sdls: sdls as never,
+    services: services as never,
+    context: async ({ context }: { context: CedarGraphQLContext }) => {
+      seen.push(context)
+      return {}
+    },
+  })
+
+  const response = await yoga.fetch('http://localhost/graphql', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  })
+
+  return { context: seen[0], response }
+}
+
+// A `context` function runs after Yoga has parsed the request, so it can read
+// the operation's variables and the request's headers. These tests pin the
+// shape it reads them from.
+describe('the context function argument', () => {
+  it('carries the parsed operation variables', async () => {
+    const { context, response } = await contextSeenBy({
+      query: 'query G($name: String!) { greet(name: $name) }',
+      variables: { name: 'ada' },
+    })
+
+    expect(await response.json()).toEqual({
+      data: { greet: 'hi ada' },
+      extensions: {},
+    })
+    expect(context.params.variables).toEqual({ name: 'ada' })
+  })
+
+  it('carries the request, so headers are readable', async () => {
+    const { context } = await contextSeenBy(
+      { query: '{ greet(name: "ada") }' },
+      { 'cedar-org': 'org_1' },
+    )
+
+    expect(context.request?.headers.get('cedar-org')).toBe('org_1')
+  })
+})

--- a/packages/graphql-server/src/types.ts
+++ b/packages/graphql-server/src/types.ts
@@ -7,7 +7,7 @@ import type {
   GraphQLInterfaceType,
   DocumentNode,
 } from 'graphql'
-import type { Plugin } from 'graphql-yoga'
+import type { GraphQLParams, Plugin } from 'graphql-yoga'
 
 import type { AuthContextPayload, CorsConfig, Decoder } from '@cedarjs/api'
 import type { CedarRequestContext } from '@cedarjs/api/runtime'
@@ -89,6 +89,11 @@ export interface CedarGraphQLContext {
   event?: APIGatewayProxyEvent
   requestContext?: LambdaContext | undefined
   currentUser?: ThenArg<ReturnType<GetCurrentUser>> | AuthContextPayload | null
+  /**
+   * The GraphQL request's query, variables and operation name, as Yoga parsed
+   * them. Available to a `context` function, which runs after parsing.
+   */
+  params: GraphQLParams
 
   [index: string]: unknown
 }


### PR DESCRIPTION
A `context` function passed to `createGraphQLHandler` runs after Yoga has parsed the request, so the context it receives carries the operation's query, variables and operation name on `params`.

`CedarGraphQLContext` did not declare that field, and the interface's index signature widens anything unlisted to `unknown`, so reading a variable in a `context` function meant casting:

```ts
context: async ({ context: gqlContext }) => {
  const params = gqlContext.params as
    | { variables?: Record<string, unknown> }
    | undefined

  // ...
}
```

Declaring `params: GraphQLParams` makes the cast unnecessary.

Also adds tests for the shape a `context` function actually receives, which nothing covered: that it sees the parsed operation variables, and that it sees the `Request` so headers are readable. The second is worth pinning because on the fetch-native path the context carries `request` and no `event`, which is easy to get wrong when writing a `context` function that reads a header.

Split out of the multi-tenancy work (#2621), which reads both, since it stands on its own.
