### PR TITLE
fix(tenancy): make lookupOrg's id/slug resolution deterministic

### DIFF
--- a/docs/docs/how-to/multi-tenancy.md
+++ b/docs/docs/how-to/multi-tenancy.md
@@ -264,9 +264,13 @@ before any resolver runs:
 +      event: requestEvent,
 +      variables: params.variables,
 +      currentUser,
-+      lookupOrg: (idOrSlug) =>
-+        db.organization.findFirst({
-+          where: { OR: [{ id: idOrSlug }, { slug: idOrSlug }] },
++      lookupOrg: async (idOrSlug) =>
++        (await db.organization.findUnique({
++          where: { id: idOrSlug },
++          select: { id: true, slug: true },
++        })) ??
++        db.organization.findUnique({
++          where: { slug: idOrSlug },
 +          select: { id: true, slug: true },
 +        }),
 +    })

--- a/docs/docs/how-to/multi-tenancy.md
+++ b/docs/docs/how-to/multi-tenancy.md
@@ -265,11 +265,11 @@ before any resolver runs:
 +      variables: params.variables,
 +      currentUser,
 +      lookupOrg: async (idOrSlug) =>
-+        (await db.organization.findFirst({
++        (await db.organization.findUnique({
 +          where: { id: idOrSlug },
 +          select: { id: true, slug: true },
 +        })) ??
-+        db.organization.findFirst({
++        db.organization.findUnique({
 +          where: { slug: idOrSlug },
 +          select: { id: true, slug: true },
 +        }),

--- a/docs/docs/how-to/multi-tenancy.md
+++ b/docs/docs/how-to/multi-tenancy.md
@@ -265,11 +265,11 @@ before any resolver runs:
 +      variables: params.variables,
 +      currentUser,
 +      lookupOrg: async (idOrSlug) =>
-+        (await db.organization.findUnique({
++        (await db.organization.findFirst({
 +          where: { id: idOrSlug },
 +          select: { id: true, slug: true },
 +        })) ??
-+        db.organization.findUnique({
++        db.organization.findFirst({
 +          where: { slug: idOrSlug },
 +          select: { id: true, slug: true },
 +        }),

--- a/docs/docs/tenancy.md
+++ b/docs/docs/tenancy.md
@@ -224,11 +224,11 @@ import { authDecoder, getCurrentUser } from 'src/lib/auth'
 import { db } from 'src/lib/db'
 
 const lookupOrg = async (idOrSlug: string) =>
-  (await db.organization.findFirst({
+  (await db.organization.findUnique({
     where: { id: idOrSlug },
     select: { id: true, slug: true },
   })) ??
-  db.organization.findFirst({
+  db.organization.findUnique({
     where: { slug: idOrSlug },
     select: { id: true, slug: true },
   })
@@ -255,11 +255,11 @@ import { authDecoder, getCurrentUser } from 'api/src/lib/auth'
 import { db } from 'api/src/lib/db'
 
 const lookupOrg = async (idOrSlug: string) =>
-  (await db.organization.findFirst({
+  (await db.organization.findUnique({
     where: { id: idOrSlug },
     select: { id: true, slug: true },
   })) ??
-  db.organization.findFirst({
+  db.organization.findUnique({
     where: { slug: idOrSlug },
     select: { id: true, slug: true },
   })

--- a/docs/docs/tenancy.md
+++ b/docs/docs/tenancy.md
@@ -223,9 +223,13 @@ import { withTenancy } from '@cedarjs/tenancy'
 import { authDecoder, getCurrentUser } from 'src/lib/auth'
 import { db } from 'src/lib/db'
 
-const lookupOrg = (idOrSlug: string) =>
-  db.organization.findFirst({
-    where: { OR: [{ id: idOrSlug }, { slug: idOrSlug }] },
+const lookupOrg = async (idOrSlug: string) =>
+  (await db.organization.findUnique({
+    where: { id: idOrSlug },
+    select: { id: true, slug: true },
+  })) ??
+  db.organization.findUnique({
+    where: { slug: idOrSlug },
     select: { id: true, slug: true },
   })
 
@@ -250,9 +254,13 @@ import { withTenancy } from '@cedarjs/tenancy'
 import { authDecoder, getCurrentUser } from 'api/src/lib/auth'
 import { db } from 'api/src/lib/db'
 
-const lookupOrg = (idOrSlug: string) =>
-  db.organization.findFirst({
-    where: { OR: [{ id: idOrSlug }, { slug: idOrSlug }] },
+const lookupOrg = async (idOrSlug: string) =>
+  (await db.organization.findUnique({
+    where: { id: idOrSlug },
+    select: { id: true, slug: true },
+  })) ??
+  db.organization.findUnique({
+    where: { slug: idOrSlug },
     select: { id: true, slug: true },
   })
 

--- a/docs/docs/tenancy.md
+++ b/docs/docs/tenancy.md
@@ -224,11 +224,11 @@ import { authDecoder, getCurrentUser } from 'src/lib/auth'
 import { db } from 'src/lib/db'
 
 const lookupOrg = async (idOrSlug: string) =>
-  (await db.organization.findUnique({
+  (await db.organization.findFirst({
     where: { id: idOrSlug },
     select: { id: true, slug: true },
   })) ??
-  db.organization.findUnique({
+  db.organization.findFirst({
     where: { slug: idOrSlug },
     select: { id: true, slug: true },
   })
@@ -255,11 +255,11 @@ import { authDecoder, getCurrentUser } from 'api/src/lib/auth'
 import { db } from 'api/src/lib/db'
 
 const lookupOrg = async (idOrSlug: string) =>
-  (await db.organization.findUnique({
+  (await db.organization.findFirst({
     where: { id: idOrSlug },
     select: { id: true, slug: true },
   })) ??
-  db.organization.findUnique({
+  db.organization.findFirst({
     where: { slug: idOrSlug },
     select: { id: true, slug: true },
   })

--- a/packages/cli/src/commands/setup/tenancy/__testfixtures__/defaultGraphql.output.ts
+++ b/packages/cli/src/commands/setup/tenancy/__testfixtures__/defaultGraphql.output.ts
@@ -50,11 +50,11 @@ export const handler = createGraphQLHandler({
       variables: params.variables,
       currentUser,
       lookupOrg: async (idOrSlug) =>
-        (await db.organization.findUnique({
+        (await db.organization.findFirst({
           where: { id: idOrSlug },
           select: { id: true, slug: true },
         })) ??
-        db.organization.findUnique({
+        db.organization.findFirst({
           where: { slug: idOrSlug },
           select: { id: true, slug: true },
         }),

--- a/packages/cli/src/commands/setup/tenancy/__testfixtures__/defaultGraphql.output.ts
+++ b/packages/cli/src/commands/setup/tenancy/__testfixtures__/defaultGraphql.output.ts
@@ -49,9 +49,13 @@ export const handler = createGraphQLHandler({
       event: requestEvent,
       variables: params.variables,
       currentUser,
-      lookupOrg: (idOrSlug) =>
-        db.organization.findFirst({
-          where: { OR: [{ id: idOrSlug }, { slug: idOrSlug }] },
+      lookupOrg: async (idOrSlug) =>
+        (await db.organization.findUnique({
+          where: { id: idOrSlug },
+          select: { id: true, slug: true },
+        })) ??
+        db.organization.findUnique({
+          where: { slug: idOrSlug },
           select: { id: true, slug: true },
         }),
     })

--- a/packages/cli/src/commands/setup/tenancy/__testfixtures__/defaultGraphql.output.ts
+++ b/packages/cli/src/commands/setup/tenancy/__testfixtures__/defaultGraphql.output.ts
@@ -50,11 +50,11 @@ export const handler = createGraphQLHandler({
       variables: params.variables,
       currentUser,
       lookupOrg: async (idOrSlug) =>
-        (await db.organization.findFirst({
+        (await db.organization.findUnique({
           where: { id: idOrSlug },
           select: { id: true, slug: true },
         })) ??
-        db.organization.findFirst({
+        db.organization.findUnique({
           where: { slug: idOrSlug },
           select: { id: true, slug: true },
         }),

--- a/packages/cli/src/commands/setup/tenancy/graphqlCodemod.ts
+++ b/packages/cli/src/commands/setup/tenancy/graphqlCodemod.ts
@@ -32,11 +32,11 @@ function buildContextProperty() {
           variables: params.variables,
           currentUser,
           lookupOrg: async (idOrSlug) =>
-            (await db.organization.findFirst({
+            (await db.organization.findUnique({
               where: { id: idOrSlug },
               select: { id: true, slug: true },
             })) ??
-            db.organization.findFirst({
+            db.organization.findUnique({
               where: { slug: idOrSlug },
               select: { id: true, slug: true },
             }),

--- a/packages/cli/src/commands/setup/tenancy/graphqlCodemod.ts
+++ b/packages/cli/src/commands/setup/tenancy/graphqlCodemod.ts
@@ -31,9 +31,13 @@ function buildContextProperty() {
           event: requestEvent,
           variables: params.variables,
           currentUser,
-          lookupOrg: (idOrSlug) =>
-            db.organization.findFirst({
-              where: { OR: [{ id: idOrSlug }, { slug: idOrSlug }] },
+          lookupOrg: async (idOrSlug) =>
+            (await db.organization.findUnique({
+              where: { id: idOrSlug },
+              select: { id: true, slug: true },
+            })) ??
+            db.organization.findUnique({
+              where: { slug: idOrSlug },
               select: { id: true, slug: true },
             }),
         })

--- a/packages/cli/src/commands/setup/tenancy/graphqlCodemod.ts
+++ b/packages/cli/src/commands/setup/tenancy/graphqlCodemod.ts
@@ -32,11 +32,11 @@ function buildContextProperty() {
           variables: params.variables,
           currentUser,
           lookupOrg: async (idOrSlug) =>
-            (await db.organization.findUnique({
+            (await db.organization.findFirst({
               where: { id: idOrSlug },
               select: { id: true, slug: true },
             })) ??
-            db.organization.findUnique({
+            db.organization.findFirst({
               where: { slug: idOrSlug },
               select: { id: true, slug: true },
             }),


### PR DESCRIPTION
## Summary

The `graphqlCodemod`-generated `lookupOrg` resolved an organization with `findFirst` over `OR: [{ id }, { slug }]`. Slugs and cuids share an alphabet, so a slugified name can equal another organization's id. When both branches of the `OR` match different rows, `findFirst` with no `orderBy` returns an arbitrary one — resolution becomes nondeterministic in that corner case.

This replaces the `OR`/`findFirst` shape with two deterministic `findUnique` lookups, id first:

```ts
lookupOrg: async (idOrSlug) =>
  (await db.organization.findUnique({
    where: { id: idOrSlug },
    select: { id: true, slug: true },
  })) ??
  db.organization.findUnique({
    where: { slug: idOrSlug },
    select: { id: true, slug: true },
  }),
```

Both columns are unique, so this is two indexed lookups with zero ambiguity, and the same can't-probe security property (`setCurrentOrg` still requires membership; non-member/nonexistent stay indistinguishable). `findUnique` also enforces that assumption at compile time: if `Organization.slug`'s `@unique` is ever dropped (the generated template declares it, so this only bites a customized model), the build fails loudly instead of silently reintroducing the nondeterminism this PR fixes.

Updated the codemod snippet, its test fixture, and the two docs pages that show the same shape (`docs/docs/tenancy.md`, `docs/docs/how-to/multi-tenancy.md`).

Fixes #2637

## Test plan

- `yarn vitest run --project "setup codemods" src/commands/setup/tenancy/__codemod_tests__/graphqlCodemod.test.ts` (from `packages/cli`) — passes
- `yarn eslint packages/cli/src/commands/setup/tenancy/graphqlCodemod.ts` — clean