### PR TITLE
docs(tenancy): state the write-path contract

### DIFF
--- a/docs/docs/tenancy.md
+++ b/docs/docs/tenancy.md
@@ -65,6 +65,13 @@ global.
 
 ### Behavior
 
+**Writes are explicit and verified; reads are ambient and fail closed.**
+Prisma's generated types still require the tenant field on creates, so you
+should keep writing it. The extension checks that every create (nested ones
+included) targets the current organization and refuses cross-tenant writes.
+Reads, updates and deletes are scoped automatically and throw
+`TenantScopeError` when no organization is in scope.
+
 Every operation keeps its own method; the extension only adds a `tenantField`
 equality to the arguments.
 

--- a/docs/docs/tenancy.md
+++ b/docs/docs/tenancy.md
@@ -67,10 +67,11 @@ global.
 
 **Creates are explicit and verified; reads, updates and deletes are ambient
 and fail closed.** Prisma's generated types still require the tenant field on
-creates, so you should keep writing it. The extension checks that every
-create (nested ones included) targets the current organization and refuses
-cross-tenant writes. Reads, updates and deletes are scoped automatically and
-throw `TenantScopeError` when no organization is in scope.
+creates, so you should keep writing it. On a scoped client, the extension
+checks that every create (nested ones included) targets the current
+organization and refuses cross-tenant writes. For tenant-owned models, reads,
+updates and deletes are scoped automatically and throw `TenantScopeError`
+when no organization is in scope.
 
 Every operation keeps its own method; the extension only adds a `tenantField`
 equality to the arguments.

--- a/docs/docs/tenancy.md
+++ b/docs/docs/tenancy.md
@@ -65,12 +65,12 @@ global.
 
 ### Behavior
 
-**Writes are explicit and verified; reads are ambient and fail closed.**
-Prisma's generated types still require the tenant field on creates, so you
-should keep writing it. The extension checks that every create (nested ones
-included) targets the current organization and refuses cross-tenant writes.
-Reads, updates and deletes are scoped automatically and throw
-`TenantScopeError` when no organization is in scope.
+**Creates are explicit and verified; reads, updates and deletes are ambient
+and fail closed.** Prisma's generated types still require the tenant field on
+creates, so you should keep writing it. The extension checks that every
+create (nested ones included) targets the current organization and refuses
+cross-tenant writes. Reads, updates and deletes are scoped automatically and
+throw `TenantScopeError` when no organization is in scope.
 
 Every operation keeps its own method; the extension only adds a `tenantField`
 equality to the arguments.


### PR DESCRIPTION
## Summary

- States the write-path contract in the tenancy reference doc, next to the create/update behavior table: writes are explicit and verified (Prisma's generated types still require the tenant field on creates, and the extension verifies every create targets the current organization), reads/updates/deletes are ambient and fail closed.

Without this, a TypeScript app's first contact with the extension's create behavior looks like a bug: Prisma query extensions can't alter generated types, so `XUncheckedCreateInput` still requires the tenant field even though the extension would inject it at runtime. Belt and suspenders — the type system stops you omitting the tenant field, the extension stops you naming the wrong one.

Closes #2629

## Testing notes

- `yarn format` (ran automatically via pre-push hook)