### PR TITLE
fix(cli): Fail `cedar test` early when Vitest runs on a different Vite than the framework

### DIFF
--- a/packages/cli/src/commands/test/__tests__/viteVersionCheck.test.ts
+++ b/packages/cli/src/commands/test/__tests__/viteVersionCheck.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { getViteVersionMismatchMessage } from '../viteVersionCheck.js'
+
+const frameworkVite = { version: '7.3.6', dir: '/project/node_modules/vite' }
+const nestedVite = {
+  version: '8.2.2',
+  dir: '/project/node_modules/vitest/node_modules/vite',
+}
+
+describe('getViteVersionMismatchMessage', () => {
+  it('returns undefined when the versions match', () => {
+    const message = getViteVersionMismatchMessage({
+      vitestVite: frameworkVite,
+      frameworkVite,
+    })
+
+    expect(message).toBeUndefined()
+  })
+
+  it('returns undefined when either side is unresolved', () => {
+    expect(
+      getViteVersionMismatchMessage({ vitestVite: undefined, frameworkVite }),
+    ).toBeUndefined()
+    expect(
+      getViteVersionMismatchMessage({
+        vitestVite: nestedVite,
+        frameworkVite: undefined,
+      }),
+    ).toBeUndefined()
+  })
+
+  it('names both versions, their paths, and the pin when they differ', () => {
+    const message = getViteVersionMismatchMessage({
+      vitestVite: nestedVite,
+      frameworkVite,
+    })
+
+    expect(message).toContain('Vitest is using Vite 8.2.2')
+    expect(message).toContain(nestedVite.dir)
+    expect(message).toContain('built against Vite 7.3.6')
+    expect(message).toContain(frameworkVite.dir)
+    expect(message).toContain('override/resolution')
+    expect(message).toContain('pins vite to 7.3.6')
+  })
+})

--- a/packages/cli/src/commands/test/testHandler.ts
+++ b/packages/cli/src/commands/test/testHandler.ts
@@ -8,6 +8,7 @@ import { getPaths } from '../../lib/index.js'
 import * as project from '../../lib/project.js'
 
 import { warnIfNonStandardDatasourceUrl } from './datasourceWarning.js'
+import { assertSingleViteVersion } from './viteVersionCheck.js'
 
 type TestEsmHandlerArgs = Record<string, unknown> & {
   filter?: string[]
@@ -127,6 +128,10 @@ export const handler = async ({
 
     if (sides.includes('api')) {
       await warnIfNonStandardDatasourceUrl({ force })
+    }
+
+    if (sides.includes('web')) {
+      assertSingleViteVersion()
     }
 
     // TODO: Run vitest programmatically. See https://vitest.dev/advanced/api/

--- a/packages/cli/src/commands/test/viteVersionCheck.ts
+++ b/packages/cli/src/commands/test/viteVersionCheck.ts
@@ -1,0 +1,140 @@
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+
+import { getPaths } from '@cedarjs/project-config'
+
+export interface ResolvedVite {
+  version: string
+  dir: string
+}
+
+export interface ViteVersions {
+  /** The Vite that Vitest imports at runtime */
+  vitestVite?: ResolvedVite
+  /** The Vite that the CedarJS Vite plugins are built against */
+  frameworkVite?: ResolvedVite
+}
+
+/**
+ * Resolves `<packageName>/package.json` the way Node would from `fromFile`,
+ * returning the package's version and directory. Returns `undefined` when
+ * the package can't be resolved from there.
+ */
+function resolvePackage(
+  fromFile: string,
+  packageName: string,
+): ResolvedVite | undefined {
+  try {
+    const require = createRequire(fromFile)
+    const packageJsonPath = require.resolve(`${packageName}/package.json`)
+    const packageJson: unknown = JSON.parse(
+      fs.readFileSync(packageJsonPath, 'utf-8'),
+    )
+
+    if (
+      typeof packageJson !== 'object' ||
+      packageJson === null ||
+      !('version' in packageJson) ||
+      typeof packageJson.version !== 'string'
+    ) {
+      return undefined
+    }
+
+    return {
+      version: packageJson.version,
+      dir: path.dirname(packageJsonPath),
+    }
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Finds the Vite copy Vitest runs on and the Vite copy the framework's plugins
+ * are built against.
+ *
+ * Vitest declares a wide `vite` dependency range, so a project that doesn't
+ * pin `vite` can end up with a newer Vite nested under `node_modules/vitest`
+ * while `@cedarjs/vite` resolves the version the framework ships with. Both
+ * lookups start from the package that does the importing, which is what makes
+ * the nested copy show up.
+ */
+export function resolveViteVersions({
+  projectBase,
+  webBase,
+}: {
+  projectBase: string
+  webBase: string
+}): ViteVersions {
+  const vitest = resolvePackage(
+    path.join(projectBase, 'package.json'),
+    'vitest',
+  )
+  const vitestVite = vitest
+    ? resolvePackage(path.join(vitest.dir, 'package.json'), 'vite')
+    : undefined
+
+  const cedarVite = resolvePackage(
+    path.join(webBase, 'package.json'),
+    '@cedarjs/vite',
+  )
+  const frameworkVite = cedarVite
+    ? resolvePackage(path.join(cedarVite.dir, 'package.json'), 'vite')
+    : undefined
+
+  return { vitestVite, frameworkVite }
+}
+
+/**
+ * Returns an error message when Vitest runs on a different Vite than the
+ * framework, and `undefined` when the versions match or either side can't be
+ * resolved.
+ */
+export function getViteVersionMismatchMessage({
+  vitestVite,
+  frameworkVite,
+}: ViteVersions): string | undefined {
+  if (!vitestVite || !frameworkVite) {
+    return undefined
+  }
+
+  if (vitestVite.version === frameworkVite.version) {
+    return undefined
+  }
+
+  return (
+    `Vitest is using Vite ${vitestVite.version} from\n` +
+    `  ${vitestVite.dir}\n` +
+    `but CedarJS is built against Vite ${frameworkVite.version} from\n` +
+    `  ${frameworkVite.dir}\n\n` +
+    "The CedarJS Vite plugins only work with the Vite version they're built " +
+    "against, so web tests can't run while Vitest uses a different copy. " +
+    "This happens when the project doesn't pin `vite`, because Vitest " +
+    'accepts a wide range of Vite versions and installs the newest one.\n\n' +
+    `Please add an override/resolution that pins vite to ` +
+    `${frameworkVite.version}, then reinstall your dependencies.`
+  )
+}
+
+/**
+ * Exits with an explanatory error when Vitest would run on a different Vite
+ * than the one the CedarJS Vite plugins are built against. Called before
+ * Vitest starts so the user sees the cause instead of parse errors in every
+ * `.test.tsx` file.
+ */
+export function assertSingleViteVersion() {
+  const cedarPaths = getPaths()
+
+  const message = getViteVersionMismatchMessage(
+    resolveViteVersions({
+      projectBase: cedarPaths.base,
+      webBase: cedarPaths.web.base,
+    }),
+  )
+
+  if (message) {
+    console.error(message)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
Fixes #2601

## Summary

Vitest declares `vite: ^6 || ^7 || ^8` as a dependency, so a project that doesn't pin `vite` gets a newer Vite nested under `node_modules/vitest`. Vitest then runs on that copy while `@cedarjs/vite` and `@vitejs/plugin-react` are built against the Vite version the framework ships with. With Vite 8 nested there, Vitest sets the `oxc` option, Vite 8 discards the `esbuild.jsx` config that plugin-react contributes, Oxc falls back to the web tsconfig's `jsx: "preserve"`, and every `.test.tsx` file fails to parse with `Unexpected JSX expression`.

The crwa templates pin `vite` through yarn `resolutions` and npm/pnpm `overrides`, and the pre-upgrade scripts warn when the pin is missing, so this only affects projects that were migrated by hand. Running Vite 7 plugins inside a Vite 8 host isn't a supported layout, so rather than patching the JSX symptom, `cedar test` now fails before Vitest starts with a message that names both Vite copies and asks for a pin:

```
Vitest is using Vite 8.2.2 from
  <project>/node_modules/vitest/node_modules/vite
but CedarJS is built against Vite 7.3.6 from
  <project>/node_modules/vite

The CedarJS Vite plugins only work with the Vite version they're built against, so web tests can't run while Vitest uses a different copy. This happens when the project doesn't pin `vite`, because Vitest accepts a wide range of Vite versions and installs the newest one.

Please add an override/resolution that pins vite to 7.3.6, then reinstall your dependencies.
```

The check resolves `vite/package.json` twice the way Node would: once from vitest's own directory, once from `@cedarjs/vite`'s directory. It only runs when the web side is part of the test run, and it's skipped when either package can't be resolved. The message deliberately doesn't name the file to edit, since that differs between yarn, npm and pnpm.

## Testing

- `yarn vitest run src/commands/test` in `packages/cli`: 3 files, 33 tests pass. The new unit test covers the message function with literal inputs.
- Reproduced the issue in a tarsynced copy of the test-project fixture with the `vite` resolution removed: all 17 web test files failed with the parse error from the issue. With this change the same project exits with the message above. With the pin restored, all 17 files and 45 tests pass as before.
- `yarn workspace @cedarjs/cli build`, eslint and prettier are clean.
