### PR TITLE
fix(cca): don't seed lockfile generation with stale overlay lockfiles

### DIFF
--- a/packages/create-cedar-app/package.json
+++ b/packages/create-cedar-app/package.json
@@ -20,7 +20,7 @@
     "build:watch": "nodemon --watch src --ignore dist,template --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "set-up-test-project": "node ./scripts/setUpTestProject.js",
-    "test": "vitest run templates",
+    "test": "vitest run templates generateLockfile",
     "test:e2e": "vitest --pool=forks run e2e",
     "ts-to-js": "yarn node ./scripts/tsToJS.js"
   },

--- a/packages/create-cedar-app/scripts/generateLockfile.js
+++ b/packages/create-cedar-app/scripts/generateLockfile.js
@@ -43,7 +43,16 @@ export async function generateLockfile(
       recursive: true,
       filter: (src) => !EXCLUDED_TEMPLATE_ENTRIES.includes(path.basename(src)),
     })
-    fs.cpSync(overlayDir, tmpDir, { recursive: true, force: true })
+    // Filter out lockfiles here too: patch release branches are cut from the
+    // previous release's tag, where the overlay dirs carry that release's
+    // committed lockfiles. Copying one into the compose dir would make pnpm's
+    // CI-default frozen install refuse to update it (and would influence the
+    // other package managers' resolution), so always regenerate from scratch
+    fs.cpSync(overlayDir, tmpDir, {
+      recursive: true,
+      force: true,
+      filter: (src) => !EXCLUDED_TEMPLATE_ENTRIES.includes(path.basename(src)),
+    })
 
     await within(async () => {
       cd(tmpDir)

--- a/packages/create-cedar-app/scripts/generateLockfile.js
+++ b/packages/create-cedar-app/scripts/generateLockfile.js
@@ -34,6 +34,7 @@ export async function generateLockfile(
   env = {},
 ) {
   console.log(`Generating ${lockfileName}...`)
+  const originalCwd = process.cwd()
   const tmpDir = fs.mkdtempSync(
     path.join(os.tmpdir(), `cedar-${packageManager}-`),
   )
@@ -70,6 +71,10 @@ export async function generateLockfile(
 
     return lockDest
   } finally {
+    // zx's `cd` changes the process's working directory (`within` only
+    // scopes zx's own cwd), and Windows can't remove a directory that is
+    // the process's cwd, so restore the original cwd first
+    process.chdir(originalCwd)
     fs.rmSync(tmpDir, { recursive: true, force: true })
   }
 }

--- a/packages/create-cedar-app/scripts/generateLockfile.js
+++ b/packages/create-cedar-app/scripts/generateLockfile.js
@@ -43,11 +43,13 @@ export async function generateLockfile(
       recursive: true,
       filter: (src) => !EXCLUDED_TEMPLATE_ENTRIES.includes(path.basename(src)),
     })
-    // Filter out lockfiles here too: patch release branches are cut from the
-    // previous release's tag, where the overlay dirs carry that release's
-    // committed lockfiles. Copying one into the compose dir would make pnpm's
-    // CI-default frozen install refuse to update it (and would influence the
-    // other package managers' resolution), so always regenerate from scratch
+    // The overlay copy excludes the same entries, upholding the invariant
+    // that the compose dir never contains install artifacts or a
+    // pre-existing lockfile: the install below always resolves dependencies
+    // from the composed template contents and generates `lockfileName` from
+    // scratch. (Overlay dirs can carry the previous release's committed
+    // lockfiles - patch release branches are cut from the previous release's
+    // tag - which pnpm's CI-default frozen install would refuse to update.)
     fs.cpSync(overlayDir, tmpDir, {
       recursive: true,
       force: true,

--- a/packages/create-cedar-app/tests/generateLockfile.test.ts
+++ b/packages/create-cedar-app/tests/generateLockfile.test.ts
@@ -23,6 +23,31 @@ const STUB_INSTALL_SCRIPT = `
 
 const LOCKFILE_NAMES = ['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml']
 
+interface InstallReport {
+  entries: string[]
+  lockfileContent: string
+}
+
+function readReport(file: string): InstallReport {
+  const report: unknown = JSON.parse(fs.readFileSync(file, 'utf-8'))
+
+  if (
+    typeof report !== 'object' ||
+    report === null ||
+    !('entries' in report) ||
+    !Array.isArray(report.entries) ||
+    !report.entries.every((entry): entry is string => {
+      return typeof entry === 'string'
+    }) ||
+    !('lockfileContent' in report) ||
+    typeof report.lockfileContent !== 'string'
+  ) {
+    throw new Error(`Malformed install report: ${JSON.stringify(report)}`)
+  }
+
+  return { entries: report.entries, lockfileContent: report.lockfileContent }
+}
+
 let testDir: string
 let templateDir: string
 let overlayDir: string
@@ -56,8 +81,8 @@ afterEach(() => {
 test.each(LOCKFILE_NAMES)(
   'regenerates %s even when the overlay carries a stale one',
   async (lockfileName) => {
-    // The situation on a patch release branch: the previous release committed
-    // its generated lockfiles into the overlay dirs
+    // The overlay carries a stale lockfile for every package manager, as it
+    // does on a patch release branch
     for (const staleLockfileName of LOCKFILE_NAMES) {
       fs.writeFileSync(
         path.join(overlayDir, staleLockfileName),
@@ -74,10 +99,10 @@ test.each(LOCKFILE_NAMES)(
       { REPORT_FILE: reportFile, LOCKFILE_NAME: lockfileName },
     )
 
-    const report = JSON.parse(fs.readFileSync(reportFile, 'utf-8'))
+    const report = readReport(reportFile)
 
-    // The stale lockfiles never made it into the compose dir: the install
-    // only saw the empty placeholder for the lockfile it generates
+    // The stale overlay lockfiles are excluded from the compose dir: the
+    // install sees only the empty placeholder for the lockfile it generates
     expect(report.lockfileContent).toBe('')
     expect(report.entries).toEqual(['package.json', lockfileName, 'web'].sort())
 
@@ -103,7 +128,7 @@ test('excludes install artifacts from the template copy', async () => {
     { REPORT_FILE: reportFile, LOCKFILE_NAME: 'yarn.lock' },
   )
 
-  const report = JSON.parse(fs.readFileSync(reportFile, 'utf-8'))
+  const report = readReport(reportFile)
 
   expect(report.lockfileContent).toBe('')
   expect(report.entries).toEqual(['package.json', 'web', 'yarn.lock'].sort())

--- a/packages/create-cedar-app/tests/generateLockfile.test.ts
+++ b/packages/create-cedar-app/tests/generateLockfile.test.ts
@@ -1,0 +1,110 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, expect, test } from 'vitest'
+
+import { generateLockfile } from '../scripts/generateLockfile.js'
+
+// Stands in for `yarn`/`npm install`/`pnpm install`. It records what the
+// compose dir contained when the install ran (directory entries and the
+// lockfile's content) and writes a fresh lockfile, like a real install would
+const STUB_INSTALL_SCRIPT = `
+  const fs = require('node:fs')
+  fs.writeFileSync(
+    process.env.REPORT_FILE,
+    JSON.stringify({
+      entries: fs.readdirSync('.').sort(),
+      lockfileContent: fs.readFileSync(process.env.LOCKFILE_NAME, 'utf-8'),
+    }),
+  )
+  fs.writeFileSync(process.env.LOCKFILE_NAME, 'freshly generated lockfile')
+`
+
+const LOCKFILE_NAMES = ['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml']
+
+let testDir: string
+let templateDir: string
+let overlayDir: string
+let reportFile: string
+
+beforeEach(() => {
+  testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cedar-lockfile-test-'))
+  templateDir = path.join(testDir, 'template')
+  overlayDir = path.join(testDir, 'overlay')
+  reportFile = path.join(testDir, 'report.json')
+
+  fs.mkdirSync(path.join(templateDir, 'web'), { recursive: true })
+  fs.writeFileSync(
+    path.join(templateDir, 'package.json'),
+    '{ "name": "template" }',
+  )
+  fs.writeFileSync(path.join(templateDir, 'web', 'index.html'), '<html></html>')
+  fs.mkdirSync(path.join(templateDir, 'node_modules'), { recursive: true })
+
+  fs.mkdirSync(overlayDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(overlayDir, 'package.json'),
+    '{ "name": "overlay" }',
+  )
+})
+
+afterEach(() => {
+  fs.rmSync(testDir, { recursive: true, force: true })
+})
+
+test.each(LOCKFILE_NAMES)(
+  'regenerates %s even when the overlay carries a stale one',
+  async (lockfileName) => {
+    // The situation on a patch release branch: the previous release committed
+    // its generated lockfiles into the overlay dirs
+    for (const staleLockfileName of LOCKFILE_NAMES) {
+      fs.writeFileSync(
+        path.join(overlayDir, staleLockfileName),
+        'stale lockfile from the previous release',
+      )
+    }
+
+    const lockDest = await generateLockfile(
+      templateDir,
+      overlayDir,
+      lockfileName,
+      'node',
+      ['-e', STUB_INSTALL_SCRIPT],
+      { REPORT_FILE: reportFile, LOCKFILE_NAME: lockfileName },
+    )
+
+    const report = JSON.parse(fs.readFileSync(reportFile, 'utf-8'))
+
+    // The stale lockfiles never made it into the compose dir: the install
+    // only saw the empty placeholder for the lockfile it generates
+    expect(report.lockfileContent).toBe('')
+    expect(report.entries).toEqual(['package.json', lockfileName, 'web'].sort())
+
+    // The overlay's package.json replaced the template's
+    // and the generated lockfile was copied back into the overlay dir
+    expect(lockDest).toBe(path.join(overlayDir, lockfileName))
+    expect(fs.readFileSync(lockDest, 'utf-8')).toBe(
+      'freshly generated lockfile',
+    )
+  },
+)
+
+test('excludes install artifacts from the template copy', async () => {
+  fs.mkdirSync(path.join(templateDir, '.yarn'), { recursive: true })
+  fs.writeFileSync(path.join(templateDir, 'yarn.lock'), 'stale template lock')
+
+  await generateLockfile(
+    templateDir,
+    overlayDir,
+    'yarn.lock',
+    'node',
+    ['-e', STUB_INSTALL_SCRIPT],
+    { REPORT_FILE: reportFile, LOCKFILE_NAME: 'yarn.lock' },
+  )
+
+  const report = JSON.parse(fs.readFileSync(reportFile, 'utf-8'))
+
+  expect(report.lockfileContent).toBe('')
+  expect(report.entries).toEqual(['package.json', 'web', 'yarn.lock'].sort())
+})


### PR DESCRIPTION
## Problem

The v6.0.1 RC publish failed in CI ([run](https://github.com/cedarjs/cedar/actions/runs/33150185149)) with:

```
ERR_PNPM_OUTDATED_LOCKFILE Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with package.json
  - @cedarjs/core (lockfile: 6.0.0, manifest: 6.0.1-rc.6)
```

`generateLockfile()` composes a base template + package-manager overlay in a temp dir and runs an install there. The template copy filters out lockfiles (`EXCLUDED_TEMPLATE_ENTRIES`), but the overlay copy doesn't. Since every release's tag commit now includes the generated overlay lockfiles, and patch release branches are cut from the previous release's tag, the compose dir starts with a lockfile pinned to the previous version — and pnpm's CI-default frozen install refuses to update it. (Yarn is already handled via `YARN_ENABLE_IMMUTABLE_INSTALLS=false`; npm has no frozen default.)

v6.0.1 only shipped after a manual commit deleting the six overlay lockfiles from the release branch. Without this fix, v6.0.2 (and v5.0.8) would need the same manual step.

## Fix

Apply the same `EXCLUDED_TEMPLATE_ENTRIES` filter to the overlay copy, so lockfiles are always regenerated from scratch — the state every successful release has run from. No change to frozen-install semantics anywhere else.

Note: since the RC workflow runs this script from the release branch (cut from the old tag), this PR only takes effect there via the patch-release cherry-pick — hence the `next-release-patch` milestone.

The release-tooling repo's inlined copy of `generateLockfile` got the same fix in cedarjs/release-tooling@a7eefebd8.