### PR TITLE
docs(tenancy): state the URL opinion — the organization lives in the URL

### DIFF
--- a/docs/docs/how-to/multi-tenancy.md
+++ b/docs/docs/how-to/multi-tenancy.md
@@ -114,9 +114,9 @@ are carried over from the article, stated as Cedar defaults:
   swapping in a Prisma enum.
 - **`Organization.slug` exists for URLs** (`/org/acme/projects`). Resolving the
   current organization by `id` or by `slug` are both supported. **The
-  organization lives in the URL** &mdash; see
-  [section 4](#4-request-flow-url-to-header-to-context) for why this is a
-  Cedar opinion, not just an option.
+  organization is part of the URL**. See
+  [section 4](#4-request-flow-url-to-header-to-context) for why this is a Cedar
+  opinion, not just an option.
 - **Every user belongs to an organization from signup.** Signup either claims a
   pending invitation or creates an `Organization` named after the user with an
   `owner` membership, so an app never accumulates user-owned resources that
@@ -461,19 +461,20 @@ which is the intended fail-closed behaviour rather than a silent empty list.
 ## 4. Request flow: URL to header to context
 
 **The organization lives in the URL.** Put the slug in the path
-(`/org/{orgSlug}/…`) even while every user has exactly one organization: links
+(`/org/{orgSlug}/...`) even while every user has exactly one organization: links
 and bookmarks stay unambiguous once a user later belongs to several, support
 staff can reach a customer organization with a URL and a membership, and going
-multi-org changes no routes. Deriving the current organization from the
-signed-in user's membership instead (skipping the URL segment) looks
-convenient and is almost always regretted &mdash; the first shared link or the
-first "look at this customer's account" request exposes the gap.
+multi-org changes no routes. Deriving the current organization from the signed-
+in user's membership instead (skipping the URL segment) looks convenient and is
+almost always regretted. As soon as you want to share a link to a page or the
+first time you want to handle a "look at this customer's account" request you'll
+be thankful you made the org a part of the URL.
 
 The `orgSlug` prop and `resolveCurrentOrg`'s variable fallbacks (below) exist
-for the cases where the organization genuinely can't live in the path &mdash;
-a subdomain- or custom-domain-derived organization (white-label deployments),
-or an in-page switcher that doesn't navigate. They are not an invitation to
-keep it out of the URL for tidiness.
+for the cases where the organization genuinely can't live in the path, like for
+a subdomain- or custom-domain-derived organization (white-label deployments), or
+an in-page switcher that doesn't navigate. They are not an invitation to keep it
+out of the URL for tidiness.
 
 Every GraphQL request that carries a current organization goes through the same
 four steps:

--- a/docs/docs/how-to/multi-tenancy.md
+++ b/docs/docs/how-to/multi-tenancy.md
@@ -472,8 +472,8 @@ first "look at this customer's account" request exposes the gap.
 The `orgSlug` prop and `resolveCurrentOrg`'s variable fallbacks (below) exist
 for the cases where the organization genuinely can't live in the path &mdash;
 a subdomain- or custom-domain-derived organization (white-label deployments),
-or an in-page switcher that navigates. They are not an invitation to keep it
-out of the URL for tidiness.
+or an in-page switcher that doesn't navigate. They are not an invitation to
+keep it out of the URL for tidiness.
 
 Every GraphQL request that carries a current organization goes through the same
 four steps:

--- a/docs/docs/how-to/multi-tenancy.md
+++ b/docs/docs/how-to/multi-tenancy.md
@@ -113,7 +113,10 @@ are carried over from the article, stated as Cedar defaults:
   [section 7](#7-strict-variant-compound-primary-keys-and-postgres-rls) for
   swapping in a Prisma enum.
 - **`Organization.slug` exists for URLs** (`/org/acme/projects`). Resolving the
-  current organization by `id` or by `slug` are both supported.
+  current organization by `id` or by `slug` are both supported. **The
+  organization lives in the URL** &mdash; see
+  [section 4](#4-request-flow-url-to-header-to-context) for why this is a
+  Cedar opinion, not just an option.
 - **Every user belongs to an organization from signup.** Signup either claims a
   pending invitation or creates an `Organization` named after the user with an
   `owner` membership, so an app never accumulates user-owned resources that
@@ -457,12 +460,27 @@ which is the intended fail-closed behaviour rather than a silent empty list.
 
 ## 4. Request flow: URL to header to context
 
+**The organization lives in the URL.** Put the slug in the path
+(`/org/{orgSlug}/…`) even while every user has exactly one organization: links
+and bookmarks stay unambiguous once a user later belongs to several, support
+staff can reach a customer organization with a URL and a membership, and going
+multi-org changes no routes. Deriving the current organization from the
+signed-in user's membership instead (skipping the URL segment) looks
+convenient and is almost always regretted &mdash; the first shared link or the
+first "look at this customer's account" request exposes the gap.
+
+The `orgSlug` prop and `resolveCurrentOrg`'s variable fallbacks (below) exist
+for the cases where the organization genuinely can't live in the path &mdash;
+a subdomain- or custom-domain-derived organization (white-label deployments),
+or an in-page switcher that navigates. They are not an invitation to keep it
+out of the URL for tidiness.
+
 Every GraphQL request that carries a current organization goes through the same
 four steps:
 
-1. **URL or variable.** The web app is either on a route like
-   `/org/acme/projects` (an `orgSlug` route param) or has an organization
-   id/slug available some other way (a switcher stored in state, for example).
+1. **URL or variable.** The web app is on a route like `/org/acme/projects`
+   (an `orgSlug` route param), or, for the cases above, has an organization
+   id/slug available some other way.
 2. **Header.** `OrgScope` (see
    [section 5](#5-services-directives-and-web-hooks)) builds a per-organization
    Apollo client that sends a `cedar-org` header with every request. This is the

--- a/docs/docs/tenancy.md
+++ b/docs/docs/tenancy.md
@@ -380,8 +380,8 @@ The generated `web/src/components/OrgScope/OrgScope.tsx` wraps the core
 can't import your app's auth directly, so it takes `useAuth` as a prop,
 defaulting to `useNoAuth` from `@cedarjs/auth`) and a not-a-member message.
 
-`orgSlug` resolves from `useParams().orgSlug` by default &mdash; the
-organization lives in the URL (see the
+`orgSlug` resolves from `useParams().orgSlug` by default as the organization
+lives in the URL (see the
 [multi-tenancy how-to](./how-to/multi-tenancy.md#4-request-flow-url-to-header-to-context)
 for why). Pass the `orgSlug` prop only when it genuinely can't come from the
 route: a subdomain- or custom-domain-derived organization, or an in-page

--- a/docs/docs/tenancy.md
+++ b/docs/docs/tenancy.md
@@ -380,9 +380,12 @@ The generated `web/src/components/OrgScope/OrgScope.tsx` wraps the core
 can't import your app's auth directly, so it takes `useAuth` as a prop,
 defaulting to `useNoAuth` from `@cedarjs/auth`) and a not-a-member message.
 
-`orgSlug` resolves from `useParams().orgSlug` by default; pass the `orgSlug`
-prop to source it from state instead (an organization switcher that isn't
-URL-driven, for example). `memberships` come from
+`orgSlug` resolves from `useParams().orgSlug` by default &mdash; the
+organization lives in the URL (see the
+[multi-tenancy how-to](./how-to/multi-tenancy.md#4-request-flow-url-to-header-to-context)
+for why). Pass the `orgSlug` prop only when it genuinely can't come from the
+route: a subdomain- or custom-domain-derived organization, or an in-page
+switcher that doesn't navigate. `memberships` come from
 `getMemberships(useAuth().currentUser)`. Internally, `OrgScope` builds (or
 reuses) a per-organization Apollo client keyed by `${userId}:${organizationId}`
 and renders:


### PR DESCRIPTION
## Summary

The tenancy how-to was opinionated about the *model* (the assistant test, the loose-tenant default) but neutral about the *URL*: section 4 presented "a route like `/org/acme/projects`" and "an organization id/slug available some other way (a switcher stored in state, for example)" as equal choices, with no stated preference. The `OrgScope` reference doc had the same neutrality.

Cedar does have an opinion here, and this states it: **the organization lives in the URL.**

- Links must identify the org — once a user has (or can ever have) two organizations, a shared/bookmarked link without the org in the path is ambiguous.
- Support/admin access — org-in-URL plus a support membership is the natural way to let someone at the company look at a customer's account; the state-derived shape has no story for this.
- Multi-org becomes purely additive — with the slug already in the path, going from one org per user to many changes no routes and breaks no links.

The `orgSlug` prop and `resolveCurrentOrg`'s header/variable fallbacks are kept as documented escape hatches for the cases where the org genuinely can't live in the path (subdomain-/custom-domain-derived orgs, an in-page switcher that navigates) — not as a routine alternative.

Changes:
- `docs/docs/how-to/multi-tenancy.md`: opinionated paragraph at the top of section 4, plus a pointer from the `Organization.slug` bullet in section 2.
- `docs/docs/tenancy.md`: aligned the `OrgScope` reference section to the same opinion instead of presenting the state-derived `orgSlug` prop neutrally.

Fixes #2638

## Test plan

- `yarn prettier --write` on both changed docs files — no formatting issues
- Read through both files to check the new prose flows with the surrounding sections