### PR TITLE
fix(deps): update dependency uuid to v11.1.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -50,8 +50,7 @@
         "stdout-update",
         "title-case",
         "untildify",
-        "/^@cedarjs//",
-        "uuid"
+        "/^@cedarjs//"
       ]
     },
     {

--- a/packages/auth-providers/dbAuth/api/package.json
+++ b/packages/auth-providers/dbAuth/api/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@cedarjs/project-config": "workspace:*",
     "md5": "2.3.0",
-    "uuid": "11.1.0"
+    "uuid": "11.1.1"
   },
   "devDependencies": {
     "@cedarjs/api": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -89,7 +89,7 @@
     "termi-link": "1.1.0",
     "title-case": "3.0.3",
     "unionfs": "4.6.0",
-    "uuid": "11.1.0",
+    "uuid": "11.1.1",
     "verkit": "0.4.0",
     "yargs": "17.7.3"
   },

--- a/packages/create-cedar-app/package.json
+++ b/packages/create-cedar-app/package.json
@@ -43,7 +43,7 @@
     "systeminformation": "5.33.8",
     "termi-link": "1.1.0",
     "untildify": "4.0.0",
-    "uuid": "11.1.0",
+    "uuid": "11.1.1",
     "verkit": "0.4.0",
     "vitest": "4.1.11",
     "yargs": "17.7.3"

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -50,7 +50,7 @@
     "graphql-tag": "2.12.7",
     "graphql-yoga": "5.22.0",
     "lodash": "4.18.1",
-    "uuid": "11.1.0"
+    "uuid": "11.1.1"
   },
   "devDependencies": {
     "@cedarjs/framework-tools": "workspace:*",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -28,7 +28,7 @@
     "ci-info": "4.4.0",
     "envinfo": "7.21.0",
     "systeminformation": "5.33.8",
-    "uuid": "11.1.0",
+    "uuid": "11.1.1",
     "yargs": "17.7.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2499,7 +2499,7 @@ __metadata:
     md5: "npm:2.3.0"
     publint: "npm:0.3.24"
     typescript: "npm:5.9.3"
-    uuid: "npm:11.1.0"
+    uuid: "npm:11.1.1"
     vitest: "npm:4.1.11"
   peerDependencies:
     "@simplewebauthn/server": ^13.0.0
@@ -3005,7 +3005,7 @@ __metadata:
     ts-dedent: "npm:2.3.0"
     typescript: "npm:5.9.3"
     unionfs: "npm:4.6.0"
-    uuid: "npm:11.1.0"
+    uuid: "npm:11.1.1"
     verkit: "npm:0.4.0"
     vitest: "npm:4.1.11"
     yargs: "npm:17.7.3"
@@ -3292,7 +3292,7 @@ __metadata:
     lodash: "npm:4.18.1"
     publint: "npm:0.3.24"
     typescript: "npm:5.9.3"
-    uuid: "npm:11.1.0"
+    uuid: "npm:11.1.1"
     vitest: "npm:4.1.11"
   languageName: unknown
   linkType: soft
@@ -3705,7 +3705,7 @@ __metadata:
     envinfo: "npm:7.21.0"
     systeminformation: "npm:5.33.8"
     typescript: "npm:5.9.3"
-    uuid: "npm:11.1.0"
+    uuid: "npm:11.1.1"
     vitest: "npm:4.1.11"
     yargs: "npm:17.7.3"
   languageName: unknown
@@ -15710,7 +15710,7 @@ __metadata:
     systeminformation: "npm:5.33.8"
     termi-link: "npm:1.1.0"
     untildify: "npm:4.0.0"
-    uuid: "npm:11.1.0"
+    uuid: "npm:11.1.1"
     verkit: "npm:0.4.0"
     vitest: "npm:4.1.11"
     yargs: "npm:17.7.3"
@@ -29941,12 +29941,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:11.1.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
+"uuid@npm:11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
   bin:
     uuid: dist/esm/bin/uuid
-  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
+  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps `uuid` from 11.1.0 to 11.1.1 in the five packages that pin it (`@cedarjs/auth-dbauth-api`, `@cedarjs/cli`, `create-cedar-app`, `@cedarjs/graphql-server`, `@cedarjs/telemetry`).

11.1.0 is affected by [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (missing buffer bounds check in `v3`/`v5`/`v6` when `buf` is provided). 11.1.1 is the patched release, and after this change `yarn npm audit -A` reports no uuid advisory.

Renovate never proposed the bump because `uuid` sat in the disabled "ESM and @cedarjs packages" group in `.github/renovate.json`. Every package in this repo is ESM now, so `uuid` is removed from that list and Renovate handles it like any other dependency. The rest of the list is left as is for now.