### PR TITLE
chore(testing): resolve mockContext.ts TODOs from #355 review

### DIFF
--- a/.changesets/2674.md
+++ b/.changesets/2674.md
@@ -1,0 +1,12 @@
+- chore(testing): resolve mockContext.ts TODOs from #355 review (#2674) by @lisa-assistant
+
+Tightens `mockContextStore` from `Map<string, any>` to
+`Map<string, GlobalContext>` to match the production store type.
+
+Also resolves the `setContext` TODO from the same review, which suggested
+returning `newContext` instead of `mockContext`. Production's `setContext`
+also returns a Proxy, not the raw object passed in, and both proxies read
+from their store dynamically on every access - so the current mock
+implementation already preserves the `context === setContext(x)` invariant
+exactly like production does. No behavior change; internal test-utility
+package only.

--- a/packages/testing/src/api/mockContext.ts
+++ b/packages/testing/src/api/mockContext.ts
@@ -1,7 +1,4 @@
-// TODO: See if we can use `GlobalContext` instead of `any` here to more
-// closely match the production context.
-// https://github.com/cedarjs/cedar/pull/355#discussion_r2264851576
-const mockContextStore = new Map<string, any>()
+const mockContextStore = new Map<string, GlobalContext>()
 const mockContext = new Proxy(
   {},
   {
@@ -40,7 +37,14 @@ export const context = mockContext
 
 export const setContext = (newContext: GlobalContext): GlobalContext => {
   mockContextStore.set('context', newContext)
-  // TODO: See if this should be `newContext` instead
-  // https://github.com/cedarjs/cedar/pull/355#discussion_r2264851567
+  // Intentionally returns `mockContext` (the Proxy), not `newContext`.
+  // Production's `setContext` also returns a Proxy (a freshly-created one
+  // wrapping newContext), not the raw object — see packages/context/src/context.ts.
+  // Both proxies read from their store dynamically on every access, so old
+  // and new proxy instances are behaviorally interchangeable; the important
+  // invariant `context === setContext(x)` holds here exactly like it does
+  // in production. Returning `newContext` (a plain object, not a Proxy)
+  // would actually break that parity. No callers currently use the return
+  // value, but keep this correct for anyone who starts relying on it.
   return mockContext
 }

--- a/packages/testing/src/api/mockContext.ts
+++ b/packages/testing/src/api/mockContext.ts
@@ -1,34 +1,33 @@
 const mockContextStore = new Map<string, GlobalContext>()
-const mockContext = new Proxy(
+const mockContext = new Proxy<GlobalContext>(
   {},
   {
-    get: (_target, prop) => {
-      // Handle toJSON() calls, i.e. JSON.stringify(context)
-      if (prop === 'toJSON') {
-        return () => mockContextStore.get('context')
-      }
+  get: (_target, prop: string) => {
+    // Handle toJSON() calls, i.e. JSON.stringify(context)
+    if (prop === 'toJSON') {
+      return () => mockContextStore.get('context')
+    }
 
-      const ctx = mockContextStore.get('context')
+    const ctx = mockContextStore.get('context')
 
-      if (!ctx) {
-        return undefined
-      }
+    if (!ctx) {
+      return undefined
+    }
 
-      return ctx[prop]
-    },
-    set: (_target, prop, value) => {
-      const ctx = mockContextStore.get('context')
-
-      if (!ctx) {
-        return false
-      }
-
-      ctx[prop] = value
-
-      return true
-    },
+    return ctx[prop]
   },
-)
+  set: (_target, prop: string, value) => {
+    const ctx = mockContextStore.get('context')
+
+    if (!ctx) {
+      return false
+    }
+
+    ctx[prop] = value
+
+    return true
+  },
+})
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface GlobalContext extends Record<string, unknown> {}

--- a/packages/testing/src/api/mockContext.ts
+++ b/packages/testing/src/api/mockContext.ts
@@ -2,32 +2,33 @@ const mockContextStore = new Map<string, GlobalContext>()
 const mockContext = new Proxy<GlobalContext>(
   {},
   {
-  get: (_target, prop: string) => {
-    // Handle toJSON() calls, i.e. JSON.stringify(context)
-    if (prop === 'toJSON') {
-      return () => mockContextStore.get('context')
-    }
+    get: (_target, prop: string) => {
+      // Handle toJSON() calls, i.e. JSON.stringify(context)
+      if (prop === 'toJSON') {
+        return () => mockContextStore.get('context')
+      }
 
-    const ctx = mockContextStore.get('context')
+      const ctx = mockContextStore.get('context')
 
-    if (!ctx) {
-      return undefined
-    }
+      if (!ctx) {
+        return undefined
+      }
 
-    return ctx[prop]
+      return ctx[prop]
+    },
+    set: (_target, prop: string, value) => {
+      const ctx = mockContextStore.get('context')
+
+      if (!ctx) {
+        return false
+      }
+
+      ctx[prop] = value
+
+      return true
+    },
   },
-  set: (_target, prop: string, value) => {
-    const ctx = mockContextStore.get('context')
-
-    if (!ctx) {
-      return false
-    }
-
-    ctx[prop] = value
-
-    return true
-  },
-})
+)
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface GlobalContext extends Record<string, unknown> {}


### PR DESCRIPTION
## Summary

Resolves both long-standing TODOs in `packages/testing/src/api/mockContext.ts`, left over from bot review comments on #355:

**Line 1 TODO** (`Map<string, any>`): tightened `mockContextStore` to `Map<string, GlobalContext>` to match the production store's type. Safe, no behavior change.

**Line 43 TODO** (`return mockContext` vs `return newContext`): closer inspection shows the original bot suggestion (https://github.com/cedarjs/cedar/pull/355#discussion_r2264851567) was actually wrong.

Production's `setContext` (`packages/context/src/context.ts`) doesn't return the raw `newContext` object either — it returns `context`, which was just reassigned to a **new Proxy** wrapping `newContext`. That Proxy's `get`/`set` traps read from the AsyncLocalStorage-backed store dynamically on every access, not from a closed-over snapshot. So any Proxy instance — old or new — reflects the live current context.

The mock's singleton `mockContext` Proxy works the same way: its traps read from `mockContextStore` dynamically. That makes old and new proxy instances behaviorally interchangeable in *both* mock and production, and it means `context === setContext(x)` is `true` in both today.

Switching to `return newContext` (a plain object, not a Proxy) would have broken that parity instead of fixing anything — it would make the mock diverge from production's actual return-value semantics.

I also checked: no code in the repo currently consumes `setContext`'s return value (production or test callers only use it for its side effect), so this was a latent-but-currently-inert correctness question rather than an active bug. Left an explanatory comment so this doesn't get re-flagged by future bot passes.

## Test plan
- [x] `yarn vitest run` in `packages/testing` — 6 files / 25 tests pass
- [x] `yarn vitest run globalContext useCedarGlobalContextSetter` in `packages/graphql-server` — 2 files / 6 tests pass
- [x] `tsc --noEmit` on `packages/testing` — no new errors (only pre-existing unrelated `TS6059` rootDir noise)
- [x] `eslint` on the changed file — clean