### PR TITLE
feat(testing): add mockRouteParams() for testing components with route params

### DIFF
--- a/docs/docs/how-to/multi-tenancy.md
+++ b/docs/docs/how-to/multi-tenancy.md
@@ -1107,3 +1107,9 @@ articles this how-to draws on both call out, restated for Cedar:
   grouping by `userId` mixes activity from every organization that user is in
   into one bucket, which is exactly the cross-tenant leak the rest of this
   feature exists to prevent.
+- **Cell tests for org-scoped components.** A component rendered in isolation
+  has no matched route, so `useParams()` sees no `orgSlug`; a component that
+  reads it and passes it to a generated `routes.*()` call fails route param
+  validation in the test. Use `mockRouteParams({ orgSlug: 'acme' })` before
+  `render()` &mdash; see [`mockRouteParams()`](../testing.md#mockrouteparams)
+  in the testing docs.

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -767,6 +767,47 @@ mockCurrentUser({ roles: [] })
 
 That's it!
 
+#### mockRouteParams()
+
+A component rendered in isolation (a cell test, for example) has no matched
+route, so `useParams()` returns an empty object: any route param your route
+declares &mdash; `{orgSlug}` in `/org/{orgSlug}/projects`, say &mdash; is
+`undefined`. If the component reads that param and passes it to a generated
+`routes.*()` call (building a `<Link>`, for instance), the missing value
+fails route param validation:
+
+```
+Error: Missing parameter 'orgSlug' for route '/org/{orgSlug}/projects'
+```
+
+`mockRouteParams()` sets what `useParams()` (and, through it, any `routes.*()`
+call built from those params) sees in that render, the same way
+`mockCurrentUser()` sets what `useAuth().currentUser` sees:
+
+```jsx title="web/src/components/ProjectsCell/ProjectsCell.test.js"
+import { render, screen } from '@cedarjs/testing/web'
+import { mockRouteParams } from '@cedarjs/testing/web'
+
+import { Success } from './ProjectsCell'
+
+describe('ProjectsCell', () => {
+  it('renders links scoped to the current organization', () => {
+    mockRouteParams({ orgSlug: 'acme' })
+
+    render(<Success projects={[{ id: 1, name: 'Website redesign' }]} />)
+
+    expect(screen.getByRole('link', { name: 'Website redesign' })).toHaveAttribute(
+      'href',
+      '/org/acme/projects/1'
+    )
+  })
+})
+```
+
+Call it before `render()`, the same as `mockCurrentUser()`. It's a plain
+substitute for the route params a matched route would otherwise provide, not
+a router mock &mdash; it doesn't affect `location` or navigation.
+
 ### Handling Duplication
 
 We had to duplicate the `mockCurrentUser()` call and duplication is usually another sign that things can be refactored. In Vitest you can nest `describe` blocks and include setup that is shared by the members of that block:

--- a/packages/testing/src/web/MockParamsProvider.tsx
+++ b/packages/testing/src/web/MockParamsProvider.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import { useLocation, ParamsContext, parseSearch } from '@cedarjs/router'
 
+import { mockedRouteParamsMeta } from './mockRequests.js'
+
 interface Props {
   children?: React.ReactNode
 }
@@ -10,8 +12,15 @@ export const MockParamsProvider: React.FC<Props> = ({ children }) => {
   const location = useLocation()
   const searchParams = parseSearch(location.search)
 
+  // Path params (set via `mockRouteParams`) take precedence over search
+  // params, the same order `Router` combines them in when actually matching
+  // a route: `{ ...searchParams, ...pathParams }`.
   return (
-    <ParamsContext.Provider value={{ params: { ...searchParams } }}>
+    <ParamsContext.Provider
+      value={{
+        params: { ...searchParams, ...mockedRouteParamsMeta.params },
+      }}
+    >
       {children}
     </ParamsContext.Provider>
   )

--- a/packages/testing/src/web/__tests__/MockParamsProvider.test.tsx
+++ b/packages/testing/src/web/__tests__/MockParamsProvider.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+
+import { LocationProvider, useParams } from '@cedarjs/router'
+
+import { MockParamsProvider } from '../MockParamsProvider.js'
+import { mockRouteParams } from '../mockRequests.js'
+
+const ParamsDisplay = () => {
+  const params = useParams()
+
+  return <div data-testid="params">{JSON.stringify(params)}</div>
+}
+
+describe('MockParamsProvider', () => {
+  it('exposes params set with mockRouteParams() to useParams()', () => {
+    mockRouteParams({ orgSlug: 'acme' })
+
+    render(
+      <LocationProvider>
+        <MockParamsProvider>
+          <ParamsDisplay />
+        </MockParamsProvider>
+      </LocationProvider>,
+    )
+
+    expect(screen.getByTestId('params')).toHaveTextContent(
+      JSON.stringify({ orgSlug: 'acme' }),
+    )
+  })
+
+  it('lets route params set with mockRouteParams() take precedence over the URL search string', () => {
+    mockRouteParams({ orgSlug: 'from-mock' })
+
+    render(
+      <LocationProvider
+        location={new URL('https://example.com/?orgSlug=from-url')}
+      >
+        <MockParamsProvider>
+          <ParamsDisplay />
+        </MockParamsProvider>
+      </LocationProvider>,
+    )
+
+    expect(screen.getByTestId('params')).toHaveTextContent(
+      JSON.stringify({ orgSlug: 'from-mock' }),
+    )
+  })
+})

--- a/packages/testing/src/web/mockRequests.ts
+++ b/packages/testing/src/web/mockRequests.ts
@@ -327,3 +327,21 @@ export const mockCurrentUser = (user: Record<string, unknown> | null) => {
     }
   })
 }
+
+export const mockedRouteParamsMeta: { params: Record<string, string> } = {
+  params: {},
+}
+
+/**
+ * Sets the route params `useParams()` (and generated `routes.*()` calls, via
+ * `MockRouter`) see in a rendered-in-isolation test -- a cell test, for
+ * example, has no matched route to read `{orgSlug}` or similar path params
+ * from. Mirrors `mockCurrentUser`'s effect on `useAuth().currentUser`.
+ *
+ * ```ts
+ * mockRouteParams({ orgSlug: 'acme' })
+ * ```
+ */
+export const mockRouteParams = (params: Record<string, string>) => {
+  mockedRouteParamsMeta.params = params
+}


### PR DESCRIPTION
## Summary

Cell/component tests for apps whose routes carry params (e.g. tenancy's URL-org pattern, `/org/{orgSlug}/…`) failed with `Missing parameter 'orgSlug' for route …` unless each test file hand-mocked `useParams`. A component rendered in isolation (a cell test, for example) has no matched route, so `useParams()` returns `{}`; if the component passes that param straight to a generated `routes.*()` call (building a `<Link>`, say), `replaceParams`'s strict validation throws.

The working per-file workaround was:

```ts
vi.mock('@cedarjs/router', async (importOriginal) => ({
  ...(await importOriginal<typeof import('@cedarjs/router')>()),
  useParams: () => ({ orgSlug: 'test-vvs' }),
}))
```

— brittle across framework refactors, and boilerplate per test file.

This adds a supported helper, `mockRouteParams()`, alongside the existing `mockCurrentUser()`:

```ts
import { mockRouteParams } from '@cedarjs/testing/web'

mockRouteParams({ orgSlug: 'acme' })
```

It works by feeding `MockParamsProvider` (which already builds the `ParamsContext` value `useParams()` reads, previously only from the URL search string) a second source: path params set via `mockRouteParams`, merged over the search-derived params in the same order the real `Router` does (`{ ...searchParams, ...pathParams }`), so path params take precedence, same as in a real render.

Also documents it in `docs/docs/testing.md` (a `mockRouteParams()` subsection next to `mockCurrentUser()`) and adds a pointer to it from the tenancy how-to's pitfalls section, since URL-scoped organizations are the case that surfaced this.

Fixes #2631

## Test plan

- New `packages/testing/src/web/__tests__/MockParamsProvider.test.tsx`: `useParams()` reflects `mockRouteParams()`, and route params take precedence over the URL search string
- `yarn vitest run` (from `packages/testing`) — 25/25 passing
- `yarn nx run @cedarjs/testing:build` — builds/type-checks clean
- `yarn eslint packages/testing/src/web/mockRequests.ts packages/testing/src/web/MockParamsProvider.tsx packages/testing/src/web/__tests__/MockParamsProvider.test.tsx` — clean