### PR TITLE
fix(cca): include db in api tsconfig/jsconfig

### DIFF
--- a/__fixtures__/empty-project/api/tsconfig.json
+++ b/__fixtures__/empty-project/api/tsconfig.json
@@ -27,6 +27,7 @@
   },
   "include": [
     "src",
+    "db",
     "../.cedar/types/includes/all-*",
     "../.cedar/types/includes/api-*",
     "../types"

--- a/__fixtures__/test-project-live/api/tsconfig.json
+++ b/__fixtures__/test-project-live/api/tsconfig.json
@@ -20,6 +20,7 @@
   },
   "include": [
     "src",
+    "db",
     "../.cedar/types/includes/all-*",
     "../.cedar/types/includes/api-*",
     "../types"

--- a/__fixtures__/test-project-pnpm/api/tsconfig.json
+++ b/__fixtures__/test-project-pnpm/api/tsconfig.json
@@ -20,6 +20,7 @@
   },
   "include": [
     "src",
+    "db",
     "../.cedar/types/includes/all-*",
     "../.cedar/types/includes/api-*",
     "../types"

--- a/__fixtures__/test-project/api/tsconfig.json
+++ b/__fixtures__/test-project/api/tsconfig.json
@@ -20,6 +20,7 @@
   },
   "include": [
     "src",
+    "db",
     "../.cedar/types/includes/all-*",
     "../.cedar/types/includes/api-*",
     "../types"

--- a/local-testing-project-live/api/tsconfig.json
+++ b/local-testing-project-live/api/tsconfig.json
@@ -20,6 +20,7 @@
   },
   "include": [
     "src",
+    "db",
     "../.cedar/types/includes/all-*",
     "../.cedar/types/includes/api-*",
     "../types"

--- a/local-testing-project/api/tsconfig.json
+++ b/local-testing-project/api/tsconfig.json
@@ -20,6 +20,7 @@
   },
   "include": [
     "src",
+    "db",
     "../.cedar/types/includes/all-*",
     "../.cedar/types/includes/api-*",
     "../types"

--- a/packages/create-cedar-app/templates/js/api/jsconfig.json
+++ b/packages/create-cedar-app/templates/js/api/jsconfig.json
@@ -34,6 +34,7 @@
   },
   "include": [
     "src",
+    "db",
     "../.cedar/types/includes/all-*",
     "../.cedar/types/includes/api-*",
     "../types"

--- a/packages/create-cedar-app/templates/ts/api/tsconfig.json
+++ b/packages/create-cedar-app/templates/ts/api/tsconfig.json
@@ -20,6 +20,7 @@
   },
   "include": [
     "src",
+    "db",
     "../.cedar/types/includes/all-*",
     "../.cedar/types/includes/api-*",
     "../types"


### PR DESCRIPTION
## Summary

`api/tsconfig.json` and `api/jsconfig.json` only `include` `src`, so files under `api/db/` are not part of the TS project that defines the `src/*` path mapping (`paths` and `rootDirs`). Files placed under `api/db/dataMigrations/` conventionally import using `src/*`-style paths — both the base `dataMigration` generator convention and, more concretely, the `yarn cedar setup tenancy` template `ensureDefaultOrganizations.dataMigration.ts.template`, which imports `src/lib/db` and `src/services/organizations/organizations` directly.

Because `db` isn't in `include`, editors show "Cannot find module 'src/...'" on these files immediately after `yarn cedar setup tenancy`. The data migration runner itself resolves the `src/*` alias independently at execution time (a hardcoded Vite `resolve.alias` in `@cedarjs/cli-data-migrate`), so migrations run correctly — this is purely an editor/type-checking issue.

## Fix

Add `db` to the `include` array in both `api/tsconfig.json` and `api/jsconfig.json` templates, and propagate the same change to the checked-in fixture/test-project copies of these files (`local-testing-project`, `local-testing-project-live`, `__fixtures__/test-project*`, `__fixtures__/empty-project`) so they stay in sync with the template.

## Scope check

Searched all generator/setup templates for the same pattern (writes outside `api/src` while importing `src/*`-style paths). The only occurrence is the tenancy `ensureDefaultOrganizations.dataMigration.ts.template` → `api/db/dataMigrations/`, which this fix resolves. The base `dataMigration` generator template imports from a resolved package path, not `src/*`, so it was never affected.

## Testing

- `yarn workspace create-cedar-app lint` / template eslint — passes
- Verified against `local-testing-project`: added a test file at `api/db/dataMigrations/999_testImportResolution.ts` importing `from 'src/lib/db'`
  - Before the fix: the file isn't part of the `tsc -p api/tsconfig.json` program at all (no errors reported, since it's simply excluded — this matches the "editor falls back to a loose/inferred project" symptom, which only shows up in an actual editor/LSP, not a CLI `tsc -p` run)
  - After the fix: the file resolves correctly with zero new errors
  - `tsc -p api/tsconfig.json --noEmit` output is byte-identical before/after (same pre-existing, unrelated errors)

Fixes #2663