### PR TITLE
feat(api): add signed token helpers

### DIFF
--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -78,3 +78,11 @@ Since each of these webhooks will call a function endpoint in your CedarJS api, 
 - Ensure that the hook isn't reprocessed or replayed
 
 For details on how to keep your incoming webhooks secure and how to sign your outgoing webhooks, please see [Webhooks](webhooks.md).
+
+## Signed Tokens
+
+Some values have to leave your api side and come back through an untrusted channel: the `state` parameter of an OAuth flow, a confirmation or unsubscribe link in an email, a short-lived token that grants one specific action. Rather than storing a nonce somewhere and checking it later, you can mint a token that carries its own claims and expiry and is signed with a secret only your app knows.
+
+`@cedarjs/api` exports `createSignedToken` and `verifySignedToken` for exactly this. Each token is bound to a named purpose so it cannot be replayed in a different flow, always expires, and verification throws rather than returning `null`, so a forgotten check cannot fail open.
+
+For details, please see [Signed Tokens](signed-tokens.md).

--- a/docs/docs/signed-tokens.md
+++ b/docs/docs/signed-tokens.md
@@ -1,0 +1,270 @@
+---
+description:
+  Mint and verify short-lived, tamper-proof tokens for OAuth state, signed
+  links, and more
+---
+
+# Signed Tokens
+
+A signed token is a short, URL-safe string that carries a few claims, expires,
+and provably came from your application. Your api side hands it out, it travels
+through an untrusted place (a query string, an email, a third-party redirect),
+and when it comes back you can trust what's inside it without having stored
+anything.
+
+Typical uses:
+
+- **OAuth `state`.** The callback from Google or GitHub is a plain function
+  receiving a redirect, with no session to check a nonce against. A signed token
+  in `state` carries the nonce _and_ tells the callback which user or
+  organization started the flow.
+- **Email links.** Confirmation, password-set, magic-login, and unsubscribe
+  links all need "a URL that provably came from us, says who it is for, and
+  stops working after a while."
+- **Capability tokens.** A token that lets a client do one specific thing for a
+  few minutes, such as upload a file into one specific bucket.
+
+`@cedarjs/api` exports two functions for this, `createSignedToken` and
+`verifySignedToken`, plus a `SignedTokenError` that verification throws whenever
+a token cannot be trusted.
+
+## Setup
+
+Tokens are signed with a secret. Generate one and put it in your api side's
+`.env` file as `SIGNED_TOKEN_SECRET`:
+
+```bash
+yarn cedar generate secret
+```
+
+```bash title=".env"
+SIGNED_TOKEN_SECRET=...the generated value...
+```
+
+Do not check this file into version control, and use a different value in each
+environment. Use a separate secret from `SESSION_SECRET` so the two can be
+rotated independently.
+
+Both functions also accept a `secret` option, which takes precedence over the
+environment variable. There is no built-in fallback secret: if neither is set,
+both functions throw a `SignedTokenError` with code `MISSING_SECRET` rather than
+signing with a guessable value.
+
+## Creating a token
+
+```ts
+import { createSignedToken } from '@cedarjs/api'
+
+const state = createSignedToken({
+  payload: { organizationId, userId },
+  purpose: 'google-oauth-state',
+  expiresIn: '10m',
+})
+```
+
+| Option      | Description                                                                                                                                                                                                                              |
+| :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `payload`   | The claims to carry. Any JSON-serializable object. Values that are not JSON, such as a `Date`, come back as whatever `JSON.stringify` turns them into.                                                                                   |
+| `purpose`   | Required. What the token is for, like `'google-oauth-state'` or `'email-confirmation'`. Verification only succeeds with the same purpose, so a token minted for one flow cannot be replayed in another. Pick a distinct string per flow. |
+| `expiresIn` | Required. How long the token stays valid. A number is a count of seconds; a string is a duration such as `'10m'`, `'2h'`, or `'7 days'`. Keep it as short as the flow allows.                                                            |
+| `secret`    | Optional. Overrides `SIGNED_TOKEN_SECRET`.                                                                                                                                                                                               |
+
+The result is a standard JSON Web Token signed with HS256, so it is URL-safe
+as-is and can be inspected with any JWT debugger. The payload is not encrypted,
+only signed: anyone holding the token can read the claims, they just cannot
+change them. Don't put secrets in the payload.
+
+## Verifying a token
+
+```ts
+import { verifySignedToken } from '@cedarjs/api'
+
+const { organizationId, userId } = verifySignedToken<{
+  organizationId: string
+  userId: string
+}>(event.queryStringParameters?.state, { purpose: 'google-oauth-state' })
+```
+
+`verifySignedToken` returns the payload exactly as it was passed to
+`createSignedToken`. The type parameter tells TypeScript what shape to expect;
+the framework cannot check it at runtime, so treat it the way you would treat
+any value your own code serialized earlier.
+
+Anything that stops the token from being trusted throws a `SignedTokenError`. It
+never returns `null` or `false`, so forgetting to check the result cannot let a
+bad token through. The token argument accepts `undefined` and `null` on purpose:
+pass the raw query-string or header value straight in, and a missing token is a
+verification failure like any other.
+
+| Option    | Description                                                  |
+| :-------- | :----------------------------------------------------------- |
+| `purpose` | Required. Must match the purpose the token was created with. |
+| `secret`  | Optional. Overrides `SIGNED_TOKEN_SECRET`.                   |
+
+### Handling failures
+
+`SignedTokenError` has a `code` property so you can tell the cases apart, for
+instance to show "this link has expired, request a new one" instead of a generic
+error:
+
+| Code               | Meaning                                                                                                               |
+| :----------------- | :-------------------------------------------------------------------------------------------------------------------- |
+| `MISSING_TOKEN`    | The token argument was `undefined`, `null`, or an empty string.                                                       |
+| `EXPIRED`          | The token was valid but its `expiresIn` has passed.                                                                   |
+| `INVALID`          | The token is malformed, was signed with a different secret, has been tampered with, or was not created by Cedar.      |
+| `PURPOSE_MISMATCH` | The token was created for a different `purpose`. The message names both purposes.                                     |
+| `MISSING_PURPOSE`  | `purpose` was not passed or was empty. This is a programming error, not a bad token.                                  |
+| `MISSING_SECRET`   | No `secret` option and no `SIGNED_TOKEN_SECRET` environment variable. This is a configuration error, not a bad token. |
+| `SIGN_FAILED`      | Thrown by `createSignedToken` when the token could not be produced, such as an unparseable `expiresIn`.               |
+
+```ts
+import { SignedTokenError, verifySignedToken } from '@cedarjs/api'
+
+try {
+  const { userId } = verifySignedToken<{ userId: string }>(token, {
+    purpose: 'email-confirmation',
+  })
+  await confirmEmail(userId)
+} catch (e) {
+  if (e instanceof SignedTokenError && e.code === 'EXPIRED') {
+    return { statusCode: 410, body: 'This link has expired.' }
+  }
+
+  throw e
+}
+```
+
+Only `EXPIRED` is usually worth a specific message to the user. The other codes
+are either a tampered or foreign token, which deserves a generic rejection, or a
+mistake in your own code or configuration, which should surface as an error
+during development.
+
+## Example: OAuth state without a session store
+
+A function that starts an OAuth flow with a third-party calendar API puts a
+signed token in the `state` parameter. The callback verifies it and learns which
+organization to attach the integration to from the token itself, rather than
+from any ambient context.
+
+```ts title="api/src/functions/calendarConnect.ts"
+import type { APIGatewayProxyEvent } from 'aws-lambda'
+
+import { createSignedToken } from '@cedarjs/api'
+
+import { requireAuth } from 'src/lib/auth'
+import { context } from '@cedarjs/context'
+
+export const handler = async (event: APIGatewayProxyEvent) => {
+  requireAuth()
+
+  const state = createSignedToken({
+    payload: {
+      organizationId: context.currentUser.organizationId,
+      userId: context.currentUser.id,
+    },
+    purpose: 'calendar-oauth-state',
+    expiresIn: '10m',
+  })
+
+  const url = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+  url.searchParams.set('client_id', process.env.GOOGLE_CLIENT_ID)
+  url.searchParams.set(
+    'redirect_uri',
+    `${process.env.API_URL}/calendarCallback`
+  )
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('scope', 'https://www.googleapis.com/auth/calendar')
+  url.searchParams.set('state', state)
+
+  return { statusCode: 302, headers: { Location: url.toString() } }
+}
+```
+
+```ts title="api/src/functions/calendarCallback.ts"
+import type { APIGatewayProxyEvent } from 'aws-lambda'
+
+import { SignedTokenError, verifySignedToken } from '@cedarjs/api'
+
+import { db } from 'src/lib/db'
+
+interface CalendarOAuthState {
+  organizationId: string
+  userId: string
+}
+
+export const handler = async (event: APIGatewayProxyEvent) => {
+  let state: CalendarOAuthState
+
+  try {
+    state = verifySignedToken<CalendarOAuthState>(
+      event.queryStringParameters?.state,
+      { purpose: 'calendar-oauth-state' }
+    )
+  } catch (e) {
+    if (e instanceof SignedTokenError) {
+      return { statusCode: 400, body: 'Invalid or expired OAuth state.' }
+    }
+
+    throw e
+  }
+
+  const tokens = await exchangeCodeForTokens(event.queryStringParameters?.code)
+
+  await db.integration.upsert({
+    where: { organizationId: state.organizationId },
+    create: { organizationId: state.organizationId, ...tokens },
+    update: tokens,
+  })
+
+  return { statusCode: 302, headers: { Location: '/settings/integrations' } }
+}
+```
+
+Because the organization comes from the verified token and nowhere else, the
+callback works the same whether or not any user session is present, and a forged
+or reused `state` is rejected before any database write.
+
+## Design notes
+
+These are the properties the helper guarantees so that you don't have to think
+about them at each call site:
+
+- **Purpose binding is mandatory.** There is no way to mint a token without a
+  purpose, and no way to verify one without naming the purpose you expect. One
+  secret can safely serve every flow in the app.
+- **Expiry is mandatory and always enforced.** A token with no `exp` claim is
+  rejected even when its signature is valid.
+- **Fails closed.** A missing secret, a missing token, or a missing purpose all
+  throw. Nothing is skipped because a value happened to be absent.
+- **Only HS256 is accepted on verification.** A token whose header names another
+  algorithm, including `none`, is rejected before its signature is compared,
+  which closes the algorithm-confusion class of JWT bugs.
+- **Signatures are compared in constant time.**
+
+## Testing
+
+In tests, set `SIGNED_TOKEN_SECRET` like any other environment variable, and use
+fake timers to exercise expiry:
+
+```ts
+import { createSignedToken, verifySignedToken } from '@cedarjs/api'
+
+test('rejects an expired confirmation link', () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+
+  const token = createSignedToken({
+    payload: { userId: '1' },
+    purpose: 'email-confirmation',
+    expiresIn: '1h',
+  })
+
+  vi.setSystemTime(new Date('2026-01-01T02:00:00Z'))
+
+  expect(() =>
+    verifySignedToken(token, { purpose: 'email-confirmation' })
+  ).toThrow('expired')
+
+  vi.useRealTimers()
+})
+```

--- a/docs/docs/signed-tokens.md
+++ b/docs/docs/signed-tokens.md
@@ -147,14 +147,19 @@ organization to attach the integration to from the token itself, rather than
 from any ambient context.
 
 ```ts title="api/src/functions/calendarConnect.ts"
-import type { APIGatewayProxyEvent } from 'aws-lambda'
+import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 
 import { createSignedToken } from '@cedarjs/api'
+import { authDecoder } from '@cedarjs/auth-dbauth-api'
+import { useRequireAuth } from '@cedarjs/graphql-server'
 
-import { requireAuth } from 'src/lib/auth'
-import { context } from '@cedarjs/context'
+import { getCurrentUser, requireAuth } from 'src/lib/auth'
 
-export const handler = async (event: APIGatewayProxyEvent) => {
+const calendarConnect = async (
+  _event: APIGatewayProxyEvent,
+  _context: Context
+) => {
+  // `useRequireAuth` below populates `context.currentUser` for this function
   requireAuth()
 
   const state = createSignedToken({
@@ -178,6 +183,12 @@ export const handler = async (event: APIGatewayProxyEvent) => {
 
   return { statusCode: 302, headers: { Location: url.toString() } }
 }
+
+export const handler = useRequireAuth({
+  handlerFn: calendarConnect,
+  getCurrentUser,
+  authDecoder,
+})
 ```
 
 ```ts title="api/src/functions/calendarCallback.ts"
@@ -222,7 +233,12 @@ export const handler = async (event: APIGatewayProxyEvent) => {
 
 Because the organization comes from the verified token and nowhere else, the
 callback works the same whether or not any user session is present, and a forged
-or reused `state` is rejected before any database write.
+or expired `state` is rejected before any database write.
+
+Verification is stateless: a valid token is accepted every time it is presented
+until it expires. When a flow must be single-use, record the token when it is
+consumed (for example by storing the `state` value on the row it creates) and
+refuse a second callback that carries the same one.
 
 ## Design notes
 

--- a/docs/docs/signed-tokens.md
+++ b/docs/docs/signed-tokens.md
@@ -147,7 +147,7 @@ organization to attach the integration to from the token itself, rather than
 from any ambient context.
 
 ```ts title="api/src/functions/calendarConnect.ts"
-import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
+import type { APIGatewayProxyEvent } from 'aws-lambda'
 
 import { createSignedToken } from '@cedarjs/api'
 import { authDecoder } from '@cedarjs/auth-dbauth-api'
@@ -156,10 +156,7 @@ import { useRequireAuth } from '@cedarjs/graphql-server'
 
 import { getCurrentUser, requireAuth } from 'src/lib/auth'
 
-const calendarConnect = async (
-  _event: APIGatewayProxyEvent,
-  _context: Context
-) => {
+const calendarConnect = async (_event: APIGatewayProxyEvent) => {
   // `useRequireAuth` below populates `context.currentUser` for this function
   requireAuth()
 

--- a/docs/docs/signed-tokens.md
+++ b/docs/docs/signed-tokens.md
@@ -151,6 +151,7 @@ import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 
 import { createSignedToken } from '@cedarjs/api'
 import { authDecoder } from '@cedarjs/auth-dbauth-api'
+import { context } from '@cedarjs/context'
 import { useRequireAuth } from '@cedarjs/graphql-server'
 
 import { getCurrentUser, requireAuth } from 'src/lib/auth'

--- a/docs/sidebars.cjs
+++ b/docs/sidebars.cjs
@@ -222,6 +222,7 @@ module.exports = {
         'server-file',
         'serverless-functions',
         'services',
+        'signed-tokens',
         'storybook',
         'studio',
         'tenancy',

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -6,6 +6,7 @@ export * from './types.js'
 export * from './transforms.js'
 export * from './cors.js'
 export * from './event.js'
+export * from './signedTokens/index.js'
 
 // @cedarjs/api's version is injected at compile time by esbuild's `define`
 // option in build.mts (applied to both CJS and ESM builds). This avoids a

--- a/packages/api/src/signedTokens/__tests__/signedTokens.test.ts
+++ b/packages/api/src/signedTokens/__tests__/signedTokens.test.ts
@@ -1,0 +1,273 @@
+import jwt from 'jsonwebtoken'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  createSignedToken,
+  SIGNED_TOKEN_SECRET_ENV_VAR,
+  SignedTokenError,
+  verifySignedToken,
+} from '../signedTokens.js'
+
+const secret = 'MY_VOICE_IS_MY_PASSPORT_VERIFY_ME'
+const purpose = 'google-oauth-state'
+const payload = { organizationId: 'org_1', userId: 'user_1' }
+
+function expectSignedTokenError(fn: () => unknown, code: string) {
+  let thrown: unknown
+
+  try {
+    fn()
+  } catch (e) {
+    thrown = e
+  }
+
+  expect(thrown).toBeInstanceOf(SignedTokenError)
+  expect(thrown).toMatchObject({ name: 'SignedTokenError', code })
+
+  return thrown as SignedTokenError
+}
+
+describe('signed tokens', () => {
+  beforeEach(() => {
+    vi.stubEnv(SIGNED_TOKEN_SECRET_ENV_VAR, secret)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.useRealTimers()
+  })
+
+  describe('createSignedToken', () => {
+    test('produces a compact URL-safe token', () => {
+      const token = createSignedToken({ payload, purpose, expiresIn: '10m' })
+
+      expect(token).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/)
+    })
+
+    test('binds the purpose and sets an expiry', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-09-05T12:00:00Z'))
+
+      const token = createSignedToken({ payload, purpose, expiresIn: 60 })
+      const claims = jwt.decode(token, { json: true })
+
+      expect(claims).toMatchObject({ payload, purpose })
+      expect(claims?.exp).toBe(claims!.iat! + 60)
+    })
+
+    test('signs with HS256', () => {
+      const token = createSignedToken({ payload, purpose, expiresIn: '1h' })
+      const decoded = jwt.decode(token, { complete: true })
+
+      expect(decoded?.header.alg).toBe('HS256')
+    })
+
+    test('throws MISSING_PURPOSE for an empty purpose', () => {
+      expectSignedTokenError(
+        () => createSignedToken({ payload, purpose: '', expiresIn: '1h' }),
+        'MISSING_PURPOSE',
+      )
+    })
+
+    test('throws MISSING_SECRET when no secret is configured', () => {
+      vi.stubEnv(SIGNED_TOKEN_SECRET_ENV_VAR, '')
+
+      const error = expectSignedTokenError(
+        () => createSignedToken({ payload, purpose, expiresIn: '1h' }),
+        'MISSING_SECRET',
+      )
+
+      expect(error.message).toContain(SIGNED_TOKEN_SECRET_ENV_VAR)
+      expect(error.message).toContain('yarn cedar generate secret')
+    })
+
+    test('does not fall back to the env var when an empty secret is passed', () => {
+      expectSignedTokenError(
+        () =>
+          createSignedToken({ payload, purpose, expiresIn: '1h', secret: '' }),
+        'MISSING_SECRET',
+      )
+    })
+
+    test('throws SIGN_FAILED for an unparseable expiresIn', () => {
+      const error = expectSignedTokenError(
+        () =>
+          createSignedToken({
+            payload,
+            purpose,
+            // @ts-expect-error - deliberately passing an invalid duration
+            expiresIn: 'soon-ish',
+          }),
+        'SIGN_FAILED',
+      )
+
+      expect(error.cause).toBeInstanceOf(Error)
+    })
+  })
+
+  describe('verifySignedToken', () => {
+    test('returns the payload for a valid token', () => {
+      const token = createSignedToken({ payload, purpose, expiresIn: '10m' })
+
+      expect(verifySignedToken(token, { purpose })).toEqual(payload)
+    })
+
+    test('round-trips payload keys that look like JWT claims', () => {
+      const trickyPayload = { exp: 'not a timestamp', purpose: 'inner', iat: 1 }
+      const token = createSignedToken({
+        payload: trickyPayload,
+        purpose,
+        expiresIn: '10m',
+      })
+
+      expect(verifySignedToken(token, { purpose })).toEqual(trickyPayload)
+    })
+
+    test('uses an explicit secret over the env var', () => {
+      const token = createSignedToken({
+        payload,
+        purpose,
+        expiresIn: '10m',
+        secret: 'another-secret',
+      })
+
+      expect(
+        verifySignedToken(token, { purpose, secret: 'another-secret' }),
+      ).toEqual(payload)
+      expectSignedTokenError(
+        () => verifySignedToken(token, { purpose }),
+        'INVALID',
+      )
+    })
+
+    test('throws PURPOSE_MISMATCH for a token created for another purpose', () => {
+      const token = createSignedToken({ payload, purpose, expiresIn: '10m' })
+
+      const error = expectSignedTokenError(
+        () => verifySignedToken(token, { purpose: 'upload' }),
+        'PURPOSE_MISMATCH',
+      )
+
+      expect(error.message).toContain(`'${purpose}'`)
+      expect(error.message).toContain("'upload'")
+    })
+
+    test('throws EXPIRED once expiresIn has passed', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-09-05T12:00:00Z'))
+
+      const token = createSignedToken({ payload, purpose, expiresIn: '10m' })
+
+      vi.setSystemTime(new Date('2026-09-05T12:09:59Z'))
+      expect(verifySignedToken(token, { purpose })).toEqual(payload)
+
+      vi.setSystemTime(new Date('2026-09-05T12:10:01Z'))
+      expectSignedTokenError(
+        () => verifySignedToken(token, { purpose }),
+        'EXPIRED',
+      )
+    })
+
+    test('throws INVALID for a tampered payload', () => {
+      const token = createSignedToken({ payload, purpose, expiresIn: '10m' })
+      const [header, , signature] = token.split('.')
+      const forgedClaims = Buffer.from(
+        JSON.stringify({
+          payload: { ...payload, userId: 'user_2' },
+          purpose,
+          exp: Math.floor(Date.now() / 1000) + 600,
+        }),
+      ).toString('base64url')
+
+      expectSignedTokenError(
+        () =>
+          verifySignedToken(`${header}.${forgedClaims}.${signature}`, {
+            purpose,
+          }),
+        'INVALID',
+      )
+    })
+
+    test('throws INVALID for a token signed with a different secret', () => {
+      const token = createSignedToken({
+        payload,
+        purpose,
+        expiresIn: '10m',
+        secret: 'not so secret',
+      })
+
+      expectSignedTokenError(
+        () => verifySignedToken(token, { purpose }),
+        'INVALID',
+      )
+    })
+
+    test('rejects an unsigned token (alg: none)', () => {
+      const unsigned = jwt.sign({ payload, purpose }, '', {
+        algorithm: 'none',
+        expiresIn: '10m',
+      })
+
+      expectSignedTokenError(
+        () => verifySignedToken(unsigned, { purpose }),
+        'INVALID',
+      )
+    })
+
+    test('rejects a correctly signed token that has no expiry', () => {
+      const noExpiry = jwt.sign({ payload, purpose }, secret, {
+        algorithm: 'HS256',
+      })
+
+      expectSignedTokenError(
+        () => verifySignedToken(noExpiry, { purpose }),
+        'INVALID',
+      )
+    })
+
+    test('rejects a correctly signed token that has no purpose claim', () => {
+      const noPurpose = jwt.sign({ payload }, secret, {
+        algorithm: 'HS256',
+        expiresIn: '10m',
+      })
+
+      expectSignedTokenError(
+        () => verifySignedToken(noPurpose, { purpose }),
+        'INVALID',
+      )
+    })
+
+    test.each([undefined, null, ''])('throws MISSING_TOKEN for %o', (token) => {
+      expectSignedTokenError(
+        () => verifySignedToken(token, { purpose }),
+        'MISSING_TOKEN',
+      )
+    })
+
+    test('throws INVALID for garbage input', () => {
+      expectSignedTokenError(
+        () => verifySignedToken('definitely.not.a.token', { purpose }),
+        'INVALID',
+      )
+    })
+
+    test('throws MISSING_PURPOSE before touching the token', () => {
+      const token = createSignedToken({ payload, purpose, expiresIn: '10m' })
+
+      expectSignedTokenError(
+        () => verifySignedToken(token, { purpose: '' }),
+        'MISSING_PURPOSE',
+      )
+    })
+
+    test('throws MISSING_SECRET when no secret is configured', () => {
+      const token = createSignedToken({ payload, purpose, expiresIn: '10m' })
+      vi.stubEnv(SIGNED_TOKEN_SECRET_ENV_VAR, '')
+
+      expectSignedTokenError(
+        () => verifySignedToken(token, { purpose }),
+        'MISSING_SECRET',
+      )
+    })
+  })
+})

--- a/packages/api/src/signedTokens/__tests__/signedTokens.test.ts
+++ b/packages/api/src/signedTokens/__tests__/signedTokens.test.ts
@@ -7,12 +7,13 @@ import {
   SignedTokenError,
   verifySignedToken,
 } from '../signedTokens.js'
+import type { SignedTokenErrorCode } from '../signedTokens.js'
 
 const secret = 'MY_VOICE_IS_MY_PASSPORT_VERIFY_ME'
 const purpose = 'google-oauth-state'
 const payload = { organizationId: 'org_1', userId: 'user_1' }
 
-function expectSignedTokenError(fn: () => unknown, code: string) {
+function expectSignedTokenError(fn: () => unknown, code: SignedTokenErrorCode) {
   let thrown: unknown
 
   try {
@@ -21,10 +22,13 @@ function expectSignedTokenError(fn: () => unknown, code: string) {
     thrown = e
   }
 
-  expect(thrown).toBeInstanceOf(SignedTokenError)
+  if (!(thrown instanceof SignedTokenError)) {
+    throw new Error(`Expected a SignedTokenError, got ${String(thrown)}`)
+  }
+
   expect(thrown).toMatchObject({ name: 'SignedTokenError', code })
 
-  return thrown as SignedTokenError
+  return thrown
 }
 
 describe('signed tokens', () => {

--- a/packages/api/src/signedTokens/index.ts
+++ b/packages/api/src/signedTokens/index.ts
@@ -1,0 +1,1 @@
+export * from './signedTokens.js'

--- a/packages/api/src/signedTokens/signedTokens.ts
+++ b/packages/api/src/signedTokens/signedTokens.ts
@@ -1,0 +1,253 @@
+import jwt from 'jsonwebtoken'
+import type { SignOptions } from 'jsonwebtoken'
+
+/**
+ * Name of the environment variable that holds the default secret used to
+ * sign and verify tokens when no `secret` option is passed.
+ */
+export const SIGNED_TOKEN_SECRET_ENV_VAR = 'SIGNED_TOKEN_SECRET'
+
+/**
+ * Machine-readable reason a `SignedTokenError` was thrown. Use it to tell an
+ * expired link apart from a tampered one without matching on the message.
+ */
+export type SignedTokenErrorCode =
+  | 'MISSING_SECRET'
+  | 'MISSING_PURPOSE'
+  | 'MISSING_TOKEN'
+  | 'SIGN_FAILED'
+  | 'INVALID'
+  | 'EXPIRED'
+  | 'PURPOSE_MISMATCH'
+
+/**
+ * Thrown by `createSignedToken` and `verifySignedToken` whenever a token
+ * cannot be created or cannot be trusted. Verification never returns `null`
+ * or `false` for a bad token; it always throws so a missing check cannot
+ * silently pass.
+ */
+export class SignedTokenError extends Error {
+  code: SignedTokenErrorCode
+
+  constructor(code: SignedTokenErrorCode, message: string, cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause })
+    this.name = 'SignedTokenError'
+    this.code = code
+  }
+}
+
+/**
+ * How long a token stays valid. A number is a count of seconds. A string is
+ * a duration such as `'10m'`, `'2h'`, or `'7 days'`.
+ */
+export type SignedTokenExpiresIn = NonNullable<SignOptions['expiresIn']>
+
+export interface CreateSignedTokenOptions<TPayload extends object> {
+  /**
+   * The claims to carry inside the token. Serialized as JSON, so only
+   * JSON-compatible values survive the round trip (a `Date` comes back as a
+   * string).
+   */
+  payload: TPayload
+  /**
+   * What the token is for, such as `'google-oauth-state'` or
+   * `'email-confirmation'`. A token only verifies when the same purpose is
+   * passed to `verifySignedToken`, so a token minted for one flow cannot be
+   * replayed in another.
+   */
+  purpose: string
+  /** How long the token stays valid. See `SignedTokenExpiresIn`. */
+  expiresIn: SignedTokenExpiresIn
+  /**
+   * The secret to sign with. Defaults to the `SIGNED_TOKEN_SECRET`
+   * environment variable. There is no built-in fallback: when neither is set
+   * a `SignedTokenError` with code `MISSING_SECRET` is thrown.
+   */
+  secret?: string
+}
+
+export interface VerifySignedTokenOptions {
+  /** The purpose the token must have been created with. */
+  purpose: string
+  /**
+   * The secret to verify with. Defaults to the `SIGNED_TOKEN_SECRET`
+   * environment variable. There is no built-in fallback: when neither is set
+   * a `SignedTokenError` with code `MISSING_SECRET` is thrown.
+   */
+  secret?: string
+}
+
+/** The claims Cedar stores inside a signed token. */
+interface SignedTokenClaims {
+  payload: object
+  purpose: string
+  exp: number
+}
+
+/**
+ * Tokens are signed with HS256 and verification only accepts HS256, so a
+ * token that names another algorithm in its header (including `none`) is
+ * rejected before its signature is even looked at.
+ */
+const ALGORITHM = 'HS256'
+
+function resolveSecret(
+  secret: string | undefined,
+  action: 'create' | 'verify',
+): string {
+  const resolved = secret ?? process.env[SIGNED_TOKEN_SECRET_ENV_VAR]
+
+  if (typeof resolved === 'string' && resolved.length > 0) {
+    return resolved
+  }
+
+  throw new SignedTokenError(
+    'MISSING_SECRET',
+    `Cannot ${action} a signed token because no secret is configured. Set ` +
+      `the ${SIGNED_TOKEN_SECRET_ENV_VAR} environment variable (generate a ` +
+      'value with `yarn cedar generate secret`), or pass the `secret` ' +
+      'option explicitly.',
+  )
+}
+
+function assertPurpose(purpose: unknown): asserts purpose is string {
+  if (typeof purpose === 'string' && purpose.length > 0) {
+    return
+  }
+
+  throw new SignedTokenError(
+    'MISSING_PURPOSE',
+    'A signed token needs a non-empty `purpose` string, such as ' +
+      "'google-oauth-state' or 'email-confirmation'. The purpose is what " +
+      'stops a token created for one flow from verifying in another.',
+  )
+}
+
+function isSignedTokenClaims(claims: unknown): claims is SignedTokenClaims {
+  if (typeof claims !== 'object' || claims === null) {
+    return false
+  }
+
+  if (!('payload' in claims) || !('purpose' in claims) || !('exp' in claims)) {
+    return false
+  }
+
+  return (
+    typeof claims.payload === 'object' &&
+    claims.payload !== null &&
+    typeof claims.purpose === 'string' &&
+    typeof claims.exp === 'number'
+  )
+}
+
+/**
+ * Creates a compact, URL-safe token that carries `payload`, is bound to
+ * `purpose`, expires after `expiresIn`, and is signed so it can only have
+ * come from this application.
+ *
+ * Use it wherever a value has to leave the server and come back untouched:
+ * OAuth `state`, email confirmation and password-set links, unsubscribe
+ * links, or short-lived capability tokens.
+ *
+ * @example
+ *
+ *    const state = createSignedToken({
+ *      payload: { organizationId, userId },
+ *      purpose: 'google-oauth-state',
+ *      expiresIn: '10m',
+ *    })
+ */
+export function createSignedToken<TPayload extends object>({
+  payload,
+  purpose,
+  expiresIn,
+  secret,
+}: CreateSignedTokenOptions<TPayload>): string {
+  assertPurpose(purpose)
+  const resolvedSecret = resolveSecret(secret, 'create')
+
+  try {
+    return jwt.sign({ payload, purpose }, resolvedSecret, {
+      algorithm: ALGORITHM,
+      expiresIn,
+    })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+
+    throw new SignedTokenError(
+      'SIGN_FAILED',
+      `Could not create signed token: ${message}`,
+      e,
+    )
+  }
+}
+
+/**
+ * Verifies a token created by `createSignedToken` and returns its payload.
+ *
+ * Throws a `SignedTokenError` when the token is missing, was signed with a
+ * different secret, has been tampered with, has expired, or was created for
+ * a different `purpose`. The error's `code` says which.
+ *
+ * The token argument accepts `null` and `undefined` on purpose so a value
+ * read straight from a query string or a header can be passed in as-is. A
+ * missing token is a verification failure, never a skipped check.
+ *
+ * @example
+ *
+ *    const { organizationId, userId } = verifySignedToken<{
+ *      organizationId: string
+ *      userId: string
+ *    }>(event.queryStringParameters?.state, {
+ *      purpose: 'google-oauth-state',
+ *    })
+ */
+export function verifySignedToken<
+  TPayload extends object = Record<string, unknown>,
+>(
+  token: string | null | undefined,
+  { purpose, secret }: VerifySignedTokenOptions,
+): TPayload {
+  assertPurpose(purpose)
+  const resolvedSecret = resolveSecret(secret, 'verify')
+
+  if (typeof token !== 'string' || token.length === 0) {
+    throw new SignedTokenError('MISSING_TOKEN', 'No signed token was provided.')
+  }
+
+  let claims: unknown
+
+  try {
+    claims = jwt.verify(token, resolvedSecret, { algorithms: [ALGORITHM] })
+  } catch (e) {
+    if (e instanceof jwt.TokenExpiredError) {
+      throw new SignedTokenError('EXPIRED', 'The signed token has expired.', e)
+    }
+
+    throw new SignedTokenError(
+      'INVALID',
+      'The signed token is invalid or was not created by this application.',
+      e,
+    )
+  }
+
+  if (!isSignedTokenClaims(claims)) {
+    throw new SignedTokenError(
+      'INVALID',
+      'The signed token is invalid or was not created by this application.',
+    )
+  }
+
+  if (claims.purpose !== purpose) {
+    throw new SignedTokenError(
+      'PURPOSE_MISMATCH',
+      `The signed token was created for purpose '${claims.purpose}' but ` +
+        `was verified with purpose '${purpose}'.`,
+    )
+  }
+
+  // The signature has been verified with our own secret, so the payload is
+  // whatever this application put there when it called `createSignedToken`.
+  // TypeScript cannot know that shape; the caller names it via `TPayload`.
+  return claims.payload as TPayload
+}


### PR DESCRIPTION
## Summary

Adds `createSignedToken`, `verifySignedToken`, and `SignedTokenError` to `@cedarjs/api`. They mint and verify compact, URL-safe, self-contained tokens that carry a payload, are bound to a named purpose, and expire. This is the primitive behind OAuth `state` on a session-less api side, signed email links (confirmation, password-set, unsubscribe), and short-lived capability tokens such as the upload tokens planned in #2596.

```ts
import { createSignedToken, verifySignedToken } from '@cedarjs/api'

const state = createSignedToken({
  payload: { organizationId, userId },
  purpose: 'google-oauth-state',
  expiresIn: '10m',
})

const claims = verifySignedToken<{ organizationId: string; userId: string }>(
  event.queryStringParameters?.state,
  { purpose: 'google-oauth-state' },
)
```

## Design

Implemented as a thin wrapper over the existing `jsonwebtoken` dependency (option (a) from the issue). Tokens are standard HS256 JWTs and can be inspected with any JWT debugger.

- **Purpose binding is mandatory.** Both functions require a non-empty `purpose`, so a token minted for one flow cannot verify in another. One secret can serve every flow in an app.
- **Expiry is mandatory and always enforced.** `expiresIn` is required at mint time, and verification rejects a validly signed token that has no `exp` claim.
- **Fails closed.** The secret comes from `SIGNED_TOKEN_SECRET` or an explicit `secret` option. There is no dev fallback. A missing secret throws at mint and verify time with a message that names both fixes and points at `yarn cedar generate secret`. `verifySignedToken` accepts `undefined`/`null` so a raw query-string value can be passed straight in, and a missing token is a verification failure rather than a skipped check.
- **Algorithm pinned.** Verification passes `algorithms: ['HS256']`, so a token whose header names another algorithm (including `none`) is rejected before its signature is looked at. HMAC comparison is constant-time via `jwa`.
- **Machine-readable failures.** `SignedTokenError.code` is one of `MISSING_TOKEN`, `EXPIRED`, `INVALID`, `PURPOSE_MISMATCH`, `MISSING_PURPOSE`, `MISSING_SECRET`, `SIGN_FAILED`, so apps can show "this link has expired" without matching on message text.
- The app payload is nested under its own claim, so app keys such as `exp` or `purpose` round-trip untouched.

Exported from the `@cedarjs/api` root. A `tokens` subpath can be added later without a breaking change if preferred. The webhook verifiers are untouched.

## Docs

- New `docs/docs/signed-tokens.md` page (setup, API, error codes, an OAuth-state-without-a-session example, and a testing recipe) with a sidebar entry.
- Short pointer section in `docs/docs/security.md`.

## Testing

```
yarn workspace @cedarjs/api test    # 24 files, 278 tests passing (23 new)
yarn workspace @cedarjs/api build
yarn eslint packages/api/src/signedTokens
yarn prettier --check ...
```

New tests cover round-trip, purpose mismatch, expiry via fake timers, tampered payload, wrong secret, `alg: none`, missing `exp` and `purpose` claims, empty/null token input, missing secret, and missing purpose. A smoke test against the built `dist` confirms the root export round-trips a token.

Closes #2609
